### PR TITLE
Ship the pre-DHCP delay stanza in every autoexec.ipxe, commented out

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -2694,13 +2694,64 @@ _uefiBootFile() {
             ;;
     esac
 }
-# Write the pre-DHCP sleep into autoexec.ipxe, per --boot-delay.
+# The pre-DHCP delay stanza, in the one form every copy of autoexec.ipxe uses.
 #
-# Some switches take several seconds to bring a port out of STP listening or
-# out of powersave, and iPXE's first DHCP attempt goes out before that. FOG has
-# always shipped a second copy of every binary with a 10-second sleep compiled
-# in (10secdelay/) as the answer. On EFI that is now two lines of text in a
-# file instead, which is the whole point of dropping EMBED.
+# Some switches take several seconds to bring a port out of STP listening or out
+# of powersave, and iPXE's first DHCP attempt goes out before that. FOG's answer
+# used to be a second set of compiled binaries (10secdelay/); on EFI it is two
+# lines of text, which is what makes the commented arm below possible at all --
+# an admin who hits this at 2am uncomments one line instead of reinstalling the
+# server, and there is nothing to rebuild.
+#
+# ONE generator for both surfaces: the server's own TFTP copy via
+# _applyBootDelay(), and the ESP archives via _espAutoexecScript(). They used to
+# be two separate bodies of text kept in step by a comment asking future editors
+# to keep them in step, and they had already drifted -- the ESP copy shipped the
+# commented arm and the TFTP copy shipped nothing at all, so a site that read the
+# USB stick and then the netboot script found two different scripts. The note in
+# _espAutoexecScript() already described the commented arm as what the TFTP copy
+# did; it does now.
+#
+# Both arms carry the same sentinels, which is what makes _applyBootDelay()'s
+# rewrite idempotent in both directions -- raising, lowering and clearing the
+# delay all replace exactly one block. The cost is that an uncommented edit
+# INSIDE the block is reverted by the next install, so the commented arm says so
+# and names --boot-delay as the way to make it stick. An admin's own sleep
+# written outside the block is never touched.
+#
+# The delay cannot be a UI setting, before anyone tries: it has to run before
+# DHCP, and the web UI is only reachable after DHCP has succeeded.
+_bootDelayBlock() {
+    local delay="${BOOT_dhcp_delay_seconds:-0}"
+    if [[ $delay -gt 0 ]]; then
+        cat <<BOOTDELAY
+# FOG-BOOT-DELAY-BEGIN  (installfog.sh --boot-delay; do not edit by hand)
+echo Sleeping ${delay} seconds to wait for STP/Powersave to switchoff and on
+sleep ${delay}
+# FOG-BOOT-DELAY-END
+BOOTDELAY
+    else
+        cat <<'BOOTNODELAY'
+# FOG-BOOT-DELAY-BEGIN  (no pre-DHCP delay configured)
+# If your switch runs STP or port power-save and the link is not up by the time
+# iPXE first asks for DHCP, uncomment the two lines below. That fixes this copy
+# now, with nothing to rebuild. installfog.sh rewrites this whole block on every
+# run, so make it permanent by reinstalling with --boot-delay <seconds>, which
+# writes it live into every copy of this script and points legacy BIOS clients at
+# the 10-second build at the same time.
+#echo Sleeping 10 seconds to wait for STP/Powersave to switchoff and on
+#sleep 10
+# FOG-BOOT-DELAY-END
+BOOTNODELAY
+    fi
+}
+# Write the pre-DHCP delay stanza into the TFTP copy of autoexec.ipxe.
+#
+# ALWAYS written, whether or not --boot-delay was given: _bootDelayBlock()
+# returns the commented arm when it was not, so the netboot script carries the
+# same self-documenting escape hatch the ESP archives have always carried. It
+# used to be written only when a delay was set, which left an admin diagnosing a
+# 2am STP problem reading a file that says nothing about the sleep it needs.
 #
 # Bracketed by sentinel comments rather than matched on the sleep line. An
 # admin may have added their own sleep for their own reason, and a bare
