### PR TITLE
Widen the zero-date gate to the whole tree, and to one definition

### DIFF
--- a/packages/web/src/Audit/FleetStats.php
+++ b/packages/web/src/Audit/FleetStats.php
@@ -62,23 +62,6 @@ class FleetStats extends WindowedStats
     const AGE_BUCKETS = [30, 90, 365];
 
     /**
-     * "Has no usable date", in SQL, for one column.
-     *
-     * Written once because it is needed in four statements and getting it
-     * half right -- NULL but not the zero date, or the other way round --
-     * produces a plausible number rather than an error. See the class
-     * docblock.
-     *
-     * @param string $col a fully qualified column reference
-     *
-     * @return string
-     */
-    private static function _noDate($col)
-    {
-        return "($col IS NULL OR $col = '0000-00-00 00:00:00')";
-    }
-
-    /**
      * Deploy age counted in whole days back from the as-of date.
      *
      * @return string
@@ -112,7 +95,7 @@ class FleetStats extends WindowedStats
      */
     private static function _ageBucketSql()
     {
-        $never = self::_noDate('`hosts`.`hostLastDeploy`');
+        $never = self::noDateSql('`hosts`.`hostLastDeploy`');
         $age = self::_ageExpr();
         $cases = '';
         foreach (self::AGE_BUCKETS as $i => $days) {
@@ -156,8 +139,8 @@ class FleetStats extends WindowedStats
      */
     private static function _totalsSql()
     {
-        $never = self::_noDate('`hosts`.`hostLastDeploy`');
-        $noCheckin = self::_noDate('`hosts`.`hostLastCheckin`');
+        $never = self::noDateSql('`hosts`.`hostLastDeploy`');
+        $noCheckin = self::noDateSql('`hosts`.`hostLastCheckin`');
 
         return "SELECT COUNT(*) AS `hosts`,
                        SUM($never) AS `never`,
@@ -194,7 +177,7 @@ class FleetStats extends WindowedStats
                        `hosts`.`hostLastDeploy` AS `lastDeploy`,
                        `hosts`.`hostLastCheckin` AS `lastCheckin`,
                        `hosts`.`hostCreateDate` AS `created`,
-                       CASE WHEN " . self::_noDate('`hosts`.`hostLastDeploy`')
+                       CASE WHEN " . self::noDateSql('`hosts`.`hostLastDeploy`')
                            . " THEN NULL ELSE $age END AS `ageDays`,
                        (`inventory`.`iID` IS NOT NULL) AS `hasInventory`
                   FROM `hosts`

--- a/packages/web/src/Audit/StorageStats.php
+++ b/packages/web/src/Audit/StorageStats.php
@@ -125,8 +125,7 @@ class StorageStats extends WindowedStats
      */
     private static function _totalsSql()
     {
-        $never = "(`imageLastDeploy` IS NULL
-                   OR `imageLastDeploy` = '0000-00-00 00:00:00')";
+        $never = self::noDateSql('`imageLastDeploy`');
 
         return "SELECT COUNT(*) AS `images`,
                        COALESCE(SUM(`imageServerSize`), 0) AS `bytes`,

--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -1898,6 +1898,28 @@ abstract class FOGBase
         return self::humanify($diff / 31536000, 'year');
     }
     /**
+     * validDate(), expressed in SQL, for one column.
+     *
+     * The same question as validDate() asked of the server instead of of
+     * PHP, and here for the same reason: there is ONE definition of what an
+     * empty date is, and getting it half right -- NULL but not the zero
+     * date, or the other way round -- produces a plausible number rather
+     * than an error. Both spellings have to be covered because an upgraded
+     * server carries both until schema step 344 has run.
+     *
+     * Concatenated, not bound: a column name is not a value, so it cannot
+     * be a placeholder. Callers pass a literal column reference they wrote
+     * themselves -- never anything off a request.
+     *
+     * @param string $column a fully qualified, backtick-quoted column
+     *
+     * @return string a SQL boolean expression, already parenthesised
+     */
+    protected static function noDateSql($column)
+    {
+        return "($column IS NULL OR $column = '0000-00-00 00:00:00')";
+    }
+    /**
      * Checks if the time passed is valid or not.
      *
      * FALSY FOR EVERY FORM OF "no date": '', NULL, an unparseable string,

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4400');
+        define('FOG_VERSION', '1.6.0-beta.4403');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/TaskHandling/TaskQueue.php
+++ b/packages/web/src/TaskHandling/TaskQueue.php
@@ -100,8 +100,12 @@ class TaskQueue extends TaskingElement
         if (!$Task->isValid()) {
             return;
         }
+        // Asked of validDate() rather than compared to a literal. It is
+        // falsy for '', for NULL and for BOTH spellings of the zero date,
+        // which an upgraded server carries until schema step 344 has run --
+        // the reason this was two comparisons and not one.
         $checkin = trim((string)$Task->get('checkInTime'));
-        if ($checkin === '' || $checkin === '0000-00-00 00:00:00') {
+        if (!self::validDate($checkin)) {
             return;
         }
         try {

--- a/tests/date-columns-nullable.test.php
+++ b/tests/date-columns-nullable.test.php
@@ -204,34 +204,80 @@ if ($dateFields < 25) {
 // ---------------------------------------------------------------
 // The zero date is not a value the code writes or looks for.
 // ---------------------------------------------------------------
+// ONE file, not two, and every PHP file under packages/ rather than only
+// those under packages/web/lib. The scan used to stop at `lib`, which was
+// the whole codebase when it was written and is now the pages, reports,
+// hooks and events -- every core class moved to `src/` and quietly left
+// coverage, so a literal written in a rollup, a daemon or a model passed.
+// It cost nothing to notice because nothing had written one yet; the first
+// two that did were both added the day this was widened.
+//
+// TaskQueue came off the list rather than staying on it: it was comparing
+// against both spellings by hand, which is what validDate() is, and the
+// two rollups that needed the SQL form now call FOGBase::noDateSql(). So
+// the exemption is the definition itself and nothing else, in either
+// language, which is the invariant worth having:
+//
+//   exactly one file in the tree may name the zero date
 $allowed = [
-    // The one place that defines what an empty date means.
+    // The one place that defines what an empty date means -- validDate()
+    // for PHP, noDateSql() for SQL.
     'packages/web/src/Base/FOGBase.php',
-    // Reads BOTH spellings, because an upgraded server carries both until
-    // schema step 344 has run.
-    'packages/web/src/TaskHandling/TaskQueue.php',
 ];
 $dirs = new \RecursiveIteratorIterator(
-    new \RecursiveDirectoryIterator($web . '/lib', \FilesystemIterator::SKIP_DOTS)
+    new \RecursiveDirectoryIterator(
+        $root . '/packages',
+        \FilesystemIterator::SKIP_DOTS
+    )
 );
+$scanned = 0;
 foreach ($dirs as $file) {
     if ('php' !== strtolower($file->getExtension())) {
         continue;
     }
     $path = $file->getPathname();
     $rel = substr($path, strlen($root) + 1);
-    if (in_array($rel, $allowed, true) || false !== strpos($rel, '/plugins/')) {
+    // Plugins ship from their own repository (ADR 0009) and vendor is not
+    // ours to hold to this.
+    if (in_array($rel, $allowed, true)
+        || false !== strpos($rel, '/plugins/')
+        || false !== strpos($rel, '/vendor/')
+    ) {
         continue;
     }
     $checks++;
+    $scanned++;
     $clean = dcStripComments(file_get_contents($path));
     if (false !== strpos($clean, '0000-00-00')) {
         $failures[] = sprintf(
-            '%s still carries a 0000-00-00 literal; NULL is what "never '
-            . 'happened" means now',
+            '%s still carries a 0000-00-00 literal; ask '
+            . 'FOGBase::validDate() in PHP or FOGBase::noDateSql() in SQL, '
+            . 'so there stays one definition of what an empty date means',
             $rel
         );
     }
+}
+
+// A scan that reached nothing would pass silently, and this one just moved.
+$checks++;
+if ($scanned < 300) {
+    $failures[] = sprintf(
+        'only %d PHP file(s) reached by the zero-date scan; it is not '
+        . 'walking the tree and would pass vacuously',
+        $scanned
+    );
+}
+
+// And the definition has to still BE there. Without this the exemption is
+// a hole: emptying FOGBase of both helpers would leave every other file
+// clean and the suite green.
+$checks++;
+$base = file_get_contents($web . '/src/Base/FOGBase.php');
+if (false === strpos($base, 'function validDate(')
+    || false === strpos($base, 'function noDateSql(')
+) {
+    $failures[] = 'FOGBase must declare BOTH validDate() and noDateSql(); '
+        . 'they are what the single exemption above is exempting';
 }
 
 if (count($failures) > 0) {


### PR DESCRIPTION
`tests/date-columns-nullable.test.php` scanned only `packages/web/lib`. That
was the whole codebase when it was written; it is now the pages, reports,
hooks and events, because every core class moved to `src/` under ADR 0013.
Coverage went with them and nobody noticed — nothing had written a zero-date
literal outside `lib` yet. The first two that did were added this week, in
the ADR 0030 rollups.

It now walks **every** PHP file under `packages/` (348, plugins and vendor
excluded), so a literal in a rollup, a model, a router or a daemon fails the
same way one in a page always did.

## The exemption list shrank rather than grew

Widening it needed one definition to point at, which is the more useful half
of the change:

| Was | Now |
|---|---|
| `FleetStats::_noDate()` — a private SQL copy | calls `FOGBase::noDateSql()` |
| `StorageStats` — the same expression inline | calls `FOGBase::noDateSql()` |
| `TaskQueue` — `$c === '' \|\| $c === '0000-00-00 00:00:00'` | asks `FOGBase::validDate()`, and comes **off** the exemption list |

`noDateSql()` is the SQL counterpart to `validDate()` and sits beside it, so
"this date column is empty" has one definition per language and both are in
the same place. The reasoning — that an upgraded server carries
`0000-00-00` and `0000-00-00 00:00:00` until schema step 344 has run, so both
spellings must be covered — now lives in one docblock instead of four call
sites.

The invariant is therefore the strong one: **exactly one file in the tree may
name the zero date.** The test also fails if that file stops declaring either
helper, without which the exemption would be a hole big enough to empty
`FOGBase` through.

## Verification

- Mutation-verified: a literal in `src/`, a literal in `packages/service/`,
  and a renamed `noDateSql()` each turn it red. A scan reaching fewer than
  300 files fails rather than passing vacuously — proven by tripping it.
- 193/193 in `tests/run-all.sh`; both `phpstan` passes clean, unscoped.
- Fleet Report and Storage Report re-read against the lab database after the
  refactor: 86 hosts / 83 never imaged / doughnut totalling 86, and 29 images
  / 58.03 GiB / 25 stale — identical to before.