### PR TITLE
Classify the three plugin id columns nothing was asking about

### DIFF
--- a/docs/adr/0031-referential-integrity-is-declared-in-the-database.md
+++ b/docs/adr/0031-referential-integrity-is-declared-in-the-database.md
@@ -10,17 +10,26 @@ sweep), 382 (host-owned junctions and satellites, 14 constraints), 383
 corrected), 386 (the `0` sentinel becomes NULL), 387 (a sweep for the one
 group 5 relationship that becomes a CASCADE), 388 (configuration references,
 12), 389 (a repair for the four rows group 6 cannot be declared over) and 390
-(tasks and work, 16). The five plugin groups -- location 4, ou 2, windowskey
-2, ldap 6, oidc 8 -- are declared in core's map and applied by a step in each
-plugin's own `schema()` in `FOGProject/fog-plugins`.
+(tasks and work, 16). The seven plugin groups -- location 4, ou 2,
+windowskey 2, ldap 6, oidc 8, capone 2, subnetgroup 1 -- are declared in
+core's map and applied by a step in each plugin's own `schema()` in
+`FOGProject/fog-plugins`.
 
-**89 of the map's 105 relationships are declared.** The other 16 are not
+**92 of the map's 108 relationships are declared.** The other 16 are not
 pending work: they carry action `none`, which the map's docblock defines as a
 decision rather than an omission. Nine are audit rows, which MUST NOT
 constrain the thing they record (ADR 0021, `schema.php` step 341); seven are
 polymorphic columns whose target table is chosen by a sibling column, where
 no constraint is expressible at all. Nothing in the map is waiting on a
 future step.
+
+`capone` and `subnetgroup` were added later than the other five, and only
+because they were looked for: the classification gate reads
+`commons/schema-expected.php`, which is 70 CORE tables, so nothing ever
+required a decision about a plugin table's id columns. `capone.cImageID`,
+`capone.cOSID` and `subnetgroup.sgGroupID` had simply never been classified.
+The gate that closes that lives in the plugin repo, which is the only side
+that knows its own tables -- see decision 8.
 
 The plan's step 6 -- `deletemass()` gaining `storagegroup`/`storagenode`
 cases -- was dropped after its step 5 (schema 384) measured it as

--- a/docs/development/foreign-keys.md
+++ b/docs/development/foreign-keys.md
@@ -603,7 +603,7 @@ half-converted column.
 ## Phase D — plugins, and the direction rule
 
 18 plugin tables ship in `FOGProject/fog-plugins`. All 18 clone cleanly into
-the survey and 22 of the map's 105 relationships live in them.
+the survey and 25 of the map's 108 relationships live in them.
 
 ### Direction is the whole rule
 

