### PR TITLE
Pin the plugins release that names its own reports

### DIFF
--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -5034,6 +5034,10 @@ msgid "Location is a plugin that allows your FOG Server"
 msgstr "Standort ist ein Plugin, mit dem Ihr FOG-Server"
 
 #, fuzzy
+msgid "Location schema"
+msgstr "Standorte"
+
+#, fuzzy
 msgid "Location update failed!"
 msgstr "Standortupdate fehlgeschlagen"
 
@@ -10761,6 +10765,9 @@ msgid "register this too, if you enable single logout"
 msgstr ""
 
 msgid "row(s)"
+msgstr ""
+
+msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -5032,6 +5032,10 @@ msgid "Location is a plugin that allows your FOG Server"
 msgstr ""
 
 #, fuzzy
+msgid "Location schema"
+msgstr "Locations"
+
+#, fuzzy
 msgid "Location update failed!"
 msgstr "Snapin update failed"
 
@@ -10752,6 +10756,9 @@ msgid "register this too, if you enable single logout"
 msgstr ""
 
 msgid "row(s)"
+msgstr ""
+
+msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5135,6 +5135,10 @@ msgid "Location is a plugin that allows your FOG Server"
 msgstr ""
 
 #, fuzzy
+msgid "Location schema"
+msgstr "Acción"
+
+#, fuzzy
 msgid "Location update failed!"
 msgstr "actualización de servicio no pudo"
 
@@ -10936,6 +10940,9 @@ msgid "register this too, if you enable single logout"
 msgstr ""
 
 msgid "row(s)"
+msgstr ""
+
+msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
 msgid "second"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5035,6 +5035,10 @@ msgid "Location is a plugin that allows your FOG Server"
 msgstr "Standort ist ein Plugin, mit dem Ihr FOG-Server"
 
 #, fuzzy
+msgid "Location schema"
+msgstr "Standorte"
+
+#, fuzzy
 msgid "Location update failed!"
 msgstr "Standortupdate fehlgeschlagen"
 
@@ -10762,6 +10766,9 @@ msgid "register this too, if you enable single logout"
 msgstr ""
 
 msgid "row(s)"
+msgstr ""
+
+msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -5034,6 +5034,10 @@ msgid "Location is a plugin that allows your FOG Server"
 msgstr ""
 
 #, fuzzy
+msgid "Location schema"
+msgstr "Emplacements"
+
+#, fuzzy
 msgid "Location update failed!"
 msgstr "mise à jour a échoué Snapin"
 
@@ -10754,6 +10758,9 @@ msgid "register this too, if you enable single logout"
 msgstr ""
 
 msgid "row(s)"
+msgstr ""
+
+msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -4868,6 +4868,10 @@ msgstr "Posizione aggiunta!"
 msgid "Location is a plugin that allows your FOG Server"
 msgstr "Luoghi è un plugin che consente al server FOG"
 
+#, fuzzy
+msgid "Location schema"
+msgstr "sedi"
+
 msgid "Location update failed!"
 msgstr "Aggiornamento posizione non riuscito"
 
@@ -10402,6 +10406,9 @@ msgid "register this too, if you enable single logout"
 msgstr ""
 
 msgid "row(s)"
+msgstr ""
+
+msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
 msgid "second"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -4830,6 +4830,10 @@ msgstr "ロケーションを追加しました！"
 msgid "Location is a plugin that allows your FOG Server"
 msgstr "ロケーションは、FOG サーバーで利用できるプラグインです"
 
+#, fuzzy
+msgid "Location schema"
+msgstr "ロケーション"
+
 msgid "Location update failed!"
 msgstr "ロケーションの更新に失敗しました！"
 
@@ -10346,6 +10350,9 @@ msgid "register this too, if you enable single logout"
 msgstr ""
 
 msgid "row(s)"
+msgstr ""
+
+msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
 msgid "second"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -4262,6 +4262,9 @@ msgstr ""
 msgid "Location is a plugin that allows your FOG Server"
 msgstr ""
 
+msgid "Location schema"
+msgstr ""
+
 msgid "Location update failed!"
 msgstr ""
 
@@ -9194,6 +9197,9 @@ msgid "register this too, if you enable single logout"
 msgstr ""
 
 msgid "row(s)"
+msgstr ""
+
+msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
 msgid "second"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -5033,6 +5033,10 @@ msgid "Location is a plugin that allows your FOG Server"
 msgstr ""
 
 #, fuzzy
+msgid "Location schema"
+msgstr "localizações"
+
+#, fuzzy
 msgid "Location update failed!"
 msgstr "atualização Snapin falhou"
 
@@ -10753,6 +10757,9 @@ msgid "register this too, if you enable single logout"
 msgstr ""
 
 msgid "row(s)"
+msgstr ""
+
+msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -5033,6 +5033,10 @@ msgid "Location is a plugin that allows your FOG Server"
 msgstr ""
 
 #, fuzzy
+msgid "Location schema"
+msgstr "位置"
+
+#, fuzzy
 msgid "Location update failed!"
 msgstr "管理单元更新失败"
 
@@ -10753,6 +10757,9 @@ msgid "register this too, if you enable single logout"
 msgstr ""
 
 msgid "row(s)"
+msgstr ""
+
+msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4437');
+        define('FOG_VERSION', '1.6.0-beta.4440');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -108,7 +108,7 @@ class System
         // installer reads this to pick which release to download, so a given
         // FOG release ships a known set of plugins rather than whatever the
         // default branch held on the day someone installed.
-        define('FOG_PLUGINS_VERSION', 'v1.6.18');
+        define('FOG_PLUGINS_VERSION', 'v1.6.19');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already


### PR DESCRIPTION
Bumps `FOG_PLUGINS_VERSION` to [`v1.6.19`](https://github.com/FOGProject/fog-plugins/releases/tag/v1.6.19).

Third and last step of the sequence #1470 opened:

1. #1470 — core gains the `REPORT_TITLE_DATA` event, and `registerReportTable()` gains `fullExport`. **Merged.**
2. [fog-plugins#30](https://github.com/FOGProject/fog-plugins/pull/30) → [v1.6.19](https://github.com/FOGProject/fog-plugins/releases/tag/v1.6.19) — the eight bundled plugin reports name themselves through that event, move from `getList()` to `reportRows()`, and opt into **CSV (All)**. **Merged and released.**
3. This — the pin, which is what makes an install actually fetch it.

## Why the pin is not a formality

ADR 0009 has `bin/fetch-plugins.sh` and `lib/common/config.sh` read this constant to choose the release to download. Until it moves, a fresh install still pulls `v1.6.18`, so the eight reports keep the sidebar labels `ucwords()` derived from their file names — "Ou Report" opening a page headed "Export OUs" — and keep the one-page CSV that #1467 replaced everywhere else.

## Order

Deliberately last. The reverse order — plugins pinned before core carries the seam — leaves those grids **empty**: `sub=exportAll` serves `ReportManagement::reportRows()`, and a core predating #1467 has none.

## Downstream

None. No route class added or removed, so FogApi's hardcoded class list is unaffected.

## Verification

`tests/run-all.sh`: 200 passed, 0 failed. Both phpstan passes clean.
