### PR TITLE
Say what the constraint work actually landed, and gate the count

### DIFF
--- a/docs/adr/0031-referential-integrity-is-declared-in-the-database.md
+++ b/docs/adr/0031-referential-integrity-is-declared-in-the-database.md
@@ -2,15 +2,29 @@
 
 ## Status
 
-accepted -- steps 0 through 5 implemented on `working-1.6`: the machinery,
-schema 380 (column widening), schema 381 (the orphan sweep), schema 382
-(host-owned junctions and satellites, 14 constraints), schema 383 (identity:
-users, roles, user groups and sites, 21) and schema 384 (storage: groups,
-nodes, image and snapin assoc, 5). 40 of 87 declared; the remaining 47 still
-ship disabled and land group by group.
+accepted, and implemented in full. Core landed on `working-1.6` as schema
+380 through 390: the machinery, 380 (column widening), 381 (the orphan
+sweep), 382 (host-owned junctions and satellites, 14 constraints), 383
+(identity: users, roles, user groups and sites, 21), 384 (storage junctions,
+5), 385 (retiring one of those five, whose action the map had since
+corrected), 386 (the `0` sentinel becomes NULL), 387 (a sweep for the one
+group 5 relationship that becomes a CASCADE), 388 (configuration references,
+12), 389 (a repair for the four rows group 6 cannot be declared over) and 390
+(tasks and work, 16). The five plugin groups -- location 4, ou 2, windowskey
+2, ldap 6, oidc 8 -- are declared in core's map and applied by a step in each
+plugin's own `schema()` in `FOGProject/fog-plugins`.
 
-The planned step 6 -- `deletemass()` gaining `storagegroup`/`storagenode`
-cases -- was dropped after step 5 measured it as unnecessary: the database
+**89 of the map's 105 relationships are declared.** The other 16 are not
+pending work: they carry action `none`, which the map's docblock defines as a
+decision rather than an omission. Nine are audit rows, which MUST NOT
+constrain the thing they record (ADR 0021, `schema.php` step 341); seven are
+polymorphic columns whose target table is chosen by a sibling column, where
+no constraint is expressible at all. Nothing in the map is waiting on a
+future step.
+
+The plan's step 6 -- `deletemass()` gaining `storagegroup`/`storagenode`
+cases -- was dropped after its step 5 (schema 384) measured it as
+unnecessary: the database
 now cascades everything such a case would delete, and a storage node has no
 CASCADE children at all. Sequencing 5 before 6 was what made that a
 measurement rather than a guess.

--- a/docs/development/foreign-keys.md
+++ b/docs/development/foreign-keys.md
@@ -603,7 +603,7 @@ half-converted column.
 ## Phase D — plugins, and the direction rule
 
 18 plugin tables ship in `FOGProject/fog-plugins`. All 18 clone cleanly into
-the survey and 22 of the 87 candidate relationships live in them.
+the survey and 22 of the map's 105 relationships live in them.
 
 ### Direction is the whole rule
 

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4487');
+        define('FOG_VERSION', '1.6.0-beta.4490');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/tests/foreign-key-map.test.php
+++ b/tests/foreign-key-map.test.php
@@ -416,6 +416,71 @@ foreach (array_diff($expected, $actual) as $missing) {
         . ' A constraint that ships disabled is one FOG is not enforcing';
 }
 
