### PR TITLE
Draw a refused cancel as a failure, not a green success

### DIFF
--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4479');
+        define('FOG_VERSION', '1.6.0-beta.4482');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Router/OpenAPI.php
+++ b/packages/web/src/Router/OpenAPI.php
@@ -1313,12 +1313,7 @@ class OpenAPI extends FOGBase
                     _('Another record still refers to this one and the '
                         . 'database refused the delete. The message names '
                         . 'what is holding it; retry once that is reassigned '
-                        . 'or removed.'),
-                    // `error`, not `msg`: this one is raised as an exception
-                    // and emitted by _sendCaught(), which uses the router's
-                    // error shape. The cancel route builds its 409 by hand
-                    // and keeps `msg`.
-                    'error'
+                        . 'or removed.')
                 )
             );
         }
@@ -2182,13 +2177,14 @@ class OpenAPI extends FOGBase
      * A 409, for a request that is well formed but cannot be applied to the
      * resource in its current state.
      *
-     * Carries the same {msg} object the 200 does, rather than the Error
-     * schema: the reason is written for a person, and the UI reads it with
-     * the same $.notifyFromAPI() call either way.
+     * Carries `{error}`, the shape every non-2xx in the router uses. It is
+     * also the only one $.notifyFromAPI() colors as a failure -- a body
+     * keyed on `msg` is typed as a SUCCESS -- which is why the property is
+     * fixed here rather than left to the caller.
      *
      * Two routes answer it and they conflict for unrelated reasons -- cancel
      * because the task has already finished, delete because a foreign key
-     * still refers to the row (ADR 0031) -- so the description is the
+     * still refers to the row (ADR 0031) -- so the description IS the
      * caller's to supply. Both are retryable once the blocking condition is
      * gone, which is what makes 409 the right code for each.
      *
@@ -2197,7 +2193,7 @@ class OpenAPI extends FOGBase
      *
      * @return array
      */
