### PR TITLE
Pin iPXE to v2.0.0-fog.7.1, which ships the pre-DHCP sleep

### DIFF
--- a/packages/web/lib/fog/system.class.php
+++ b/packages/web/lib/fog/system.class.php
@@ -62,7 +62,7 @@ class System
         // given FOG release ships a known iPXE -- the installer uses this both
         // to pick the download and to check out the matching source when an
         // HTTPS install has to rebuild with its own CA.
-        define('FOG_IPXE_VERSION', 'v2.0.0-fog.7');
+        define('FOG_IPXE_VERSION', 'v2.0.0-fog.7.1');
         // GH-850: the base path is installer-driven. Initiator loads the
         // generated commons/fogpaths.php (written from the installer's
         // $fogprogramdir) before the autoloader runs, so in a normal boot this


### PR DESCRIPTION
One-line change: `FOG_IPXE_VERSION` `v2.0.0-fog.7` → `v2.0.0-fog.7.1`.

## Why

`fog-ipxe`'s `autoexec.ipxe` has told admins since GH-957 that the STP/powersave delay is *"a two-line edit to autoexec.ipxe"* rather than a second set of binaries, and `buildipxe.sh` repeats it where it explains why there is no `autoexec` counterpart to `10secdelay/`. **Neither line was ever shipped.** Someone chasing a client that reports no DHCP answer on a link that is fine seconds later opened the file they were pointed at and found the only occurrence of the word "sleep" was the sentence telling them to change one.

Confirmed on both 1.5.10 lab servers (10.253.25.2, 10.254.25.2) and in the published `v2.0.0-fog.7` release asset itself.

## What v2.0.0-fog.7.1 changes

Ships the two lines commented out, plus the two things that are true here and cannot be guessed from the file:

- **It only affects the `autoexec/` binaries** — the EMBED-less build, which is the only one that reads a downloaded script, and which a site opts into with a DHCP filename change. A server still handing out a boot file from the TFTP root is running binaries with the script compiled in and needs `10secdelay/` instead. Legacy BIOS needs `10secdelay/` either way; it has no `efi_autoexec_load()` at all.
- **The edit does not survive `installfog.sh`.** This line's copy loop (`find -type f -exec cp -Rfv`) overwrites the staged tree unconditionally, so it has to be re-applied after an upgrade.

Nothing else in the release changed. `IPXEVER` is pinned to upstream `v2.0.0` with the same FOG patch set, so these are the fog.7 binaries rebuilt.

## Why a maintenance release instead of moving to fog.8

fog.8 is the EMBED-less change: the boot script moves to the TFTP root and becomes the script every EFI binary reads. This installer **deliberately removes** a root `autoexec.ipxe` in `configureTFTPandPXE()`, and a root script sitting beside the `10secdelay/` EFI binaries this line still ships is exactly the combination where `efi_autoexec_network()` downloads a script the binary never runs, leaving `initrd_load_all()` to concatenate it ahead of `init.xz`:

```
VFS: Unable to mount root fs on "/dev/ram0"
```

So fog.8 is not a pin this branch can take. The fix was cut from `v2.0.0-fog.7` on `maint/v2.0.0-fog.7` in FOGProject/fog-ipxe, which does not merge to master — master already carries the corrected text as part of the fog.8 layout.

## No installer change here

The 1.6 line got the equivalent as an installer feature (#1466), where `--boot-delay` already existed and `_applyBootDelay()` could write the block itself. There is no `--boot-delay` on this branch to extend, and adding one would be a new installer option on the patches line for a problem that already has an answer in `10secdelay/`.

## Verification

- `maint/v2.0.0-fog.7` built green via `workflow_dispatch` before tagging; the build artifact carried the corrected file in all three `autoexec/` copies.
- The tag build published the release; the asset was fetched over the same URL the installer uses, `sha256sum -c` passed, and `./autoexec/autoexec.ipxe` inside it carries the block.
- The `release pins resolve` job in this PR re-proves the pin downloads independently of any of the above.

## Downstream

None. No routes, no schema, no API surface.