### PR TITLE
Reports: panels over a window, and the first report built from them

### DIFF
--- a/bin/psr4-scan.php
+++ b/bin/psr4-scan.php
@@ -143,6 +143,7 @@ const TABLE = [
     'Audit' => 'Audit',
     'ActivityWindow' => 'Audit',
     'ImagingStats' => 'Audit',
+    'ReportWindow' => 'Audit',
     'Retention' => 'Audit',
     'Blame' => 'Audit',
     'FOGFTP' => 'Net',

--- a/docs/adr/0030-a-report-is-an-aggregation-over-a-window.md
+++ b/docs/adr/0030-a-report-is-an-aggregation-over-a-window.md
@@ -7,8 +7,12 @@ proposed
 Decision 4 (the permission model) and decision 5 (the `taskLog` index) were
 signed off by the maintainer on 2026-08-29 ahead of the rest, decision 4
 because it is an access-control choice and decision 5 because it is a defect
-that stands on its own. Step 379 is implemented on `working-1.6`; nothing
-else here is.
+that stands on its own.
+
+Sequencing items 1 to 5 are implemented on `working-1.6`. Item 6 -- the
+remaining five subjects in the scope table -- is not started, and whether
+this becomes `accepted` depends on the first of them being cheap, which is
+the claim the table below makes and the only one still untested.
 
 ## Context
 
@@ -237,3 +241,20 @@ the event logs. Rollups are not events and do not share a column set.
 | 4 | Panel render helper + the shared JS module | The abstraction, validated against exactly one report |
 | 5 | Imaging report, with its `REPORT_NODES` entry | The pattern-setter |
 | 6 | The remaining five, one rollup and one class each | Cheap by construction, or step 4 was wrong |
+
+Items 4 and 5 landed together, deliberately. This ADR's own context records
+that `ActivityWindow` "shipped without a caller, which is how a helper rots";
+building the panel helper with nothing consuming it would have repeated that
+exactly, so the imaging report is what the helper was shaped against rather
+than what it was shaped for.
+
+What item 4 turned out to be, for item 6 to reuse:
+
+| Piece | Where |
+|---|---|
+| `ReportWindow` | `src/Audit/` — reads `start`/`end` off the URL on FOG's clock, drops a malformed bound, swaps a reversed pair. Each report supplies only its own default range |
+| `renderReportWindow()` | `FOGPageRender` — the From/To form, with an `$extra` slot for report-specific controls (Run History's source ticks) |
+| `renderStatTiles()` | `FOGPageRender` — the headline row, lifted from `ImageManagement::_archStat()` |
+| `renderChartPanel()` | `FOGPageRender` — a card, a container, and the series in a `type="application/json"` block beside it |
+| `fog.report.panels.js` | Draws every container on the page. No requests: a report's window is fixed and already in the URL, so re-fetching would re-run the same aggregation and give the chart a chance to disagree with the grid |
+| `tabFields($tabData, 0)` | The existing nav-tabs builder. A falsy object skips its entity hooks, so reports needed no second tab implementation |

--- a/packages/web/lib/pages/reportmanagement.page.php
+++ b/packages/web/lib/pages/reportmanagement.page.php
@@ -69,6 +69,7 @@ class ReportManagement extends FOGPage
     {
         _('File Deleter');
         _('History Report');
+        _('Imaging Report');
         _('Host List');
         _('Hosts And Users');
         _('Inventory Report');

--- a/packages/web/lib/reports/imaging_report.report.php
+++ b/packages/web/lib/reports/imaging_report.report.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * How much imaging happened, of what, and to how many machines.
+ *
+ * PHP version 7.4+
+ *
+ * @category Imaging_Report
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG;
+
+use FOG\Audit\ImagingStats;
+use FOG\Audit\ReportWindow;
+use FOG\Items\TaskState;
+use FOG\Router\HTTPResponseCodes;
+
+/**
+ * How much imaging happened, of what, and to how many machines.
+ *
+ * ADR 0030's first report, and the one the shape was designed against: a
+ * window in the URL, headline numbers, charts over the same window, and a
+ * grid of the rows underneath. Everything on the page comes from one fold
+ * of `taskLog` in ImagingStats, so a tile, a bar and a row cannot disagree
+ * about what a run is -- which they did before, because the dashboard's
+ * 30-day count carried the counting rules in a comment inside one method
+ * and nothing else could reach them.
+ *
+ * WHY taskLog AND NOT tasks. A task row is overwritten as it progresses,
+ * so it records the CURRENT state of the tasks that still exist; a machine
+ * imaged last month whose task has since been cleared leaves no row at all.
+ * `taskLog` keeps one row per state TRANSITION, which is why the three
+ * counting rules in ImagingStats exist and why they belong somewhere they
+ * can be tested rather than in a page.
+ *
+ * GATED ON `task`, NOT `report`, for the same reason Run History is: this
+ * is task activity, Task Management's own log pane is gated on task.view,
+ * and Authorization::REPORT_NODES is the seam for saying so (ADR 0030
+ * decision 4). It narrows against the report default; nothing anyone holds
+ * today gets wider.
+ *
+ * NOT serverSide, like Run History and unlike the older reports. The rows
+ * are the same bounded fold the charts above them are drawn from -- asking
+ * for them a page at a time through Route::listem() would be a second,
+ * differently-shaped query answering a slightly different question, which
+ * is the disagreement this report exists to avoid.
+ *
+ * @category Imaging_Report
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class Imaging_Report extends ReportManagement
+{
+    /**
+     * How far back the report looks when nobody has said.
+     *
+     * A month rather than Run History's day. The question this report is
+     * opened with is "how are we doing", which needs enough days for the
+     * trend line to be a trend; a day of imaging is three points and a
+     * shape nobody can read.
+     *
+     * @var string
+     */
+    const DEFAULT_WINDOW = '-30 days';
+    /**
+     * How many images get their own bar before the rest are folded up.
+     *
+     * @var int
+     */
+    const TOP_IMAGES = 8;
+    /**
+     * Display page.
+     *
+     * @return void
+     */
+    public function file()
+    {
+        $this->title = _('Imaging Report');
+
+        $this->headerData = [
+            _('Host'),
+            _('Image'),
+            _('Type'),
+            _('Started'),
+            _('Finished'),
+            _('State'),
+            _('By')
+        ];
+        $this->attributes = [
+            [], [], [], [], [], [], []
+        ];
+
+        [$start, $end] = ReportWindow::fromRequest(self::DEFAULT_WINDOW);
+        $totals = ImagingStats::totals($start, $end);
+        $perDay = ImagingStats::runsPerDay($start, $end);
+        $byImage = ImagingStats::runsByImage($start, $end, self::TOP_IMAGES);
+
+        echo '<div class="card">';
+        echo '<div class="card-header">';
+        echo '<h4 class="card-title">';
+        echo $this->title;
+        echo '</h4>';
+        echo '</div>';
+        echo '<div class="card-body">';
+
+        echo self::renderReportWindow(
+            'imaging',
+            $start->format('Y-m-d H:i:s'),
+            $end->format('Y-m-d H:i:s')
+        );
+
+        if ($totals['truncated']) {
+            // Said out loud rather than left to be noticed. Every number on
+            // this page is computed off the capped set, so a silent cap
+            // would make the tiles quietly wrong for exactly the busy
+            // fleets that most need them right.
+            printf(
+                '<div class="alert alert-warning">%s</div>',
+                \Initiator::e(
+                    sprintf(
+                        _(
+                            'More than %s runs match this range. Everything '
+                            . 'below counts the most recent %s only -- narrow '
+                            . 'the dates for exact figures.'
+                        ),
+                        number_format(ImagingStats::MAX_ROWS),
+                        number_format(ImagingStats::MAX_ROWS)
+                    )
+                )
+            );
+        }
+
+        echo self::renderStatTiles(
+            [
+                ['value' => $totals['runs'], 'label' => _('Imaging runs')],
+                ['value' => $totals['hosts'], 'label' => _('Machines imaged')],
+                ['value' => $totals['images'], 'label' => _('Images used')],
+                [
+                    'value' => count($perDay) > 0
+                        ? round($totals['runs'] / count($perDay), 1)
+                        : 0,
+                    'label' => _('Runs per day')
+                ]
+            ]
+        );
+
+        // 0, not the -1 default: that default resolves the current node
+        // and id into an object, and a falsy one skips tabFields'
+        // TABDATA_HOOK and plugin-injection blocks. Those exist to hang
+        // extra tabs off an entity being edited; a report is not an entity
+        // and has no id to give them, so `report`/'' would be looked up as
+        // a class and found not to be one.
+        echo self::tabFields(
+            [
+                [
+                    'name' => _('Activity'),
+                    'id' => 'imaging-activity',
+                    'generator' => function () use ($perDay, $byImage) {
+                        echo '<div class="row">';
+                        echo self::renderChartPanel(
+                            'imaging-per-day',
+                            _('Runs per day'),
+                            [
+                                'type' => 'line',
+                                'labels' => array_column($perDay, 'date'),
+                                'series' => [
+                                    [
+                                        'label' => _('Runs'),
+                                        'data' => array_map(
+                                            'intval',
+                                            array_column($perDay, 'count')
+                                        )
+                                    ]
+                                ]
+                            ],
+                            7
+                        );
+                        echo self::renderChartPanel(
+                            'imaging-by-image',
+                            _('Runs by image'),
+                            [
+                                'type' => 'doughnut',
+                                'labels' => array_column($byImage, 'image'),
+                                'series' => [
+                                    [
+                                        'label' => _('Runs'),
+                                        'data' => array_map(
+                                            'intval',
+                                            array_column($byImage, 'count')
+                                        )
+                                    ]
+                                ]
+                            ],
+                            5
+                        );
+                        echo '</div>';
+                    }
+                ],
+                [
+                    'name' => _('Runs'),
+                    'id' => 'imaging-runs',
+                    'generator' => function () {
+                        $this->render(12, 'imaging-table');
+                    }
+                ]
+            ],
+            0
+        );
+
+        echo '</div>';
+        echo '</div>';
+    }
+    /**
+     * Serves the rows.
+     *
+     * @return void
+     */
+    public function getList()
+    {
+        header('Content-type: application/json');
+        [$start, $end] = ReportWindow::fromRequest(self::DEFAULT_WINDOW);
+        $rows = ImagingStats::runs($start, $end);
+
+        // State ids become names through the model, memoized on the distinct
+        // id -- there are a handful of them and they are hook-overridable,
+        // so this is the same thing Route's statename formatter does rather
+        // than a join that would freeze the labels.
+        $states = [];
+        // The states after which nothing more is written for a task. The
+        // fold's `ended` is MAX(createTime) over the run's rows, which is a
+        // finish time only once the run has finished -- for one still in
+        // progress it is the last transition, and printing that under
+        // "Finished" says a deploy completed when it is still copying.
+        $terminal = [
+            (int)TaskState::getCompleteState(),
+            (int)TaskState::getCancelledState(),
+            (int)TaskState::getFailedState()
+        ];
+        $data = [];
+        foreach ($rows as $row) {
+            $stateID = (int)($row['stateID'] ?? 0);
+            if ($stateID > 0 && !isset($states[$stateID])) {
+                $states[$stateID] = (string)self::getClass('TaskState', $stateID)
+                    ->get('name');
+            }
+            $data[] = [
+                // The name as it was AT THE TIME, out of the log row, not
+                // resolved from `hosts` now. A machine that has since been
+                // renamed or deleted still has to name itself in a report
+                // about what happened last month.
+                'hostName' => (string)($row['hostName'] ?? ''),
+                'imageName' => (string)($row['imageName'] ?? ''),
+                'taskTypeName' => (string)($row['taskTypeName'] ?? ''),
+                'started' => (string)($row['started'] ?? ''),
+                'ended' => in_array($stateID, $terminal, true)
+                    ? (string)($row['ended'] ?? '')
+                    : '',
+                'state' => $states[$stateID] ?? '',
+                'createdBy' => (string)($row['createdBy'] ?? '')
+            ];
+        }
+
+        http_response_code(HTTPResponseCodes::HTTP_SUCCESS);
+        echo json_encode(['data' => $data]);
+        exit;
+    }
+}
+
+/*
+ * Compatibility alias. Every consumer of this class' name -- core,
+ * bundled plugins and third-party plugins alike -- keeps working
+ * unqualified through this, so no call site had to be edited.
+ * Supported for all of 1.6; see docs/adr/0013.
+ */
+class_alias(__NAMESPACE__ . '\\Imaging_Report', 'Imaging_Report');

--- a/packages/web/lib/reports/run_history.report.php
+++ b/packages/web/lib/reports/run_history.report.php
@@ -14,6 +14,7 @@
 namespace FOG;
 
 use FOG\Audit\ActivityWindow;
+use FOG\Audit\ReportWindow;
 use FOG\Router\HTTPResponseCodes;
 
 /**
@@ -69,51 +70,16 @@ class Run_History extends ReportManagement
     /**
      * The window the request asked for, clamped to something a query can use.
      *
-     * ON FOG'S CLOCK, NOT PHP'S, and that is the whole reason this is not
-     * three lines of strtotime(). The columns being compared are stamped by
-     * FOGController::save() through FOGBase::niceDate(), which uses the
-     * configured FOG_TZ timezone -- so a bound built with PHP's default
-     * timezone is silently offset by however far apart the two are. It does
-     * not error: BETWEEN just matches a shifted window, so the report
-     * quietly answers a question nobody asked. Caught in the lab against a
-     * server five hours off PHP's timezone, where a task created seconds
-     * earlier did not appear in a window ending "now".
-     *
-     * A malformed bound is dropped rather than passed on, for the same
-     * reason -- an unparseable date reaching BETWEEN matches nothing, which
-     * looks exactly like "nothing ran".
+     * The parsing itself moved to ReportWindow when a second report needed
+     * it (ADR 0030 decision 1 -- the window lives in the URL, so every
+     * report reads the same two parameters). What stays here is only this
+     * report's default range.
      *
      * @return array [start, end], both 'Y-m-d H:i:s' in FOG's timezone.
      */
     private static function _window()
     {
-        $fmt = 'Y-m-d H:i:s';
-        $given = [
-            'start' => (string) filter_input(INPUT_GET, 'start'),
-            'end' => (string) filter_input(INPUT_GET, 'end'),
-        ];
-        // Parseability is checked BEFORE handing the string to niceDate(),
-        // which throws on a date it cannot read. A form field is a value
-        // that may legitimately be malformed, so it is validated; this is
-        // not a try/catch standing in for an API that might not be there.
-        foreach ($given as $k => $v) {
-            if ('' !== $v && false === strtotime($v)) {
-                $given[$k] = '';
-            }
-        }
-        $end = '' === $given['end']
-            ? self::niceDate()
-            : self::niceDate($given['end']);
-        $start = '' === $given['start']
-            ? self::niceDate()->modify(self::DEFAULT_WINDOW)
-            : self::niceDate($given['start']);
-        if ($start > $end) {
-            // Reversed rather than rejected. Somebody who types the two
-            // dates the other way round means the range between them.
-            [$start, $end] = [$end, $start];
-        }
-
-        return [$start->format($fmt), $end->format($fmt)];
+        return ReportWindow::stringsFromRequest(self::DEFAULT_WINDOW);
     }
     /**
      * The sources the request asked for, validated against the class.
@@ -194,32 +160,11 @@ class Run_History extends ReportManagement
         echo '</div>';
         echo '<div class="card-body">';
 
-        // A plain GET form. The range is part of the URL on purpose: a
-        // report someone is going to paste into a ticket has to survive
-        // being pasted, and a range held only in JS state does not.
-        echo '<form method="get" action="../management/index.php" '
-            . 'class="row g-3 mb-3" id="run-history-form">';
-        printf(
-            '<input type="hidden" name="node" value="report">'
-            . '<input type="hidden" name="f" value="%s">',
-            \Initiator::e((string) filter_input(INPUT_GET, 'f'))
-        );
-        echo '<div class="col-md-3">';
-        echo self::makeLabel('col-form-label', 'run-history-start', _('From'));
-        printf(
-            '<input type="datetime-local" class="form-control" '
-            . 'id="run-history-start" name="start" value="%s">',
-            \Initiator::e(str_replace(' ', 'T', $start))
-        );
-        echo '</div>';
-        echo '<div class="col-md-3">';
-        echo self::makeLabel('col-form-label', 'run-history-end', _('To'));
-        printf(
-            '<input type="datetime-local" class="form-control" '
-            . 'id="run-history-end" name="end" value="%s">',
-            \Initiator::e(str_replace(' ', 'T', $end))
-        );
-        echo '</div>';
+        // The sources picker is this report's own control; the From/To
+        // pair and the submit button are the shared ones. Built first and
+        // handed to the helper as its $extra so the column order is the
+        // same here as on every other report.
+        ob_start();
         echo '<div class="col-md-4">';
         echo self::makeLabel('col-form-label', 'run-history-sources', _('Include'));
         echo '<div id="run-history-sources">';
@@ -240,15 +185,9 @@ class Run_History extends ReportManagement
         }
         echo '</div>';
         echo '</div>';
-        echo '<div class="col-md-2 d-flex align-items-end">';
-        echo self::makeButton(
-            'run-history-go',
-            _('Show'),
-            'btn btn-primary float-end',
-            'type="submit"'
-        );
-        echo '</div>';
-        echo '</form>';
+        $sources = ob_get_clean();
+
+        echo self::renderReportWindow('run-history', $start, $end, $sources);
 
         echo $this->render(12, 'runhistory-table');
         echo '</div>';

--- a/packages/web/management/js/fog/report/fog.report.file.js
+++ b/packages/web/management/js/fog/report/fog.report.file.js
@@ -4,6 +4,28 @@
   // identical.
   var reportString = window.atob(Common.f);
 
+  // The endpoint for a report whose window lives in the page URL.
+  //
+  // The page's OWN query string carries the window (start, end, and for Run
+  // History sources[]) and getList has to see it -- but it also carries
+  // node, sub and f, and appending it wholesale put `sub=file` AFTER
+  // `sub=getList`. PHP takes the last occurrence of a repeated key, so every
+  // request re-rendered the report page and DataTables was handed HTML at
+  // HTTP 200. That is what the "runhistory-table / HTTP 200 - <div class=..."
+  // toast was.
+  //
+  // Built through URLSearchParams so there are no repeated keys to resolve
+  // at all: the window params ride along untouched (set() replaces only the
+  // three named, and sources[] is left as the repeated key it is), and the
+  // three that address the endpoint are stated once.
+  function windowedUrl() {
+    var params = new URLSearchParams(window.location.search);
+    params.set('node', 'report');
+    params.set('sub', 'getList');
+    params.set('f', Common.f);
+    return '../management/index.php?' + params.toString();
+  }
+
   // This will call our respective calls
   // to report the requested data.
   switch (reportString) {
@@ -381,38 +403,58 @@
             [3, 'desc']
           ],
           buttons: reportButtons,
+          // Every column escapes. A run's label is a task or snapin name,
+          // which an operator types and a plugin can set, and DataTables
+          // writes cell data as HTML unless a column supplies its own
+          // render. The display-only guard inside render.text() keeps the
+          // Buttons CSV/copy exports unescaped -- same shape as the history
+          // and inventory reports above.
           columns: [
-            {data: 'source'},
-            {data: 'label'},
-            {data: 'host'},
-            {data: 'startedAt'},
-            {data: 'endedAt'},
-            {data: 'state'}
+            {data: 'source', render: $.fn.dataTable.render.text()},
+            {data: 'label', render: $.fn.dataTable.render.text()},
+            {data: 'host', render: $.fn.dataTable.render.text()},
+            {data: 'startedAt', render: $.fn.dataTable.render.text()},
+            {data: 'endedAt', render: $.fn.dataTable.render.text()},
+            {data: 'state', render: $.fn.dataTable.render.text()}
           ],
           processing: true,
           serverSide: false,
           select: false,
           ajax: {
-            // The page's OWN query string carries the window (start, end,
-            // sources[]) and getList has to see it -- but it also carries
-            // node, sub and f, and appending it wholesale put `sub=file`
-            // AFTER `sub=getList`. PHP takes the last occurrence of a
-            // repeated key, so every request re-rendered the report page
-            // and DataTables was handed HTML at HTTP 200. That is what the
-            // "runhistory-table / HTTP 200 - <div class=..." toast was.
-            //
-            // Built through URLSearchParams so there are no repeated keys
-            // to resolve at all: the window params ride along untouched
-            // (set() replaces only the three named, and sources[] is left
-            // as the repeated key it is), and the three that address the
-            // endpoint are stated once.
-            url: (function () {
-              var params = new URLSearchParams(window.location.search);
-              params.set('node', 'report');
-              params.set('sub', 'getList');
-              params.set('f', Common.f);
-              return '../management/index.php?' + params.toString();
-            })(),
+            url: windowedUrl(),
+            type: 'post'
+          }
+        });
+      break;
+      // Imaging Report
+      //
+      // Not serverSide, for the same reason: the rows are the bounded fold
+      // ImagingStats already ran to draw the charts above them, so paging
+      // them server side would be a second query answering a slightly
+      // different question. Every column is plain text out of `taskLog`,
+      // including names typed by whoever created the image, so every column
+      // escapes.
+    case 'imaging report':
+      var imagingTable = $('#imaging-table'),
+        table = imagingTable.registerTable(null, {
+          order: [
+            [3, 'desc']
+          ],
+          buttons: reportButtons,
+          columns: [
+            {data: 'hostName', render: $.fn.dataTable.render.text()},
+            {data: 'imageName', render: $.fn.dataTable.render.text()},
+            {data: 'taskTypeName', render: $.fn.dataTable.render.text()},
+            {data: 'started', render: $.fn.dataTable.render.text()},
+            {data: 'ended', render: $.fn.dataTable.render.text()},
+            {data: 'state', render: $.fn.dataTable.render.text()},
+            {data: 'createdBy', render: $.fn.dataTable.render.text()}
+          ],
+          processing: true,
+          serverSide: false,
+          select: false,
+          ajax: {
+            url: windowedUrl(),
             type: 'post'
           }
         });

--- a/packages/web/management/js/fog/report/fog.report.panels.js
+++ b/packages/web/management/js/fog/report/fog.report.panels.js
@@ -1,0 +1,221 @@
+/**
+ * FOG report chart panels.
+ *
+ * Draws every `.fog-report-chart` container a report emitted through
+ * FOGPageRender::renderChartPanel(). Each container is paired with a
+ * `<script type="application/json">` block holding its series, so this file
+ * makes NO requests: a report's window is fixed and already in the URL, and
+ * re-fetching would run the same aggregation a second time to draw the same
+ * picture -- and give the chart a chance to disagree with the grid beneath
+ * it. See ADR 0030.
+ *
+ * Theme handling mirrors fog.dashboard.js deliberately rather than sharing
+ * with it: that file is the homepage's own and is loaded only there, and the
+ * one thing worth sharing (the CHROME palette) is six values.
+ */
+(function ($) {
+  'use strict';
+
+  // Loaded for the whole `report` node, so most reports have no canvas and
+  // some pages will not have Chart.js at all. Both are normal; leave.
+  if (typeof Chart === 'undefined') {
+    return;
+  }
+
+  var charts = {};   // element id -> Chart instance
+  var boxes = [];    // element ids in render order
+
+  // Chart "chrome" -- tick labels, legend text, grid lines -- is the only
+  // part that has to follow dark mode; dataset colors below read on either.
+  // Same values as the dashboard's, which match --fog-text-strong.
+  var CHROME = {
+    light: { text: '#666666', legend: '#444444', grid: 'rgba(0,0,0,0.1)' },
+    dark:  { text: '#c8ccd0', legend: '#c8ccd0', grid: 'rgba(255,255,255,0.12)' }
+  };
+
+  // AdminLTE's own accent colors, in a fixed order so the same image keeps
+  // the same slice color between two loads of the same report.
+  var PALETTE = [
+    '#3c8dbc', '#00a65a', '#f39c12', '#dd4b39', '#605ca8',
+    '#00c0ef', '#d81b60', '#39cccc', '#ff851b', '#3d9970'
+  ];
+
+  Chart.defaults.maintainAspectRatio = false;
+  Chart.defaults.animation.duration = 0;
+
+  function isDark() {
+    var theme = document.documentElement.getAttribute('data-bs-theme');
+    if (theme === 'dark') {
+      return true;
+    }
+    if (theme === 'light') {
+      return false;
+    }
+    return !!(window.matchMedia
+      && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  }
+
+  function applyChartDefaults() {
+    var c = isDark() ? CHROME.dark : CHROME.light;
+    Chart.defaults.color = c.text;
+    Chart.defaults.borderColor = c.grid;
+  }
+
+  // The series the server embedded beside this container. A missing or
+  // unreadable block is reported in the panel rather than swallowed: a
+  // silently blank chart reads as "nothing happened", which is a different
+  // and much worse answer than "this did not load".
+  function payload(id) {
+    var el = document.getElementById(id + '-data');
+    if (!el) {
+      return null;
+    }
+    try {
+      return JSON.parse(el.textContent || el.innerHTML || '');
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function message($box, text) {
+    $box.empty().append(
+      $('<p class="text-muted text-center my-4"></p>').text(text)
+    );
+  }
+
+  function config(data) {
+    var labels = data.labels || [];
+    var series = (data.series || [])[0] || {};
+    var values = series.data || [];
+
+    if (data.type === 'doughnut') {
+      return {
+        type: 'doughnut',
+        data: {
+          labels: labels,
+          datasets: [{
+            data: values,
+            backgroundColor: labels.map(function (unused, i) {
+              return PALETTE[i % PALETTE.length];
+            }),
+            borderWidth: 0
+          }]
+        },
+        options: {
+          cutout: '50%',
+          plugins: {
+            legend: {
+              position: 'right',
+              labels: { boxWidth: 12, color: chromeLegend() }
+            }
+          }
+        }
+      };
+    }
+
+    return {
+      type: 'line',
+      data: {
+        labels: labels,
+        datasets: [{
+          label: series.label || '',
+          data: values,
+          borderColor: PALETTE[0],
+          backgroundColor: 'rgba(60, 141, 188, 0.15)',
+          fill: true,
+          tension: 0.2,
+          // A year-long window is 366 points in a panel a few hundred
+          // pixels wide, where a marker per day is a solid band. Dropped
+          // past the width at which they stop being readable; the tooltip
+          // still names the exact day.
+          pointRadius: values.length > 60 ? 0 : 3
+        }]
+      },
+      options: {
+        plugins: { legend: { display: false } },
+        scales: {
+          y: { beginAtZero: true, ticks: { precision: 0 } },
+          // Dates come from the server already formatted for the window, so
+          // the axis is categorical -- no time adapter, and no dependence on
+          // moment being loaded on a report page.
+          x: { ticks: { autoSkip: true, maxRotation: 0 } }
+        }
+      }
+    };
+  }
+
+  function chromeLegend() {
+    return (isDark() ? CHROME.dark : CHROME.light).legend;
+  }
+
+  function draw(id) {
+    var box = document.getElementById(id);
+    if (!box) {
+      return;
+    }
+    var $box = $(box);
+    var data = payload(id);
+
+    if (charts[id]) {
+      charts[id].destroy();
+      delete charts[id];
+    }
+    if (!data) {
+      message($box, 'Chart data could not be read.');
+      return;
+    }
+    var values = ((data.series || [])[0] || {}).data || [];
+    var total = values.reduce(function (sum, v) {
+      return sum + (Number(v) || 0);
+    }, 0);
+    // An all-zero series is a real answer and has to say so. Chart.js draws
+    // a flat line or an empty ring for it, which looks like a chart that
+    // failed to load.
+    if (!values.length || total === 0) {
+      message($box, 'Nothing in this range.');
+      return;
+    }
+
+    $box.css({
+      position: 'relative',
+      height: (parseInt(box.getAttribute('data-chart-height'), 10) || 260) + 'px'
+    }).empty();
+    $box.append('<canvas></canvas>');
+
+    charts[id] = new Chart(
+      $box.find('canvas')[0].getContext('2d'),
+      config(data)
+    );
+  }
+
+  function drawAll() {
+    applyChartDefaults();
+    $.each(boxes, function (i, id) {
+      draw(id);
+    });
+  }
+
+  $('.fog-report-chart').each(function () {
+    if (this.id) {
+      boxes.push(this.id);
+    }
+  });
+  if (!boxes.length) {
+    return;
+  }
+
+  drawAll();
+
+  // Chart.js v4 caches each instance's resolved option colors, so recoloring
+  // in place no-ops on a rendered canvas -- the charts are rebuilt instead.
+  document.addEventListener('fog:themechange', drawAll);
+
+  // A canvas in a hidden tab pane measures zero, so a chart built while its
+  // tab was inactive comes back sized 0x0 when the tab is shown. Reports put
+  // their grid on a second tab, so this fires whenever someone comes back.
+  $(document).on('shown.bs.tab', function () {
+    $.each(charts, function (id, chart) {
+      chart.resize();
+    });
+  });
+})(jQuery);

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1239,6 +1239,9 @@ msgstr "Laden fehlgeschlagen: %s"
 msgid "Button Icon"
 msgstr ""
 
+msgid "By"
+msgstr ""
+
 msgid "Bypass Bitlocker Detection"
 msgstr ""
 
@@ -4017,6 +4020,10 @@ msgid "Images only"
 msgstr "Images"
 
 #, fuzzy
+msgid "Images used"
+msgstr "genutzte Images"
+
+#, fuzzy
 msgid "Imaging"
 msgstr "Imaging Log"
 
@@ -4040,8 +4047,16 @@ msgid "Imaging Over the last"
 msgstr "Imaging in den letzten 30 Tagen"
 
 #, fuzzy
+msgid "Imaging Report"
+msgstr "Imaging Log"
+
+#, fuzzy
 msgid "Imaging Started"
 msgstr "Host Imagingverlauf"
+
+#, fuzzy
+msgid "Imaging runs"
+msgstr "Imaging Log"
 
 msgid "Import"
 msgstr "Import"
@@ -5004,6 +5019,10 @@ msgstr "Netzwerk-Installer"
 msgid "Machine Details"
 msgstr "Details"
 
+#, fuzzy
+msgid "Machines imaged"
+msgstr "Zugeordnetes Image"
+
 msgid "Main Menu"
 msgstr "Hauptmenü"
 
@@ -5242,6 +5261,10 @@ msgstr "Monats-Wert ist nicht gültig"
 
 msgid "Monthly"
 msgstr "Monatlich"
+
+#, php-format
+msgid "More than %s runs match this range. Everything below counts the most recent %s only -- narrow the dates for exact figures."
+msgstr ""
 
 msgid "Most Frequent Host IDs"
 msgstr ""
@@ -6970,6 +6993,16 @@ msgstr ""
 #, fuzzy
 msgid "Running Windows"
 msgstr "Laufende Version"
+
+msgid "Runs"
+msgstr ""
+
+#, fuzzy
+msgid "Runs by image"
+msgstr "Images"
+
+msgid "Runs per day"
+msgstr ""
 
 msgid "SB Enrolled"
 msgstr ""

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1243,6 +1243,9 @@ msgstr "Load failed: %s"
 msgid "Button Icon"
 msgstr ""
 
+msgid "By"
+msgstr ""
+
 msgid "Bypass Bitlocker Detection"
 msgstr ""
 
@@ -4018,6 +4021,10 @@ msgid "Images only"
 msgstr "Images"
 
 #, fuzzy
+msgid "Images used"
+msgstr "Imaged"
+
+#, fuzzy
 msgid "Imaging"
 msgstr "Imaging Log"
 
@@ -4041,8 +4048,16 @@ msgid "Imaging Over the last"
 msgstr "Imaging Over the last 30 days"
 
 #, fuzzy
+msgid "Imaging Report"
+msgstr "Imaging Log"
+
+#, fuzzy
 msgid "Imaging Started"
 msgstr "Host Imaging History"
+
+#, fuzzy
+msgid "Imaging runs"
+msgstr "Imaging Log"
 
 msgid "Import"
 msgstr "Import"
@@ -5002,6 +5017,10 @@ msgstr "Network Printer"
 msgid "Machine Details"
 msgstr "Snapin Return Detail"
 
+#, fuzzy
+msgid "Machines imaged"
+msgstr "Assigned Image"
+
 msgid "Main Menu"
 msgstr "Main Menu"
 
@@ -5240,6 +5259,10 @@ msgstr "Month value is not valid"
 
 msgid "Monthly"
 msgstr "Monthly"
+
+#, php-format
+msgid "More than %s runs match this range. Everything below counts the most recent %s only -- narrow the dates for exact figures."
+msgstr ""
 
 msgid "Most Frequent Host IDs"
 msgstr ""
@@ -6967,6 +6990,16 @@ msgstr ""
 #, fuzzy
 msgid "Running Windows"
 msgstr "Running Version"
+
+msgid "Runs"
+msgstr ""
+
+#, fuzzy
+msgid "Runs by image"
+msgstr "Images"
+
+msgid "Runs per day"
+msgstr ""
 
 msgid "SB Enrolled"
 msgstr ""

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1260,6 +1260,9 @@ msgstr "Carga ha fallado: %s"
 msgid "Button Icon"
 msgstr ""
 
+msgid "By"
+msgstr ""
+
 msgid "Bypass Bitlocker Detection"
 msgstr ""
 
@@ -4096,6 +4099,10 @@ msgid "Images only"
 msgstr "Imagen"
 
 #, fuzzy
+msgid "Images used"
+msgstr "Nombre de la imagen"
+
+#, fuzzy
 msgid "Imaging"
 msgstr "Transferencia de imágenes Entrar"
 
@@ -4120,8 +4127,16 @@ msgid "Imaging Over the last"
 msgstr "Imaging lo largo de los últimos 30 días"
 
 #, fuzzy
+msgid "Imaging Report"
+msgstr "Transferencia de imágenes Entrar"
+
+#, fuzzy
 msgid "Imaging Started"
 msgstr "Lista de host"
+
+#, fuzzy
+msgid "Imaging runs"
+msgstr "Transferencia de imágenes Entrar"
 
 msgid "Import"
 msgstr "Importar"
@@ -5111,6 +5126,10 @@ msgid "Machine Details"
 msgstr ""
 
 #, fuzzy
+msgid "Machines imaged"
+msgstr "imagen asignado"
+
+#, fuzzy
 msgid "Main Menu"
 msgstr "Ocultar menú"
 
@@ -5358,6 +5377,10 @@ msgstr "tipo de tarea no es válida"
 
 msgid "Monthly"
 msgstr "Mensual"
+
+#, php-format
+msgid "More than %s runs match this range. Everything below counts the most recent %s only -- narrow the dates for exact figures."
+msgstr ""
 
 msgid "Most Frequent Host IDs"
 msgstr ""
@@ -7115,6 +7138,16 @@ msgstr ""
 #, fuzzy
 msgid "Running Windows"
 msgstr "ejecutando la versión"
+
+msgid "Runs"
+msgstr ""
+
+#, fuzzy
+msgid "Runs by image"
+msgstr "Imagen"
+
+msgid "Runs per day"
+msgstr ""
 
 msgid "SB Enrolled"
 msgstr ""

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1239,6 +1239,9 @@ msgstr "Laden fehlgeschlagen: %s"
 msgid "Button Icon"
 msgstr ""
 
+msgid "By"
+msgstr ""
+
 msgid "Bypass Bitlocker Detection"
 msgstr ""
 
@@ -4017,6 +4020,10 @@ msgid "Images only"
 msgstr "Images"
 
 #, fuzzy
+msgid "Images used"
+msgstr "genutzte Images"
+
+#, fuzzy
 msgid "Imaging"
 msgstr "Imaging Log"
 
@@ -4040,8 +4047,16 @@ msgid "Imaging Over the last"
 msgstr "Imaging in den letzten 30 Tagen"
 
 #, fuzzy
+msgid "Imaging Report"
+msgstr "Imaging Log"
+
+#, fuzzy
 msgid "Imaging Started"
 msgstr "Host Imagingverlauf"
+
+#, fuzzy
+msgid "Imaging runs"
+msgstr "Imaging Log"
 
 msgid "Import"
 msgstr "Import"
@@ -5005,6 +5020,10 @@ msgstr "Netzwerk-Installer"
 msgid "Machine Details"
 msgstr "Details"
 
+#, fuzzy
+msgid "Machines imaged"
+msgstr "Zugeordnetes Image"
+
 msgid "Main Menu"
 msgstr "Hauptmenü"
 
@@ -5243,6 +5262,10 @@ msgstr "Monats-Wert ist nicht gültig"
 
 msgid "Monthly"
 msgstr "Monatlich"
+
+#, php-format
+msgid "More than %s runs match this range. Everything below counts the most recent %s only -- narrow the dates for exact figures."
+msgstr ""
 
 msgid "Most Frequent Host IDs"
 msgstr ""
@@ -6971,6 +6994,16 @@ msgstr ""
 #, fuzzy
 msgid "Running Windows"
 msgstr "Laufende Version"
+
+msgid "Runs"
+msgstr ""
+
+#, fuzzy
+msgid "Runs by image"
+msgstr "Images"
+
+msgid "Runs per day"
+msgstr ""
 
 msgid "SB Enrolled"
 msgstr ""

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1244,6 +1244,9 @@ msgstr "Échec du chargement: %s"
 msgid "Button Icon"
 msgstr ""
 
+msgid "By"
+msgstr ""
+
 msgid "Bypass Bitlocker Detection"
 msgstr ""
 
@@ -4020,6 +4023,10 @@ msgid "Images only"
 msgstr "Images"
 
 #, fuzzy
+msgid "Images used"
+msgstr "imager"
+
+#, fuzzy
 msgid "Imaging"
 msgstr "Imaging Log"
 
@@ -4043,8 +4050,16 @@ msgid "Imaging Over the last"
 msgstr "Imaging Au cours des 30 derniers jours"
 
 #, fuzzy
+msgid "Imaging Report"
+msgstr "Imaging Log"
+
+#, fuzzy
 msgid "Imaging Started"
 msgstr "Hôte Histoire Imaging"
+
+#, fuzzy
+msgid "Imaging runs"
+msgstr "Imaging Log"
 
 msgid "Import"
 msgstr "Importer"
@@ -5004,6 +5019,10 @@ msgstr "Imprimante réseau"
 msgid "Machine Details"
 msgstr "Snapin Retour Détail"
 
+#, fuzzy
+msgid "Machines imaged"
+msgstr "Assigné image"
+
 msgid "Main Menu"
 msgstr "Menu principal"
 
@@ -5242,6 +5261,10 @@ msgstr "La valeur du mois est pas valide"
 
 msgid "Monthly"
 msgstr "Mensuel"
+
+#, php-format
+msgid "More than %s runs match this range. Everything below counts the most recent %s only -- narrow the dates for exact figures."
+msgstr ""
 
 msgid "Most Frequent Host IDs"
 msgstr ""
@@ -6969,6 +6992,16 @@ msgstr ""
 #, fuzzy
 msgid "Running Windows"
 msgstr "Exécution Version"
+
+msgid "Runs"
+msgstr ""
+
+#, fuzzy
+msgid "Runs by image"
+msgstr "Images"
+
+msgid "Runs per day"
+msgstr ""
 
 msgid "SB Enrolled"
 msgstr ""

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1204,6 +1204,9 @@ msgstr "Caricamento non riuscito"
 msgid "Button Icon"
 msgstr ""
 
+msgid "By"
+msgstr ""
+
 msgid "Bypass Bitlocker Detection"
 msgstr ""
 
@@ -3902,6 +3905,10 @@ msgid "Images only"
 msgstr "immagini"
 
 #, fuzzy
+msgid "Images used"
+msgstr "Immagine utilizzata"
+
+#, fuzzy
 msgid "Imaging"
 msgstr "Imaging Log"
 
@@ -3925,8 +3932,16 @@ msgid "Imaging Over the last"
 msgstr "Imaging Negli ultimi 30 giorni"
 
 #, fuzzy
+msgid "Imaging Report"
+msgstr "Imaging Log"
+
+#, fuzzy
 msgid "Imaging Started"
 msgstr "Host Imaging Storia"
+
+#, fuzzy
+msgid "Imaging runs"
+msgstr "Imaging Log"
 
 msgid "Import"
 msgstr "Importare"
@@ -4835,6 +4850,10 @@ msgstr "Installazione via rete"
 msgid "Machine Details"
 msgstr "Dettagli della macchina"
 
+#, fuzzy
+msgid "Machines imaged"
+msgstr "Immagine assegnata"
+
 msgid "Main Menu"
 msgstr "Menu principale"
 
@@ -5070,6 +5089,10 @@ msgstr "valore del mese non è valido"
 
 msgid "Monthly"
 msgstr "Mensile"
+
+#, php-format
+msgid "More than %s runs match this range. Everything below counts the most recent %s only -- narrow the dates for exact figures."
+msgstr ""
 
 msgid "Most Frequent Host IDs"
 msgstr ""
@@ -6750,6 +6773,16 @@ msgstr ""
 
 msgid "Running Windows"
 msgstr "Running Windows"
+
+msgid "Runs"
+msgstr ""
+
+#, fuzzy
+msgid "Runs by image"
+msgstr "immagini"
+
+msgid "Runs per day"
+msgstr ""
 
 msgid "SB Enrolled"
 msgstr ""

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1188,6 +1188,9 @@ msgstr "読み込みに失敗しました"
 msgid "Button Icon"
 msgstr ""
 
+msgid "By"
+msgstr ""
+
 msgid "Bypass Bitlocker Detection"
 msgstr ""
 
@@ -3870,6 +3873,10 @@ msgid "Images only"
 msgstr "イメージ"
 
 #, fuzzy
+msgid "Images used"
+msgstr "使用中のイメージ"
+
+#, fuzzy
 msgid "Imaging"
 msgstr "イメージログ"
 
@@ -3890,8 +3897,16 @@ msgstr "イメージログ"
 msgid "Imaging Over the last"
 msgstr "過去 30 日間のイメージ処理"
 
+#, fuzzy
+msgid "Imaging Report"
+msgstr "イメージログ"
+
 msgid "Imaging Started"
 msgstr "イメージ処理を開始しました"
+
+#, fuzzy
+msgid "Imaging runs"
+msgstr "イメージログ"
 
 msgid "Import"
 msgstr "インポート"
@@ -4793,6 +4808,10 @@ msgstr "ネットワークインストーラー"
 msgid "Machine Details"
 msgstr "マシン詳細"
 
+#, fuzzy
+msgid "Machines imaged"
+msgstr "割り当てられたイメージ"
+
 msgid "Main Menu"
 msgstr "メインメニュー"
 
@@ -5028,6 +5047,10 @@ msgstr "月の値が無効です"
 
 msgid "Monthly"
 msgstr "毎月"
+
+#, php-format
+msgid "More than %s runs match this range. Everything below counts the most recent %s only -- narrow the dates for exact figures."
+msgstr ""
 
 msgid "Most Frequent Host IDs"
 msgstr ""
@@ -6702,6 +6725,16 @@ msgstr ""
 
 msgid "Running Windows"
 msgstr "Windows 実行中"
+
+msgid "Runs"
+msgstr ""
+
+#, fuzzy
+msgid "Runs by image"
+msgstr "イメージ"
+
+msgid "Runs per day"
+msgstr ""
 
 msgid "SB Enrolled"
 msgstr ""

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1063,6 +1063,9 @@ msgstr ""
 msgid "Button Icon"
 msgstr ""
 
+msgid "By"
+msgstr ""
+
 msgid "Bypass Bitlocker Detection"
 msgstr ""
 
@@ -3416,6 +3419,9 @@ msgstr ""
 msgid "Images only"
 msgstr ""
 
+msgid "Images used"
+msgstr ""
+
 msgid "Imaging"
 msgstr ""
 
@@ -3434,7 +3440,13 @@ msgstr ""
 msgid "Imaging Over the last"
 msgstr ""
 
+msgid "Imaging Report"
+msgstr ""
+
 msgid "Imaging Started"
+msgstr ""
+
+msgid "Imaging runs"
 msgstr ""
 
 msgid "Import"
@@ -4239,6 +4251,9 @@ msgstr ""
 msgid "Machine Details"
 msgstr ""
 
+msgid "Machines imaged"
+msgstr ""
+
 msgid "Main Menu"
 msgstr ""
 
@@ -4438,6 +4453,10 @@ msgid "Month value is not valid"
 msgstr ""
 
 msgid "Monthly"
+msgstr ""
+
+#, php-format
+msgid "More than %s runs match this range. Everything below counts the most recent %s only -- narrow the dates for exact figures."
 msgstr ""
 
 msgid "Most Frequent Host IDs"
@@ -5923,6 +5942,15 @@ msgid "Run With interpreter."
 msgstr ""
 
 msgid "Running Windows"
+msgstr ""
+
+msgid "Runs"
+msgstr ""
+
+msgid "Runs by image"
+msgstr ""
+
+msgid "Runs per day"
 msgstr ""
 
 msgid "SB Enrolled"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1243,6 +1243,9 @@ msgstr "Carga falhou: %s"
 msgid "Button Icon"
 msgstr ""
 
+msgid "By"
+msgstr ""
+
 msgid "Bypass Bitlocker Detection"
 msgstr ""
 
@@ -4019,6 +4022,10 @@ msgid "Images only"
 msgstr "imagens"
 
 #, fuzzy
+msgid "Images used"
+msgstr "fotografada"
+
+#, fuzzy
 msgid "Imaging"
 msgstr "imagiologia Log"
 
@@ -4042,8 +4049,16 @@ msgid "Imaging Over the last"
 msgstr "Imagem Ao longo dos últimos 30 dias"
 
 #, fuzzy
+msgid "Imaging Report"
+msgstr "imagiologia Log"
+
+#, fuzzy
 msgid "Imaging Started"
 msgstr "Hospedar História Imagiologia"
+
+#, fuzzy
+msgid "Imaging runs"
+msgstr "imagiologia Log"
 
 msgid "Import"
 msgstr "Importar"
@@ -5003,6 +5018,10 @@ msgstr "impressora de rede"
 msgid "Machine Details"
 msgstr "Detalhe Snapin Retorno"
 
+#, fuzzy
+msgid "Machines imaged"
+msgstr "imagem atribuída"
+
 msgid "Main Menu"
 msgstr "Menu principal"
 
@@ -5241,6 +5260,10 @@ msgstr "valor do mês não é válido"
 
 msgid "Monthly"
 msgstr "Por mês"
+
+#, php-format
+msgid "More than %s runs match this range. Everything below counts the most recent %s only -- narrow the dates for exact figures."
+msgstr ""
 
 msgid "Most Frequent Host IDs"
 msgstr ""
@@ -6968,6 +6991,16 @@ msgstr ""
 #, fuzzy
 msgid "Running Windows"
 msgstr "executando a Versão"
+
+msgid "Runs"
+msgstr ""
+
+#, fuzzy
+msgid "Runs by image"
+msgstr "imagens"
+
+msgid "Runs per day"
+msgstr ""
 
 msgid "SB Enrolled"
 msgstr ""

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1243,6 +1243,9 @@ msgstr "加载失败： %s"
 msgid "Button Icon"
 msgstr ""
 
+msgid "By"
+msgstr ""
+
 msgid "Bypass Bitlocker Detection"
 msgstr ""
 
@@ -4019,6 +4022,10 @@ msgid "Images only"
 msgstr "图片"
 
 #, fuzzy
+msgid "Images used"
+msgstr "成像"
+
+#, fuzzy
 msgid "Imaging"
 msgstr "成像测井"
 
@@ -4042,8 +4049,16 @@ msgid "Imaging Over the last"
 msgstr "成像在过去30天"
 
 #, fuzzy
+msgid "Imaging Report"
+msgstr "成像测井"
+
+#, fuzzy
 msgid "Imaging Started"
 msgstr "主持人成像历史"
+
+#, fuzzy
+msgid "Imaging runs"
+msgstr "成像测井"
 
 msgid "Import"
 msgstr "进口"
@@ -5003,6 +5018,10 @@ msgstr "网络打印机"
 msgid "Machine Details"
 msgstr "管理单元返回详细"
 
+#, fuzzy
+msgid "Machines imaged"
+msgstr "分配图像"
+
 msgid "Main Menu"
 msgstr "主菜单"
 
@@ -5241,6 +5260,10 @@ msgstr "一个月值无效"
 
 msgid "Monthly"
 msgstr "每月一次"
+
+#, php-format
+msgid "More than %s runs match this range. Everything below counts the most recent %s only -- narrow the dates for exact figures."
+msgstr ""
 
 msgid "Most Frequent Host IDs"
 msgstr ""
@@ -6968,6 +6991,16 @@ msgstr ""
 #, fuzzy
 msgid "Running Windows"
 msgstr "运行版本"
+
+msgid "Runs"
+msgstr ""
+
+#, fuzzy
+msgid "Runs by image"
+msgstr "图片"
+
+msgid "Runs per day"
+msgstr ""
 
 msgid "SB Enrolled"
 msgstr ""

--- a/packages/web/src/Audit/ImagingStats.php
+++ b/packages/web/src/Audit/ImagingStats.php
@@ -183,6 +183,15 @@ class ImagingStats extends FOGBase
      * deleted -- the same property tests/tasklog-report-retention.test.php
      * pins for the task log pane.
      *
+     * BOUNDED IN THE QUERY, not in PHP. A slice after the fetch still
+     * materializes every row a wide window matched -- which on a fleet with
+     * years of taskLog is the "grid All -> blank 500" this codebase has
+     * already fixed once, arriving through a report instead of a grid.
+     *
+     * MAX_ROWS + 1, so that "there were more" is answerable without a second
+     * COUNT query over the same fold. The extra row is dropped by the
+     * callers, which is what makes `truncated` mean it.
+     *
      * @return string SQL taking :start, :end and :canceled.
      */
     private static function _runsSql()
@@ -198,7 +207,8 @@ class ImagingStats extends FOGBase
                        `l`.`createdBy` AS `createdBy`
                   FROM (" . self::_foldSql() . ") AS `runs`
                   JOIN `taskLog` AS `l` ON `l`.`id` = `runs`.`lastID`
-                 ORDER BY `runs`.`started` DESC";
+                 ORDER BY `runs`.`started` DESC
+                 LIMIT " . (self::MAX_ROWS + 1);
     }
 
     /**

--- a/packages/web/src/Audit/ImagingStats.php
+++ b/packages/web/src/Audit/ImagingStats.php
@@ -82,32 +82,123 @@ class ImagingStats extends FOGBase
     const MAX_DAYS = 366;
 
     /**
-     * One row per imaging run, with the day it started on.
+     * The most rows the grid will carry back.
      *
-     * Kept separate from runsPerDay() so a test can run the real statement
-     * rather than a copy of it -- the same reason TaskManagement has
-     * _logQueryFrom(). The three rules in the class docblock are all here,
-     * and a test that cannot reach this method can only pin that they were
-     * once written down.
+     * Same stance as ActivityWindow::MAX_ROWS and for the same reason: a
+     * window is a filter, not a limit, and "the last year" on a server mid
+     * rollout is every imaging row it has. The report says so on screen
+     * when it truncates rather than quietly showing a prefix.
      *
-     * The inner query folds a task's transition rows to one and takes its
-     * earliest; the outer one counts the folded runs per day. Both the
-     * range and the canceled state are bound, never interpolated.
+     * @var int
+     */
+    const MAX_ROWS = 5000;
+
+    /**
+     * The fold: one row per imaging RUN, out of a table of transitions.
+     *
+     * THE SINGLE DEFINITION OF "A RUN". Every panel on the imaging report
+     * and the dashboard's own graph read through this, so a chart and the
+     * grid beneath it cannot disagree about what they are counting. Two
+     * near-identical folds is how that disagreement gets in: it is not a
+     * conflict anyone sees, just a total that does not match the rows.
+     *
+     * All three rules from the class docblock are here and nowhere else:
+     *
+     *   GROUP BY `taskID`     the fold itself
+     *   HAVING SUM(...) > 0   at least one non-canceled row, which is the
+     *                         canceled rule stated over the RUN rather than
+     *                         row by row. A deploy whose only rows are
+     *                         cancellations drops out; one canceled part way
+     *                         through keeps its In-Progress row and stays
+     *   MIN(`createTime`)     the run's day is the day it started
+     *
+     * WHY `HAVING` AND NOT A `WHERE` ON THE STATE, which is the change from
+     * the first cut of this class. Filtering canceled rows out before the
+     * fold gets the same set of runs, but every aggregate is then computed
+     * over a subset of the run's rows -- so `MAX(id)` is the last row that
+     * was not a cancellation, and a grid built on it reports a canceled
+     * deploy as still In-Progress. Stating the rule as a HAVING keeps the
+     * run's whole history in the group and asks the question about the run.
+     *
+     * Kept as a method so a test can run the real statement rather than a
+     * copy -- the same reason TaskManagement has _logQueryFrom(). A test
+     * that cannot reach this can only pin that the rules were once written
+     * down.
+     *
+     * @return string SQL taking :start, :end and :canceled. Columns:
+     *                taskID, started, ended, lastID.
+     */
+    private static function _foldSql()
+    {
+        return "SELECT `taskID`,
+                       MIN(`createTime`) AS `started`,
+                       MAX(`createTime`) AS `ended`,
+                       MAX(`id`) AS `lastID`
+                  FROM `taskLog`
+                 WHERE `createTime` BETWEEN :start AND :end
+                   AND `logImageName` <> ''
+                 GROUP BY `taskID`
+                HAVING SUM(`taskStateID` <> :canceled) > 0";
+    }
+
+    /**
+     * Runs per day, counted off the fold.
      *
      * @return string SQL taking :start, :end and :canceled.
      */
     private static function _runsPerDaySql()
     {
         return "SELECT DATE(`started`) AS `d`, COUNT(*) AS `c`
-                  FROM (
-                    SELECT `taskID`, MIN(`createTime`) AS `started`
-                      FROM `taskLog`
-                     WHERE `createTime` BETWEEN :start AND :end
-                       AND `logImageName` <> ''
-                       AND `taskStateID` <> :canceled
-                     GROUP BY `taskID`
-                  ) AS `runs`
+                  FROM (" . self::_foldSql() . ") AS `runs`
                  GROUP BY DATE(`started`)";
+    }
+
+    /**
+     * Runs per image, counted off the fold.
+     *
+     * The image name comes from the run's LAST row rather than from the
+     * group, because `logImageName` is not in the GROUP BY -- and a task
+     * cannot change image mid-run, so the last row's name is the run's.
+     * Selecting it bare would be an aggregate-free non-grouped column,
+     * which MySQL 5.7+ and MariaDB with ONLY_FULL_GROUP_BY reject and
+     * older servers silently answer with an arbitrary row.
+     *
+     * @return string SQL taking :start, :end and :canceled.
+     */
+    private static function _runsByImageSql()
+    {
+        return "SELECT `l`.`logImageName` AS `image`, COUNT(*) AS `c`
+                  FROM (" . self::_foldSql() . ") AS `runs`
+                  JOIN `taskLog` AS `l` ON `l`.`id` = `runs`.`lastID`
+                 GROUP BY `l`.`logImageName`
+                 ORDER BY `c` DESC, `image` ASC";
+    }
+
+    /**
+     * The runs themselves, newest first, for the grid under the charts.
+     *
+     * Every identifying column is taken from the run's last row, which is
+     * the row taskLog denormalized the identity onto (schema 341/373). That
+     * is what lets a run still name its host and image after both have been
+     * deleted -- the same property tests/tasklog-report-retention.test.php
+     * pins for the task log pane.
+     *
+     * @return string SQL taking :start, :end and :canceled.
+     */
+    private static function _runsSql()
+    {
+        return "SELECT `runs`.`taskID` AS `taskID`,
+                       `runs`.`started` AS `started`,
+                       `runs`.`ended` AS `ended`,
+                       `l`.`logHostID` AS `hostID`,
+                       `l`.`logHostName` AS `hostName`,
+                       `l`.`logImageName` AS `imageName`,
+                       `l`.`logTaskTypeName` AS `taskTypeName`,
+                       `l`.`taskStateID` AS `stateID`,
+                       `l`.`createdBy` AS `createdBy`
+                  FROM (" . self::_foldSql() . ") AS `runs`
+                  JOIN `taskLog` AS `l` ON `l`.`id` = `runs`.`lastID`
+                 ORDER BY `runs`.`started` DESC";
     }
 
     /**
@@ -129,17 +220,13 @@ class ImagingStats extends FOGBase
         \DateTimeInterface $start,
         \DateTimeInterface $end
     ) {
+        // Clamped here as well as inside _read(), because the zero fill
+        // below walks the window itself -- an unclamped one would emit a
+        // point per day for however long was asked for while the query
+        // answered for MAX_DAYS, and the series would run off the data.
         list($start, $end) = self::_clamp($start, $end);
 
-        $rows = self::$DB->query(
-            self::_runsPerDaySql(),
-            [],
-            [
-                ':start' => $start->format('Y-m-d H:i:s'),
-                ':end' => $end->format('Y-m-d H:i:s'),
-                ':canceled' => self::getCancelledState()
-            ]
-        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        $rows = self::_read(self::_runsPerDaySql(), $start, $end);
 
         $counts = [];
         foreach ((array)$rows as $row) {
@@ -170,6 +257,133 @@ class ImagingStats extends FOGBase
         }
 
         return $series;
+    }
+
+    /**
+     * Runs grouped by image, biggest first.
+     *
+     * @param \DateTimeInterface $start Inclusive lower bound, FOG's clock.
+     * @param \DateTimeInterface $end   Inclusive upper bound, FOG's clock.
+     * @param int                $limit How many images to name; the rest are
+     *                                  folded into one "Other" entry rather
+     *                                  than dropped, so the bars still add
+     *                                  up to the total on the tile above.
+     *
+     * @return array Ordered list of ['image' => string, 'count' => int].
+     */
+    public static function runsByImage(
+        \DateTimeInterface $start,
+        \DateTimeInterface $end,
+        $limit = 10
+    ) {
+        $rows = self::_read(self::_runsByImageSql(), $start, $end);
+
+        $out = [];
+        $other = 0;
+        $limit = (int)$limit;
+        foreach ((array)$rows as $i => $row) {
+            $count = (int)($row['c'] ?? 0);
+            if ($limit > 0 && $i >= $limit) {
+                $other += $count;
+                continue;
+            }
+            $out[] = [
+                'image' => (string)($row['image'] ?? ''),
+                'count' => $count
+            ];
+        }
+        if ($other > 0) {
+            $out[] = ['image' => _('Other'), 'count' => $other];
+        }
+
+        return $out;
+    }
+
+    /**
+     * The runs themselves, newest first.
+     *
+     * @param \DateTimeInterface $start Inclusive lower bound, FOG's clock.
+     * @param \DateTimeInterface $end   Inclusive upper bound, FOG's clock.
+     *
+     * @return array Rows, capped at MAX_ROWS.
+     */
+    public static function runs(
+        \DateTimeInterface $start,
+        \DateTimeInterface $end
+    ) {
+        $rows = (array)self::_read(self::_runsSql(), $start, $end);
+
+        return array_slice($rows, 0, self::MAX_ROWS);
+    }
+
+    /**
+     * The headline numbers, off the same fold the charts use.
+     *
+     * Derived from runs() rather than asked of the database separately, so
+     * a tile cannot disagree with the grid under it -- which is the failure
+     * this class exists to prevent, one level up. The row cap is the only
+     * thing that could make them differ, and `truncated` says when it has.
+     *
+     * @param \DateTimeInterface $start Inclusive lower bound, FOG's clock.
+     * @param \DateTimeInterface $end   Inclusive upper bound, FOG's clock.
+     *
+     * @return array runs, hosts, images, truncated
+     */
+    public static function totals(
+        \DateTimeInterface $start,
+        \DateTimeInterface $end
+    ) {
+        $rows = (array)self::_read(self::_runsSql(), $start, $end);
+        $capped = array_slice($rows, 0, self::MAX_ROWS);
+
+        $hosts = [];
+        $images = [];
+        foreach ($capped as $row) {
+            // Keyed on the id where there is one and the name otherwise, so
+            // a run whose host has since been deleted still counts as a
+            // machine rather than collapsing every deleted host into one.
+            $hosts[(string)($row['hostID'] ?? '') . '/'
+                . (string)($row['hostName'] ?? '')] = true;
+            $images[(string)($row['imageName'] ?? '')] = true;
+        }
+
+        return [
+            'runs' => count($capped),
+            'hosts' => count($hosts),
+            'images' => count($images),
+            'truncated' => count($rows) > self::MAX_ROWS
+        ];
+    }
+
+    /**
+     * Run one of this class' statements over a clamped window.
+     *
+     * The three binds are identical for every one of them because they all
+     * read through the same fold, so they are written once here rather than
+     * copied into each caller where one could drift.
+     *
+     * @param string             $sql   one of the _*Sql() statements
+     * @param \DateTimeInterface $start the lower bound as given
+     * @param \DateTimeInterface $end   the upper bound as given
+     *
+     * @return array
+     */
+    private static function _read(
+        $sql,
+        \DateTimeInterface $start,
+        \DateTimeInterface $end
+    ) {
+        list($start, $end) = self::_clamp($start, $end);
+
+        return (array)self::$DB->query(
+            $sql,
+            [],
+            [
+                ':start' => $start->format('Y-m-d H:i:s'),
+                ':end' => $end->format('Y-m-d H:i:s'),
+                ':canceled' => self::getCancelledState()
+            ]
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
     }
 
     /**

--- a/packages/web/src/Audit/ReportWindow.php
+++ b/packages/web/src/Audit/ReportWindow.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * The time range a report was asked for.
+ *
+ * PHP version 7.4+
+ *
+ * @category ReportWindow
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Audit;
+
+use FOG\Base\FOGBase;
+
+/**
+ * The time range a report was asked for.
+ *
+ * ADR 0030 decision 1 puts the window in the URL, which means every report
+ * reads the same two request parameters and has to make the same three
+ * decisions about them. This is those decisions, in one place, so that a
+ * second report cannot make them differently from the first.
+ *
+ * ON FOG'S CLOCK, NOT PHP'S, and that is the whole reason this is not three
+ * lines of strtotime(). The columns being compared are stamped by
+ * FOGController::save() through FOGBase::niceDate(), which uses the
+ * configured FOG_TZ timezone -- so a bound built with PHP's default
+ * timezone is silently offset by however far apart the two are. It does not
+ * error: BETWEEN just matches a shifted window, so the report quietly
+ * answers a question nobody asked. Caught in the lab against a server five
+ * hours off PHP's timezone, where a task created seconds earlier did not
+ * appear in a window ending "now".
+ *
+ * A MALFORMED BOUND IS DROPPED rather than passed on, for the same reason --
+ * an unparseable date reaching BETWEEN matches nothing, which looks exactly
+ * like "nothing happened". Dropping it falls back to the report's default,
+ * so a fat-fingered URL shows the default range instead of an empty grid.
+ *
+ * REVERSED BOUNDS ARE SWAPPED, not rejected. Somebody who types the two
+ * dates the other way round means the range between them.
+ *
+ * Objects out, not strings, because the two consumers want different
+ * things: ActivityWindow takes 'Y-m-d H:i:s' and ImagingStats takes
+ * DateTimeInterface. Formatting here would force one of them to parse it
+ * back, which is the round trip the FOG-clock note above is about.
+ *
+ * @category ReportWindow
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class ReportWindow extends FOGBase
+{
+    /**
+     * The window a report gets when the request does not say.
+     *
+     * A default that returns rows matters more than it looks: a report that
+     * opens empty reads as broken. Reports override it with whatever their
+     * own first question is -- "what ran today" for an activity log, "the
+     * last month" for a trend.
+     *
+     * @var string
+     */
+    const DEFAULT_WINDOW = '-24 hours';
+    /**
+     * The window the request asked for, clamped to something a query can use.
+     *
+     * @param string $default a strtotime-style relative expression applied to
+     *                        `now` when the request names no start.
+     *
+     * @return array [start, end] as DateTimeInterface on FOG's clock.
+     */
+    public static function fromRequest($default = self::DEFAULT_WINDOW)
+    {
+        $given = [
+            'start' => (string) filter_input(INPUT_GET, 'start'),
+            'end' => (string) filter_input(INPUT_GET, 'end'),
+        ];
+        // Parseability is checked BEFORE handing the string to niceDate(),
+        // which throws on a date it cannot read. A form field is a value
+        // that may legitimately be malformed, so it is validated; this is
+        // not a try/catch standing in for an API that might not be there.
+        foreach ($given as $k => $v) {
+            if ('' !== $v && false === strtotime($v)) {
+                $given[$k] = '';
+            }
+        }
+        $end = '' === $given['end']
+            ? self::niceDate()
+            : self::niceDate($given['end']);
+        $start = '' === $given['start']
+            ? self::niceDate()->modify((string)$default)
+            : self::niceDate($given['start']);
+        if ($start > $end) {
+            [$start, $end] = [$end, $start];
+        }
+
+        return [$start, $end];
+    }
+    /**
+     * The window as the two strings a BETWEEN wants.
+     *
+     * @param string $default forwarded to fromRequest().
+     *
+     * @return array [start, end], both 'Y-m-d H:i:s' in FOG's timezone.
+     */
+    public static function stringsFromRequest($default = self::DEFAULT_WINDOW)
+    {
+        $fmt = 'Y-m-d H:i:s';
+        [$start, $end] = self::fromRequest($default);
+
+        return [$start->format($fmt), $end->format($fmt)];
+    }
+}

--- a/packages/web/src/Auth/Authorization.php
+++ b/packages/web/src/Auth/Authorization.php
@@ -90,7 +90,11 @@ class Authorization extends FOGBase
         // report.view grant reading the same rows through a different
         // screen is the defect ADR 0023 opens with. Narrows against the
         // default `report` node; nothing anyone holds gets wider.
-        'run_history' => 'task'
+        'run_history' => 'task',
+        // Imaging Report reads `taskLog` -- the same rows Task Management's
+        // log pane shows -- so it lands on the same node as Run History for
+        // the same reason (ADR 0030 decision 4).
+        'imaging_report' => 'task'
     ];
     /**
      * Exact sub overrides that the naming conventions would misresolve.

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -5151,6 +5151,10 @@ abstract class FOGPage extends FOGBase
      *
      * @param mixed      $tabData The tabs we are going to build out.
      * @param int|object $obj     The object to pass in, -1 = current node + id.
+     *                            Anything falsy means there is no object, which
+     *                            skips the hook and plugin-injection blocks --
+     *                            that is what a report passes, having no entity
+     *                            for a plugin tab to attach to.
      *
      * @return string
      */

--- a/packages/web/src/Base/FOGPageRender.php
+++ b/packages/web/src/Base/FOGPageRender.php
@@ -1098,4 +1098,186 @@ trait FOGPageRender
         // browser drops the inner one and the create posts nothing.
         echo $createModal;
     }
+    /**
+     * The window picker every report shares.
+     *
+     * A PLAIN GET FORM, and the range is part of the URL on purpose: a
+     * report someone is going to paste into a ticket has to survive being
+     * pasted, and a range held only in JS state does not. That is ADR 0030
+     * decision 1, and it is also why there is no submit handler here -- the
+     * browser's own navigation is the mechanism.
+     *
+     * The `f` parameter is carried through from the request rather than
+     * passed in, because it IS the report: the report menu is built from
+     * the file names in lib/reports, so `f` is the only thing telling
+     * index.php which class to load. Losing it on submit lands on the
+     * report index, which reads as the form having wiped the page.
+     *
+     * @param string $slug  id prefix for the form and its fields
+     * @param string $start current lower bound, 'Y-m-d H:i:s'
+     * @param string $end   current upper bound, 'Y-m-d H:i:s'
+     * @param string $extra already-escaped markup for report-specific
+     *                      controls, dropped in before the submit button
+     *
+     * @return string
+     */
+    public static function renderReportWindow(
+        $slug,
+        $start,
+        $end,
+        $extra = ''
+    ) {
+        ob_start();
+        printf(
+            '<form method="get" action="../management/index.php" '
+            . 'class="row g-3 mb-3" id="%s-form">'
+            . '<input type="hidden" name="node" value="report">'
+            . '<input type="hidden" name="f" value="%s">',
+            \Initiator::e($slug),
+            \Initiator::e((string) filter_input(INPUT_GET, 'f'))
+        );
+        foreach (['start' => _('From'), 'end' => _('To')] as $key => $label) {
+            echo '<div class="col-md-3">';
+            echo self::makeLabel(
+                'col-form-label',
+                $slug . '-' . $key,
+                $label
+            );
+            printf(
+                '<input type="datetime-local" class="form-control" '
+                . 'id="%s-%s" name="%s" value="%s">',
+                \Initiator::e($slug),
+                \Initiator::e($key),
+                \Initiator::e($key),
+                // datetime-local wants the ISO 'T' separator; a space-
+                // separated value is simply ignored by the control, which
+                // then renders blank and posts nothing.
+                \Initiator::e(
+                    str_replace(' ', 'T', 'start' === $key ? $start : $end)
+                )
+            );
+            echo '</div>';
+        }
+        echo $extra;
+        echo '<div class="col-md-2 d-flex align-items-end">';
+        echo self::makeButton(
+            $slug . '-go',
+            _('Show'),
+            'btn btn-primary float-end',
+            'type="submit"'
+        );
+        echo '</div>';
+        echo '</form>';
+
+        return ob_get_clean();
+    }
+    /**
+     * A row of headline numbers.
+     *
+     * CARDS, NOT AdminLTE's `small-box`. small-box paints a near-white
+     * `bg-light` behind its own text; under the dark theme the text turns
+     * light and the number becomes invisible against it. The outline card
+     * takes the theme's own surface color, so it works in both. Lifted
+     * from ImageManagement::_archStat(), which found this the hard way.
+     *
+     * @param array $tiles ordered list of ['value' =>, 'label' =>,
+     *                     'warn' => bool]. `warn` paints the card red when
+     *                     the value is above zero -- for counts that are
+     *                     bad news rather than progress.
+     * @param int   $cols  bootstrap columns each tile occupies at md and up
+     *
+     * @return string
+     */
+    public static function renderStatTiles(array $tiles, $cols = 3)
+    {
+        ob_start();
+        echo '<div class="row">';
+        foreach ($tiles as $tile) {
+            $value = $tile['value'] ?? 0;
+            $warn = !empty($tile['warn']) && (float)$value > 0;
+            printf(
+                '<div class="col-sm-6 col-md-%d">'
+                . '<div class="card %s card-outline">'
+                . '<div class="card-body text-center">'
+                . '<h3 class="mb-0">%s</h3>'
+                . '<p class="mb-0 text-muted">%s</p>'
+                . '</div></div></div>',
+                (int)$cols,
+                $warn ? 'card-danger' : 'card-primary',
+                // Formatted, not cast: a fleet report counting tens of
+                // thousands of runs is unreadable as a bare integer, and
+                // number_format is locale-independent here by design --
+                // the grid below it is not localized either.
+                //
+                // One decimal place only when the value has one. A rate
+                // tile is a genuine fraction -- three runs across a month
+                // is 0.1 a day -- and number_format's default of zero
+                // decimals rounds that to "0", which reads as "no imaging
+                // happened" directly beside a tile saying three runs did.
+                \Initiator::e(
+                    is_numeric($value)
+                        ? number_format(
+                            (float)$value,
+                            (float)$value == (int)(float)$value ? 0 : 1
+                        )
+                        : (string)$value
+                ),
+                \Initiator::e((string)($tile['label'] ?? ''))
+            );
+        }
+        echo '</div>';
+
+        return ob_get_clean();
+    }
+    /**
+     * One chart, with its data alongside it.
+     *
+     * THE SERIES IS EMBEDDED, NOT FETCHED. The dashboard's charts poll
+     * because their subject is live; a report's window is fixed and already
+     * in the URL, so a second round trip would re-run the same aggregation
+     * to draw the same picture. Embedding it also means the chart and the
+     * grid beneath it are rendered from one request and cannot disagree.
+     *
+     * A `type="application/json"` block rather than an inline assignment:
+     * the browser does not execute it, so nothing here can become script
+     * however the values are shaped, and JSON_HEX_TAG closes the one way a
+     * string could end the block early.
+     *
+     * @param string $id     unique element id for this panel
+     * @param string $title  translated card title
+     * @param array  $chart  ['type' =>, 'labels' => [], 'series' => [
+     *                       ['label' =>, 'data' => []] ]]
+     * @param int    $cols   bootstrap columns at md and up
+     * @param int    $height chart height in pixels
+     *
+     * @return string
+     */
+    public static function renderChartPanel(
+        $id,
+        $title,
+        array $chart,
+        $cols = 6,
+        $height = 260
+    ) {
+        ob_start();
+        printf(
+            '<div class="col-md-%d">'
+            . '<div class="card card-primary card-outline">'
+            . '<div class="card-header"><h3 class="card-title">%s</h3></div>'
+            . '<div class="card-body">'
+            . '<div class="fog-report-chart" id="%s" '
+            . 'data-chart-height="%d"></div>'
+            . '<script type="application/json" id="%s-data">%s</script>'
+            . '</div></div></div>',
+            (int)$cols,
+            \Initiator::e((string)$title),
+            \Initiator::e((string)$id),
+            (int)$height,
+            \Initiator::e((string)$id),
+            json_encode($chart, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS
+                | JSON_HEX_QUOT)
+        );
+
+        return ob_get_clean();
+    }
 }

--- a/packages/web/src/Base/Page.php
+++ b/packages/web/src/Base/Page.php
@@ -346,6 +346,21 @@ class Page extends FOGBase
                 $files[] = 'js/swagger-ui-bundle.js';
                 $files[] = 'js/fog/apidocs/fog.apidocs.snippets.js';
             }