@@ -2721,22 +2772,22 @@ _applyBootDelay() {
     local script="${tftpdirdst%/}/autoexec.ipxe"
     [[ -f $script ]] || return 0
     local delay="${BOOT_dhcp_delay_seconds:-0}"
+    local block
+    block="$(_bootDelayBlock)"
     local tmp
     tmp=$(mktemp) || return 0
-    awk -v delay="$delay" '
-        # Prefix match, not anchored: the BEGIN line carries a trailing
-        # "(installfog.sh --boot-delay...)" note, so a $-anchored pattern never
+    awk -v block="$block" '
+        # Prefix match, not anchored: the BEGIN line carries a trailing note
+        # that differs between the two arms, so a $-anchored pattern never
         # matches what this same function writes and the blocks stack on every
         # run instead of being replaced.
         /^# FOG-BOOT-DELAY-BEGIN/ { skip = 1 }
         skip { if ( $0 ~ /^# FOG-BOOT-DELAY-END/ ) skip = 0; next }
         { print }
-        NR == 1 && delay > 0 {
-            print "# FOG-BOOT-DELAY-BEGIN  (installfog.sh --boot-delay; do not edit by hand)"
-            print "echo Sleeping " delay " seconds to wait for STP/Powersave to switchoff and on"
-            print "sleep " delay
-            print "# FOG-BOOT-DELAY-END"
-        }
+        # After the first line this actually PRINTS, not NR == 1: if a previous
+        # run ever left a sentinel block at the very top, line 1 is consumed by
+        # the skip rule above and an NR test would drop the block entirely.
+        !inserted { print block; inserted = 1 }
     ' "$script" > "$tmp" 2>>$error_log
     # Never truncate the real script on a failed rewrite -- an empty
     # autoexec.ipxe is a server that netboots nothing.
@@ -12697,34 +12748,6 @@ _espFileNote() {
         *)  echo "" ;;
     esac
 }
-# The pre-DHCP delay, emitted into BOTH ESP scripts.
-#
-# Some switches take several seconds to bring a port out of STP listening or out
-# of powersave, and iPXE's first DHCP attempt goes out before that. Written live
-# from --boot-delay, bracketed by the same sentinels _applyBootDelay() uses on
-# the TFTP copy so the two read the same way; shipped commented out otherwise,
-# because an admin who discovers the problem on one machine at 2am should be able
-# to fix it by uncommenting a line rather than by reinstalling the server.
-_espDelayBlock() {
-    local delay="${BOOT_dhcp_delay_seconds:-0}"
-    if [[ $delay -gt 0 ]]; then
-        cat <<ESPDELAY
-# FOG-BOOT-DELAY-BEGIN  (installfog.sh --boot-delay; do not edit by hand)
-echo Sleeping ${delay} seconds to wait for STP/Powersave to switchoff and on
-sleep ${delay}
-# FOG-BOOT-DELAY-END
-ESPDELAY
-    else
-        cat <<'ESPNODELAY'
-# No pre-DHCP delay is configured. If your switch runs STP or port power-save
-# and the link is not up by the time iPXE first asks for DHCP, uncomment the two
-# lines below -- or reinstall with --boot-delay <seconds>, which writes them here
-# and in the server's own netboot copy at the same time.
-#echo Sleeping 10 seconds to wait for STP/Powersave to switchoff and on
-#sleep 10
-ESPNODELAY
-    fi
-}
 # FOG's boot logic: find a DHCP answer, work out which server to talk to, chain
 # FOG's menu.
 #
@@ -12846,7 +12869,7 @@ _espAutoexecScript() {
 # autoexec.ipxe, and with src/ipxescript, the script the BIOS binaries still
 # embed. All of them must behave identically.
 ESPAUTOEXEC
-    _espDelayBlock
+    _bootDelayBlock
     _espBootWalk
 }
 # The archive's README. Written per archive rather than once, because which

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4406');
+        define('FOG_VERSION', '1.6.0-beta.4409');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/tests/boot-delay-stanza.test.sh
+++ b/tests/boot-delay-stanza.test.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+#
+# Guards the pre-DHCP delay stanza that --boot-delay writes into autoexec.ipxe.
+#
+#   tests/boot-delay-stanza.test.sh
+#
+# The delay exists because some switches take several seconds to bring a port
+# out of STP listening or out of powersave, and iPXE's first DHCP attempt goes
+# out before that. It cannot be a UI setting -- it has to run BEFORE DHCP, and
+# the web UI is only reachable after DHCP has succeeded -- so the installer is
+# the only place it can come from, and the file an admin edits at 2am is the
+# only escape hatch between installs. Both of those make this stanza worth
+# pinning:
+#
+#   1. The commented arm has to be THERE. It was the whole reason the delay
+#      could stop being a second set of compiled binaries, and the ESP archives
+#      shipped it while the server's own TFTP copy silently did not -- an admin
+#      diagnosing a link-up problem read a netboot script that said nothing
+#      about the sleep it needed. Both surfaces come from _bootDelayBlock() now
+#      and this asserts they still do.
+#
+#   2. The rewrite has to stay idempotent in BOTH directions. installfog.sh runs
+#      many times over a server's life; blocks that stack, or a cleared delay
+#      that leaves a live sleep behind, are both silent and both change how
+#      every EFI client on the network boots.
+#
+# Also pinned: an admin's own sleep written OUTSIDE the sentinels survives. That
+# is why the block is bracketed rather than matched on the sleep line, and a
+# future edit to a bare /^sleep /d would eat it with nothing to show for it.
+#
+# No install, no network, no root.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+error_log="$WORK/error.log"
+: > "$error_log"
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+
+# _applyBootDelay() reads $tftpdirdst and rewrites the file in place.
+tftpdirdst="$WORK/tftpboot"
+mkdir -p "$tftpdirdst"
+SCRIPT="$tftpdirdst/autoexec.ipxe"
+
+# A stand-in for the real boot script: only the shebang and one recognizable
+# line matter, because everything this function does is anchored on the
+# sentinels rather than on the surrounding content.
+fresh() {
+    cat > "$SCRIPT" <<'EOS'
+#!ipxe
+echo Checking net0 for DHCP...
+isset ${net0/mac} && ifopen net0 && dhcp net0 || goto dhcpnet1
+EOS
+}
+
+count() { grep -c -- "$1" "$SCRIPT"; }
+
+echo "== no delay configured =="
+BOOT_dhcp_delay_seconds=0
+fresh
+_applyBootDelay >/dev/null
+is "$(count '^# FOG-BOOT-DELAY-BEGIN')" "1" \
+   "the stanza is written even with no delay -- one block"
+is "$(count '^# FOG-BOOT-DELAY-END')" "1" \
+   "and it is closed exactly once"
+is "$(count '^#sleep 10')" "1" \
+   "the sleep ships commented out, ready to uncomment"
+is "$(count '^sleep ')" "0" \
+   "no delay is active when --boot-delay was not given"
+# The text has to name the flag: uncommenting fixes this copy until the next
+# install, and an admin who is not told that loses the fix to a reinstall and
+# has no idea why.
+if grep -q -- '--boot-delay' "$SCRIPT"; then
+    ok "the commented arm names --boot-delay as the way to make it permanent"
+else
+    bad "the commented arm does not say how to make the delay survive a reinstall"
+fi
+# The shebang must stay first or iPXE will not run the script at all.
+is "$(head -n1 "$SCRIPT")" "#!ipxe" \
+   "the block is inserted after the shebang, not before it"
+
+echo "== a delay configured =="
+BOOT_dhcp_delay_seconds=15
+fresh
+_applyBootDelay >/dev/null
+is "$(count '^sleep 15')" "1" "--boot-delay 15 writes a live sleep"
+is "$(count '^#sleep ')" "0" "and drops the commented arm"
+is "$(count '^# FOG-BOOT-DELAY-BEGIN')" "1" "still exactly one block"
+is "$(head -n1 "$SCRIPT")" "#!ipxe" "the shebang is still first"
+
+echo "== idempotency, in both directions =="
+_applyBootDelay >/dev/null
+_applyBootDelay >/dev/null
+is "$(count '^# FOG-BOOT-DELAY-BEGIN')" "1" \
+   "re-running does not stack a second block"
+is "$(count '^sleep 15')" "1" "and does not stack a second sleep"
+BOOT_dhcp_delay_seconds=30
+_applyBootDelay >/dev/null
+is "$(count '^sleep 30')" "1" "raising the delay replaces the block"
+is "$(count '^sleep 15')" "0" "and leaves no trace of the old value"
+BOOT_dhcp_delay_seconds=0
+_applyBootDelay >/dev/null
+is "$(count '^sleep ')" "0" \
+   "clearing the delay removes the live sleep"
+is "$(count '^#sleep 10')" "1" \
+   "and puts the commented arm back"
+
+echo "== an admin's own sleep is not eaten =="
+BOOT_dhcp_delay_seconds=0
+fresh
+printf 'sleep 3\n' >> "$SCRIPT"
+_applyBootDelay >/dev/null
+is "$(count '^sleep 3')" "1" \
+   "a sleep written outside the sentinels survives the rewrite"
+BOOT_dhcp_delay_seconds=20
+_applyBootDelay >/dev/null
+is "$(count '^sleep 3')" "1" \
+   "and survives a delay being set as well"
+is "$(count '^sleep 20')" "1" "alongside the installer's own"
+
+echo "== a missing tftp root is a no-op =="
+# _applyBootDelay() runs from configureTFTPandPXE() and also has to be safe on a
+# server where that tree was never staged. Returning early is what keeps it from
+# creating an autoexec.ipxe with a delay block and no boot logic in it.
+BOOT_dhcp_delay_seconds=0
+fresh
+before="$(cat "$SCRIPT")"
+tftpdirdst="$WORK/nosuchdir" _applyBootDelay >/dev/null
+is "$(cat "$SCRIPT")" "$before" \
+   "no tftp root means the script is left exactly as it was"
+if [[ -e $WORK/nosuchdir/autoexec.ipxe ]]; then
+    bad "a script was created under a tftp root that does not exist"
+else
+    ok "and nothing is created where the tree was never staged"
+fi
+
+echo "== both surfaces come from one generator =="
+# The TFTP copy and the ESP archives used to be two bodies of text kept in step
+# by a comment. If they drift again, a site that reads the USB stick and then
+# the netboot script finds two different scripts.
+for d in 0 10 15; do
+    BOOT_dhcp_delay_seconds=$d
+    fresh
+    _applyBootDelay >/dev/null
+    tftp_block="$(awk '/^# FOG-BOOT-DELAY-BEGIN/,/^# FOG-BOOT-DELAY-END/' "$SCRIPT")"
+    esp_block="$(_bootDelayBlock)"
+    is "$tftp_block" "$esp_block" \
+       "delay=$d writes the same stanza to the TFTP copy and the ESP archives"
+done
+
+unset BOOT_dhcp_delay_seconds
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/tests/localboot-publish.test.sh
+++ b/tests/localboot-publish.test.sh
@@ -453,10 +453,13 @@ is "$(grep -c '^#sleep 10' "$L")" "1" \
    "the pre-DHCP sleep ships commented out, ready to uncomment"
 is "$(grep -c '^sleep ' "$L")" "0" \
    "no delay is active when --boot-delay was not given"
-if grep -q 'FOG-BOOT-DELAY-BEGIN' "$L"; then
-    bad "the sentinel block is present with no delay configured"
+# Sentinels on BOTH arms, which is what lets the next install replace one block
+# whether the delay is being set, changed or cleared. They used to be written
+# only around a live sleep, so the commented arm could not be replaced at all.
+if grep -q 'FOG-BOOT-DELAY-BEGIN' "$L" && grep -q 'FOG-BOOT-DELAY-END' "$L"; then
+    ok "the commented arm is bracketed by the sentinels too"
 else
-    ok "no sentinel block without --boot-delay"
+    bad "the commented arm is written without the sentinels that replace it"
 fi
 BOOT_dhcp_delay_seconds=15
 _publishLocalBootFiles >/dev/null


### PR DESCRIPTION
## Why

The `--boot-delay` sleep has to run **before** iPXE's first DHCP attempt. That is the whole reason it exists — some switches take several seconds to bring a port out of STP listening or out of powersave — and it is also why it can never become a UI setting: the web UI is only reachable *after* DHCP has succeeded. So the installer is the only thing that can write it, and the file itself is the only escape hatch an admin has between installs.

That escape hatch was only half built. The ESP archives shipped the two lines commented out with a note saying when to uncomment them; the server's own netboot copy shipped nothing at all, because `_applyBootDelay()` wrote the block only when a delay was set. An admin diagnosing a link-up failure read `/tftpboot/autoexec.ipxe` and found no mention of the sleep they needed — the only hint was prose in the file's header comment.

The comment in `_espAutoexecScript()` has claimed since it was written that shipping the commented lines is *"exactly what `_applyBootDelay()` already does to the TFTP copy"*. It does now.

## What changed

- **New `_bootDelayBlock()`** — one generator for the stanza, live or commented, used by both `_applyBootDelay()` (TFTP) and `_espAutoexecScript()` (ESP archives). They were two separate bodies of text kept in step by a comment asking future editors to keep them in step, and they had already drifted: a site that read the USB stick and then the netboot script found two different scripts.
- **The commented arm carries the same sentinels as the live one.** That is what keeps the rewrite idempotent in both directions — raising, lowering and clearing the delay each replace exactly one block. The cost is that uncommenting *inside* the block is reverted by the next install, so the text says so and names `--boot-delay` as the way to make it stick. A `sleep` written outside the sentinels is still never touched, which is why the block is bracketed rather than matched on the sleep line.
- **The awk insert no longer tests `NR == 1`**, but "after the first line actually printed". If a block ever sat at the very top of the file, line 1 was consumed by the skip rule and an `NR` test dropped the new block entirely.

Nothing changes for legacy BIOS: it has no `efi_autoexec_load()`, so its script is still compiled in and it still takes its delay from the `10secdelay/` build via DHCP. `_biosBootFile()` is untouched.

## What it looks like

Against the real `/tftpboot/autoexec.ipxe` on a dev box, with no delay configured:

```
#!ipxe
# FOG-BOOT-DELAY-BEGIN  (no pre-DHCP delay configured)
# If your switch runs STP or port power-save and the link is not up by the time
# iPXE first asks for DHCP, uncomment the two lines below. That fixes this copy
# now, with nothing to rebuild. installfog.sh rewrites this whole block on every
# run, so make it permanent by reinstalling with --boot-delay <seconds>, which
# writes it live into every copy of this script and points legacy BIOS clients at
# the 10-second build at the same time.
#echo Sleeping 10 seconds to wait for STP/Powersave to switchoff and on
#sleep 10
# FOG-BOOT-DELAY-END
```

…and after `--boot-delay 7`:

```
#!ipxe
# FOG-BOOT-DELAY-BEGIN  (installfog.sh --boot-delay; do not edit by hand)
echo Sleeping 7 seconds to wait for STP/Powersave to switchoff and on
sleep 7
# FOG-BOOT-DELAY-END
```

## Tests

New `tests/boot-delay-stanza.test.sh` (24 assertions) pins: the commented arm is present and names the flag; the shebang stays first; both-direction idempotency across re-runs, raise, and clear; an admin's own sleep outside the sentinels survives; a missing TFTP root is a no-op; and the TFTP copy and the ESP archives emit byte-identical stanzas at three different delay values.

Every assertion was verified against a mutation that makes it fail:

| Mutation | Assertions that went red |
|---|---|
| Reinstate the old `delay > 0` guard | 6 |
| Anchor the BEGIN sentinel match (`$`) so blocks stack | 4 |
| Match on the sleep line instead of the sentinels | 2 |
| Let `_applyBootDelay()` write its own text instead of `_bootDelayBlock()`'s | 3 |
| Drop the `-f` guard on the script | 1 |

`tests/localboot-publish.test.sh` had an assertion that the sentinels were *absent* when no delay was configured — now inverted, since both arms are bracketed.

Full local suite: **195 passed, 0 failed**. Both phpstan passes clean (no PHP changed).

## Downstream

None. No route classes, no schema, no API surface.