### PR TITLE
Grid layouts persist per user

### DIFF
--- a/packages/web/commons/schema-constraints.php
+++ b/packages/web/commons/schema-constraints.php
@@ -109,6 +109,14 @@ return [
     ['child' => 'greenFog', 'column' => 'gfHostID', 'parent' => 'hosts', 'pcolumn' => 'hostID', 'class' => 'satellite', 'action' => 'CASCADE', 'enabled' => true, 'group' => 1],
     ['child' => 'apiTokens', 'column' => 'atUserID', 'parent' => 'users', 'pcolumn' => 'uId', 'class' => 'satellite', 'action' => 'CASCADE', 'enabled' => true, 'group' => 2],
     ['child' => 'userAuths', 'column' => 'uaUserID', 'parent' => 'users', 'pcolumn' => 'uId', 'class' => 'satellite', 'action' => 'CASCADE', 'enabled' => true, 'group' => 2],
+    // Group 7, added with the table itself (schema 391/392). A NUMBER, not a
+    // name: names are reserved for the plugin groups, whose steps live in the
+    // plugin's own schema(), and tests/foreign-key-map enforces that split.
+    // Unlike groups 1-6 there is nothing to migrate here -- a table created
+    // empty one step earlier cannot hold an orphan -- so no sweep precedes it.
+    // A preference means nothing without the user it belongs to: CASCADE, the
+    // same call as apiTokens and userAuths above.
+    ['child' => 'userPrefs', 'column' => 'upUserID', 'parent' => 'users', 'pcolumn' => 'uId', 'class' => 'satellite', 'action' => 'CASCADE', 'enabled' => true, 'group' => 7],
 
     // ---- config: references to configuration with its own life ----------
     //

--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -916,6 +916,17 @@ return [
                 'uaPasswordHash' => 'varchar(255) NOT NULL DEFAULT \'\'',
             ],
         ],
+        'userPrefs' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `userPrefs` ( `upID` int(11) NOT NULL AUTO_INCREMENT, `upUserID` int(11) NOT NULL DEFAULT 0, `upKey` varchar(190) NOT NULL DEFAULT \'\', `upValue` longtext DEFAULT NULL, `upCreatedTime` datetime NOT NULL DEFAULT current_timestamp(), `upModifiedTime` datetime DEFAULT NULL, PRIMARY KEY (`upID`), UNIQUE KEY `upUserKey` (`upUserID`,`upKey`), KEY `upUserID` (`upUserID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'upID' => 'int(11) NOT NULL',
+                'upUserID' => 'int(11) NOT NULL DEFAULT 0',
+                'upKey' => 'varchar(190) NOT NULL DEFAULT \'\'',
+                'upValue' => 'longtext DEFAULT NULL',
+                'upCreatedTime' => 'datetime NOT NULL DEFAULT current_timestamp()',
+                'upModifiedTime' => 'datetime DEFAULT NULL',
+            ],
+        ],
         'userCleanup' => [
             'create' => 'CREATE TABLE IF NOT EXISTS `userCleanup` ( `ucID` int(11) NOT NULL AUTO_INCREMENT, `ucName` varchar(254) NOT NULL DEFAULT \'\', PRIMARY KEY (`ucID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -9557,3 +9557,63 @@ $this->schema[] = [
         return true;
     },
 ];
+// 391
+// Per-user preferences, as an opaque key/value store.
+//
+// The first consumer is DataTables' own saved state -- column order, which
+// columns are showing, page length, sort -- which every grid throws away on
+// reload today because registerTable sets stateSave:false. DataTables already
+// serializes that state and exposes stateSaveCallback/stateLoadCallback to
+// put it somewhere, so this table deliberately does NOT model "column
+// positions": it stores whatever the client hands it, under a key, for one
+// user. That is what keeps the schema from having to track DataTables'
+// internals, which change between its major versions.
+//
+// upKey is varchar(190) rather than the house 254 because it is half of a
+// UNIQUE KEY: utf8mb3 costs 3 bytes a character, and 254 would put the index
+// over InnoDB's 767-byte prefix limit on the older row formats FOG still
+// supports. 190 * 3 + 4 = 574.
+//
+// The UNIQUE KEY is what makes a write an upsert rather than an append -- see
+// UserPref::store(). That is normally a bug (a create silently overwriting an
+// existing row); here overwriting the previous value of the same preference
+// for the same user IS the operation.
+$this->schema[] = [
+    "CREATE TABLE IF NOT EXISTS `userPrefs` ( "
+    . "`upID` int(11) NOT NULL AUTO_INCREMENT, "
+    . "`upUserID` int(11) NOT NULL DEFAULT 0, "
+    . "`upKey` varchar(190) NOT NULL DEFAULT '', "
+    // Nullable rather than NOT NULL: a TEXT column cannot portably carry a
+    // literal DEFAULT (MySQL 8 refuses one outright), so NOT NULL with no
+    // default would make any INSERT that omitted the value error 1364 on a
+    // strict server -- which is what tests/optional-columns-carry-defaults
+    // exists to catch, and did.
+    . "`upValue` longtext DEFAULT NULL, "
+    . "`upCreatedTime` datetime NOT NULL DEFAULT current_timestamp(), "
+    . "`upModifiedTime` datetime DEFAULT NULL, "
+    . "PRIMARY KEY (`upID`), "
+    . "UNIQUE KEY `upUserKey` (`upUserID`,`upKey`), "
+    . "KEY `upUserID` (`upUserID`) "
+    // One line: the collation gate reads the CREATE statement line by line,
+    // so splitting CHARSET from COLLATE reads to it as a bare charset.
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC",
+];
+// 392
+// The foreign key for the table step 391 just created, per ADR 0031.
+//
+// Group 7. A number rather than a name: the named groups belong to plugins,
+// whose constraints are applied by a step in the plugin's own schema().
+//
+// Unlike groups 1 through 6 this one has nothing to migrate. Those phase in
+// constraints over tables that already hold years of data, so each is a
+// sweep plus a flip; a table created empty one step earlier cannot hold an
+// orphan, so there is no sweep to sequence before this.
+//
+// A preference is a satellite of the user it belongs to and means nothing
+// without them, so CASCADE -- the same call as apiTokens and userAuths.
+$this->schema[] =
+    function () {
+        \FOG\Db\SchemaReconciler::applyConstraints(7);
+
+        return true;
+    };

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -186,11 +186,30 @@ function fogColumnSearchRestore(api) {
 function fogColumnSearchRow(api, types) {
   var header = $(api.table().header()),
     title = header.find('tr').not('.fog-colsearch-row').first(),
-    visible = api.columns(':visible').indexes().toArray(),
     columns = api.settings()[0].aoColumns,
     existing = header.find('tr.fog-colsearch-row'),
-    signature = visible.join(','),
+    visible = [],
+    signature,
+    position,
     row;
+  // Map each header cell to the column it is showing. With ColReorder on, a
+  // column's index no longer says where its heading sits, so walking
+  // columns(':visible') in index order pairs every box with the wrong column
+  // the moment anything is dragged -- and the box then filters a column the
+  // user is not looking at, silently.
+  //
+  // ':visIdx' resolves a DISPLAY position back to a column, accounting for
+  // both hidden and reordered columns, so it is the right selector -- but it
+  // is only right at the moment it is read. A saved layout's column order is
+  // applied AFTER the first response, so a row built at xhr time and left
+  // alone describes the pre-restore layout and every box filters a column its
+  // heading does not belong to. That is why the rebuild below is bound to
+  // init and draw as well as to the reorder event itself; the signature check
+  // makes the extra passes free.
+  for (position = 0; position < title.children().length; position++) {
+    visible.push(api.column(position + ':visIdx').index());
+  }
+  signature = visible.join(',');
   // In scrolling mode DataTables keeps a second, sizing-only copy of the
   // header in the scroll body and clones the whole thead into it -- our row
   // included. That copy is collapsed to zero height, so it is invisible
@@ -222,6 +241,168 @@ function fogColumnSearchRow(api, types) {
     row.append(cell);
   });
   header.append(row);
+}
+
+/**
+ * Where the REST API lives, from the hidden input the page shell emits.
+ *
+ * Derived server-side from FOG_WEB_ROOT rather than assumed to be '/fog/',
+ * which the installer's -W/--webroot can change.
+ *
+ * @return {string} the API base path, with a trailing slash
+ */
+function fogApiBase() {
+  return $('#apiBase').val() || '/fog/';
+}
+
+/**
+ * The preference key a table's saved state is stored under.
+ *
+ * Namespaced so that preferences added later cannot collide with a grid's,
+ * and keyed on the table's DOM id -- which is what distinguishes the host
+ * list from the image list, since every FOG grid is built by the same helper.
+ *
+ * @param {object} settings the DataTables settings object
+ *
+ * @return {string} the key, or '' when the table has no id to key on
+ */
+function fogStateKey(settings) {
+  var id = settings.sTableId || '';
+  // Read from the URL directly rather than from $_GET, which is populated
+  // during page init and so may not be ready when a table is built. Getting
+  // that wrong is not a crash -- it is every page silently sharing one key,
+  // which is exactly the collision this function exists to prevent.
+  var params = new URLSearchParams(window.location.search);
+  var node = params.get('node') || '';
+  var sub = params.get('sub') || '';
+  if (!id) {
+    return '';
+  }
+  // The id alone is not enough: FOG builds most grids as `#dataTable`, so
+  // the host list and the image list would share one saved layout and each
+  // would load the other's column widths. The page the table is on is what
+  // actually identifies it.
+  return 'dt.' + node + '.' + sub + '.' + id;
+}
+
+/**
+ * Strips the parts of a DataTables state that must not be restored.
+ *
+ * Column ORDER, VISIBILITY, page length and sort are preferences: they say
+ * how you like to look at the list. A SEARCH is a question you asked once,
+ * and restoring one silently is the same failure the Column search toggle
+ * avoids by clearing when it closes -- you open Hosts, see 3 of 86, and
+ * nothing on screen says why. So the searches are dropped on the way out
+ * rather than on the way in, which also keeps them out of the stored value
+ * entirely: a filter someone typed is not something to persist server-side
+ * on their behalf.
+ *
+ * @param {object} state the state DataTables wants saved
+ *
+ * @return {object} a copy safe to store
+ */
+function fogOrderKeys(settings, order) {
+  var columns = settings.aoColumns,
+    keys = [],
+    i;
+  for (i = 0; i < (order || []).length; i++) {
+    if (columns[order[i][0]] && columns[order[i][0]].data) {
+      keys.push([columns[order[i][0]].data, order[i][1]]);
+    }
+  }
+  return keys;
+}
+/**
+ * Puts the sort back on the column it was saved against.
+ *
+ * A no-op unless the restored sort actually names a different column than
+ * the one saved, which is only the case when the columns have been reordered
+ * -- so the common visit costs nothing, and the redraw (a request, on a
+ * server-side table) happens only where the alternative is a table sorted by
+ * the wrong column.
+ */
+function fogApplyOrder(api) {
+  var loaded = api.state.loaded(),
+    columns = api.settings()[0].aoColumns,
+    wanted = [],
+    lookup = {},
+    i;
+  if (!loaded || !loaded.fogOrder || !loaded.fogOrder.length) {
+    return;
+  }
+  for (i = 0; i < columns.length; i++) {
+    lookup[columns[i].data] = i;
+  }
+  for (i = 0; i < loaded.fogOrder.length; i++) {
+    if (loaded.fogOrder[i][0] in lookup) {
+      wanted.push([lookup[loaded.fogOrder[i][0]], loaded.fogOrder[i][1]]);
+    }
+  }
+  if (!wanted.length || JSON.stringify(wanted) === JSON.stringify(api.order())) {
+    return;
+  }
+  api.order(wanted).draw(false);
+}
+function fogStripStateSearch(state) {
+  var copy = $.extend(true, {}, state), i;
+  delete copy.search;
+  delete copy.searchBuilder;
+  for (i = 0; i < (copy.columns || []).length; i++) {
+    delete copy.columns[i].search;
+  }
+  // `time` is deliberately KEPT. DataTables will not apply a state that has
+  // no timestamp -- _fnImplementState opens with `if (state && state.time)`
+  // and silently drops it otherwise -- and it is also what stateDuration
+  // measures against, which is the escape hatch that lets a bad saved layout
+  // age out instead of following someone forever. Stripping it made every
+  // saved layout unrestorable, with nothing logged and no error: the table
+  // simply came up in its default arrangement every time.
+  return copy;
+}
+
+/**
+ * Stores one preference for the signed-in user.
+ *
+ * Deliberately not $.apiCall: that raises a toast on every response, and
+ * these fire on every column drag and every sort. A failure is not worth
+ * interrupting anybody over either -- the state is also written to
+ * localStorage, so the worst case is that the layout stops following the
+ * user between machines, which is where it already was.
+ *
+ * @param {string}   key   the preference key
+ * @param {string}   value the value to store
+ * @param {function} cb    optional callback, receives an error or null
+ *
+ * @return {void}
+ */
+function fogPrefStore(key, value, cb) {
+  $.ajax({
+    url: fogApiBase() + 'system/userpref/' + encodeURIComponent(key),
+    type: 'POST',
+    contentType: 'application/json',
+    data: JSON.stringify({ value: value }),
+    global: false,
+    success: function() { if (cb) { cb(null); } },
+    error: function(xhr) { if (cb) { cb(xhr); } }
+  });
+}
+
+/**
+ * Reads one preference for the signed-in user.
+ *
+ * @param {string}   key the preference key
+ * @param {function} cb  receives (error, value)
+ *
+ * @return {void}
+ */
+function fogPrefFetch(key, cb) {
+  $.ajax({
+    url: fogApiBase() + 'system/userpref/' + encodeURIComponent(key),
+    type: 'GET',
+    global: false,
+    success: function(data) { cb(null, (data && data.value) || ''); },
+    error: function(xhr) { cb(xhr, ''); }
+  });
 }
 
 var shouldReAuth,