-    private static function _conflictResponse($description, $property = 'msg')
+    private static function _conflictResponse($description)
     {
         return [
             '409' => [
@@ -2206,7 +2202,7 @@ class OpenAPI extends FOGBase
                     'application/json' => [
                         'schema' => [
                             'type' => 'object',
-                            'properties' => [$property => ['type' => 'string']]
+                            'properties' => ['error' => ['type' => 'string']]
                         ]
                     ]
                 ]

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -5219,13 +5219,21 @@ class Route extends FOGBase
     /**
      * Refuses a cancel the named resource is not in a state to accept.
      *
-     * The body is a JSON object, not the bare reason string the older non-2xx
-     * paths in this class emit. breakHead() has always declared
-     * `Content-Type: application/json` and then echoed whatever it was given,
-     * so those replies claim a type they are not; 409 is a status no caller
-     * receives today, so it can start out matching its own header without
-     * breaking anyone. Same `{"msg": ...}` shape the 200 already uses, which
-     * is what $.notifyFromAPI() reads.
+     * The body is a JSON object keyed on `error`, like every other non-2xx
+     * this class emits since the bare reason strings were retired.
+     *
+     * It used to be `{"msg": ...}`, chosen to match the shape the 200
+     * already used on the reasoning that $.notifyFromAPI() reads it either
+     * way. It does read it -- and then types it as a SUCCESS: `if (res.msg)
+     * { type = 'success'; }`. So a 409 explaining that a task had already
+     * finished drew a GREEN toast, and a caller who asked to cancel nothing
+     * was told it worked. That is the failure this route exists to prevent,
+     * reintroduced one layer further out, and it is the same shape as the
+     * signed-out-save bug in GH-1370.
+     *
+     * `error` is what colors it red. Nothing else reads these two keys
+     * differently, so this is a display fix, not a contract change -- but it
+     * IS visible: the cancel route's refusal toast changes color.
      *
      * @param string $msg Why the resource cannot be canceled.
      *
@@ -5235,7 +5243,7 @@ class Route extends FOGBase
     {
         self::sendResponse(
             HTTPResponseCodes::HTTP_CONFLICT,
-            json_encode(['msg' => $msg])
+            json_encode(['error' => $msg])
         );
     }
     /**

--- a/tests/error-bodies-are-parseable.test.php
+++ b/tests/error-bodies-are-parseable.test.php
@@ -195,4 +195,93 @@ $t->check(
     && false !== strpos((string)($body['error'] ?? ''), 'for key')
 );
 
+/*
+ * A failure must not be keyed on `msg`.
+ *
+ * This is the half that has nothing to do with parsing and everything to do
+ * with what the user is told. $.notifyFromAPI() decides the toast color from
+ * WHICH key the body carries, and its `msg` branch sets `type = 'success'`:
+ *
+ *     if (res.error)   { type = 'error';   msg = res.error; }
+ *     ...
+ *     if (res.msg)     { type = 'success'; msg = res.msg;   }
+ *
+ * So a 4xx answering {"msg": ...} is drawn GREEN. The cancel route did
+ * exactly that: it built its 409 by hand with the same shape the 200 uses,
+ * on the reasoning that notifyFromAPI reads it either way -- true, and it
+ * reads it as a success. A request that canceled nothing reported that it
+ * worked, which is the very failure Route::cancel()'s 409 was added to
+ * prevent (GH-1215), reintroduced one layer out in the display.
+ *
+ * Driven, not grepped: the point is the emitted body, and _notCancellable()
+ * is reached through sendResponse() like everything else here.
+ */
+$notCancellable = static function ($reason) {
+    $m = new \ReflectionMethod('FOG\Router\Route', '_notCancellable');
+    $m->setAccessible(true);
+    try {
+        $m->invoke(null, $reason);
+    } catch (\RuntimeException $r) {
+        return $r;
+    }
+    return null;
+};
+
+$raised = $notCancellable('Host has no active task to cancel');
+$t->check(
+    'a refused cancel still ends the response, with 409',
+    null !== $raised && 409 === $raised->getCode()
+);
+$body = null === $raised ? null : json_decode($raised->getMessage(), true);
+$t->check(
+    'a refused cancel is keyed on `error`, which is what colors it a failure',
+    is_array($body)
+    && ($body['error'] ?? null) === 'Host has no active task to cancel'
+);
+$t->check(
+    'and NOT on `msg`, which notifyFromAPI would draw as a green success',
+    is_array($body) && !isset($body['msg'])
+);
+
+/*
+ * The same rule, over the whole emitted document rather than one route.
+ *
+ * A hand-built response is where this goes wrong -- the generic operations
+ * all funnel through _sendCaught() and cannot -- so the gate has to look at
+ * every error status the spec describes, not at the one route known to have
+ * had the bug. Anything 4xx or 5xx whose schema names `msg` is telling a
+ * client to read a key the UI treats as success.
+ */
+// document() reflects every model's fields, which reads the schema through
+// the DB. Nothing here depends on the rows -- only on the shapes the
+// document declares.
+FogTestHarness::fakeDb();
+
+$doc = \FOG\Router\OpenAPI::document();
+$greenErrors = [];
+foreach (($doc['paths'] ?? []) as $path => $ops) {
+    foreach ((array)$ops as $verb => $op) {
+        if (!is_array($op) || !isset($op['responses'])) {
+            continue;
+        }
+        foreach ($op['responses'] as $status => $resp) {
+            if ((int)$status < 400) {
+                continue;
+            }
+            $props = $resp['content']['application/json']['schema']
+                ['properties'] ?? null;
+            if (is_array($props) && isset($props['msg'])) {
+                $greenErrors[] = strtoupper($verb) . ' ' . $path
+                    . ' -> ' . $status;
+            }
+        }
+    }
+}
+$t->check(
+    'no error response in the document is keyed on `msg` ('
+    . (count($greenErrors) ? implode('; ', array_slice($greenErrors, 0, 4)) : 'none')
+    . ')',
+    $greenErrors === []
+);
+
 $t->finish();


### PR DESCRIPTION
The last of the two items left open by #1475.

## The bug

`Route::_notCancellable()` built its 409 by hand as `{"msg": …}`, matching the shape the 200 uses, on the stated reasoning that `$.notifyFromAPI()` reads it either way. It does read it — and then types it as a **success**:

```js
if (res.error) { type = 'error';   msg = res.error; }
...
if (res.msg)   { type = 'success'; msg = res.msg;   }
```

So a 409 reading *"Host has no active task to cancel"* drew a **green** toast, and a caller who cancelled nothing was told it worked.

That is precisely the failure the 409 was added for in #1215 — a route reporting success it did not perform — reintroduced one layer further out, in the display rather than the router. Same shape as the signed-out-save bug in GH-1370.

## The fix

`error` is what colors it red, and it is what every other non-2xx in the router emits since #1475 retired the bare reason strings. Nothing reads the two keys differently otherwise, so this is a display fix rather than a contract change — but it **is** user-visible: the cancel refusal toast changes color, which is the entire point.

`OpenAPI::_conflictResponse()` loses its `$property` parameter. That parameter existed only because cancel was the odd one out; with both callers on `error` the property is fixed in the helper, where the comment can say *why* — it is not a stylistic choice, it is the only key the UI treats as a failure. The delete call site drops its argument and its explanatory comment with it, so this change makes the code smaller.

## Verification

Four checks added to `tests/error-bodies-are-parseable.test.php`, driven through `sendResponse()` rather than grepped.

The last one is the one that generalizes: it walks the **emitted document** and fails if any 4xx or 5xx response anywhere declares a schema keyed on `msg`. A hand-built response is where this goes wrong — the generic operations funnel through `_sendCaught()` and cannot — so the gate covers every error status the spec describes, not just the one route known to have had the bug.

Three mutations, all killing the suite: reverting the body to `msg`, declaring `msg` in the document, dropping the 409 status.

204/204 tests, both phpstan passes clean.