+// ---------------------------------------------------------------------------
+// The prose that quotes the map must be recomputed from the map.
+//
+// ADR 0031's Status paragraph and the survey's Phase D both state a count of
+// declared relationships. Those numbers are what a reviewer reads FIRST and
+// they are the part with no mechanism behind them -- the map is executable
+// and cannot drift, but a sentence about the map silently can. It did: the
+// Status paragraph sat at "40 of 87 declared; the remaining 47 still ship
+// disabled" through six more groups and all five plugins, understating the
+// work by half and pointing a reader at 47 pending constraints that did not
+// exist.
+//
+// Matching on the digits rather than on the whole sentence deliberately: the
+// prose around them should stay free to be rewritten, and only the claim
+// about quantity is being pinned.
+$declared = count(array_filter($map, static function ($r) {
+    return !empty($r['enabled']);
+}));
+$total = count($map);
+$plugin = count(array_filter($map, static function ($r) {
+    return !empty($r['enabled']) && !is_int($r['group'] ?? null);
+}));
+
+$prose = [
+    'docs/adr/0031-referential-integrity-is-declared-in-the-database.md' => [
+        '#\*\*(\d+) of the map\'s (\d+) relationships are declared\.\*\*#',
+        [$declared, $total],
+        'the declared/total count in the Status paragraph',
+    ],
+    'docs/development/foreign-keys.md' => [
+        '#(\d+) of the map\'s (\d+) relationships live in them#',
+        [$plugin, $total],
+        'the plugin/total count in Phase D',
+    ],
+];
+
+foreach ($prose as $relative => $spec) {
+    list($pattern, $want, $what) = $spec;
+    $checked++;
+    $path = $root . '/' . $relative;
+    $text = is_readable($path) ? file_get_contents($path) : '';
+    if ('' === $text) {
+        $failures[] = "$relative could not be read, so $what is unverified";
+        continue;
+    }
+    if (!preg_match($pattern, $text, $m)) {
+        $failures[] = "$relative no longer states $what in the form this test"
+            . ' pins. Restate it, or move the pin -- an unpinned count is the'
+            . ' one that goes stale';
+        continue;
+    }
+    $got = [(int)$m[1], (int)$m[2]];
+    if ($got !== $want) {
+        $failures[] = sprintf(
+            '%s states %d of %d for %s; the map says %d of %d',
+            $relative,
+            $got[0],
+            $got[1],
+            $what,
+            $want[0],
+            $want[1]
+        );
+    }
+}
+
 if (count($failures)) {
     echo "FAIL: " . count($failures) . " problem(s).\n\n";
     foreach ($failures as $f) {


### PR DESCRIPTION
## What

ADR 0031's Status paragraph described the constraint work as a third done. It
had been wrong for six schema steps and all five plugins.

It read:

> steps 0 through 5 implemented on `working-1.6` ... 40 of 87 declared; the
> remaining 47 still ship disabled and land group by group.

Reality on this branch: core landed through **schema 390**, and the five
plugin steps are merged in `FOGProject/fog-plugins` (#29). **89 of the map's
105 relationships are declared.**

| | |
|---|---|
| core, schema 382–390 | 67 (groups 1, 2, 3, 5, 6) |
| plugins, each in its own `schema()` | 22 (location 4, ou 2, windowskey 2, ldap 6, oidc 8) |
| **declared** | **89** |
| action `none` — audit | 9 |
| action `none` — polymorphic | 7 |

## The part that was wrong in kind, not just in degree

"the remaining 47 still ship disabled and land group by group" implies pending
work. The 16 undeclared relationships carry action `none`, which
`schema-constraints.php`'s own docblock defines as *"a decision rather than an
omission"*: nine are audit rows that must not constrain what they record (ADR
0021, `schema.php` step 341), seven are polymorphic columns whose target table
is named by a sibling column, where no constraint is expressible at all.
Nothing in the map is waiting on a future step.

Phase D of the survey had the same drift — "22 of the 87 candidate
relationships" predated the plugins being added to the map, which took it to
105.

## Why a gate

The map is executable and cannot drift. A *sentence about* the map silently
can, and this one did for six groups with nothing to notice. So
`tests/foreign-key-map.test.php` now recomputes both quoted counts from the
map and fails if the prose disagrees — or if the sentence it pins stops being
there at all, because an unpinned count is the one that goes stale. It matches
on the digits rather than the whole sentence, so the prose stays free to be
rewritten.

Mutation-verified five ways, each confirmed red:

| mutation | result |
|---|---|
| ADR declared count `89` → `40` (the exact stale number) | FAIL |
| ADR total `105` → `87` | FAIL |
| survey plugin count `22` → `18` | FAIL |
| delete the pinned sentence | FAIL — "no longer states ... in the form this test pins" |
| flip one map entry `enabled` off | FAIL — "the map says 88 of 105" |

The last one is the one that matters: it proves the gate reads the map rather
than comparing the prose to itself.

## Verification

- `foreign-key-map` 434 checks, 105 relationships, 89 enabled
- `foreign-key-reconcile` 65, `constraint-violation` 29
- `sh tests/run-all.sh` — **204 passed, 0 failed**
- both phpstan passes, unscoped — no errors
- `us-spelling` — 732 files, none in scope

Docs and one test only; no runtime code, no schema step, no behavior change.
