### PR TITLE
Pin plugins v1.6.20

### DIFF
--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1467,6 +1467,10 @@ msgid "Capone added!"
 msgstr "Snapin hinzugefügt"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "Standorte"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "Snapin Update fehlgeschlagen"
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1470,6 +1470,10 @@ msgid "Capone added!"
 msgstr "Snapin Name"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "Locations"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "Snapin update failed"
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1488,6 +1488,10 @@ msgid "Capone added!"
 msgstr "Nombre snapin"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "Acción"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "actualización de servicio no pudo"
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1467,6 +1467,10 @@ msgid "Capone added!"
 msgstr "Snapin hinzugefügt"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "Standorte"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "Snapin Update fehlgeschlagen"
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1471,6 +1471,10 @@ msgid "Capone added!"
 msgstr "Nom snapin"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "Emplacements"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "mise à jour a échoué Snapin"
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1429,6 +1429,10 @@ msgid "Capone added!"
 msgstr "Snapin aggiunto!"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "sedi"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "Aggiornamento Snapin fallito!"
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1412,6 +1412,10 @@ msgid "Capone added!"
 msgstr "スナップインを追加しました！"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "ロケーション"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "スナップインの更新に失敗しました！"
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1259,6 +1259,9 @@ msgstr ""
 msgid "Capone added!"
 msgstr ""
 
+msgid "Capone schema"
+msgstr ""
+
 msgid "Capone update failed!"
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1470,6 +1470,10 @@ msgid "Capone added!"
 msgstr "Nome Snapin"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "localizações"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "atualização Snapin falhou"
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1470,6 +1470,10 @@ msgid "Capone added!"
 msgstr "管理单元名称"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "位置"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "管理单元更新失败"
 

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4493');
+        define('FOG_VERSION', '1.6.0-beta.4496');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -108,7 +108,7 @@ class System
         // installer reads this to pick which release to download, so a given
         // FOG release ships a known set of plugins rather than whatever the
         // default branch held on the day someone installed.
-        define('FOG_PLUGINS_VERSION', 'v1.6.19');
+        define('FOG_PLUGINS_VERSION', 'v1.6.20');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already


### PR DESCRIPTION
Carries [fog-plugins #31](https://github.com/FOGProject/fog-plugins/pull/31) / [v1.6.20](https://github.com/FOGProject/fog-plugins/releases/tag/v1.6.20), which applies the three relationships #1481 declared.

Without this bump those steps exist in the repository and reach **no server**: `bin/fetch-plugins.sh` resolves `FOG_PLUGINS_VERSION`, not `main`.

| column | → | action |
|---|---|---|
| `capone.cImageID` | `images.imageID` | RESTRICT |
| `capone.cOSID` | `os.osID` | RESTRICT |
| `subnetgroup.sgGroupID` | `groups.groupID` | CASCADE |

The release also carries `tests/plugin-id-columns-are-classified.test.php`, the half of the classification gate that has to live in the plugin repo — core's gate walks `commons/schema-expected.php`, which is 70 core tables, so a plugin's id columns were never asked about.

**Verified by running the real thing**, not by inspection: `bin/fetch-plugins.sh` against the new pin downloads v1.6.20, verifies its sha256, unpacks 17 plugins, and the resulting `caponemanager.class.php` carries `applyConstraints('capone')`.