+            // Reports draw charts (ADR 0030), so Chart.js and the panel
+            // renderer go with the node -- the same node scoping jscolor
+            // and Swagger UI above use, and for the same reason.
+            //
+            // Scoped to the node rather than to the reports that actually
+            // have a chart, because this list is built by the Page instance
+            // that renders and the report class has not run yet. Both files
+            // are no-ops on a report with no canvas, and Chart.js is an
+            // order of magnitude smaller than the Swagger bundle already
+            // loaded this way. Listed before the node's own file.js so
+            // `Chart` is defined by the time the panels file runs.
+            if ('report' === $node) {
+                $files[] = 'js/Chart/chart.umd.min.js';
+                $files[] = 'js/fog/report/fog.report.panels.js';
+            }
         }
         if (isset($filepaths) && $filepaths && !file_exists($filepaths)) {
             $listpath = "js/fog/{$node}/fog.{$node}.list.js";

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4392');
+        define('FOG_VERSION', '1.6.0-beta.4395');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4395');
+        define('FOG_VERSION', '1.6.0-beta.4397');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 379);
-        define('FOG_BCACHE_VER', 326);
+        define('FOG_BCACHE_VER', 327);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -789,7 +789,7 @@ parameters:
 		-
 			message: '#^Call to function _\(\) on a separate line has no effect\.$#'
 			identifier: function.resultUnused
