### PR TITLE
Sweep honour to honor, and give the gate the word

### DIFF
--- a/bin/prefix-global-classes.php
+++ b/bin/prefix-global-classes.php
@@ -75,7 +75,7 @@ function collectFiles($root, array $paths)
         // checked, and a bare listing cannot see it. That gap let a new test
         // file ship a bare ReflectionClass -- green locally, red the moment
         // the merge made it tracked. --exclude-standard keeps .gitignore
-        // honoured, so vendor/ and lib/plugins stay out.
+        // honored, so vendor/ and lib/plugins stay out.
         $out = [];
         exec(
             'git -C ' . escapeshellarg($root)

--- a/docs/HTTPPROTO_COVERAGE_AUDIT.md
+++ b/docs/HTTPPROTO_COVERAGE_AUDIT.md
@@ -1,6 +1,6 @@
 # `WEB_url_proto` coverage audit, and the conditional HTTPS redirect
 
-> **Headline:** `WEB_url_proto` is honoured by every URL the installer emits, so
+> **Headline:** `WEB_url_proto` is honored by every URL the installer emits, so
 > redefining it as *"the protocol FOG uses for its own **non-netboot** URLs"* is
 > safe on the installer side. It is **not** safe yet on three other fronts:
 > three sites still gate the iPXE download, the Secure Boot staging and the
@@ -297,7 +297,7 @@ installer settings work.
 
 Point-in-time, against `working-1.6` as of 2026-08-17. Line numbers drift.
 
-## B1. Item 1 — does everything honour `httpproto`?
+## B1. Item 1 — does everything honor `httpproto`?
 
 **Installer: yes, with three exceptions.** Every `curl` to FOG's own web tier
 builds its URL from `$httpproto` — node existence probe (`functions.sh:480`),

--- a/docs/adr/0017-hook-dispatch-contract.md
+++ b/docs/adr/0017-hook-dispatch-contract.md
@@ -73,7 +73,7 @@ above it was *active*. At dispatch, any listener whose file path contained the
 substring `plugins` was force-activated regardless of its flag.
 
 A value computed in a constructor is deliberately still not consulted at load —
-that was true of the regex too — but it *is* honoured at dispatch, which is why
+that was true of the regex too — but it *is* honored at dispatch, which is why
 the dispatch-time read stays rather than gating construction on the flag.
 
 ### 3. A plugin's file path is not part of the activation decision

--- a/docs/adr/0018-netboot-addresses-this-server-by-its-certificate-name.md
+++ b/docs/adr/0018-netboot-addresses-this-server-by-its-certificate-name.md
@@ -61,7 +61,7 @@ second call.
    same value the self-calls verify against.
 2. It is then **checked against that certificate** by `_certServesName()`, which
    applies *iPXE's* rule rather than OpenSSL's: per ADR 0016, iPXE's
-   `x509_check_name()` honours a `commonName` only when the certificate carries
+   `x509_check_name()` honors a `commonName` only when the certificate carries
    no `subjectAltName` at all. Once any SAN exists the CN is ignored. IP SANs are
    ignored throughout — they cannot satisfy a URL built from a name.
 3. A failure to satisfy this is **fatal, before anything is written**. An install
@@ -99,7 +99,7 @@ netboot is HTTPS.
   message. It only feeds FOG's own SAN list, and the branch fires mostly on
   installs whose leaf FOG did not issue.
 - A wildcard-only match is accepted **with a printed note**, because whether
-  iPXE's `x509_check_name()` honours a wildcard SAN is unverified — `fog-ipxe`
+  iPXE's `x509_check_name()` honors a wildcard SAN is unverified — `fog-ipxe`
   is an overlay and carries no upstream `crypto/x509.c` to read. Verify against
   upstream and tighten or relax then.
 - `tests/netboot-host.test.sh` pins all of it, including the case most likely to

--- a/docs/adr/0020-event-logs-share-a-record-shape-not-a-table.md
+++ b/docs/adr/0020-event-logs-share-a-record-shape-not-a-table.md
@@ -562,7 +562,7 @@ relies on, and left the host name with nowhere to go.
 
 Three policies are defensible; three policies chosen by accident are not. Each
 event model declares which it is, and `Route::deletemass()` is the one place it
-is honoured:
+is honored:
 
 - **cascade** — the rows go with the subject (`nfsFailures`; arguably
   `imagingLog`, which the span ADR should settle).

--- a/docs/nodecert-test-results.md
+++ b/docs/nodecert-test-results.md
@@ -151,7 +151,7 @@ have helped. Three changes:
 
 - the installer derives a name from `hostname -f` (not `$hostname`, which a
   `.fogsettings`-seeded node install never has — that path skips `input.sh`);
-- `create_update_node.php` honours it, but only when it is a real hostname and
+- `create_update_node.php` honors it, but only when it is a real hostname and
   is not already taken. `ngmMemberName` is UNIQUE and `FOGController::save()`
   inserts with `ON DUPLICATE KEY UPDATE`, so an unchecked name collision would
   silently rewrite the other node's row rather than fail — and hostnames are not

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -73,7 +73,7 @@ linkIfAbsent() {
 #
 # WHY THIS DIRECTION, given GH-1012 deliberately chose stable/staging/dev to
 # match README.md's table. That decision was "match README", not "these three
-# words are fixed", so changing README honours it rather than reversing it. And
+# words are fixed", so changing README honors it rather than reversing it. And
 # FOG_CHANNEL was already the more accurate half: dev-branch really is the
 # 1.5.x PATCHES line rather than anything staged for stable, and working-1.6
 # really is the 1.6 BETA. Worse, `dev` pointed at working-1.6 while a branch
@@ -4050,7 +4050,7 @@ configureFirewall() {
     # Runs late, unlike the checkFirewall() it replaces, for two reasons
     # that both used to be broken:
     #   - .fogsettings is not sourced until after the old call site, so a
-    #     remembered choice could not be honoured. An admin who said "leave
+    #     remembered choice could not be honored. An admin who said "leave
     #     my firewall alone" got re-asked, or under -y re-ignored, on every
     #     single upgrade.
     #   - the port set depends on what was actually installed (${DHCP_enabled},
@@ -5649,7 +5649,7 @@ _certDnsNames() {
 # and iPXE matches addresses and names separately anyway.
 #
 # Echoes "exact" or "wildcard" and returns 0 on a match; echoes nothing and
-# returns 1 otherwise. The two are distinguished because whether iPXE honours a
+# returns 1 otherwise. The two are distinguished because whether iPXE honors a
 # wildcard SAN is UNVERIFIED -- fog-ipxe is an overlay and carries no upstream
 # crypto/x509.c to read -- so the caller reports a wildcard match rather than
 # trusting it silently.
@@ -5754,7 +5754,7 @@ _resolveNetbootHost() {
     if [[ $match == wildcard ]]; then
         echo
         echo "   Note: $netboothost matches only a WILDCARD name in the served"
-        echo "   certificate. Whether iPXE honours a wildcard SAN is unverified,"
+        echo "   certificate. Whether iPXE honors a wildcard SAN is unverified,"
         echo "   so if netboot stops at the TLS handshake, re-issue with"
         echo "   $netboothost as an explicit name."
         echo
@@ -7866,7 +7866,7 @@ _applyInstallMode() {
 }
 _resolveNetbootProto() {
     # An explicit --netboot-proto wins, and is REMEMBERED as explicit so a later
-    # run without the flag goes on honouring it.
+    # run without the flag goes on honoring it.
     #
     # That marker is the fix. This used to return early on any non-empty
     # ${BOOT_url_proto} -- and ${BOOT_url_proto} is persisted, so a value this function
@@ -13491,7 +13491,7 @@ _publishLocalBootFiles() {
 #
 # _resignKernels() covers the three names FOG downloads -- bzImage, bzImage32,
 # arm_Image -- and nothing else. But a kernel reaching a client does not have to
-# be one of those: bootmenu.class.php honours a per-host hostKernel/hostInit
+# be one of those: bootmenu.class.php honors a per-host hostKernel/hostInit
 # override, groups set the same fields, and FOG_TFTP_PXE_KERNEL/_32/_ARM change
 # the default globally. Any of those boots a file this server has never signed,
 # which under Secure Boot fails exactly like the unsigned rEFInd did -- only at

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -5047,7 +5047,7 @@ $this->schema[] = [
     // The plugin roots are fixed in code instead (BASEPATH/lib/plugins,
     // plus FOG_PLUGIN_DIR for third-party plugins -- see ADR 0009).
     // FOG_PLUGINSYS_ENABLED is deliberately NOT touched: that one is a real
-    // on/off switch getActivePlugins() still honours.
+    // on/off switch getActivePlugins() still honors.
     "DELETE FROM `globalSettings` WHERE `settingKey` = 'FOG_PLUGINSYS_DIR'",
 ];
 // 327
@@ -5194,7 +5194,7 @@ $this->schema[] = [
     // number of NULLs in a UNIQUE index but only one of a given value,
     // so at most one row can ever carry the marker.
     //
-    // Consequence a writer MUST honour: a site that is not the catch-all
+    // Consequence a writer MUST honor: a site that is not the catch-all
     // stores NULL, never 0. 0 is a value like any other, so the second
     // site to store it collides -- and under FOGController::save() that
     // collision is NOT an error. save() builds INSERT ... ON DUPLICATE KEY
@@ -6237,7 +6237,7 @@ $this->schema[] = [
     // Each column lands on its FIRST member, which is what save() now writes
     // for an empty value and what MySQL uses as a NOT NULL enum's implicit
     // default. Deliberately not the column's declared DEFAULT: `hostEnforce`
-    // declares DEFAULT '1', so honouring it here would silently turn
+    // declares DEFAULT '1', so honoring it here would silently turn
     // enforcement ON for 73 hosts as a side effect of a storage repair. '' and
     // '0' are both falsey in PHP, so every consumer sees what it saw before.
     //

--- a/packages/web/lib/pages/pluginmanagement.page.php
+++ b/packages/web/lib/pages/pluginmanagement.page.php
@@ -59,7 +59,7 @@ class PluginManagement extends FOGPage
         // Percentages, not content-driven widths. Without them the browser
         // sizes columns to their longest cell, and Description -- a full
         // sentence next to four short values -- took most of the table while
-        // Plugin Name wrapped. These proportions are only honoured because
+        // Plugin Name wrapped. These proportions are only honored because
         // the table carries .fog-table-fixed (see fog.plugin.list.js), which
         // switches it to a fixed layout.
         $this->attributes = [

--- a/packages/web/lib/pages/usermanagement.page.php
+++ b/packages/web/lib/pages/usermanagement.page.php
@@ -544,7 +544,7 @@ class UserManagement extends FOGPage
              * that provider works, and core cannot tell which kind this is:
              * a provider that vouches through USER_LOGGING_IN (LDAP) is
              * refused once the stamp is gone, because passwordValidate()
-             * honours that vouching ONLY for stamped accounts -- that
+             * honors that vouching ONLY for stamped accounts -- that
              * restriction is what stops a plugin authenticating a local
              * account. A provider that establishes the session itself
              * (OIDC) never reaches passwordValidate() and is unaffected.

--- a/packages/web/management/js/fog/plugin/fog.plugin.list.js
+++ b/packages/web/management/js/fog/plugin/fog.plugin.list.js
@@ -40,7 +40,7 @@
     // Fixed layout, clipping and column resizing all come from registerTable()
     // now -- every list page gets them, so there is nothing to set up here.
     // This page's header widths (18/32/10/20/10/10, set in
-    // pluginmanagement.page) are what the fixed layout then honours, instead
+    // pluginmanagement.page) are what the fixed layout then honors, instead
     // of the longest Description dictating the whole table.
     var table = $('#dataTable').registerTable(onSelect, {
         // This list has only six short columns and a small, fixed row set,

--- a/packages/web/management/js/fog/report/fog.report.file.js
+++ b/packages/web/management/js/fog/report/fog.report.file.js
@@ -182,7 +182,7 @@
     case 'product keys':
       // Keys are masked by default (5x5 with the middle three groups
       // bulleted). The reveal button flips this closure flag and redraws;
-      // both the column and the row-group header honour it. The full key is
+      // both the column and the row-group header honor it. The full key is
       // still present in the JSON payload, so this guards shoulder-surfing,
       // not a determined viewer.
       var revealKeys = false;

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -7158,7 +7158,7 @@ msgstr "Zeile"
 msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
 msgstr ""
 
-msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
+msgid "Row offset. Only honored when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -7155,7 +7155,7 @@ msgstr "Row"
 msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
 msgstr ""
 
-msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
+msgid "Row offset. Only honored when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -7301,7 +7301,7 @@ msgstr "Fila"
 msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
 msgstr ""
 
-msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
+msgid "Row offset. Only honored when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -7159,7 +7159,7 @@ msgstr "Zeile"
 msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
 msgstr ""
 
-msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
+msgid "Row offset. Only honored when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -7157,7 +7157,7 @@ msgstr "Rangée"
 msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
 msgstr ""
 
-msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
+msgid "Row offset. Only honored when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -6939,7 +6939,7 @@ msgstr "Riga"
 msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
 msgstr ""
 
-msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
+msgid "Row offset. Only honored when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -6897,7 +6897,7 @@ msgstr "行"
 msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
 msgstr ""
 
-msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
+msgid "Row offset. Only honored when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -6085,7 +6085,7 @@ msgstr ""
 msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
 msgstr ""
 
-msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
+msgid "Row offset. Only honored when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
 msgid "Rows in this page."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -7156,7 +7156,7 @@ msgstr "Linha"
 msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
 msgstr ""
 
-msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
+msgid "Row offset. Only honored when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -7156,7 +7156,7 @@ msgstr "行"
 msgid "Row cap applied to a list request that omits start, asks for length=-1, or sends a negative length. An explicit non-negative start with a positive length is served verbatim."
 msgstr ""
 
-msgid "Row offset. Only honoured when length is also sent -- the server reads start from inside the length branch."
+msgid "Row offset. Only honored when length is also sent -- the server reads start from inside the length branch."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/login.php
+++ b/packages/web/management/login.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
  *
  *     https://<fog>/fog/management/login.php
  *
- * The guarantee is STRUCTURAL, not a flag somebody remembers to honour.
+ * The guarantee is STRUCTURAL, not a flag somebody remembers to honor.
  * index.php only offers the LOGIN_PAGE_REDIRECT hook when this constant is
  * absent, so a redirect listener is not consulted-and-overruled here -- it is
  * never reached. A plugin cannot opt back in, and a plugin that is broken,

--- a/packages/web/src/Auth/Authorization.php
+++ b/packages/web/src/Auth/Authorization.php
@@ -2248,7 +2248,7 @@ class Authorization extends FOGBase
      * scalar filter value into a SQL LIKE wildcard. This is a query whose
      * wrong answer unlocks -- or bricks -- the install, so it owns its SQL.
      *
-     * @param array $changes the proposed changes; 'authSources' is honoured
+     * @param array $changes the proposed changes; 'authSources' is honored
      *
      * @return array user ids
      */
@@ -2304,7 +2304,7 @@ class Authorization extends FOGBase
      * bricked, so it owns its SQL rather than inheriting the query
      * builder's wildcard handling.
      *
-     * @param array $changes the proposed changes; 'apiOnly' is honoured
+     * @param array $changes the proposed changes; 'apiOnly' is honored
      *
      * @return array user ids
      */

--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -5401,7 +5401,7 @@ abstract class FOGBase
      * The integer and enum choices deliberately match the coercion rather
      * than the column's DEFAULT. `hosts.hostEnforce` is declared
      * DEFAULT '1' and 73 of 86 rows on the maintainer's server hold '' --
-     * so honouring the default would silently turn enforcement ON for those
+     * so honoring the default would silently turn enforcement ON for those
      * hosts as a side effect of a storage fix. '' and '0' are both falsey in
      * PHP, so the first enum member behaves as the error value already did.
      *

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -5998,7 +5998,7 @@ abstract class FOGPage extends FOGBase
      * Unlike getExportList(), which pages for the on-screen table, this
      * replays the DataTables request (sent on the query string) with no row
      * limit, so every matching record is written. The active search and sort
-     * are honoured because the request is passed straight to
+     * are honored because the request is passed straight to
      * FOGManagerController::simple(); forcing length=-1 drops the SQL LIMIT.
      *
      * The header row uses the friendly column keys, which are exactly the

--- a/packages/web/src/Base/FOGPagePost.php
+++ b/packages/web/src/Base/FOGPagePost.php
@@ -350,7 +350,7 @@ trait FOGPagePost
     /**
      * Handles a standard association add/remove POST: reads the additems /
      * remitems arrays and dispatches them to the object's add/remove methods.
-     * When $orderMethod is supplied, also honours a snapinorder array (used by
+     * When $orderMethod is supplied, also honors a snapinorder array (used by
      * the group/host snapin tabs to persist execution order).
      *
      * @param string $addMethod    obj method to add associations (e.g. 'addGroup')

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4482');
+        define('FOG_VERSION', '1.6.0-beta.4487');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Boot/IpxeBootMenu.php
+++ b/packages/web/src/Boot/IpxeBootMenu.php
@@ -418,7 +418,7 @@ class IpxeBootMenu extends BootMenuBase
             return $override;
         }
         // Say so on screen rather than just ignoring it: from the operator's
-        // side an ignored override and an honoured one look identical, and
+        // side an ignored override and an honored one look identical, and
         // the machine that is misconfigured is the one that needs telling.
         $this->_notices[] = sprintf(
             'echo Ignoring host %s %s -- this machine is %s. Using %s.',
@@ -875,7 +875,7 @@ class IpxeBootMenu extends BootMenuBase
          * had just been chosen.
          *
          * Say so on screen rather than just ignoring it: from the operator's
-         * side an ignored override and an honoured one look identical, and
+         * side an ignored override and an honored one look identical, and
          * the machine that is misconfigured is the one that needs telling.
          */
         $bzImage = $this->_hostOverride('kernel', $bzImage);
@@ -919,7 +919,7 @@ class IpxeBootMenu extends BootMenuBase
          * reference, and this used to reassign $initrd = $imagefile
          * unconditionally -- so a plugin that set 'initrd' had its value
          * discarded on the very next line, while one that set 'imagefile'
-         * was honoured. Nothing said which of the two to write to, and
+         * was honored. Nothing said which of the two to write to, and
          * the one named after the thing being chosen was the dead one.
          *
          * Follow 'imagefile' only when the hook left 'initrd' alone, so

--- a/packages/web/src/Items/User.php
+++ b/packages/web/src/Items/User.php
@@ -237,7 +237,7 @@ class User extends FOGController
         // "this person is who they claim" and its only option was to write
         // the directory password into uPass so the compare below would pass
         // -- which is why FOG has been storing bcrypt hashes of live AD
-        // passwords. It is honoured ONLY for accounts carrying an
+        // passwords. It is honored ONLY for accounts carrying an
         // authsource stamp, so it can never be used to bypass the password
         // of a local account.
         $authenticated = false;

--- a/packages/web/src/Net/FOGURLRequests.php
+++ b/packages/web/src/Net/FOGURLRequests.php
@@ -848,7 +848,7 @@ class FOGURLRequests extends FOGBase
             $timeout = 1;
         }
         // When no port is passed the probe falls back to the ssh port, so it
-        // has to honour FOG_SSH_PORT the same way FOGSSH::connect() does.
+        // has to honor FOG_SSH_PORT the same way FOGSSH::connect() does.
         // Assuming 22 made every node look offline on installs that moved ssh
         // (forums 18210). Only looked up when it can actually be needed.
         $sshPort = 0;

--- a/packages/web/src/Router/OpenAPI.php
+++ b/packages/web/src/Router/OpenAPI.php
@@ -528,7 +528,7 @@ class OpenAPI extends FOGBase
      * An entity whose model has no `name` field has nothing to match on and
      * nothing to label a result with, so Route::_searchRows() returns null
      * for it and the route answers an empty set. Documenting search there
-     * advertises an operation the server cannot honour.
+     * advertises an operation the server cannot honor.
      *
      * The test is deliberately the same isset() Route::_searchRows()
      * applies, against the same reflected $databaseFields, rather than a
@@ -2838,7 +2838,7 @@ class OpenAPI extends FOGBase
                 'required' => false,
                 'schema' => ['type' => 'integer', 'minimum' => 0],
                 'description' => _(
-                    'Row offset. Only honoured when length is also sent -- the '
+                    'Row offset. Only honored when length is also sent -- the '
                     . 'server reads start from inside the length branch.'
                 )
             ],

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -4707,7 +4707,7 @@ class Route extends FOGBase
                             isset($vars->macs) ? (array)$vars->macs : []
                         );
                     }
-                    // edit() honours 'primac' but create() did not, and 'primac'
+                    // edit() honors 'primac' but create() did not, and 'primac'
                     // is an additionalFields entry derived from the
                     // MACAddressAssociation join rather than a real column, so
                     // the databaseFields loop above skips it too. The result was

--- a/packages/web/src/Service/FOGService.php
+++ b/packages/web/src/Service/FOGService.php
@@ -892,7 +892,7 @@ abstract class FOGService extends FOGBase
      * The replication script passed to `lftp -e` is parsed by lftp, not by
      * a shell, so shell escaping is the wrong tool for it (and was actively
      * harmful -- see replicate_items). lftp treats a double-quoted string as
-     * one word and honours backslash escapes inside it, so escaping the
+     * one word and honors backslash escapes inside it, so escaping the
      * backslash and the double quote is sufficient to keep a path with
      * spaces, quotes or metacharacters from splitting into extra lftp
      * commands. Introduced with GHSA-2hqx-5ffg-w4c3.

--- a/packages/web/src/Service/MulticastTask.php
+++ b/packages/web/src/Service/MulticastTask.php
@@ -72,7 +72,7 @@ class MulticastTask extends FOGService
         // written onto every session as msInterface and then dropped -- so
         // it has been free to drift since install time with no feedback.
         // The reference server has 'enp0s31f6' recorded for a node whose
-        // address lives on 'eno2'; honouring it outright would have broken
+        // address lives on 'eno2'; honoring it outright would have broken
         // multicast on installs that work today. A field nothing reads is a
         // field nobody maintains, so it is demoted to a fallback for the
         // case the routing lookup genuinely cannot answer -- a VIP, a bond,

--- a/tests/api-only-users.test.php
+++ b/tests/api-only-users.test.php
@@ -200,7 +200,7 @@ $t->check(
     )
 );
 $t->check(
-    'adminExistsGiven() honours interactiveOnly',
+    'adminExistsGiven() honors interactiveOnly',
     (bool)preg_match(
         "/if \(!empty\(\\\$changes\['interactiveOnly'\]\)\) \{\s*"
         . "\\\$users = array_diff\(\\\$users, self::_apiOnlyUsers\(\\\$changes\)\);/s",

--- a/tests/apitoken-grid-and-scope.test.php
+++ b/tests/apitoken-grid-and-scope.test.php
@@ -225,7 +225,7 @@ $t->check(
 // 'about' and 'user' -- so without the override the confirm button offers to
 // delete "1 abouts" or "1 users".
 $t->check(
-    '$.reAuth honours an explicit modal, button and noun',
+    '$.reAuth honors an explicit modal, button and noun',
     (bool)preg_match(
         '/\$\.reAuth = function\(count, cb, opts\)/',
         $common

--- a/tests/list-filter-is-documented.test.php
+++ b/tests/list-filter-is-documented.test.php
@@ -207,7 +207,7 @@ foreach ((array)FOG\Router\Route::$validClasses as $class) {
             $missing[] = $path;
         }
     }
-    // search() cannot honour a filter -- it passes its matched ids down as
+    // search() cannot honor a filter -- it passes its matched ids down as
     // a non-empty array, which the guard above deliberately protects. So
     // advertising one there would recreate the exact defect being fixed.
     foreach ((array)$doc['paths'] as $path => $item) {
@@ -229,7 +229,7 @@ $t->check(
     count($missing) < 1
 );
 $t->check(
-    'no search operation advertises a filter it cannot honour',
+    'no search operation advertises a filter it cannot honor',
     count($searchWithFilter) < 1
 );
 

--- a/tests/lowercase-class-filenames.test.php
+++ b/tests/lowercase-class-filenames.test.php
@@ -20,7 +20,7 @@
  * FOGPageRender.class.php and UserGroupManagement.page.php got in.
  *
  * Case is irrelevant to resolution either way -- the autoloader lowercases
- * both sides -- so this costs nothing to honour.
+ * both sides -- so this costs nothing to honor.
  *
  * Scope note: PSR-4 files under packages/web/src/ and packages/web/vendor/
  * are `Foo.php`, not `Foo.class.php`, so they match none of these suffixes

--- a/tests/management-url-report.test.sh
+++ b/tests/management-url-report.test.sh
@@ -106,7 +106,7 @@ is "$(grep -c "10.0.0.10/fog/management" <<<"$out")" "1" "http, no name: one add
 hasnt "$out" "certificate" "http, no name: no certificate wording"
 
 echo
-echo "A non-default webroot is honoured"
+echo "A non-default webroot is honored"
 WEB_root="/"
 out=$(emit https "fog.example.com")
 has "$out" "https://fog.example.com/management" "webroot / gives a single slash"

--- a/tests/netboot-host.test.sh
+++ b/tests/netboot-host.test.sh
@@ -27,7 +27,7 @@
 # The properties pinned here, in the order they are easiest to break again:
 #
 #   1. the name comes from the CERTIFICATE, not from ${NET_hostname} (A2, I);
-#   2. a commonName is honoured only when there is no subjectAltName at all,
+#   2. a commonName is honored only when there is no subjectAltName at all,
 #      which is iPXE's own rule -- see docs/adr/0016 (D, E). E is the one most
 #      likely to be "simplified" by someone who reads D;
 #   3. an install that cannot satisfy this FAILS rather than writing an
@@ -102,7 +102,7 @@ reset_env() {
     tftpdirdst="$WORK/tftp"
     error_log="$WORK/error.log"
     # Without this the fatal paths call `exit 1` and take the test script with
-    # them. functions.sh honours it on every one of them.
+    # them. functions.sh honors it on every one of them.
     exitFail=1
 }
 
@@ -119,7 +119,7 @@ out=$(_certServesName "$WORK/fogpki.pem" "fog"); status=$?
 check "$out" "exact" "C: the short name DOES match a FOG-issued leaf (it is a SAN)"
 
 out=$(_certServesName "$WORK/cnonly.pem" "fog.example.org"); status=$?
-check "$out" "exact" "D: with no SAN at all, the commonName is honoured (ADR 0016)"
+check "$out" "exact" "D: with no SAN at all, the commonName is honored (ADR 0016)"
 
 out=$(_certServesName "$WORK/cnliar.pem" "fog"); status=$?
 rc $status 1 "E: once ANY SAN exists the commonName is ignored -- do not 'simplify' this"

--- a/tests/null-tasks-cannot-be-created-or-stranded.test.php
+++ b/tests/null-tasks-cannot-be-created-or-stranded.test.php
@@ -138,7 +138,7 @@ check(
     $checks
 );
 check(
-    'it honours the model\'s $databaseFieldsNotInt opt-out',
+    'it honors the model\'s $databaseFieldsNotInt opt-out',
     false !== strpos($guard, '$this->databaseFieldsNotInt'),
     $failures,
     $checks

--- a/tests/permission-purge-guard.test.php
+++ b/tests/permission-purge-guard.test.php
@@ -10,7 +10,7 @@
  * Those two are the same thing right up until a capability moves out of a
  * plugin and into core -- at which point the node stays in the registry,
  * owned by core, while a plugin of that name is still installed. Uninstalling
- * the leftover then deletes grants that core is still honouring, and nothing
+ * the leftover then deletes grants that core is still honoring, and nothing
  * anywhere says so: no error, no log line, just users who quietly lost
  * access. That is the failure this test exists to make impossible.
  *

--- a/tests/route-read-path-guards.test.php
+++ b/tests/route-read-path-guards.test.php
@@ -119,7 +119,7 @@ function runChild($case)
 
     // A DataTables column search against a stripped column must not reach the
     // WHERE clause. listem() marks those columns 'nosearch' after
-    // CUSTOMIZE_DT_COLUMNS; FOGManagerController::filter() is what honours it.
+    // CUSTOMIZE_DT_COLUMNS; FOGManagerController::filter() is what honors it.
     // Asserted on the SQL because that is the only place the marking becomes
     // observable -- $columns never leaves listem().
     if ('nosearch' === $case) {

--- a/tests/secureboot-authvars.test.sh
+++ b/tests/secureboot-authvars.test.sh
@@ -193,7 +193,7 @@ else
     bad "6. a failed build left blobs behind in the output directory"
 fi
 
-# --- 7. an incomplete config is refused, not half-honoured ---
+# --- 7. an incomplete config is refused, not half-honored ---
 write_conf
 sed -i '/^SECUREBOOT_PK_KEY=/d' "$WORK/conf"
 if run_builder; then

--- a/tests/selfcall-verification.test.sh
+++ b/tests/selfcall-verification.test.sh
@@ -187,7 +187,7 @@ fi
 # N. No self-addressed call may be sent to a proxy.
 #
 # A FOG server behind corporate egress filtering has http_proxy/https_proxy in
-# root's environment, and curl honours them for every host that is not in
+# root's environment, and curl honors them for every host that is not in
 # no_proxy -- including the server's own name and its own LAN address. The
 # request then goes to the proxy, which either cannot route back or refuses to
 # CONNECT. Observed on backupDB() as

--- a/tests/sensitive-fields-unfilterable.test.php
+++ b/tests/sensitive-fields-unfilterable.test.php
@@ -112,7 +112,7 @@ if (null === $assert) {
         . 'for';
 }
 
-// 4. The grid path marks those columns unsearchable, and filter() honours it.
+// 4. The grid path marks those columns unsearchable, and filter() honors it.
 //    Not removed from the column list: listem() is shared with the web tier
 //    and product_keys.report.php needs productKey to report anything.
 $checks++;
@@ -133,9 +133,9 @@ if (null === $filter) {
     // on the isset(), which appears exactly once per guard -- the guard
     // names $column['nosearch'] twice, so counting that would still pass
     // with one whole loop unguarded.
-    $honoured = substr_count($filter, "isset(\$column['nosearch'])");
-    if ($honoured < 2) {
-        $failures[] = "filter() honours nosearch in $honoured of its 2 "
+    $honored = substr_count($filter, "isset(\$column['nosearch'])");
+    if ($honored < 2) {
+        $failures[] = "filter() honors nosearch in $honored of its 2 "
             . 'search loops. Both build a LIKE from a client-named column, '
             . 'so a gap in either one reopens the whole thing.';
     }

--- a/tests/us-spelling.test.php
+++ b/tests/us-spelling.test.php
@@ -126,6 +126,7 @@ $uk = [
     'signalling', 'modelled', 'travelled',
     'catalogue', 'licence', 'centre', 'centres',
     'neighbour', 'neighbours', 'neighbouring',
+    'honour', 'honours', 'honoured', 'honouring',
     'initialise', 'initialised', 'initialises', 'initialisation', 'initialiser',
     'authorise', 'authorised', 'authorises', 'authorisation',
     'serialise', 'serialised', 'serialises', 'serialising',


### PR DESCRIPTION
The second of the two items left open by #1475.

`tests/us-spelling.test.php` had no entry for this word — which is the only reason **55 occurrences across 36 files** survived a gate whose entire job is to catch them.

Both halves are in one commit deliberately: adding the word without the sweep fails the build, and the sweep without the word leaves nothing stopping the next one.

## Read, not blanket-sed

`~/.claude/CLAUDE.md` exempts quoted strings a machine reads, existing identifiers, and upstream text — so every hit was checked. Three needed real scrutiny and all three turned out safe:

- `tests/netboot-host.test.sh:122` sits inside `check "$out" "exact" "<label>"`. The **third** argument is the label and the **second** is the expected value, so the word is never compared against anything.
- `tests/management-url-report.test.sh:109` is a section-header `echo`, not consumed by any assertion.
- `tests/sensitive-fields-unfilterable.test.php` had `$honoured` as a **local variable**, renamed along with its string interpolation. Nothing outside that function reads it — it is not an API field, a column, or a settings key, which is what the identifier exemption actually protects.

Everything else is prose in comments, docblocks, ADRs and test labels.

My own changes are **56 insertions against 55 deletions** — the 55 spelling lines, plus the one line added to the word list. A `git diff` filtered to lines not containing a `honor` variant returns only that added entry.

The PR diff now reads 48 files / 67 insertions / 66 deletions because `gh pr update-branch` brought the base forward: the extra eleven files are all bot-generated — `FOG_VERSION` (`1.6.0-beta.4482` → `1.6.0-beta.4487`) from the version-sync bot, and the `messages.pot` / `.po` regeneration from the pre-commit hook.

## Proven by mutation

A gate that has only ever been green is a gate nobody has evidence about:

| Mutation | Result |
|---|---|
| Reintroduce one `honours` in a PHP source file | **red** |
| Reintroduce one `honoured` in `docs/adr/` | **red** (docs are in `$scope`) |
| Delete the word from `$uk`, keep the bad spelling | both stop being detected |

That last one is what shows the added word is doing the work rather than something else catching it incidentally.

204/204 tests, both phpstan passes clean.