@@ -3103,7 +3284,82 @@ $.fn.registerTable = function(onSelect, opts) {
     searching: true,
     ordering: true,
     info: true,
-    stateSave: false,
+    // Drag a heading to move a column. Off until now, which meant the saved
+    // state below had no positions to save -- "customise the layout" and
+    // "remember the layout" are one feature, not two.
+    colReorder: true,
+    // Column order, which columns are showing, page length and sort now
+    // persist per user, through the preference store rather than
+    // localStorage -- see stateSaveCallback below. Searches are deliberately
+    // NOT part of it; fogStripStateSearch() says why.
+    stateSave: true,
+    // Long enough that a layout survives a holiday. DataTables discards a
+    // state older than this, which is the escape hatch if a saved layout ever
+    // goes bad: it ages out rather than following someone forever.
+    stateDuration: 60 * 60 * 24 * 365,
+    stateSaveCallback: function(settings, data) {
+      var key = fogStateKey(settings);
+      var value;
+      // Record WHICH COLUMN is sorted, not just its index. DataTables and
+      // ColReorder disagree about which frame a saved order index is in, and
+      // the sort lands on a different column after a reload once anything has
+      // been dragged -- reproduced with stock DataTables 2.0.8, ColReorder
+      // 2.0.3 and the library's own localStorage callbacks, so it is not
+      // ours to fix here. The key survives any reordering, and fogApplyOrder()
+      // puts the sort back where it belongs once the table is up.
+      data.fogOrder = fogOrderKeys(settings, data.order);
+      value = JSON.stringify(fogStripStateSearch(data));
+      if (!key) {
+        return;
+      }
+      // Written to both. localStorage is what makes the layout survive the
+      // reload you are about to do even if the server call is still in
+      // flight or the session has expired; the preference is what makes it
+      // follow you to another machine. The server wins on load.
+      try {
+        window.localStorage.setItem(key, value);
+      } catch (e) {}
+      fogPrefStore(key, value);
+    },
+    stateLoadCallback: function(settings, callback) {
+      var key = fogStateKey(settings);
+      var local = null;
+      // RETURN UNDEFINED, ALWAYS. DataTables waits for the callback only when
+      // this function returns undefined -- `void 0 !== ret && useIt(ret)`. Any
+      // other return value, null included, is taken as the state itself, so
+      // the table loads "no saved layout" and the answer this function is
+      // waiting for arrives too late to be used. Nothing errors; the feature
+      // just silently does not work.
+      if (!key) {
+        callback(null);
+        return;
+      }
+      try {
+        local = window.localStorage.getItem(key);
+      } catch (e) {}
+      fogPrefFetch(key, function(err, value) {
+        var raw = (!err && value) ? value : local;
+        if (!raw) {
+          callback(null);
+          return;
+        }
+        try {
+          // Strip on the way IN as well. A value stored by an older release
+          // -- or by localStorage before this shipped -- can carry a saved
+          // search, and restoring one invisibly is the failure this whole
+          // arrangement is written to avoid.
+          callback(fogStripStateSearch(JSON.parse(raw)));
+        } catch (e) {
+          // A corrupt or truncated value means "no saved layout", not a
+          // broken table. JSON.parse throwing here would otherwise take out
+          // the whole grid.
+          callback(null);
+        }
+      });
+      // Asynchronous: see the note above -- undefined is what makes
+      // DataTables wait for the callback rather than acting on the return.
+      return;
+    },
     autoWidth: false,
     responsive: true,
     lengthMenu: [
@@ -3299,17 +3555,31 @@ $.fn.registerTable = function(onSelect, opts) {
   // box after the hidden one would otherwise be pointed one column off.
   // column-visibility for the obvious reason; column-sizing because
   // DataTables re-renders the header (and in scrolling mode re-clones it)
-  // whenever it recalculates widths, which drops anything appended to it.
+  // whenever it recalculates widths, which drops anything appended to it;
+  // column-reorder because dragging a heading changes which column each
+  // cell position is showing, and a box left where it was would then be
+  // filtering a different column than the one above it.
   // Both are cheap when nothing has changed -- the builder returns early if
   // the row it finds already describes the right columns.
-  table.on('column-visibility.dt column-sizing.dt', function() {
-    var types = table.settings()[0]._fogSearchTypes;
-    if (!types) {
-      return;
-    }
-    fogColumnSearchRow(table, types);
-    fogColumnSearchRestore(table);
+  // init and draw are here for the saved layout: ColReorder applies a restored
+  // column order after the first response, so the row built by the xhr handler
+  // above describes the layout as it was BEFORE the restore. Without these two
+  // the boxes stay pinned to that stale layout and quietly filter the wrong
+  // columns for the rest of the visit.
+  table.on('init.dt', function() {
+    fogApplyOrder(table);
   });
+  table.on(
+    'column-visibility.dt column-sizing.dt column-reorder.dt init.dt draw.dt',
+    function() {
+        var types = table.settings()[0]._fogSearchTypes;
+        if (!types) {
+            return;
+        }
+        fogColumnSearchRow(table, types);
+        fogColumnSearchRestore(table);
+    }
+  );
 
   if (columnResize) {
     var tableNode = $(this);

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1000,6 +1000,9 @@ msgstr "Jährlich"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
+msgstr ""
+
 msgid "Anyone signing in through one of these directory groups is placed in this user group. Membership granted this way is recomputed on every sign in."
 msgstr ""
 
@@ -1602,6 +1605,9 @@ msgstr "frei"
 #, fuzzy
 msgid "Clear Fields"
 msgstr "Felder leeren"
+
+msgid "Clear one of your preferences"
+msgstr ""
 
 msgid "Click"
 msgstr "Klicken Sie"
@@ -2523,6 +2529,9 @@ msgstr "Druckertyp"
 msgid "Equipment Loan"
 msgstr "Equipmentleihe"
 
+msgid "Equivalent to storing an empty value."
+msgstr ""
+
 msgid "Error"
 msgstr "Fehler"
 
@@ -2609,6 +2618,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "Keine Datei wurde hochgeladen"
+
+msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
+msgstr ""
 
 #, fuzzy
 msgid "Existence check failed"
@@ -5829,12 +5841,19 @@ msgid "No unrunnable tasks found."
 msgstr "Keine gültigen Tasks gefunden"
 
 #, fuzzy
+msgid "No user in session"
+msgstr "Version"
+
+#, fuzzy
 msgid "No valid storage nodes found"
 msgstr "Keine gültigen Speicherknoten gefunden"
 
 #, fuzzy
 msgid "No valid tasks found"
 msgstr "Keine gültigen Tasks gefunden"
+
+msgid "No value supplied; use DELETE to clear"
+msgstr ""
 
 msgid "No values passed"
 msgstr "Keine Werte übergeben"
@@ -6060,6 +6079,9 @@ msgstr ""
 #, fuzzy
 msgid "One or more macs are associated with a host"
 msgstr "Eine oder mehrere MACs sind mit einem Host verknüpft"
+
+msgid "One preference."
+msgstr ""
 
 msgid "Online"
 msgstr ""
@@ -6585,6 +6607,9 @@ msgstr ""
 msgid "PowerShell x64 Script"
 msgstr ""
 
+msgid "Preference key or value is not storable"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -6842,6 +6867,9 @@ msgid "Re-run the installer, which restricts them to root. If this persists, che
 msgstr ""
 
 msgid "Read a server log"
+msgstr ""
+
+msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
@@ -8269,6 +8297,9 @@ msgstr "Verlaufs-ID"
 msgid "Storage nodes"
 msgstr "Storage Node"
 
+msgid "Store one of your preferences"
+msgstr ""
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -8761,7 +8792,13 @@ msgstr ""
 msgid "The archive must hold exactly one plugin directory."
 msgstr ""
 
+msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
+msgstr ""
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
+msgstr ""
+
+msgid "The calling user's preferences."
 msgstr ""
 
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
@@ -8887,6 +8924,15 @@ msgid "The plugin system is disabled"
 msgstr "* Anpingen der Hosts ist global deaktiviert"
 
 msgid "The plugin will run but its JS and CSS will 404."
+msgstr ""
+
+msgid "The preference key. Namespaced by its consumer -- a grid's saved state is stored under \"dt.<table id>\" -- so that two features cannot collide on one name."
+msgstr ""
+
+msgid "The preference was cleared."
+msgstr ""
+
+msgid "The preference was stored."
 msgstr ""
 
 msgid "The primary mac associated is"
@@ -10109,6 +10155,9 @@ msgid "Your database connection appears to be invalid"
 msgstr "Ihre Datenbankverbindung scheint ungültig zu sein"
 
 msgid "Your session has ended. Sign in again."
+msgstr ""
+
+msgid "Your stored preferences"
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1470,6 +1470,10 @@ msgid "Capone added!"
 msgstr "Snapin hinzugefügt"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "Standorte"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "Snapin Update fehlgeschlagen"
 
@@ -11247,10 +11251,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Änderungen speichern?"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "Standorte"
 
 #~ msgid "Check that database is running"
 #~ msgstr "Überprüfen Sie, ob die Datenbank ausgeführt wird"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1004,6 +1004,9 @@ msgstr "Annually"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
+msgstr ""
+
 msgid "Anyone signing in through one of these directory groups is placed in this user group. Membership granted this way is recomputed on every sign in."
 msgstr ""
 
@@ -1603,6 +1606,9 @@ msgid "Clear"
 msgstr "Clear"
 
 msgid "Clear Fields"
+msgstr ""
+
+msgid "Clear one of your preferences"
 msgstr ""
 
 msgid "Click"
@@ -2524,6 +2530,9 @@ msgstr "Printer Type"
 msgid "Equipment Loan"
 msgstr "Equipment Loan"
 
+msgid "Equivalent to storing an empty value."
+msgstr ""
+
 msgid "Error"
 msgstr "Error"
 
@@ -2610,6 +2619,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "No file was uploaded"
+
+msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
+msgstr ""
 
 #, fuzzy
 msgid "Existence check failed"
@@ -5827,12 +5839,19 @@ msgid "No unrunnable tasks found."
 msgstr "No valid class sent"
 
 #, fuzzy
+msgid "No user in session"
+msgstr "Version"
+
+#, fuzzy
 msgid "No valid storage nodes found"
 msgstr "Invalid storage node"
 
 #, fuzzy
 msgid "No valid tasks found"
 msgstr "No valid class sent"
+
+msgid "No value supplied; use DELETE to clear"
+msgstr ""
 
 msgid "No values passed"
 msgstr "No values passed"
@@ -6057,6 +6076,9 @@ msgstr ""
 #, fuzzy
 msgid "One or more macs are associated with a host"
 msgstr "Error, Is an image associated with this host"
+
+msgid "One preference."
+msgstr ""
 
 msgid "Online"
 msgstr ""
@@ -6582,6 +6604,9 @@ msgstr ""
 msgid "PowerShell x64 Script"
 msgstr ""
 
+msgid "Preference key or value is not storable"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -6839,6 +6864,9 @@ msgid "Re-run the installer, which restricts them to root. If this persists, che
 msgstr ""
 
 msgid "Read a server log"
+msgstr ""
+
+msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
@@ -8266,6 +8294,9 @@ msgstr "Host ID"
 msgid "Storage nodes"
 msgstr "Storage Node"
 
+msgid "Store one of your preferences"
+msgstr ""
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -8756,7 +8787,13 @@ msgstr ""
 msgid "The archive must hold exactly one plugin directory."
 msgstr ""
 
+msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
+msgstr ""
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
+msgstr ""
+
+msgid "The calling user's preferences."
 msgstr ""
 
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
@@ -8882,6 +8919,15 @@ msgid "The plugin system is disabled"
 msgstr "Donations are disabled"
 
 msgid "The plugin will run but its JS and CSS will 404."
+msgstr ""
+
+msgid "The preference key. Namespaced by its consumer -- a grid's saved state is stored under \"dt.<table id>\" -- so that two features cannot collide on one name."
+msgstr ""
+
+msgid "The preference was cleared."
+msgstr ""
+
+msgid "The preference was stored."
 msgstr ""
 
 msgid "The primary mac associated is"
@@ -10104,6 +10150,9 @@ msgid "Your database connection appears to be invalid"
 msgstr ""
 
 msgid "Your session has ended. Sign in again."
+msgstr ""
+
+msgid "Your stored preferences"
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1473,6 +1473,10 @@ msgid "Capone added!"
 msgstr "Snapin Name"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "Locations"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "Snapin update failed"
 
@@ -11234,10 +11238,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Save Changes"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "Locations"
 
 #~ msgid "Check that database is running"
 #~ msgstr "Check that database is running"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1491,6 +1491,10 @@ msgid "Capone added!"
 msgstr "Nombre snapin"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "Acción"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "actualización de servicio no pudo"
 
@@ -11409,10 +11413,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Guardar cambios"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "Acción"
 
 #, fuzzy
 #~ msgid "Check that database is running"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1018,6 +1018,9 @@ msgstr "Anualmente"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
+msgstr ""
+
 msgid "Anyone signing in through one of these directory groups is placed in this user group. Membership granted this way is recomputed on every sign in."
 msgstr ""
 
@@ -1621,6 +1624,9 @@ msgid "Clear"
 msgstr "Tareas"
 
 msgid "Clear Fields"
+msgstr ""
+
+msgid "Clear one of your preferences"
 msgstr ""
 
 msgid "Click"
@@ -2558,6 +2564,9 @@ msgstr "Tipo de impresora"
 msgid "Equipment Loan"
 msgstr ""
 
+msgid "Equivalent to storing an empty value."
+msgstr ""
+
 msgid "Error"
 msgstr "Error"
 
@@ -2645,6 +2654,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "Ningún archivo fue subido"
+
+msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
+msgstr ""
 
 #, fuzzy
 msgid "Existence check failed"
@@ -5951,12 +5963,19 @@ msgid "No unrunnable tasks found."
 msgstr "Ninguna clase válida enviado"
 
 #, fuzzy
+msgid "No user in session"
+msgstr "Versión"
+
+#, fuzzy
 msgid "No valid storage nodes found"
 msgstr "nodo de almacenamiento no válido"
 
 #, fuzzy
 msgid "No valid tasks found"
 msgstr "Ninguna clase válida enviado"
+
+msgid "No value supplied; use DELETE to clear"
+msgstr ""
 
 msgid "No values passed"
 msgstr "No hay valores pasados"
@@ -6184,6 +6203,9 @@ msgstr ""
 #, fuzzy
 msgid "One or more macs are associated with a host"
 msgstr "Error, es una imagen asociada con este anfitrión"
+
+msgid "One preference."
+msgstr ""
 
 msgid "Online"
 msgstr ""
@@ -6717,6 +6739,9 @@ msgstr ""
 msgid "PowerShell x64 Script"
 msgstr ""
 
+msgid "Preference key or value is not storable"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -6980,6 +7005,9 @@ msgid "Re-run the installer, which restricts them to root. If this persists, che
 msgstr ""
 
 msgid "Read a server log"
+msgstr ""
+
+msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
@@ -8444,6 +8472,9 @@ msgstr "ID de host"
 msgid "Storage nodes"
 msgstr "nodo de almacenamiento"
 
+msgid "Store one of your preferences"
+msgstr ""
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -8938,7 +8969,13 @@ msgstr ""
 msgid "The archive must hold exactly one plugin directory."
 msgstr ""
 
+msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
+msgstr ""
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
+msgstr ""
+
+msgid "The calling user's preferences."
 msgstr ""
 
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
@@ -9065,6 +9102,15 @@ msgid "The plugin system is disabled"
 msgstr "Ancho por defecto"
 
 msgid "The plugin will run but its JS and CSS will 404."
+msgstr ""
+
+msgid "The preference key. Namespaced by its consumer -- a grid's saved state is stored under \"dt.<table id>\" -- so that two features cannot collide on one name."
+msgstr ""
+
+msgid "The preference was cleared."
+msgstr ""
+
+msgid "The preference was stored."
 msgstr ""
 
 #, fuzzy
@@ -10287,6 +10333,9 @@ msgid "Your database connection appears to be invalid"
 msgstr ""
 
 msgid "Your session has ended. Sign in again."
+msgstr ""
+
+msgid "Your stored preferences"
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1470,6 +1470,10 @@ msgid "Capone added!"
 msgstr "Snapin hinzugefügt"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "Standorte"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "Snapin Update fehlgeschlagen"
 
@@ -11248,10 +11252,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Änderungen speichern?"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "Standorte"
 
 #~ msgid "Check that database is running"
 #~ msgstr "Überprüfen Sie, ob die Datenbank ausgeführt wird"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1000,6 +1000,9 @@ msgstr "Jährlich"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
+msgstr ""
+
 msgid "Anyone signing in through one of these directory groups is placed in this user group. Membership granted this way is recomputed on every sign in."
 msgstr ""
 
@@ -1602,6 +1605,9 @@ msgstr "frei"
 #, fuzzy
 msgid "Clear Fields"
 msgstr "Felder leeren"
+
+msgid "Clear one of your preferences"
+msgstr ""
 
 msgid "Click"
 msgstr "Klicken Sie"
@@ -2523,6 +2529,9 @@ msgstr "Druckertyp"
 msgid "Equipment Loan"
 msgstr "Equipmentleihe"
 
+msgid "Equivalent to storing an empty value."
+msgstr ""
+
 msgid "Error"
 msgstr "Fehler"
 
@@ -2609,6 +2618,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "Keine Datei wurde hochgeladen"
+
+msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
+msgstr ""
 
 #, fuzzy
 msgid "Existence check failed"
@@ -5830,12 +5842,19 @@ msgid "No unrunnable tasks found."
 msgstr "Keine gültigen Tasks gefunden"
 
 #, fuzzy
+msgid "No user in session"
+msgstr "Version"
+
+#, fuzzy
 msgid "No valid storage nodes found"
 msgstr "Keine gültigen Speicherknoten gefunden"
 
 #, fuzzy
 msgid "No valid tasks found"
 msgstr "Keine gültigen Tasks gefunden"
+
+msgid "No value supplied; use DELETE to clear"
+msgstr ""
 
 msgid "No values passed"
 msgstr "Keine Werte übergeben"
@@ -6061,6 +6080,9 @@ msgstr ""
 #, fuzzy
 msgid "One or more macs are associated with a host"
 msgstr "Eine oder mehrere MACs sind mit einem Host verknüpft"
+
+msgid "One preference."
+msgstr ""
 
 msgid "Online"
 msgstr ""
@@ -6586,6 +6608,9 @@ msgstr ""
 msgid "PowerShell x64 Script"
 msgstr ""
 
+msgid "Preference key or value is not storable"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -6843,6 +6868,9 @@ msgid "Re-run the installer, which restricts them to root. If this persists, che
 msgstr ""
 
 msgid "Read a server log"
+msgstr ""
+
+msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
@@ -8270,6 +8298,9 @@ msgstr "Verlaufs-ID"
 msgid "Storage nodes"
 msgstr "Storage Node"
 
+msgid "Store one of your preferences"
+msgstr ""
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -8762,7 +8793,13 @@ msgstr ""
 msgid "The archive must hold exactly one plugin directory."
 msgstr ""
 
+msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
+msgstr ""
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
+msgstr ""
+
+msgid "The calling user's preferences."
 msgstr ""
 
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
@@ -8888,6 +8925,15 @@ msgid "The plugin system is disabled"
 msgstr "* Anpingen der Hosts ist global deaktiviert"
 
 msgid "The plugin will run but its JS and CSS will 404."
+msgstr ""
+
+msgid "The preference key. Namespaced by its consumer -- a grid's saved state is stored under \"dt.<table id>\" -- so that two features cannot collide on one name."
+msgstr ""
+
+msgid "The preference was cleared."
+msgstr ""
+
+msgid "The preference was stored."
 msgstr ""
 
 msgid "The primary mac associated is"
@@ -10110,6 +10156,9 @@ msgid "Your database connection appears to be invalid"
 msgstr "Ihre Datenbankverbindung scheint ungültig zu sein"
 
 msgid "Your session has ended. Sign in again."
+msgstr ""
+
+msgid "Your stored preferences"
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1005,6 +1005,9 @@ msgstr "Annuellement"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
+msgstr ""
+
 msgid "Anyone signing in through one of these directory groups is placed in this user group. Membership granted this way is recomputed on every sign in."
 msgstr ""
 
@@ -1606,6 +1609,9 @@ msgstr "Clair"
 #, fuzzy
 msgid "Clear Fields"
 msgstr "clairement toute l'histoire"
+
+msgid "Clear one of your preferences"
+msgstr ""
 
 msgid "Click"
 msgstr "Cliquez"
@@ -2526,6 +2532,9 @@ msgstr "Type d'imprimante"
 msgid "Equipment Loan"
 msgstr "prêt d'équipement"
 
+msgid "Equivalent to storing an empty value."
+msgstr ""
+
 msgid "Error"
 msgstr "Erreur"
 
@@ -2612,6 +2621,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "Aucun fichier a été téléchargé"
+
+msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
+msgstr ""
 
 #, fuzzy
 msgid "Existence check failed"
@@ -5829,12 +5841,19 @@ msgid "No unrunnable tasks found."
 msgstr "Aucune classe valide envoyé"
 
 #, fuzzy
+msgid "No user in session"
+msgstr "Version"
+
+#, fuzzy
 msgid "No valid storage nodes found"
 msgstr "nœud de stockage non valide"
 
 #, fuzzy
 msgid "No valid tasks found"
 msgstr "Aucune classe valide envoyé"
+
+msgid "No value supplied; use DELETE to clear"
+msgstr ""
 
 msgid "No values passed"
 msgstr "Aucune valeur passées"
@@ -6059,6 +6078,9 @@ msgstr ""
 #, fuzzy
 msgid "One or more macs are associated with a host"
 msgstr "Erreur, est une image associée à cet hôte"
+
+msgid "One preference."
+msgstr ""
 
 msgid "Online"
 msgstr ""
@@ -6584,6 +6606,9 @@ msgstr ""
 msgid "PowerShell x64 Script"
 msgstr ""
 
+msgid "Preference key or value is not storable"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -6841,6 +6866,9 @@ msgid "Re-run the installer, which restricts them to root. If this persists, che
 msgstr ""
 
 msgid "Read a server log"
+msgstr ""
+
+msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
@@ -8268,6 +8296,9 @@ msgstr "ID d'hôte"
 msgid "Storage nodes"
 msgstr "nœud de stockage"
 
+msgid "Store one of your preferences"
+msgstr ""
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -8758,7 +8789,13 @@ msgstr ""
 msgid "The archive must hold exactly one plugin directory."
 msgstr ""
 
+msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
+msgstr ""
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
+msgstr ""
+
+msgid "The calling user's preferences."
 msgstr ""
 
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
@@ -8884,6 +8921,15 @@ msgid "The plugin system is disabled"
 msgstr "Les dons sont désactivés"
 
 msgid "The plugin will run but its JS and CSS will 404."
+msgstr ""
+
+msgid "The preference key. Namespaced by its consumer -- a grid's saved state is stored under \"dt.<table id>\" -- so that two features cannot collide on one name."
+msgstr ""
+
+msgid "The preference was cleared."
+msgstr ""
+
+msgid "The preference was stored."
 msgstr ""
 
 msgid "The primary mac associated is"
@@ -10106,6 +10152,9 @@ msgid "Your database connection appears to be invalid"
 msgstr ""
 
 msgid "Your session has ended. Sign in again."
+msgstr ""
+
+msgid "Your stored preferences"
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1474,6 +1474,10 @@ msgid "Capone added!"
 msgstr "Nom snapin"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "Emplacements"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "mise à jour a échoué Snapin"
 
@@ -11236,10 +11240,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Sauvegarder les modifications"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "Emplacements"
 
 #~ msgid "Check that database is running"
 #~ msgstr "Vérifiez que la base de données est en cours d'exécution"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -976,6 +976,9 @@ msgstr "Annualmente"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
+msgstr ""
+
 msgid "Anyone signing in through one of these directory groups is placed in this user group. Membership granted this way is recomputed on every sign in."
 msgstr ""
 
@@ -1559,6 +1562,9 @@ msgstr "Pulire"
 
 msgid "Clear Fields"
 msgstr "Cancellare campi"
+
+msgid "Clear one of your preferences"
+msgstr ""
 
 msgid "Click"
 msgstr "Click"
@@ -2459,6 +2465,9 @@ msgstr "Tipo stampante"
 msgid "Equipment Loan"
 msgstr "attrezzature di prestito"
 
+msgid "Equivalent to storing an empty value."
+msgstr ""
+
 msgid "Error"
 msgstr "Errore"
 
@@ -2543,6 +2552,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "Nessun file è stato caricato"
+
+msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
+msgstr ""
 
 #, fuzzy
 msgid "Existence check failed"
@@ -5646,11 +5658,18 @@ msgstr ""
 msgid "No unrunnable tasks found."
 msgstr "Non sono stati trovati compiti validi"
 
+#, fuzzy
+msgid "No user in session"
+msgstr "Versione"
+
 msgid "No valid storage nodes found"
 msgstr "Nessun nodo di archiviazione valido trovato"
 
 msgid "No valid tasks found"
 msgstr "Non sono stati trovati compiti validi"
+
+msgid "No value supplied; use DELETE to clear"
+msgstr ""
 
 msgid "No values passed"
 msgstr "Nessun valore passato"
@@ -5870,6 +5889,9 @@ msgstr ""
 
 msgid "One or more macs are associated with a host"
 msgstr "Uno o più MAC sono associati a questo host"
+
+msgid "One preference."
+msgstr ""
 
 msgid "Online"
 msgstr ""
@@ -6381,6 +6403,9 @@ msgstr ""
 msgid "PowerShell x64 Script"
 msgstr ""
 
+msgid "Preference key or value is not storable"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -6632,6 +6657,9 @@ msgid "Re-run the installer, which restricts them to root. If this persists, che
 msgstr ""
 
 msgid "Read a server log"
+msgstr ""
+
+msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
@@ -8002,6 +8030,9 @@ msgstr "Grafico storico"
 msgid "Storage nodes"
 msgstr "Storage Node"
 
+msgid "Store one of your preferences"
+msgstr ""
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -8475,7 +8506,13 @@ msgstr ""
 msgid "The archive must hold exactly one plugin directory."
 msgstr ""
 
+msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
+msgstr ""
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
+msgstr ""
+
+msgid "The calling user's preferences."
 msgstr ""
 
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
@@ -8600,6 +8637,15 @@ msgid "The plugin system is disabled"
 msgstr "* Gli host Ping sono disattivati a livello globale"
 
 msgid "The plugin will run but its JS and CSS will 404."
+msgstr ""
+
+msgid "The preference key. Namespaced by its consumer -- a grid's saved state is stored under \"dt.<table id>\" -- so that two features cannot collide on one name."
+msgstr ""
+
+msgid "The preference was cleared."
+msgstr ""
+
+msgid "The preference was stored."
 msgstr ""
 
 msgid "The primary mac associated is"
@@ -9784,6 +9830,9 @@ msgid "Your database connection appears to be invalid"
 msgstr "La connessione al database sembra non valida"
 
 msgid "Your session has ended. Sign in again."
+msgstr ""
+
+msgid "Your stored preferences"
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1432,6 +1432,10 @@ msgid "Capone added!"
 msgstr "Snapin aggiunto!"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "sedi"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "Aggiornamento Snapin fallito!"
 
@@ -10869,10 +10873,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Applicare cambiamenti?"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "sedi"
 
 #~ msgid "Check that database is running"
 #~ msgstr "Controllare che database è in esecuzione"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -961,6 +961,9 @@ msgstr "毎年"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
+msgstr ""
+
 msgid "Anyone signing in through one of these directory groups is placed in this user group. Membership granted this way is recomputed on every sign in."
 msgstr ""
 
@@ -1543,6 +1546,9 @@ msgstr "クリア"
 
 msgid "Clear Fields"
 msgstr "フィールドをクリア"
+
+msgid "Clear one of your preferences"
+msgstr ""
 
 msgid "Click"
 msgstr "クリック"
@@ -2443,6 +2449,9 @@ msgstr "プリンタータイプ"
 msgid "Equipment Loan"
 msgstr "機器貸出"
 
+msgid "Equivalent to storing an empty value."
+msgstr ""
+
 msgid "Error"
 msgstr "エラー"
 
@@ -2526,6 +2535,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "ファイルはアップロードされませんでした"
+
+msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
+msgstr ""
 
 #, fuzzy
 msgid "Existence check failed"
@@ -5608,11 +5620,18 @@ msgstr "このグループで利用可能なアクティビティ情報はあり
 msgid "No unrunnable tasks found."
 msgstr "新しいタスクは見つかりません"
 
+#, fuzzy
+msgid "No user in session"
+msgstr "バージョン"
+
 msgid "No valid storage nodes found"
 msgstr "有効なストレージノードが見つかりません"
 
 msgid "No valid tasks found"
 msgstr "有効なタスクが見つかりません"
+
+msgid "No value supplied; use DELETE to clear"
+msgstr ""
 
 msgid "No values passed"
 msgstr "値が渡されていません"
@@ -5832,6 +5851,9 @@ msgstr ""
 
 msgid "One or more macs are associated with a host"
 msgstr "1 つ以上の MAC アドレスがホストに関連付けられています"
+
+msgid "One preference."
+msgstr ""
 
 msgid "Online"
 msgstr ""
@@ -6349,6 +6371,9 @@ msgstr ""
 msgid "PowerShell x64 Script"
 msgstr ""
 
+msgid "Preference key or value is not storable"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -6599,6 +6624,9 @@ msgid "Re-run the installer, which restricts them to root. If this persists, che
 msgstr ""
 
 msgid "Read a server log"
+msgstr ""
+
+msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
@@ -7950,6 +7978,9 @@ msgstr "レポートを作成しますか？"
 msgid "Storage nodes"
 msgstr "ストレージノード"
 
+msgid "Store one of your preferences"
+msgstr ""
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -8416,7 +8447,13 @@ msgstr ""
 msgid "The archive must hold exactly one plugin directory."
 msgstr ""
 
+msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
+msgstr ""
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
+msgstr ""
+
+msgid "The calling user's preferences."
 msgstr ""
 
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
@@ -8542,6 +8579,15 @@ msgid "The plugin system is disabled"
 msgstr "このプラグインはインストールされていません"
 
 msgid "The plugin will run but its JS and CSS will 404."
+msgstr ""
+
+msgid "The preference key. Namespaced by its consumer -- a grid's saved state is stored under \"dt.<table id>\" -- so that two features cannot collide on one name."
+msgstr ""
+
+msgid "The preference was cleared."
+msgstr ""
+
+msgid "The preference was stored."
 msgstr ""
 
 msgid "The primary mac associated is"
@@ -9728,6 +9774,9 @@ msgid "Your database connection appears to be invalid"
 msgstr "データベース接続が無効のようです"
 
 msgid "Your session has ended. Sign in again."
+msgstr ""
+
+msgid "Your stored preferences"
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1415,6 +1415,10 @@ msgid "Capone added!"
 msgstr "スナップインを追加しました！"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "ロケーション"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "スナップインの更新に失敗しました！"
 
@@ -10929,10 +10933,6 @@ msgstr ""
 
 #~ msgid "Cannot view from browser"
 #~ msgstr "ブラウザーから表示できません"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "ロケーション"
 
 #~ msgid "Chat is also available on the forums for more realtime help"
 #~ msgstr "よりリアルタイムな支援が必要な場合はフォーラムのチャットも利用できます"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1262,6 +1262,9 @@ msgstr ""
 msgid "Capone added!"
 msgstr ""
 
+msgid "Capone schema"
+msgstr ""
+
 msgid "Capone update failed!"
 msgstr ""
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -858,6 +858,9 @@ msgstr ""
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
+msgstr ""
+
 msgid "Anyone signing in through one of these directory groups is placed in this user group. Membership granted this way is recomputed on every sign in."
 msgstr ""
 
@@ -1375,6 +1378,9 @@ msgid "Clear"
 msgstr ""
 
 msgid "Clear Fields"
+msgstr ""
+
+msgid "Clear one of your preferences"
 msgstr ""
 
 msgid "Click"
@@ -2153,6 +2159,9 @@ msgstr ""
 msgid "Equipment Loan"
 msgstr ""
 
+msgid "Equivalent to storing an empty value."
+msgstr ""
+
 msgid "Error"
 msgstr ""
 
@@ -2229,6 +2238,9 @@ msgid "Every configured multicast port is already in use"
 msgstr ""
 
 msgid "Every file was uploaded."
+msgstr ""
+
+msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
 msgstr ""
 
 msgid "Existence check failed"
@@ -4944,10 +4956,16 @@ msgstr ""
 msgid "No unrunnable tasks found."
 msgstr ""
 
+msgid "No user in session"
+msgstr ""
+
 msgid "No valid storage nodes found"
 msgstr ""
 
 msgid "No valid tasks found"
+msgstr ""
+
+msgid "No value supplied; use DELETE to clear"
 msgstr ""
 
 msgid "No values passed"
@@ -5143,6 +5161,9 @@ msgid "One or more files. The field name carries the [] suffix on the wire: snap
 msgstr ""
 
 msgid "One or more macs are associated with a host"
+msgstr ""
+
+msgid "One preference."
 msgstr ""
 
 msgid "Online"
@@ -5592,6 +5613,9 @@ msgstr ""
 msgid "PowerShell x64 Script"
 msgstr ""
 
+msgid "Preference key or value is not storable"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -5813,6 +5837,9 @@ msgid "Re-run the installer, which restricts them to root. If this persists, che
 msgstr ""
 
 msgid "Read a server log"
+msgstr ""
+
+msgid "Read one of your preferences"
 msgstr ""
 
 msgid "Real Time"
@@ -7022,6 +7049,9 @@ msgstr ""
 msgid "Storage nodes"
 msgstr ""
 
+msgid "Store one of your preferences"
+msgstr ""
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -7433,7 +7463,13 @@ msgstr ""
 msgid "The archive must hold exactly one plugin directory."
 msgstr ""
 
+msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
+msgstr ""
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
+msgstr ""
+
+msgid "The calling user's preferences."
 msgstr ""
 
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
@@ -7549,6 +7585,15 @@ msgid "The plugin system is disabled"
 msgstr ""
 
 msgid "The plugin will run but its JS and CSS will 404."
+msgstr ""
+
+msgid "The preference key. Namespaced by its consumer -- a grid's saved state is stored under \"dt.<table id>\" -- so that two features cannot collide on one name."
+msgstr ""
+
+msgid "The preference was cleared."
+msgstr ""
+
+msgid "The preference was stored."
 msgstr ""
 
 msgid "The primary mac associated is"
@@ -8626,6 +8671,9 @@ msgid "Your database connection appears to be invalid"
 msgstr ""
 
 msgid "Your session has ended. Sign in again."
+msgstr ""
+
+msgid "Your stored preferences"
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1004,6 +1004,9 @@ msgstr "Anualmente"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
+msgstr ""
+
 msgid "Anyone signing in through one of these directory groups is placed in this user group. Membership granted this way is recomputed on every sign in."
 msgstr ""
 
@@ -1605,6 +1608,9 @@ msgstr "Claro"
 #, fuzzy
 msgid "Clear Fields"
 msgstr "Limpar histórico"
+
+msgid "Clear one of your preferences"
+msgstr ""
 
 msgid "Click"
 msgstr "Clique"
@@ -2525,6 +2531,9 @@ msgstr "Tipo de impressora"
 msgid "Equipment Loan"
 msgstr "equipamento Loan"
 
+msgid "Equivalent to storing an empty value."
+msgstr ""
+
 msgid "Error"
 msgstr "Erro"
 
@@ -2611,6 +2620,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "Nenhum arquivo foi transferido"
+
+msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
+msgstr ""
 
 #, fuzzy
 msgid "Existence check failed"
@@ -5828,12 +5840,19 @@ msgid "No unrunnable tasks found."
 msgstr "Nenhuma classe válida enviada"
 
 #, fuzzy
+msgid "No user in session"
+msgstr "Versão"
+
+#, fuzzy
 msgid "No valid storage nodes found"
 msgstr "nó de armazenamento inválido"
 
 #, fuzzy
 msgid "No valid tasks found"
 msgstr "Nenhuma classe válida enviada"
+
+msgid "No value supplied; use DELETE to clear"
+msgstr ""
 
 msgid "No values passed"
 msgstr "Não há valores passados"
@@ -6058,6 +6077,9 @@ msgstr ""
 #, fuzzy
 msgid "One or more macs are associated with a host"
 msgstr "Erro, é uma imagem associada com este anfitrião"
+
+msgid "One preference."
+msgstr ""
 
 msgid "Online"
 msgstr ""
@@ -6583,6 +6605,9 @@ msgstr ""
 msgid "PowerShell x64 Script"
 msgstr ""
 
+msgid "Preference key or value is not storable"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -6840,6 +6865,9 @@ msgid "Re-run the installer, which restricts them to root. If this persists, che
 msgstr ""
 
 msgid "Read a server log"
+msgstr ""
+
+msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
@@ -8267,6 +8295,9 @@ msgstr "ID de acolhimento"
 msgid "Storage nodes"
 msgstr "Nó de armazenamento"
 
+msgid "Store one of your preferences"
+msgstr ""
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -8757,7 +8788,13 @@ msgstr ""
 msgid "The archive must hold exactly one plugin directory."
 msgstr ""
 
+msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
+msgstr ""
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
+msgstr ""
+
+msgid "The calling user's preferences."
 msgstr ""
 
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
@@ -8883,6 +8920,15 @@ msgid "The plugin system is disabled"
 msgstr "As doações são deficientes"
 
 msgid "The plugin will run but its JS and CSS will 404."
+msgstr ""
+
+msgid "The preference key. Namespaced by its consumer -- a grid's saved state is stored under \"dt.<table id>\" -- so that two features cannot collide on one name."
+msgstr ""
+
+msgid "The preference was cleared."
+msgstr ""
+
+msgid "The preference was stored."
 msgstr ""
 
 msgid "The primary mac associated is"
@@ -10105,6 +10151,9 @@ msgid "Your database connection appears to be invalid"
 msgstr ""
 
 msgid "Your session has ended. Sign in again."
+msgstr ""
+
+msgid "Your stored preferences"
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1473,6 +1473,10 @@ msgid "Capone added!"
 msgstr "Nome Snapin"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "localizações"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "atualização Snapin falhou"
 
@@ -11235,10 +11239,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Salvar alterações"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "localizações"
 
 #~ msgid "Check that database is running"
 #~ msgstr "Verifique o banco de dados está em execução"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1473,6 +1473,10 @@ msgid "Capone added!"
 msgstr "管理单元名称"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "位置"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "管理单元更新失败"
 
@@ -11235,10 +11239,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "保存更改"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "位置"
 
 #~ msgid "Check that database is running"
 #~ msgstr "检查数据库运行"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1004,6 +1004,9 @@ msgstr "每年"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
+msgstr ""
+
 msgid "Anyone signing in through one of these directory groups is placed in this user group. Membership granted this way is recomputed on every sign in."
 msgstr ""
 
@@ -1605,6 +1608,9 @@ msgstr "明确"
 #, fuzzy
 msgid "Clear Fields"
 msgstr "清除所有历史"
+
+msgid "Clear one of your preferences"
+msgstr ""
 
 msgid "Click"
 msgstr "点击"
@@ -2525,6 +2531,9 @@ msgstr "打印机类型"
 msgid "Equipment Loan"
 msgstr "器材信贷"
 
+msgid "Equivalent to storing an empty value."
+msgstr ""
+
 msgid "Error"
 msgstr "错误"
 
@@ -2611,6 +2620,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "没有文件被上传"
+
+msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
+msgstr ""
 
 #, fuzzy
 msgid "Existence check failed"
@@ -5828,12 +5840,19 @@ msgid "No unrunnable tasks found."
 msgstr "发送无有效类"
 
 #, fuzzy
+msgid "No user in session"
+msgstr "版"
+
+#, fuzzy
 msgid "No valid storage nodes found"
 msgstr "无效的存储节点"
 
 #, fuzzy
 msgid "No valid tasks found"
 msgstr "发送无有效类"
+
+msgid "No value supplied; use DELETE to clear"
+msgstr ""
 
 msgid "No values passed"
 msgstr "没有值传递"
@@ -6058,6 +6077,9 @@ msgstr ""
 #, fuzzy
 msgid "One or more macs are associated with a host"
 msgstr "错误，与此主机关联的图像"
+
+msgid "One preference."
+msgstr ""
 
 msgid "Online"
 msgstr ""
@@ -6583,6 +6605,9 @@ msgstr ""
 msgid "PowerShell x64 Script"
 msgstr ""
 
+msgid "Preference key or value is not storable"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -6840,6 +6865,9 @@ msgid "Re-run the installer, which restricts them to root. If this persists, che
 msgstr ""
 
 msgid "Read a server log"
+msgstr ""
+
+msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
@@ -8267,6 +8295,9 @@ msgstr "主机ID"
 msgid "Storage nodes"
 msgstr "存储节点"
 
+msgid "Store one of your preferences"
+msgstr ""
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -8757,7 +8788,13 @@ msgstr ""
 msgid "The archive must hold exactly one plugin directory."
 msgstr ""
 
+msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
+msgstr ""
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
+msgstr ""
+
+msgid "The calling user's preferences."
 msgstr ""
 
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
@@ -8883,6 +8920,15 @@ msgid "The plugin system is disabled"
 msgstr "捐款将被禁用"
 
 msgid "The plugin will run but its JS and CSS will 404."
+msgstr ""
+
+msgid "The preference key. Namespaced by its consumer -- a grid's saved state is stored under \"dt.<table id>\" -- so that two features cannot collide on one name."
+msgstr ""
+
+msgid "The preference was cleared."
+msgstr ""
+
+msgid "The preference was stored."
 msgstr ""
 
 msgid "The primary mac associated is"
@@ -10105,6 +10151,9 @@ msgid "Your database connection appears to be invalid"
 msgstr ""
 
 msgid "Your session has ended. Sign in again."
+msgstr ""
+
+msgid "Your stored preferences"
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"

--- a/packages/web/management/other/index.php
+++ b/packages/web/management/other/index.php
@@ -217,6 +217,17 @@ if (in_array(strtolower($pageLength), ['search', 'list'])) {
                 <?= FOGPage::makeInput('scrollMode', 'scrollMode', '', 'hidden', 'scrollMode', self::getSetting('FOG_TABLE_SCROLL_MODE')); ?>
                 <?= FOGPage::makeInput('showpass', 'showpass', '', 'hidden', 'showpass', self::getSetting('FOG_ENABLE_SHOW_PASSWORDS')); ?>
                 <?php
+                // Where the REST API lives, for the JS that stores a user's
+                // preferences. Normalized exactly as Route::defineRoutes()
+                // normalizes it, from the same setting, so the path the
+                // browser calls and the path the router answers on cannot
+                // drift -- FOG_WEB_ROOT is installer-settable and is not
+                // always '/fog/'.
+                $apiBase = trim((string)self::getSetting('FOG_WEB_ROOT'), '/');
+$apiBase = '/' . ($apiBase === '' ? '' : $apiBase . '/');
+?>
+                <?= FOGPage::makeInput('apiBase', 'apiBase', '', 'hidden', 'apiBase', $apiBase); ?>
+                <?php
         // No-role warning: with deny-by-default a user holding zero roles
         // can reach nothing but the exempt nodes (dashboard, logout), and
         // every menu entry disappears -- which looks like a broken install

--- a/packages/web/src/Auth/Authorization.php
+++ b/packages/web/src/Auth/Authorization.php
@@ -237,6 +237,13 @@ class Authorization extends FOGBase
         'bandwidth' => null,
         'whoami' => null,
         'unisearch' => null,
+        // A user's own preferences. null is "authenticated is enough", the
+        // same as whoami above, and for the same reason: neither route can
+        // address anything but the caller. The user id comes from the
+        // session and the path has no place to put a different one, so there
+        // is no object here for an object permission to be about.
+        'userprefs' => null,
+        'userpref' => null,
         // The API description, and its swagger.json alias. Public for the
         // same reason status/info are: a client should be able to discover
         // what it is talking to before it has credentials. Both expose only

--- a/packages/web/src/Auth/Redaction.php
+++ b/packages/web/src/Auth/Redaction.php
@@ -129,6 +129,13 @@ class Redaction extends FOGBase
             'passreset',
             'bypassbitlocker',
         ],
+        // A preference's NAME -- 'dt.host.list.dataTable' and the like. It
+        // matches only because the field is called "key"; there is no secret
+        // in a userPrefs row at all, and redacting it would blank the one
+        // column that says which preference a row is.
+        'userpref' => [
+            'key',
+        ],
     ];
     /**
      * Cached per-class union of both Route tiers.

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -94,8 +94,8 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 390);
-        define('FOG_BCACHE_VER', 333);
+        define('FOG_SCHEMA', 392);
+        define('FOG_BCACHE_VER', 334);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4496');
+        define('FOG_VERSION', '1.6.0-beta.4500');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Items/UserPref.php
+++ b/packages/web/src/Items/UserPref.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * One stored preference belonging to one user
+ *
+ * PHP version 7.4+
+ *
+ * @category UserPref
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Items;
+
+use FOG\Base\FOGController;
+
+/**
+ * One stored preference belonging to one user.
+ *
+ * The value is OPAQUE. Nothing here parses it, and nothing server-side may
+ * decide anything on the strength of what is inside it -- the first consumer
+ * is DataTables' own saved state, whose shape belongs to DataTables and
+ * changes between its major versions. Keeping the value uninterpreted is what
+ * stops that becoming a schema migration every time the library moves.
+ *
+ * @category UserPref
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class UserPref extends FOGController
+{
+    /**
+     * The largest value that will be stored, in bytes.
+     *
+     * A saved DataTables state for a wide grid runs to a couple of kilobytes;
+     * the column is a longtext and would take megabytes. The cap is here
+     * because the value arrives from a browser and is never read by anything
+     * that would notice it growing -- an unbounded per-user write is a way to
+     * fill a disk quietly, not a feature anybody asked for.
+     *
+     * @var int
+     */
+    const MAX_VALUE_BYTES = 65536;
+    /**
+     * The longest key that will be stored, in bytes.
+     *
+     * Matches the varchar(190) column. Two keys truncated to the same 190
+     * bytes would collide on the UNIQUE index and overwrite each other, so
+     * an over-long key is refused rather than cut down.
+     *
+     * @var int
+     */
+    const MAX_KEY_BYTES = 190;
+    /**
+     * The user preferences table
+     *
+     * @var string
+     */
+    protected $databaseTable = 'userPrefs';
+    /**
+     * The table fields and common names
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'upID',
+        'userID' => 'upUserID',
+        'key' => 'upKey',
+        'value' => 'upValue',
+        'createdTime' => 'upCreatedTime',
+        'modifiedTime' => 'upModifiedTime'
+    ];
+    /**
+     * The required fields
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'userID',
+        'key'
+    ];
+}

--- a/packages/web/src/Managers/UserPrefManager.php
+++ b/packages/web/src/Managers/UserPrefManager.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * User preference manager class.
+ *
+ * PHP version 7.4+
+ *
+ * @category UserPrefManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Managers;
+
+use FOG\Base\FOGManagerController;
+use FOG\Items\UserPref;
+
+/**
+ * User preference manager class.
+ *
+ * Every method takes the owning user id as its first argument and filters on
+ * it, always. That is the entire access-control story for preferences: no
+ * call in this class can reach a row belonging to somebody else, whatever key
+ * it is handed. The route layer supplies the id from the session and never
+ * from the request, so the two halves cannot be talked out of agreeing.
+ *
+ * @category UserPrefManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class UserPrefManager extends FOGManagerController
+{
+    /**
+     * Reads one preference.
+     *
+     * @param int    $userID The user the preference belongs to.
+     * @param string $key    The preference's key.
+     *
+     * @return string The stored value, or '' when there is none.
+     */
+    public function fetch($userID, $key)
+    {
+        $userID = (int)$userID;
+        $key = (string)$key;
+        if ($userID < 1 || '' === $key) {
+            return '';
+        }
+        $row = self::$DB
+            ->query(
+                'SELECT `upValue` FROM `userPrefs`'
+                . ' WHERE `upUserID` = :uid AND `upKey` = :key',
+                [],
+                [':uid' => $userID, ':key' => $key]
+            )
+            ->fetch()
+            ->get();
+
+        return (string)($row['upValue'] ?? '');
+    }
+
+    /**
+     * Reads every preference a user holds, as key => value.
+     *
+     * @param int $userID The user.
+     *
+     * @return array
+     */
+    public function fetchAll($userID)
+    {
+        $userID = (int)$userID;
+        if ($userID < 1) {
+            return [];
+        }
+        $rows = self::$DB
+            ->query(
+                'SELECT `upKey`, `upValue` FROM `userPrefs`'
+                . ' WHERE `upUserID` = :uid ORDER BY `upKey` ASC',
+                [],
+                [':uid' => $userID]
+            )
+            ->fetch('', 'fetch_all')
+            ->get();
+
+        $prefs = [];
+        foreach ((array)$rows as $row) {
+            $prefs[(string)$row['upKey']] = (string)($row['upValue'] ?? '');
+        }
+
+        return $prefs;
+    }
+
+    /**
+     * Writes one preference, replacing any previous value.
+     *
+     * An empty value DELETES rather than storing emptiness. Resetting a grid
+     * to its defaults should leave no row behind: otherwise somebody who has
+     * tidied up still carries a row saying "no opinion", which no later
+     * reader can tell from never having had one.
+     *
+     * @param int    $userID The user the preference belongs to.
+     * @param string $key    The preference's key.
+     * @param string $value  The value to store.
+     *
+     * @return bool Whether the write happened.
+     */
+    public function store($userID, $key, $value)
+    {
+        $userID = (int)$userID;
+        $key = (string)$key;
+        $value = (string)$value;
+        if ($userID < 1 || '' === $key) {
+            return false;
+        }
+        if (strlen($key) > UserPref::MAX_KEY_BYTES) {
+            // The column is varchar(190), so a longer key would be
+            // truncated -- and two different keys truncated to the same 190
+            // bytes collide on the UNIQUE index, where the upsert below then
+            // overwrites an unrelated preference. Refuse instead.
+            return false;
+        }
+        if (strlen($value) > UserPref::MAX_VALUE_BYTES) {
+            return false;
+        }
+        if ('' === $value) {
+            return $this->clear($userID, $key);
+        }
+
+        // ON DUPLICATE KEY UPDATE against the (user, key) UNIQUE index.
+        // Elsewhere in FOG that combination is a bug -- a create silently
+        // overwriting an existing row -- but replacing the previous value of
+        // the same preference for the same user is precisely the operation,
+        // and doing it in one statement is what stops two tabs saving at
+        // once from racing into a duplicate-key error.
+        return (bool)self::$DB->query(
+            'INSERT INTO `userPrefs`'
+            . ' (`upUserID`, `upKey`, `upValue`, `upModifiedTime`)'
+            . ' VALUES (:uid, :key, :val, NOW())'
+            . ' ON DUPLICATE KEY UPDATE'
+            . ' `upValue` = VALUES(`upValue`),'
+            . ' `upModifiedTime` = VALUES(`upModifiedTime`)',
+            [],
+            [':uid' => $userID, ':key' => $key, ':val' => $value]
+        );
+    }
+
+    /**
+     * Removes one preference.
+     *
+     * @param int    $userID The user the preference belongs to.
+     * @param string $key    The preference's key.
+     *
+     * @return bool
+     */
+    public function clear($userID, $key)
+    {
+        $userID = (int)$userID;
+        $key = (string)$key;
+        if ($userID < 1 || '' === $key) {
+            return false;
+        }
+
+        return (bool)self::$DB->query(
+            'DELETE FROM `userPrefs`'
+            . ' WHERE `upUserID` = :uid AND `upKey` = :key',
+            [],
+            [':uid' => $userID, ':key' => $key]
+        );
+    }
+}

--- a/packages/web/src/Router/OpenAPI.php
+++ b/packages/web/src/Router/OpenAPI.php
@@ -1673,6 +1673,7 @@ class OpenAPI extends FOGBase
             'kernelupdate' => 'List',
             'initrdupdate' => 'List',
             'unisearch' => 'SearchAll',
+            'userprefs' => 'ListPref',
             'settingscacheview' => 'Get',
             'settingscacheflush' => 'Flush',
             'settingscacherefresh' => 'Refresh',
@@ -2308,6 +2309,26 @@ class OpenAPI extends FOGBase
      *
      * @return array
      */
+    /**
+     * The {key} path parameter shared by the three userpref operations.
+     *
+     * @return array
+     */
+    private static function _prefKeyParam()
+    {
+        return [
+            [
+                'name' => 'key',
+                'in' => 'path',
+                'required' => true,
+                'description' => _('The preference key. Namespaced by its '
+                    . 'consumer -- a grid\'s saved state is stored under '
+                    . '"dt.<table id>" -- so that two features cannot '
+                    . 'collide on one name.'),
+                'schema' => ['type' => 'string', 'maxLength' => 190]
+            ]
+        ];
+    }
     private static function _fixedPaths()
     {
         $json = function ($schema, $desc) {
@@ -2351,6 +2372,113 @@ class OpenAPI extends FOGBase
                         . 'served at /swagger.json, which is where most '
                         . 'tooling looks first.'),
                     $json(['type' => 'object'], _('An OpenAPI document.'))
+                )
+            ],
+            '/system/userprefs' => [
+                'get' => self::_op(
+                    '',
+                    'userprefs',
+                    _('Your stored preferences'),
+                    _('Every preference belonging to the CALLING user, as a '
+                        . 'key/value map. There is no user in the path and no '
+                        . 'way to name one: the id comes from the session, so '
+                        . 'this cannot read anybody else\'s. Values are '
+                        . 'opaque strings the server does not interpret.'),
+                    $json(
+                        [
+                            'type' => 'object',
+                            'properties' => [
+                                'prefs' => [
+                                    'type' => 'object',
+                                    'additionalProperties' => [
+                                        'type' => 'string'
+                                    ]
+                                ],
+                                'msg' => ['type' => 'string']
+                            ]
+                        ],
+                        _('The calling user\'s preferences.')
+                    )
+                )
+            ],
+            '/system/userpref/{key}' => [
+                'get' => self::_op(
+                    '',
+                    'userpref',
+                    _('Read one of your preferences'),
+                    _('Answers an empty value when the key has never been '
+                        . 'set, rather than 404 -- "no opinion" is a normal '
+                        . 'answer here, not a missing resource.'),
+                    $json(
+                        [
+                            'type' => 'object',
+                            'properties' => [
+                                'key' => ['type' => 'string'],
+                                'value' => ['type' => 'string'],
+                                'msg' => ['type' => 'string']
+                            ]
+                        ],
+                        _('One preference.')
+                    ),
+                    self::_prefKeyParam(),
+                    [],
+                    'GetPref'
+                ),
+                'post' => self::_op(
+                    '',
+                    'userpref',
+                    _('Store one of your preferences'),
+                    _('The body is {"value": "..."}; a form field of the same '
+                        . 'name is accepted too. An EMPTY value deletes the '
+                        . 'preference rather than storing emptiness, so a '
+                        . 'reset leaves no row saying "no opinion". Values '
+                        . 'are capped at 64KB and refused rather than '
+                        . 'truncated -- a truncated saved state cannot be '
+                        . 'told from a corrupt one when it is read back.'),
+                    $json(
+                        [
+                            'type' => 'object',
+                            'properties' => [
+                                'key' => ['type' => 'string'],
+                                'msg' => ['type' => 'string']
+                            ]
+                        ],
+                        _('The preference was stored.')
+                    ),
+                    self::_prefKeyParam(),
+                    [
+                        'required' => true,
+                        'content' => [
+                            'application/json' => [
+                                'schema' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'value' => ['type' => 'string']
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
+                    'SetPref'
+                ),
+                'delete' => self::_op(
+                    '',
+                    'userpref',
+                    _('Clear one of your preferences'),
+                    _('Equivalent to storing an empty value.'),
+                    $json(
+                        [
+                            'type' => 'object',
+                            'properties' => [
+                                'key' => ['type' => 'string'],
+                                'msg' => ['type' => 'string']
+                            ]
+                        ],
+                        _('The preference was cleared.')
+                    ),
+                    self::_prefKeyParam(),
+                    [],
+                    'ClearPref'
                 )
             ],
             '/system/export' => [

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -1384,6 +1384,23 @@ class Route extends FOGBase
             '/system/export',
             [__CLASS__, 'export'],
             'export'
+        )->get(
+            // Every preference the CALLER holds, in one request. The saved
+            // state of a dozen grids is a dozen keys, and a page that had to
+            // ask for them one at a time would spend a round trip per table
+            // before it could draw any of them.
+            '/system/userprefs',
+            [__CLASS__, 'userprefs'],
+            'userprefs'
+        )->map(
+            // One preference of the CALLER's. Note there is no user in the
+            // path and no way to put one there: the id comes from the
+            // session, so this route cannot address anybody else's row. That
+            // is what lets it carry no permission beyond being signed in.
+            'GET|POST|PUT|DELETE',
+            '/system/userpref/[*:key]',
+            [__CLASS__, 'userpref'],
+            'userpref'
         )->map(
             'GET|POST',
             '/[search|unisearch]/[*:item]/[i:limit]?',
@@ -2090,6 +2107,114 @@ class Route extends FOGBase
                     JSON_INVALID_UTF8_SUBSTITUTE
                 )
         );
+    }
+    /**
+     * Answers with every preference the calling user holds.
+     *
+     * @return void
+     */
+    public static function userprefs()
+    {
+        self::$data = [
+            'prefs' => self::getClass('UserPrefManager')->fetchAll(
+                (int)self::$FOGUser->get('id')
+            ),
+            'msg' => _('success')
+        ];
+    }
+    /**
+     * Reads, writes or clears one preference of the calling user's.
+     *
+     * The user is taken from the session and never from the request, so
+     * there is no addressable way to reach another user's row -- which is
+     * why the route needs no permission beyond authentication, the same
+     * shape as whoami.
+     *
+     * The value is stored uninterpreted. It comes from a browser and the
+     * only thing that ever reads it is the same browser code that wrote it,
+     * so parsing it here would buy nothing and would couple the server to a
+     * client library's internals. It is bounded instead: an oversized value
+     * is refused rather than truncated, because a truncated saved state is
+     * indistinguishable from a corrupt one at the point it is read back.
+     *
+     * @param string $key the preference key
+     *
+     * @return void
+     */
+    public static function userpref($key)
+    {
+        $key = trim((string)$key);
+        $userID = (int)self::$FOGUser->get('id');
+        if ($userID < 1) {
+            // Belt and braces: the router authenticates before dispatching,
+            // so this is unreachable. Storing against user 0 if it ever were
+            // reachable would make one shared pile of preferences visible to
+            // everybody, so it fails closed rather than defaulting.
+            self::sendResponse(
+                HTTPResponseCodes::HTTP_UNAUTHORIZED,
+                json_encode(['error' => _('No user in session')])
+            );
+
+            return;
+        }
+        $method = strtoupper(self::$reqmethod ?: 'GET');
+        if ($method === 'GET') {
+            self::$data = [
+                'key' => $key,
+                'value' => self::getClass('UserPrefManager')
+                    ->fetch($userID, $key),
+                'msg' => _('success')
+            ];
+
+            return;
+        }
+        $value = '';
+        if ($method !== 'DELETE') {
+            // Accept both spellings a browser might send: a JSON body, which
+            // is what fetch() sends by default, and a form field, which is
+            // what jQuery sends.
+            //
+            // ABSENT AND EMPTY ARE NOT THE SAME THING. An empty value is the
+            // documented way to clear a preference, so a request that carries
+            // no value at all must not be read as one: PHP populates $_POST
+            // only for a form-encoded POST, so a form-encoded PUT arrives with
+            // nothing in either spelling and would otherwise DELETE the
+            // preference it was sent to update, and answer 200 having done it.
+            $supplied = false;
+            $body = file_get_contents('php://input');
+            $decoded = json_decode((string)$body, true);
+            if (is_array($decoded) && array_key_exists('value', $decoded)) {
+                $value = (string)$decoded['value'];
+                $supplied = true;
+            } elseif (null !== filter_input(INPUT_POST, 'value')) {
+                $value = (string)filter_input(INPUT_POST, 'value');
+                $supplied = true;
+            }
+            if (!$supplied) {
+                self::sendResponse(
+                    HTTPResponseCodes::HTTP_BAD_REQUEST,
+                    json_encode(
+                        ['error' => _('No value supplied; use DELETE to clear')]
+                    )
+                );
+
+                return;
+            }
+        }
+        if (!self::getClass('UserPrefManager')->store($userID, $key, $value)) {
+            self::sendResponse(
+                HTTPResponseCodes::HTTP_BAD_REQUEST,
+                json_encode(
+                    ['error' => _('Preference key or value is not storable')]
+                )
+            );
+
+            return;
+        }
+        self::$data = [
+            'key' => $key,
+            'msg' => _('success')
+        ];
     }
     /**
      * Presents status to show up or down state.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -129,7 +129,7 @@ parameters:
 		-
 			message: '#^Variable \$this might not be defined\.$#'
 			identifier: variable.undefined
-			count: 360
+			count: 362
 			path: packages/web/commons/schema.php
 
 		-
@@ -1401,7 +1401,7 @@ parameters:
 		-
 			message: '#^Calling self\:\:getSetting\(\) outside of class scope\.$#'
 			identifier: outOfClass.self
-			count: 5
+			count: 6
 			path: packages/web/management/other/index.php
 
 		-

--- a/tests/datatable-state-persistence.test.php
+++ b/tests/datatable-state-persistence.test.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * The saved grid layout must actually be restorable.
+ *
+ * Column order, visibility, page length and sort persist per user through the
+ * preference store. Four things in that path fail SILENTLY -- no error, no log,
+ * the table just comes up in its default arrangement or filters the wrong
+ * column -- and all four were shipped and then found in a browser:
+ *
+ *  - stateLoadCallback returning anything other than undefined. DataTables
+ *    waits for the async callback only on undefined: `void 0 !== ret &&
+ *    useIt(ret)`. Returning null means "the state is null", and the answer the
+ *    function is waiting for arrives too late to be used.
+ *  - stripping `time` from the saved state. _fnImplementState opens with
+ *    `if (state && state.time)`, so a state with no timestamp is dropped
+ *    whole. It is also what stateDuration measures against.
+ *  - building the per-column search row only on the ajax response. A restored
+ *    column order is applied AFTER that, so the boxes stay pinned to the
+ *    pre-restore layout and each one filters a column its heading does not
+ *    belong to.
+ *  - saving the sort by index alone. DataTables and ColReorder disagree about
+ *    which frame a saved order index is in, so the sort lands on a different
+ *    column after a reload once anything has been dragged -- reproduced with
+ *    stock DataTables 2.0.8 and ColReorder 2.0.3 using the library's own
+ *    localStorage callbacks, so the compensation has to live here.
+ *
+ * Usage: php tests/datatable-state-persistence.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$js = file_get_contents($root . '/packages/web/management/js/fog/fog.common.js');
+
+$fails = [];
+
+// ------------------------------------------------ the async state load
+
+if (!preg_match(
+    '#stateLoadCallback: function\(settings, callback\) \{(.*?)\n    \},#s',
+    $js,
+    $m
+)) {
+    echo "FAIL: stateLoadCallback not found -- the gate cannot see its subject\n";
+    exit(1);
+}
+// Comments in this block discuss `return null` at length, and a gate that
+// passes on its own documentation is the failure this project has hit before.
+$load = preg_replace('#^\s*//.*$#m', '', $m[1]);
+
+// Every return in it must be bare. `return null` is the shape that broke it,
+// but so is any other value: DataTables acts on anything but undefined.
+if (preg_match_all('#\breturn\s+([^;\s][^;]*);#', $load, $rets)) {
+    foreach ($rets[1] as $ret) {
+        $fails[] = 'stateLoadCallback returns a value (' . trim($ret)
+            . '); DataTables waits for the async callback only when it '
+            . 'returns undefined';
+    }
+}
+if (!preg_match('#fogPrefFetch\(key, function\(err, value\)#', $load)) {
+    $fails[] = 'stateLoadCallback no longer reads through fogPrefFetch';
+}
+
+// ------------------------------------------------------- the timestamp
+
+if (!preg_match(
+    '#function fogStripStateSearch\(state\) \{(.*?)\n\}#s',
+    $js,
+    $m
+)) {
+    $fails[] = 'fogStripStateSearch() not found';
+} else {
+    if (preg_match('#delete\s+copy\.time#', $m[1])) {
+        $fails[] = 'fogStripStateSearch() deletes the state timestamp; '
+            . 'DataTables drops a state that has no time and the saved '
+            . 'layout can never be restored';
+    }
+    // What it MUST still strip: a stored search would be reapplied invisibly.
+    foreach (['search', 'searchBuilder'] as $stripped) {
+        if (!preg_match('#delete\s+copy\.' . $stripped . '\b#', $m[1])) {
+            $fails[] = "fogStripStateSearch() no longer strips $stripped";
+        }
+    }
+    if (!preg_match('#delete\s+copy\.columns\[i\]\.search#', $m[1])) {
+        $fails[] = 'fogStripStateSearch() no longer strips per-column search';
+    }
+}
+
+// --------------------------------------- the search row follows a restore
+
+if (!preg_match(
+    "#table\.on\(\s*'([^']*column-visibility[^']*)',#s",
+    $js,
+    $m
+)) {
+    $fails[] = 'the column-search rebuild binding was not found';
+} else {
+    foreach (['init.dt', 'draw.dt', 'column-reorder.dt', 'column-sizing.dt'] as $ev) {
+        if (false === strpos($m[1], $ev)) {
+            $fails[] = "the column-search row is not rebuilt on $ev; a "
+                . 'restored column order is applied after the first response, '
+                . 'so the boxes would stay pinned to the old layout';
+        }
+    }
+}
+
+// ------------------------------------------------- the sort follows its column
+
+if (!preg_match('#data\.fogOrder = fogOrderKeys\(settings, data\.order\);#', $js)) {
+    $fails[] = 'the saved state does not record which COLUMN is sorted; a '
+        . 'saved order index alone lands on the wrong column after a reorder';
+}
+if (!preg_match("#table\.on\('init\.dt', function\(\) \{\s*fogApplyOrder\(table\);#s", $js)) {
+    $fails[] = 'fogApplyOrder() is not called once the table is up, so a '
+        . 'mis-restored sort is never corrected';
+}
+if (!preg_match('#function fogApplyOrder\(api\) \{(.*?)\n\}#s', $js, $m)) {
+    $fails[] = 'fogApplyOrder() not found';
+} elseif (!preg_match(
+    '#JSON\.stringify\(wanted\) === JSON\.stringify\(api\.order\(\)\)#',
+    $m[1]
+)) {
+    $fails[] = 'fogApplyOrder() no longer returns early when the sort is '
+        . 'already right; on a server-side table that is a redraw, and so a '
+        . 'wasted request, on every single grid load';
+}
+
+if ($fails) {
+    foreach ($fails as $f) {
+        echo "FAIL: $f\n";
+    }
+    exit(1);
+}
+echo "PASS: the saved grid layout is restorable -- async load, timestamp, "
+    . "row rebuild and sort column all pinned\n";
+exit(0);

--- a/tests/foreign-key-map.test.php
+++ b/tests/foreign-key-map.test.php
@@ -238,6 +238,9 @@ foreach ($map as $rel) {
  * Group 3 -- storage: groups, nodes, image and snapin assoc, schema step 384.
  * Group 5 -- configuration references, schema step 388.
  * Group 6 -- tasks and active work, schema step 390.
+ * Group 7 -- user preferences, schema step 392. The only group whose table
+ *   was created by the release that constrains it, so the only one with no
+ *   orphan sweep before it.
  * Groups 'location', 'ou', 'windowskey', 'ldap', 'oidc' -- the plugin
  *   tables, each applied by a step appended to that plugin's own schema()
  *   in the fog-plugins repo, not by a core step.
@@ -320,6 +323,8 @@ $expected = [
     'multicastSessions.msState',
     'multicastSessionsAssoc.msID',
     'multicastSessionsAssoc.tID',
+    // Group 7
+    'userPrefs.upUserID',
     // Plugin groups, named for the plugin rather than numbered. Each
     // lands in that plugin's own repo, in an appended step of its
     // manager's schema(); see fog-plugins tests/foreign-keys.test.php,

--- a/tests/userpref-route-absent-is-not-empty.test.php
+++ b/tests/userpref-route-absent-is-not-empty.test.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Route::userpref() must not read "no value" as "clear this".
+ *
+ * An empty value is the documented way to clear a preference, which makes an
+ * absent one dangerous: PHP populates $_POST only for a form-encoded POST, so
+ * a form-encoded PUT reaches the handler with nothing in either spelling. Read
+ * as an empty value, that DELETES the preference it was sent to update and
+ * answers 200 having done it -- the "route arm returns 200 having done
+ * nothing" shape, except it destroys something on the way.
+ *
+ * Found by exercising the route against a lab database: the store path was
+ * driven through the form-field spelling, nothing was stored, and the caller
+ * was told it succeeded.
+ *
+ * Also pinned here: the acting user comes from the session, never from the
+ * request. The whole feature is per-user storage, so a request-supplied user
+ * id would let anyone read or overwrite anyone else's preferences.
+ *
+ * Usage: php tests/userpref-route-absent-is-not-empty.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$route = file_get_contents($root . '/packages/web/src/Router/Route.php');
+
+$fails = [];
+
+// Isolate the handler: a match elsewhere in this class must not stand in for
+// the thing being tested.
+if (!preg_match(
+    '#public static function userpref\(\$key\).*?\n    \}\n#s',
+    $route,
+    $m
+)) {
+    echo "FAIL: Route::userpref() not found -- the gate cannot see its subject\n";
+    exit(1);
+}
+$handler = $m[0];
+
+// ------------------------------------------------------- absent vs empty
+
+// A flag that records whether a value was actually supplied, set in each
+// reading branch. Without it the two cases are indistinguishable.
+if (!preg_match('#\$supplied\s*=\s*false;#', $handler)) {
+    $fails[] = 'userpref() does not track whether a value was supplied; an '
+        . 'absent value is then indistinguishable from an empty one';
+}
+
+// The form-field spelling must be tested for presence, not cast. A bare
+// (string)filter_input() turns a missing field into '', which is the clear
+// instruction.
+if (!preg_match(
+    '#null\s*!==\s*filter_input\(\s*INPUT_POST,\s*\'value\'\s*\)#',
+    $handler
+)) {
+    $fails[] = 'userpref() does not test filter_input(INPUT_POST, \'value\') '
+        . 'against null; a missing form field casts to \'\' and clears';
+}
+
+// The JSON branch must use array_key_exists, so an explicit {"value":""} is
+// still recognized as supplied -- clearing by request stays possible.
+if (!preg_match('#array_key_exists\(\s*\'value\',\s*\$decoded\s*\)#', $handler)) {
+    $fails[] = 'userpref() does not use array_key_exists on the JSON body; an '
+        . 'explicit empty value would stop counting as supplied';
+}
+
+// Nothing supplied must refuse, and refuse before reaching store().
+if (!preg_match(
+    '#if\s*\(!\$supplied\)\s*\{\s*self::sendResponse\(\s*HTTPResponseCodes::HTTP_BAD_REQUEST#s',
+    $handler
+)) {
+    $fails[] = 'userpref() does not answer 400 when no value was supplied';
+}
+
+// The refusal must come BEFORE the store call, or it refuses after the
+// damage. Compared by position within the isolated handler.
+$refusal = strpos($handler, 'if (!$supplied)');
+$store = strpos($handler, "->store(");
+if (false !== $refusal && false !== $store && $refusal > $store) {
+    $fails[] = 'userpref() refuses a bodyless store only after calling store()';
+}
+
+// DELETE is the spelling that clears without a body, and must stay exempt
+// from the guard -- otherwise clearing becomes impossible.
+if (!preg_match('#if\s*\(\$method\s*!==\s*\'DELETE\'\)#', $handler)) {
+    $fails[] = 'userpref() no longer exempts DELETE from needing a body';
+}
+
+// ------------------------------------------------------------- self-scope
+
+// The acting user is read from the session. Any read of a request-supplied
+// user id here would be a cross-user read or write.
+if (!preg_match('#\$userID\s*=\s*\(int\)self::\$FOGUser->get\(\'id\'\);#', $handler)) {
+    $fails[] = 'userpref() does not take the acting user from the session';
+}
+foreach (['userID', 'user_id', 'uid'] as $param) {
+    if (preg_match(
+        '#filter_input\(\s*INPUT_(GET|POST),\s*\'' . $param . '\'#i',
+        $handler
+    )) {
+        $fails[] = "userpref() reads '$param' from the request; the acting "
+            . 'user must come from the session only';
+    }
+}
+
+// The same two properties on the list route.
+if (!preg_match(
+    '#public static function userprefs\(\).*?\n    \}\n#s',
+    $route,
+    $m
+)) {
+    $fails[] = 'Route::userprefs() not found';
+} elseif (!preg_match('#\(int\)self::\$FOGUser->get\(\'id\'\)#', $m[0])) {
+    $fails[] = 'userprefs() does not take the acting user from the session';
+}
+
+if ($fails) {
+    foreach ($fails as $f) {
+        echo "FAIL: $f\n";
+    }
+    exit(1);
+}
+echo "PASS: userpref() distinguishes an absent value from an empty one, and "
+    . "scopes to the session user\n";
+exit(0);


### PR DESCRIPTION
## What this does

Grid layouts are remembered per signed-in user: **column order, which columns
are showing, page length and sort**. They follow the user to any browser rather
than living in that one browser's `localStorage`.

ColReorder was already in the vendored DataTables bundle but switched off, so
this turns it on. "Arrange the columns" and "remember the arrangement" are one
feature — either alone is close to useless.

**Searches are deliberately not persisted.** A filter restored invisibly on a
later visit looks like missing data, which is a support call, not a
convenience. `fogStripStateSearch()` strips them on the way out *and* on the
way in, so a value stored by an older release cannot reintroduce one.

## Storage

New `userPrefs` table (schema 391), keyed `(upUserID, upKey)` with a UNIQUE
index so a store is an upsert rather than a growing pile of rows, and a
CASCADE to `users` (schema 392, constraint group 7) so deleting an account
takes its preferences with it.

Two routes, both **scoped to the session user with no way to name another** —
the acting id comes from `self::$FOGUser` and nothing in the request can
change it:

| Route | Methods |
|---|---|
| `/system/userprefs` | GET |
| `/system/userpref/{key}` | GET, POST, PUT, DELETE |

Values are capped (190-byte key, 64 KB value) and refused rather than
truncated. An empty value clears.

## Four silent failures found while verifying

Each of these looks exactly like "the feature doesn't exist" — nothing errors,
nothing is logged:

- **`stateLoadCallback` returned `null`.** DataTables waits for the async
  answer only when the callback returns `undefined`
  (`void 0 !== ret && useIt(ret)`). Returning `null` means "the state is
  null", so every table loaded its default layout and the server's answer
  arrived too late to matter.
- **The saved state had its timestamp stripped.** `_fnImplementState` opens
  with `if (state && state.time)`, so a state with no timestamp is discarded
  whole. It is also what `stateDuration` measures against, which is the escape
  hatch that lets a bad saved layout age out instead of following someone
  forever.
- **The per-column search row was built on the ajax response**, but a restored
  column order is applied *after* that. The boxes stayed pinned to the
  pre-restore layout, so each one filtered a column its heading did not belong
  to. Rebuild is now bound to `init.dt` and `draw.dt` as well; the existing
  signature check makes the extra passes free.
- **The sort landed on the wrong column after a reorder.** Reproduced with
  stock DataTables 2.0.8 + ColReorder 2.0.3 and the library's own
  `localStorage` callbacks, with no FOG code in the path — `id` came back as
  `macs`. The state now also records *which column* is sorted, by key, and
  puts the sort back once the table is up. `fogApplyOrder()` returns early
  when the sort is already right, so the common visit costs no extra request.

## Also fixed

`Route::userpref()` treated an absent value as an empty one. PHP populates
`$_POST` only for a form-encoded POST, so a form-encoded **PUT** arrived with
nothing in either spelling and would have **deleted the preference it was sent
to update, answering 200 having done it**. Absent is now refused; an explicit
empty value still clears, and DELETE is unchanged.

## Verification

- **Isolated MariaDB copy of a live database** (never the live one): both
  schema steps applied and read back, the manager's upsert / self-scoping /
  caps / empty-deletes, the REST routes per method, cross-user invisibility,
  and the `users` CASCADE.
- **A real browser**: the full state round trip, ColReorder, a corrupt stored
  value not taking out the grid, and the search boxes lining up with their
  headings after a restore.
- Two new gates, both mutation-proved (7 mutations red, then green):
  `tests/datatable-state-persistence.test.php`,
  `tests/userpref-route-absent-is-not-empty.test.php`.
- Full suite 206/206, both PHPStan passes clean, `psr4-scan --check` ok.

## Deploying

Needs a redeploy **and a schema update** — `FOG_SCHEMA` 390 → 392.
`FOG_BCACHE_VER` 333 → 334 for the changed JS.

## Downstream

No route-class change, so no FogApi sync is needed.