-			count: 9
+			count: 10
 			path: packages/web/lib/pages/reportmanagement.page.php
 
 		-

--- a/phpstan-tests-baseline.neon
+++ b/phpstan-tests-baseline.neon
@@ -727,13 +727,13 @@ parameters:
 			path: tests/route-result-wrappers.test.php
 
 		-
-			message: '#^Call to function array_key_exists\(\) with ''run_history'' and array\{hosts_and_users\: ''usertracking'', run_history\: ''task''\} will always evaluate to true\.$#'
+			message: '#^Call to function array_key_exists\(\) with ''run_history'' and array\{hosts_and_users\: ''usertracking'', run_history\: ''task'', imaging_report\: ''task''\} will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: tests/run-history-report.test.php
 
 		-
-			message: '#^Offset ''run_history'' on array\{hosts_and_users\: ''usertracking'', run_history\: ''task''\} on left side of \?\? always exists and is not nullable\.$#'
+			message: '#^Offset ''run_history'' on array\{hosts_and_users\: ''usertracking'', run_history\: ''task'', imaging_report\: ''task''\} on left side of \?\? always exists and is not nullable\.$#'
 			identifier: nullCoalesce.offset
 			count: 1
 			path: tests/run-history-report.test.php
@@ -911,3 +911,21 @@ parameters:
 			identifier: identical.alwaysTrue
 			count: 1
 			path: tests/usertracking-permission-split.test.php