--- a/packages/web/commons/schema-constraints.php
+++ b/packages/web/commons/schema-constraints.php
@@ -254,6 +254,9 @@ return [
     ['child' => 'oidcUserGrant', 'column' => 'ougUserID', 'parent' => 'users', 'pcolumn' => 'uId', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 'oidc'],
     ['child' => 'location', 'column' => 'lStorageGroupID', 'parent' => 'nfsGroups', 'pcolumn' => 'ngID', 'class' => 'config', 'action' => 'RESTRICT', 'enabled' => true, 'group' => 'location'],
     ['child' => 'location', 'column' => 'lStorageNodeID', 'parent' => 'nfsGroupMembers', 'pcolumn' => 'ngmID', 'class' => 'config', 'action' => 'SET NULL', 'sentinel' => 0, 'enabled' => true, 'group' => 'location'],
+    ['child' => 'capone', 'column' => 'cImageID', 'parent' => 'images', 'pcolumn' => 'imageID', 'class' => 'config', 'action' => 'RESTRICT', 'sentinel' => 0, 'enabled' => true, 'group' => 'capone'],
+    ['child' => 'capone', 'column' => 'cOSID', 'parent' => 'os', 'pcolumn' => 'osID', 'class' => 'config', 'action' => 'RESTRICT', 'sentinel' => 0, 'enabled' => true, 'group' => 'capone'],
+    ['child' => 'subnetgroup', 'column' => 'sgGroupID', 'parent' => 'groups', 'pcolumn' => 'groupID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 'subnetgroup'],
     ['child' => 'ldapUserGrant', 'column' => 'lugTargetID', 'parent' => '(lugTargetType)', 'pcolumn' => '-', 'class' => 'poly', 'action' => 'none'],
     ['child' => 'oidcUserGrant', 'column' => 'ougTargetID', 'parent' => '(ougTargetType)', 'pcolumn' => '-', 'class' => 'poly', 'action' => 'none'],
 ];

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4490');
+        define('FOG_VERSION', '1.6.0-beta.4493');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Db/ConstraintViolation.php
+++ b/packages/web/src/Db/ConstraintViolation.php
@@ -72,6 +72,10 @@ class ConstraintViolation extends FOGBase
         'snapinJobs' => 'snapin job',
         'snapinTasks' => 'snapin task',
         'multicastSessions' => 'multicast session',
+        // Plugin tables. A plugin's rows block a core delete exactly as
+        // core's own do, and the administrator reading the message has no
+        // reason to care which repository the table ships from.
+        'capone' => 'Capone rule',
         // Tables whose rows get blocked.
         'nfsGroups' => 'storage group',
         'taskStates' => 'task state',

--- a/tests/foreign-key-map.test.php
+++ b/tests/foreign-key-map.test.php
@@ -238,9 +238,9 @@ foreach ($map as $rel) {
  * Group 3 -- storage: groups, nodes, image and snapin assoc, schema step 384.
  * Group 5 -- configuration references, schema step 388.
  * Group 6 -- tasks and active work, schema step 390.
- * Groups 'location', 'ou', 'windowskey', 'ldap', 'oidc' -- the plugin
- *   tables, each applied by a step appended to that plugin's own schema()
- *   in the fog-plugins repo, not by a core step.
+ * Groups 'location', 'ou', 'windowskey', 'ldap', 'oidc', 'capone' and
+ *   'subnetgroup' -- the plugin tables, each applied by a step appended to
+ *   that plugin's own schema() in the fog-plugins repo, not by a core step.
  */
 $expected = [
     // Group 1
@@ -351,6 +351,11 @@ $expected = [
     'oidcGroupUserGroupAssoc.ogugGroupID',
     'oidcGroupUserGroupAssoc.ogugUserGroupID',
     'oidcUserGrant.ougUserID',
+    // Group 'capone'
+    'capone.cImageID',
+    'capone.cOSID',
+    // Group 'subnetgroup'
+    'subnetgroup.sgGroupID',
 ];
 /*
  * CORE GROUPS ARE INTS, PLUGIN GROUPS ARE STRINGS.
@@ -368,7 +373,15 @@ $expected = [
  * reconcile would ever create it -- silently, on some later upgrade,
  * unswept.
  */
-$corePlugins = ['location', 'ou', 'windowskey', 'ldap', 'oidc'];
+$corePlugins = [
+    'location',
+    'ou',
+    'windowskey',
+    'ldap',
+    'oidc',
+    'capone',
+    'subnetgroup',
+];
 foreach ($map as $rel) {
     if (empty($rel['enabled'])) {
         continue;


### PR DESCRIPTION
## What

Three id columns in live plugin tables had never been classified:

| column | → | class / action |
|---|---|---|
| `capone.cImageID` | `images.imageID` | config / **RESTRICT** |
| `capone.cOSID` | `os.osID` | config / **RESTRICT** |
| `subnetgroup.sgGroupID` | `groups.groupID` | junction / **CASCADE** |

**92 of the map's 108 relationships are now declared** (was 89 of 105).

## Why they were missed — the actual finding

The classification gate exists because *"nobody forgets a constraint they have
decided to add; what gets forgotten is DECIDING."* But it walks
`commons/schema-expected.php`, which is **70 core tables**. No plugin table is
in it, so nothing has ever required a decision about a plugin's id columns.
These were found by looking, not by any gate.

The closing gate has to live in `fog-plugins` — that repo is fetched on its own
by `bin/fetch-plugins.sh` and is the only side that knows its own tables. It
lands there in the companion PR, with the same hand-pinned-both-sides pattern
`tests/foreign-keys-applied-per-plugin.test.php` already uses.

I checked all 24 plugin tables, not just these. The other 21 are parent tables,
already in the map, or carry only their own primary key. `LDAPGroupMap` looked
like a fourth until I read further — it's a retired table a migration step
drops, so it's correctly absent.

## RESTRICT for capone, and why not CASCADE

Nothing in FOG deletes a capone row when its image or OS goes — no hook, no
`deletemass()` case — so the reference dangles. That is exactly where this
map's rule says RESTRICT. CASCADE would silently delete an administrator's
deployment rule as a side effect of deleting an image, which is the argument
step 385 used to reject CASCADE for storage nodes.

`subnetgroup` is the opposite: `removesubnetgroupgroup.hook.php` **already**
deletes those rows when a group is destroyed, so CASCADE pins existing
behavior and nothing observable changes.

## Preconditions, measured not assumed

Both capone columns carry a `0` sentinel — the model declares no
`$databaseFieldsRequired`, so `save()`'s optional-`*id` branch writes `0`. That
is the shape that made `tasks.taskStateID` a runtime 1452 and was fixed in step
389. `cOSID` is also `int(11)` against a `mediumint(9)` parent.

Against real MariaDB 11.8:

```
cImageID  -> images  : OK
sgGroupID -> groups  : OK
cOSID     -> os      : ERROR 1005 errno 150 (int(11) vs mediumint(9))
  after MODIFY ... MEDIUMINT(9): OK
  with one cOSID = 0 row present: ERROR 1452
```

The sweep deliberately excludes `<> 0`, so it cannot clean a sentinel — the
plugin's own step converts it. Both are handled in the companion PR;
end-to-end there, all three land and **no row is deleted** (nullable ⇒ the
sweep nulls rather than deletes).

Behavior proven on the same database: deleting an OS a capone rule uses is
refused 1451; deleting an image cascades... **is refused**, per RESTRICT.

## Merge order

**This PR first.** The plugin steps call `applyConstraints('capone')` /
`('subnetgroup')`, which read this map. Merged the other way round the steps
find no such group and silently do nothing.

## Verification

- `foreign-key-map` 443 checks, 108 relationships, 92 enabled
- `constraint-violation` 29 — the RESTRICT label gate demanded the `capone`
  label and got it
- `sh tests/run-all.sh` — **204 passed, 0 failed**
- both phpstan passes, unscoped — no errors
- `us-spelling` — 732 files, none in scope