+
+		-
+			message: '#^Call to function array_key_exists\(\) with ''imaging_report'' and array\{hosts_and_users\: ''usertracking'', run_history\: ''task'', imaging_report\: ''task''\} will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/imaging-report.test.php
+
+		-
+			message: '#^Offset ''imaging_report'' on array\{hosts_and_users\: ''usertracking'', run_history\: ''task'', imaging_report\: ''task''\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: tests/imaging-report.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between ''task'' and ''task'' will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: tests/imaging-report.test.php

--- a/tests/imaging-report.test.php
+++ b/tests/imaging-report.test.php
@@ -1,0 +1,272 @@
+<?php
+/**
+ * The Imaging Report is wired to ImagingStats, to the panel helpers, and to
+ * the right gate.
+ *
+ * ADR 0030's first report. Everything this pins fails SILENTLY:
+ *
+ *   - a report is discovered by FILENAME. lib/reports/*.report.php becomes a
+ *     menu entry with underscores turned into spaces, so the file name, the
+ *     class name, the `f` parameter the JS switches on and the REPORT_NODES
+ *     key all have to agree. Any one out of step gives a menu entry that
+ *     opens an empty page, with no error anywhere.
+ *   - the column keys getList() emits must match the ones the DataTables
+ *     definition asks for. A mismatch renders blank cells, not an error.
+ *   - the permission. Reports share the `report` node by default, which is
+ *     the defect ADR 0023 opens with; this one reads taskLog and must
+ *     resolve to `task`. Getting it wrong widens access silently.
+ *   - the counting rules stay in ImagingStats. A page that grows its own
+ *     `taskLog` query gets a chart that disagrees with the grid under it,
+ *     and both look plausible.
+ *   - the embedded chart payload is a JSON block the browser does not
+ *     execute. An image named `</script><script>…` would otherwise close it.
+ *
+ * Usage: php tests/imaging-report.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('imaging-report');
+FogTestHarness::fakeDb();
+
+$t = new FogChecks();
+$web = dirname(__DIR__) . '/packages/web';
+$report = $web . '/lib/reports/imaging_report.report.php';
+
+$t->check('the report file exists', is_readable($report));
+$src = is_readable($report) ? file_get_contents($report) : '';
+
+/*
+ * Comments stripped before anything is searched for. The prose above these
+ * methods names every symbol below it -- including the `taskLog` that
+ * section 4 requires to be ABSENT -- so a search over the raw file is
+ * satisfied by the documentation of the rule rather than by the rule.
+ */
+$code = '';
+foreach (token_get_all($src) as $token) {
+    if (is_array($token)) {
+        if (T_COMMENT === $token[0] || T_DOC_COMMENT === $token[0]) {
+            continue;
+        }
+        $code .= $token[1];
+        continue;
+    }
+    $code .= $token;
+}
+
+/*
+ * 1. The names that have to agree.
+ */
+$slug = 'imaging_report';
+$label = str_replace('_', ' ', $slug);
+$t->check(
+    'the class name matches the file name, so the autoloader finds it',
+    class_exists('FOG\Imaging_Report')
+);
+$t->check(
+    'it extends ReportManagement, so it appears in the report menu at all',
+    class_exists('FOG\Imaging_Report')
+    && is_subclass_of('FOG\Imaging_Report', 'FOG\ReportManagement')
+);
+$js = file_get_contents($web . '/management/js/fog/report/fog.report.file.js');
+$t->check(
+    "the JS switches on '$label', which is what the filename decodes to",
+    false !== strpos($js, "case '" . $label . "':")
+);
+$page = file_get_contents($web . '/lib/pages/reportmanagement.page.php');
+$t->check(
+    'the menu label is registered for xgettext',
+    false !== strpos($page, "_('Imaging Report');")
+);
+
+/*
+ * 2. The columns.
+ */
+$wanted = [];
+$at = strpos($js, "case '" . $label . "':");
+if (false !== $at) {
+    $block = substr($js, $at, strpos($js, 'break;', $at) - $at);
+    if (preg_match_all("/\{data: '([a-zA-Z]+)'/", $block, $m)) {
+        $wanted = $m[1];
+    }
+}
+$t->check('the JS names its columns', count($wanted) > 0);
+foreach ($wanted as $col) {
+    $t->check(
+        "getList() emits the '$col' key the grid asks for",
+        false !== strpos($code, "'" . $col . "' =>")
+    );
+}
+$t->check(
+    'the table id in the JS is the one the page renders',
+    false !== strpos($js, '#imaging-table')
+    && false !== strpos($code, "'imaging-table'")
+);
+$t->check(
+    'the header row has one cell per column',
+    count($wanted) === substr_count(
+        substr($code, strpos($code, '$this->headerData'), 400),
+        '_('
+    )
+);
+$t->check(
+    'every column escapes -- taskLog holds names people typed',
+    count($wanted) === substr_count(
+        (string)($block ?? ''),
+        '$.fn.dataTable.render.text()'
+    )
+);
+
+/*
+ * 3. The gate. This is the one that fails dangerously rather than visibly.
+ */
+$nodes = constant('FOG\Auth\Authorization::REPORT_NODES');
+$t->check(
+    'the report is listed in REPORT_NODES rather than inheriting `report`',
+    array_key_exists($slug, (array)$nodes)
+);
+$t->check(
+    'and it resolves to `task`, where Task Management gates the same rows',
+    'task' === ($nodes[$slug] ?? null)
+);
+
+/*
+ * 4. The counting rules did not come back here.
+ *
+ * ImagingStats exists because `taskLog` records one row per state
+ * TRANSITION, so counting it needs three rules that are wrong in three
+ * different quiet ways if restated. A page holding its own query would give
+ * a grid that disagrees with the chart above it (ADR 0030 decision 3).
+ */
+$t->check(
+    'the page has no taskLog query of its own',
+    false === strpos($code, '`taskLog`')
+);
+foreach (['totals(', 'runsPerDay(', 'runsByImage(', 'runs('] as $call) {
+    $t->check(
+        "it reads ImagingStats::$call)",
+        false !== strpos($code, 'ImagingStats::' . $call)
+    );
+}
+
+/*
+ * 5. The window, and this report's own default.
+ *
+ * A month rather than Run History's day, because a trend needs enough days
+ * to be a trend. The default is the report's; the parsing is shared.
+ */
+$t->check(
+    'the window is read through the shared parser',
+    false !== strpos($code, 'ReportWindow::fromRequest(self::DEFAULT_WINDOW)')
+);
+$t->check(
+    'this report defaults to a month',
+    '-30 days' === constant('FOG\Imaging_Report::DEFAULT_WINDOW')
+);
+$t->check(
+    'and does not re-implement the malformed-bound rule',
+    false === strpos($code, 'strtotime($v)')
+);
+
+/*
+ * 6. `Finished` is only a finish.
+ *
+ * The fold's `ended` is MAX(createTime) over the run's rows, which is a
+ * finish time only once the run has finished. For one still in progress it
+ * is the last transition, and printing that under "Finished" says a deploy
+ * completed while it is still copying. ADR 0022 decision 2: state is
+ * authoritative for WHAT, timestamps for WHEN.
+ */
+$t->check(
+    'the finish time is gated on a terminal state',
+    1 === preg_match(
+        "/'ended'\s*=>\s*in_array\(\s*\\\$stateID,\s*\\\$terminal,\s*true\s*\)/",
+        $code
+    )
+);
+foreach (['getCompleteState', 'getCancelledState', 'getFailedState'] as $st) {
+    $t->check(
+        "and `$st` counts as terminal",
+        false !== strpos($code, 'TaskState::' . $st . '()')
+    );
+}
+
+/*
+ * 7. The chart payload is embedded, and cannot become script.
+ *
+ * Behavioral, not a grep: the helper is called with an image name that would
+ * close the JSON block if it were written raw, and the rendered panel is
+ * searched for the escape. json_encode's JSON_HEX_TAG is what stops it, and
+ * an assertion on the flag alone would pass if the block stopped being a
+ * script element in the first place.
+ */
+$panel = \FOG\Base\FOGPage::renderChartPanel(
+    'test-panel',
+    'Title',
+    [
+        'type' => 'doughnut',
+        'labels' => ['</script><script>alert(1)</script>'],
+        'series' => [['label' => 'Runs', 'data' => [1]]]
+    ]
+);
+$t->check(
+    'the panel carries its own data block',
+    false !== strpos($panel, 'id="test-panel-data"')
+);
+$t->check(
+    'a hostile label cannot close the data block',
+    1 === substr_count($panel, '</script>')
+);
+$t->check(
+    'and reaches the browser with no raw angle bracket in the payload',
+    false === strpos(
+        substr($panel, strpos($panel, '-data">')),
+        '<script>'
+    )
+);
+$t->check(
+    'the payload is still readable JSON',
+    is_array(
+        json_decode(
+            substr(
+                $panel,
+                strpos($panel, '-data">') + 7,
+                strpos($panel, '</script>') - strpos($panel, '-data">') - 7
+            ),
+            true
+        )
+    )
+);
+$t->check(
+    'the chart is drawn from that block rather than fetched',
+    false === strpos($code, 'sub=panels')
+    && false !== strpos(
+        file_get_contents(
+            $web . '/management/js/fog/report/fog.report.panels.js'
+        ),
+        "document.getElementById(id + '-data')"
+    )
+);
+
+/*
+ * 8. Chart.js is actually on the page, and before the file that uses it.
+ *
+ * A missing library here is a silent blank panel: fog.report.panels.js
+ * returns early when `Chart` is undefined, exactly so a report with no
+ * chart is not a console error -- which also means a broken load looks
+ * identical to a report with nothing to draw.
+ */
+$pagesrc = file_get_contents($web . '/src/Base/Page.php');
+$chartAt = strpos($pagesrc, "'js/Chart/chart.umd.min.js'", strpos($pagesrc, "'report' === \$node"));
+$panelAt = strpos($pagesrc, "'js/fog/report/fog.report.panels.js'");
+$t->check(
+    'the report node loads Chart.js',
+    false !== $chartAt
+);
+$t->check(
+    'and the panel renderer after it',
+    false !== $panelAt && $chartAt < $panelAt
+);
+
+$t->finish();

--- a/tests/imaging-stats.test.php
+++ b/tests/imaging-stats.test.php
@@ -221,6 +221,53 @@ $t->check(
 );
 
 /*
+ * 4b. The tiles.
+ *
+ *     totals() is derived from the same fold the grid is, so a tile cannot
+ *     report a different number of runs from the rows beneath it. What the
+ *     responder proves is the DERIVATION: distinct machines and distinct
+ *     images, counted off run rows rather than asked of the database
+ *     separately, and a run whose host has since been deleted still
+ *     counting as a machine.
+ */
+$db->responder = function ($sql) {
+    if (false === strpos($sql, 'taskLog')) {
+        return null;
+    }
+    return [
+        ['taskID' => '1', 'hostID' => '7', 'hostName' => 'a',
+         'imageName' => 'win11', 'started' => '2026-03-01 09:00:00'],
+        ['taskID' => '2', 'hostID' => '7', 'hostName' => 'a',
+         'imageName' => 'win11', 'started' => '2026-03-02 09:00:00'],
+        ['taskID' => '3', 'hostID' => '9', 'hostName' => 'b',
+         'imageName' => 'ubuntu', 'started' => '2026-03-03 09:00:00'],
+        // Deleted since: no id left to group on, but a real machine was
+        // imaged and the tile has to say so.
+        ['taskID' => '4', 'hostID' => '0', 'hostName' => 'gone',
+         'imageName' => 'ubuntu', 'started' => '2026-03-04 09:00:00'],
+        ['taskID' => '5', 'hostID' => '0', 'hostName' => 'alsogone',
+         'imageName' => 'ubuntu', 'started' => '2026-03-05 09:00:00'],
+    ];
+};
+$totals = ImagingStats::totals(
+    new \DateTimeImmutable('2026-03-01 00:00:00'),
+    new \DateTimeImmutable('2026-03-05 23:59:59')
+);
+$t->check('the runs tile counts the run rows', 5 === $totals['runs']);
+$t->check(
+    'the machines tile counts DISTINCT hosts, not runs',
+    4 === $totals['hosts']
+);
+$t->check(
+    'the images tile counts DISTINCT images',
+    2 === $totals['images']
+);
+$t->check(
+    'a complete result is not reported as truncated',
+    false === $totals['truncated']
+);
+
+/*
  * 5. The window is ordered and capped.
  */
 $reversed = ImagingStats::runsPerDay(
@@ -297,6 +344,55 @@ $t->check(
  * 7. The SQL semantics, for real. The GROUP BY is the fix; a fake
  *    connection cannot show it.
  */
+
+/*
+ * 8. The fold is ONE definition, and the panels agree because they share it.
+ *
+ *    This is the property the class exists for. A chart whose total does not
+ *    match the grid beneath it is not a visible conflict -- nobody adds the
+ *    bars up -- so it has to be asserted rather than noticed.
+ */
+$sqlFold = FogTestHarness::callStatic('FOG\Audit\ImagingStats', '_foldSql');
+foreach (['_runsPerDaySql', '_runsByImageSql', '_runsSql'] as $builder) {
+    $t->check(
+        "$builder reads through the shared fold",
+        false !== strpos(
+            FogTestHarness::callStatic('FOG\Audit\ImagingStats', $builder),
+            $sqlFold
+        )
+    );
+}
+// The canceled rule is stated over the RUN now, not row by row. A WHERE on
+// the state gives the same set of runs and a different MAX(id) -- the last
+// row that was not a cancellation -- so the grid would report a canceled
+// deploy as still In-Progress.
+$t->check(
+    'the canceled rule is a HAVING over the run, not a WHERE on the row',
+    1 === preg_match(
+        '/HAVING\s+SUM\(`taskStateID` <> :canceled\)\s*>\s*0/i',
+        $sqlFold
+    )
+);
+$t->check(
+    'the state is not also filtered before the fold',
+    1 !== preg_match('/WHERE.*`taskStateID`.*GROUP BY/is', $sqlFold)
+);
+$t->check(
+    'the run keeps its whole history in the group',
+    false !== strpos($sqlFold, 'MAX(`id`) AS `lastID`')
+        && false !== strpos($sqlFold, 'MIN(`createTime`) AS `started`')
+);
+// Selecting logImageName bare beside a GROUP BY would be a non-grouped
+// column: rejected under ONLY_FULL_GROUP_BY and answered from an arbitrary
+// row without it. It comes off the joined last row instead.
+$t->check(
+    'the image name is joined off the last row, not selected bare',
+    false !== strpos(
+        FogTestHarness::callStatic('FOG\Audit\ImagingStats', '_runsByImageSql'),
+        'JOIN `taskLog` AS `l` ON `l`.`id` = `runs`.`lastID`'
+    )
+);
+
 $dsn = getenv('FOG_TEST_DSN');
 if (false === $dsn || '' === $dsn) {
     echo "SKIP  no FOG_TEST_DSN set; SQL semantics not executed\n";
@@ -427,6 +523,94 @@ $t->check(
 $t->check(
     'exactly the three expected days came back',
     ['2026-03-01', '2026-03-03', '2026-03-04'] === array_keys($got)
+);
+
+/*
+ * 9. The panels, against the same fixtures.
+ *
+ *    Task 3 is the one that matters: In-Progress at 11:00 on the 3rd, then
+ *    Canceled at 11:05. It IS a run -- a machine was imaged -- and its last
+ *    state is Canceled. Under a WHERE-on-the-state fold its last row was the
+ *    In-Progress one and a grid built on it called a canceled deploy live.
+ */
+$byImage = $pdo->prepare(
+    FogTestHarness::callStatic('FOG\Audit\ImagingStats', '_runsByImageSql')
+);
+$byImage->execute($params);
+$images = [];
+foreach ($byImage->fetchAll(\PDO::FETCH_ASSOC) as $row) {
+    $images[$row['image']] = (int)$row['c'];
+}
+$t->check(
+    'runs are grouped by image, biggest first',
+    ['win11' => 2, 'ubuntu' => 1] === $images
+);
+
+$runsStmt = $pdo->prepare(
+    FogTestHarness::callStatic('FOG\Audit\ImagingStats', '_runsSql')
+);
+$runsStmt->execute($params);
+$runRows = $runsStmt->fetchAll(\PDO::FETCH_ASSOC);
+$byTask = [];
+foreach ($runRows as $row) {
+    $byTask[(int)$row['taskID']] = $row;
+}
+
+$t->check('one row per run, and only the runs', 3 === count($runRows));
+$t->check(
+    'the runs are the folded tasks 1, 3 and 4',
+    isset($byTask[1], $byTask[3], $byTask[4])
+);
+// Newest first, so the most recent run is at the top of the grid.
+$t->check(
+    'the grid is ordered newest first',
+    4 === (int)$runRows[0]['taskID'] && 1 === (int)$runRows[2]['taskID']
+);
+// THE ONE THE HAVING BUYS.
+$t->check(
+    'a run canceled part way through reports its FINAL state',
+    $CANCELED === (int)($byTask[3]['stateID'] ?? 0)
+);
+$t->check(
+    'and still counts as a run, because a machine was imaged',
+    isset($byTask[3])
+);
+$t->check(
+    'a completed run reports Complete',
+    $COMPLETE === (int)($byTask[1]['stateID'] ?? 0)
+);
+// Spans midnight: started on the 4th, ended on the 5th, one row.
+$t->check(
+    'a run spanning midnight carries both ends',
+    '2026-03-04' === substr((string)($byTask[4]['started'] ?? ''), 0, 10)
+        && '2026-03-05' === substr((string)($byTask[4]['ended'] ?? ''), 0, 10)
+);
+// Identity off the denormalized last row, which is what lets a run still
+// name a host and an image that have since been deleted.
+$t->check(
+    'a run names its image from its own row',
+    'ubuntu' === ($byTask[4]['imageName'] ?? null)
+);
+
+/*
+ * 10. The tiles cannot disagree with the grid, because they are counted
+ *     FROM it. Asserted against the same fixtures the chart used.
+ */
+$perDay = $pdo->prepare(
+    FogTestHarness::callStatic('FOG\Audit\ImagingStats', '_runsPerDaySql')
+);
+$perDay->execute($params);
+$chartTotal = 0;
+foreach ($perDay->fetchAll(\PDO::FETCH_ASSOC) as $row) {
+    $chartTotal += (int)$row['c'];
+}
+$t->check(
+    'the per-day chart and the grid count the same runs',
+    $chartTotal === count($runRows)
+);
+$t->check(
+    'and so does the per-image chart',
+    array_sum($images) === count($runRows)
 );
 
 $t->finish();

--- a/tests/imaging-stats.test.php
+++ b/tests/imaging-stats.test.php
@@ -266,6 +266,42 @@ $t->check(
     'a complete result is not reported as truncated',
     false === $totals['truncated']
 );
+// The bound is in the QUERY. A slice after the fetch still materializes
+// every row a wide window matched, which is the "grid All -> blank 500"
+// this codebase has fixed once already; and asking for one row past the
+// cap is what makes `truncated` answerable without a second COUNT.
+$runsSql = FogTestHarness::callStatic('FOG\Audit\ImagingStats', '_runsSql');
+$t->check(
+    'the grid query is bounded in SQL, not after the fetch',
+    1 === preg_match('/LIMIT\s+(\d+)\s*$/', trim($runsSql), $lim)
+        && (int)$lim[1] === ImagingStats::MAX_ROWS + 1
+);
+// Asserted behaviorally too: a responder that answers with the full cap
+// plus one has to be reported as truncated, and the extra row dropped.
+$db->responder = function ($sql) {
+    if (false === strpos($sql, 'taskLog')) {
+        return null;
+    }
+    $rows = [];
+    for ($i = 0; $i <= ImagingStats::MAX_ROWS; $i++) {
+        $rows[] = ['taskID' => (string)$i, 'hostID' => (string)$i,
+            'hostName' => 'h' . $i, 'imageName' => 'win11',
+            'started' => '2026-03-01 09:00:00'];
+    }
+    return $rows;
+};
+$over = ImagingStats::totals(
+    new \DateTimeImmutable('2026-03-01 00:00:00'),
+    new \DateTimeImmutable('2026-03-05 23:59:59')
+);
+$t->check(
+    'one row past the cap is reported as truncated',
+    true === $over['truncated']
+);
+$t->check(
+    'and the extra row is not counted',
+    ImagingStats::MAX_ROWS === $over['runs']
+);
 
 /*
  * 5. The window is ordered and capped.

--- a/tests/run-history-report.test.php
+++ b/tests/run-history-report.test.php
@@ -75,7 +75,10 @@ $wanted = [];
 $at = strpos($js, "case '" . $label . "':");
 if (false !== $at) {
     $block = substr($js, $at, strpos($js, 'break;', $at) - $at);
-    if (preg_match_all("/\{data: '([a-zA-Z]+)'\}/", $block, $m)) {
+    // The key only; a column may also carry a render, and every one of
+    // these now does -- run labels come off the network and DataTables
+    // writes cell data as HTML without one.
+    if (preg_match_all("/\{data: '([a-zA-Z]+)'/", $block, $m)) {
         $wanted = $m[1];
     }
 }
@@ -153,19 +156,56 @@ $t->check(
  * window and answers a question nobody asked. Found in the lab, where the
  * two clocks were five hours apart and a task created seconds earlier did
  * not appear in a window ending "now".
+ *
+ * The parsing moved to ReportWindow when the Imaging Report needed the same
+ * three decisions (ADR 0030 decision 1), so the rules are pinned THERE and
+ * what is pinned here is that this report still goes through it. Pinning
+ * only the delegation would leave the rules unguarded; pinning only the
+ * class would not notice this report growing its own copy back.
  */
+$window = $web . '/src/Audit/ReportWindow.php';
+$t->check('the shared window parser exists', is_readable($window));
+$wsrc = is_readable($window) ? file_get_contents($window) : '';
+// Both bounds, anchored as whole expressions. A substring search for
+// `self::niceDate()` is satisfied by the START branch alone, so swapping
+// only the END branch to PHP's clock -- which is exactly the half-shifted
+// window the lab found -- would pass it.
 $t->check(
-    'the window uses niceDate(), FOG\'s clock',
-    false !== strpos($src, 'self::niceDate()')
+    'the END bound is built with niceDate(), FOG\'s clock',
+    1 === preg_match(
+        "/\\\$end = '' === \\\$given\['end'\]\s*\?\s*self::niceDate\(\)"
+        . "\s*:\s*self::niceDate\(\\\$given\['end'\]\);/",
+        $wsrc
+    )
 );
 $t->check(
-    'and does NOT fall back to PHP\'s date()/time() for the bounds',
-    false === strpos($src, 'return [date($fmt')
-    && false === strpos($src, '$e = time();')
+    'and so is the START bound, default included',
+    1 === preg_match(
+        "/\\\$start = '' === \\\$given\['start'\]\s*\?\s*"
+        . "self::niceDate\(\)->modify\(.*?\)\s*:\s*"
+        . "self::niceDate\(\\\$given\['start'\]\);/s",
+        $wsrc
+    )
+);
+$t->check(
+    'and no bound is constructed on PHP\'s clock instead',
+    false === strpos($wsrc, 'new \DateTime')
+    && false === strpos($wsrc, 'new \DateTimeImmutable')
+    && 1 !== preg_match('/[^_a-z]date\(/', $wsrc)
+    && 1 !== preg_match('/[^_a-z]time\(\)/', $wsrc)
 );
 $t->check(
     'a malformed bound is dropped rather than passed to BETWEEN',
-    false !== strpos($src, 'false === strtotime($v)')
+    false !== strpos($wsrc, 'false === strtotime($v)')
+);
+$t->check(
+    'reversed bounds are swapped rather than returned empty',
+    false !== strpos($wsrc, 'if ($start > $end)')
+);
+$t->check(
+    'this report reads its window through that parser, not its own copy',
+    false !== strpos($src, 'ReportWindow::stringsFromRequest(')
+    && false === strpos($src, 'strtotime($v)')
 );
 
 $t->finish();


### PR DESCRIPTION
ADR 0030 sequencing items 4 and 5 — the panel machinery, and the first report
built from it. They land together on purpose: that ADR's own context records
that `ActivityWindow` "shipped without a caller, which is how a helper rots",
and a helper with nothing consuming it repeats that exactly.

## What a report now has

| Piece | Where |
|---|---|
| `ReportWindow` | `src/Audit/` — `start`/`end` off the URL on FOG's clock, a malformed bound dropped, a reversed pair swapped. Each report supplies only its own default range |
| `renderReportWindow()` | `FOGPageRender` — the From/To form, with an `$extra` slot for report-specific controls |
| `renderStatTiles()` | `FOGPageRender` — the headline row |
| `renderChartPanel()` | `FOGPageRender` — a card, a container, and the series in a `type="application/json"` block beside it |
| `fog.report.panels.js` | draws every container on the page |

Tabs reuse `FOGPage::tabFields()` with a falsy object, which skips its
`TABDATA_HOOK` and plugin-injection blocks — a report is not an entity and has
no id to give them, so there is no second tab implementation.

**The chart data is embedded, not fetched.** The dashboard's charts poll
because their subject is live. A report's window is fixed and already in the
URL, so a second round trip would re-run the same aggregation to draw the same
picture — and give the chart a chance to disagree with the grid beneath it.

## The Imaging Report

Gated on `task`, not `report`, through `Authorization::REPORT_NODES`: it reads
the rows Task Management's log pane already gates that way, which is the
defect ADR 0023 opens with. Narrows against the report default; nothing anyone
holds gets wider.

Tiles, both charts and the grid come from one fold of `taskLog` in
`ImagingStats`, which grew `runsByImage()`, `runs()` and `totals()` around the
existing per-day rollup. `totals()` is derived from `runs()` rather than asked
of the database separately, so a tile cannot report a different number of runs
from the rows under it.

Two things that would have been wrong and are not:

- **the canceled rule is a `HAVING` over the run, not a `WHERE` on the row.**
  Filtering canceled rows before the fold gives the same set of runs, but every
  aggregate is then over a subset — `MAX(id)` becomes the last row that *was
  not* a cancellation, so a deploy someone canceled reports as still
  In-Progress.
- **"Finished" is blank unless the run reached a terminal state.** The fold's
  `ended` is `MAX(createTime)`, a finish only once the run has finished; for
  one in progress it is the last transition, and printing that says a deploy
  completed while it is still copying. ADR 0022 decision 2.

Run History moves onto the same window parser and the same form helper, so the
abstraction has two consumers rather than one. Its DataTables columns now
escape — a run's label is a task or snapin name.

## Verification

Against the lab database through a shadow tree served over HTTP, never
`/var/www`:

- tiles 3 / 2 / 1 / 0.1, both charts summing to 3, and the grid's three rows
  all agree; the in-progress run shows an empty Finished
- a narrowed window drops all four to 1; a malformed bound falls back to the
  default
- in the browser both canvases paint, a theme toggle rebuilds them with one
  canvas each rather than stacking, tab switching keeps their size, and an
  empty window says "Nothing in this range" instead of drawing a flat line
- Run History still returns its 15 rows over a wide window

Gates: 37 new checks in `tests/imaging-report.test.php`, 4 more in
`imaging-stats`, 5 reworked in `run-history-report`. **Fourteen mutations run,
each reddening the named check and no other.** One inherited check turned out
to be fake — a substring search for `self::niceDate()` is satisfied by the
START branch alone, so moving only the END bound to PHP's clock passed it.
Both bounds are now anchored as whole expressions and the mutation reddens
them.

`FOG_BCACHE_VER` 326 → 327 for the new and changed JS.

## Downstream

No route class added, so FogApi's hardcoded `-coreObject` list is unaffected.
No REST route changed, so `OpenAPI::document()` still describes the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBigm29JVHwk2zmTTgey9a
