### PR TITLE
Show each user times in their own timezone

### DIFF
--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -440,10 +440,11 @@ function fogBindTimezonePicker() {
     fogPrefStore('display.timezone', chosen, function(storeErr) {
       if (storeErr) {
         button.prop('disabled', false);
-        $.notify(
-          {message: 'Could not save your timezone'},
-          {type: 'danger'}
-        );
+        // notifyFromAPI, not notify: the latter does not exist here, and
+        // calling it would throw on the one path that exists to report a
+        // failure -- leaving the button disabled with nothing on screen and
+        // only a console error to say why.
+        $.notifyFromAPI(storeErr.responseJSON, storeErr);
         return;
       }
       window.location.reload();

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -405,6 +405,61 @@ function fogPrefFetch(key, cb) {
   });
 }
 
+/**
+ * Display-timezone picker in the navbar.
+ *
+ * Reads and writes the same preference store the grid layouts use, so a chosen
+ * zone follows the user to any browser. Bound once, on the shell's modal --
+ * the shell is not re-rendered by AJAX navigation, so there is nothing to
+ * rebind on a page change.
+ *
+ * Saving reloads. Dates are rendered SERVER-side (grids included, see
+ * FOGManagerController::displayDates), so nothing already on the page can be
+ * relabeled in place -- and a picker that appeared to do nothing until the
+ * next navigation would read as broken.
+ */
+function fogBindTimezonePicker() {
+  var modal = document.getElementById('tzModal');
+  if (!modal) {
+    return;
+  }
+  $(modal).on('show.bs.modal', function() {
+    // Read on open rather than at page load: this is one request per use of a
+    // control almost nobody opens, against one on every single page view.
+    fogPrefFetch('display.timezone', function(err, value) {
+      $('#tzSelect').val(err ? '' : (value || ''));
+    });
+  });
+  $('#tzSave').on('click', function() {
+    var chosen = $('#tzSelect').val() || '';
+    var button = $(this);
+    button.prop('disabled', true);
+    // An empty value clears the preference, which is exactly what "server
+    // default" means -- the store deletes the row rather than holding an
+    // empty string, so nothing has to know the default's name.
+    fogPrefStore('display.timezone', chosen, function(storeErr) {
+      if (storeErr) {
+        button.prop('disabled', false);
+        $.notify(
+          {message: 'Could not save your timezone'},
+          {type: 'danger'}
+        );
+        return;
+      }
+      window.location.reload();
+    });
+  });
+}
+
+// Bound the way theme.js binds its own shell control: the navbar is emitted
+// once by the page shell and AJAX navigation replaces only the content area,
+// so this runs once and stays wired.
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', fogBindTimezonePicker);
+} else {
+  fogBindTimezonePicker();
+}
+
 var shouldReAuth,
   reAuthModal,
   deleteConfirmButton,

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1470,10 +1470,6 @@ msgid "Capone added!"
 msgstr "Snapin hinzugefügt"
 
 #, fuzzy
-msgid "Capone schema"
-msgstr "Standorte"
-
-#, fuzzy
 msgid "Capone update failed!"
 msgstr "Snapin Update fehlgeschlagen"
 
@@ -1585,6 +1581,9 @@ msgstr ""
 
 msgid "Checking if I am the group manager"
 msgstr "Prüfe, ob ich der Gruppenmanager bin"
+
+msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
+msgstr ""
 
 #, fuzzy
 msgid "Class"
@@ -2337,6 +2336,10 @@ msgstr "Benutzername Attribut"
 #, fuzzy
 msgid "Display With"
 msgstr "Anzeige"
+
+#, fuzzy
+msgid "Display timezone"
+msgstr "Benutzername Attribut"
 
 msgid "Do not list on menu"
 msgstr "Nicht im Menü aufführen"
@@ -7255,6 +7258,9 @@ msgstr "FTP-Verbindung fehlgeschlagen"
 msgid "SSL Path"
 msgstr "SSL-Pfad"
 
+msgid "Save"
+msgstr ""
+
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
@@ -7470,6 +7476,10 @@ msgstr "Server-Shell"
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "Server default (%s)"
+msgstr "Allgemeine Informationen"
+
 msgid "Server facts. Every field is a string, and is empty rather than absent when the installer has not published it yet."
 msgstr ""
 
@@ -7579,6 +7589,9 @@ msgstr "Name der Speichergruppe"
 #, fuzzy
 msgid "Set failed"
 msgstr "Service-Update fehlgeschlagen"
+
+msgid "Set your display timezone"
+msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -11252,6 +11265,10 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Änderungen speichern?"
 
+#, fuzzy
+#~ msgid "Capone schema"
+#~ msgstr "Standorte"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Überprüfen Sie, ob die Datenbank ausgeführt wird"
 
@@ -11693,10 +11710,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Serial"
 #~ msgstr "Seriennummer"
-
-#, fuzzy
-#~ msgid "Server facts."
-#~ msgstr "Allgemeine Informationen"
 
 #, fuzzy
 #~ msgid "Site Association"

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1470,6 +1470,10 @@ msgid "Capone added!"
 msgstr "Snapin hinzugefügt"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "Standorte"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "Snapin Update fehlgeschlagen"
 
@@ -11264,10 +11268,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Änderungen speichern?"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "Standorte"
 
 #~ msgid "Check that database is running"
 #~ msgstr "Überprüfen Sie, ob die Datenbank ausgeführt wird"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1473,10 +1473,6 @@ msgid "Capone added!"
 msgstr "Snapin Name"
 
 #, fuzzy
-msgid "Capone schema"
-msgstr "Locations"
-
-#, fuzzy
 msgid "Capone update failed!"
 msgstr "Snapin update failed"
 
@@ -1587,6 +1583,9 @@ msgid "Checking for tasks that can never run..."
 msgstr ""
 
 msgid "Checking if I am the group manager"
+msgstr ""
+
+msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
 msgstr ""
 
 #, fuzzy
@@ -2339,6 +2338,10 @@ msgstr "User Name"
 #, fuzzy
 msgid "Display With"
 msgstr "Display"
+
+#, fuzzy
+msgid "Display timezone"
+msgstr "User Name"
 
 msgid "Do not list on menu"
 msgstr "Do not list on menu"
@@ -7252,6 +7255,9 @@ msgstr "FTP Connection has failed"
 msgid "SSL Path"
 msgstr "SSL Path"
 
+msgid "Save"
+msgstr ""
+
 msgid "Save Changes"
 msgstr "Save Changes"
 
@@ -7467,6 +7473,10 @@ msgstr "Server Shell"
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "Server default (%s)"
+msgstr "General Information"
+
 msgid "Server facts. Every field is a string, and is empty rather than absent when the installer has not published it yet."
 msgstr ""
 
@@ -7576,6 +7586,9 @@ msgstr "Storage Group Name"
 #, fuzzy
 msgid "Set failed"
 msgstr "Service update failed"
+
+msgid "Set your display timezone"
+msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -11239,6 +11252,10 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Save Changes"
 
+#, fuzzy
+#~ msgid "Capone schema"
+#~ msgstr "Locations"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Check that database is running"
 
@@ -11653,10 +11670,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Serial"
 #~ msgstr "System Serial"
-
-#, fuzzy
-#~ msgid "Server facts."
-#~ msgstr "General Information"
 
 #, fuzzy
 #~ msgid "Site Association"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1473,6 +1473,10 @@ msgid "Capone added!"
 msgstr "Snapin Name"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "Locations"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "Snapin update failed"
 
@@ -11251,10 +11255,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Save Changes"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "Locations"
 
 #~ msgid "Check that database is running"
 #~ msgstr "Check that database is running"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1491,6 +1491,10 @@ msgid "Capone added!"
 msgstr "Nombre snapin"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "Acción"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "actualización de servicio no pudo"
 
@@ -11426,10 +11430,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Guardar cambios"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "Acción"
 
 #, fuzzy
 #~ msgid "Check that database is running"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1491,10 +1491,6 @@ msgid "Capone added!"
 msgstr "Nombre snapin"
 
 #, fuzzy
-msgid "Capone schema"
-msgstr "Acción"
-
-#, fuzzy
 msgid "Capone update failed!"
 msgstr "actualización de servicio no pudo"
 
@@ -1603,6 +1599,9 @@ msgid "Checking for tasks that can never run..."
 msgstr ""
 
 msgid "Checking if I am the group manager"
+msgstr ""
+
+msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
 msgstr ""
 
 #, fuzzy
@@ -2372,6 +2371,10 @@ msgstr "Nombre de usuario"
 #, fuzzy
 msgid "Display With"
 msgstr "Diariamente"
+
+#, fuzzy
+msgid "Display timezone"
+msgstr "Nombre de usuario"
 
 msgid "Do not list on menu"
 msgstr ""
@@ -7399,6 +7402,9 @@ msgstr "Añadir fallidos SNAPin!"
 msgid "SSL Path"
 msgstr "Camino"
 
+msgid "Save"
+msgstr ""
+
 msgid "Save Changes"
 msgstr "Guardar cambios"
 
@@ -7615,6 +7621,10 @@ msgstr "Servidor web"
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "Server default (%s)"
+msgstr "Información general"
+
 msgid "Server facts. Every field is a string, and is empty rather than absent when the installer has not published it yet."
 msgstr ""
 
@@ -7726,6 +7736,9 @@ msgstr "Nombre del grupo de almacenamiento"
 #, fuzzy
 msgid "Set failed"
 msgstr "actualización de servicio no pudo"
+
+msgid "Set your display timezone"
+msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -11415,6 +11428,10 @@ msgstr ""
 #~ msgstr "Guardar cambios"
 
 #, fuzzy
+#~ msgid "Capone schema"
+#~ msgstr "Acción"
+
+#, fuzzy
 #~ msgid "Check that database is running"
 #~ msgstr "Compruebe que la base de datos se está ejecutando"
 
@@ -11826,10 +11843,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Serial"
 #~ msgstr "sistema de serie"
-
-#, fuzzy
-#~ msgid "Server facts."
-#~ msgstr "Información general"
 
 #, fuzzy
 #~ msgid "Site Association"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1470,6 +1470,10 @@ msgid "Capone added!"
 msgstr "Snapin hinzugefügt"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "Standorte"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "Snapin Update fehlgeschlagen"
 
@@ -11265,10 +11269,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Änderungen speichern?"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "Standorte"
 
 #~ msgid "Check that database is running"
 #~ msgstr "Überprüfen Sie, ob die Datenbank ausgeführt wird"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1470,10 +1470,6 @@ msgid "Capone added!"
 msgstr "Snapin hinzugefügt"
 
 #, fuzzy
-msgid "Capone schema"
-msgstr "Standorte"
-
-#, fuzzy
 msgid "Capone update failed!"
 msgstr "Snapin Update fehlgeschlagen"
 
@@ -1585,6 +1581,9 @@ msgstr ""
 
 msgid "Checking if I am the group manager"
 msgstr "Prüfe, ob ich der Gruppenmanager bin"
+
+msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
+msgstr ""
 
 #, fuzzy
 msgid "Class"
@@ -2337,6 +2336,10 @@ msgstr "Benutzername Attribut"
 #, fuzzy
 msgid "Display With"
 msgstr "Anzeige"
+
+#, fuzzy
+msgid "Display timezone"
+msgstr "Benutzername Attribut"
 
 msgid "Do not list on menu"
 msgstr "Nicht im Menü aufführen"
@@ -7256,6 +7259,9 @@ msgstr "FTP-Verbindung fehlgeschlagen"
 msgid "SSL Path"
 msgstr "SSL-Pfad"
 
+msgid "Save"
+msgstr ""
+
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
@@ -7471,6 +7477,10 @@ msgstr "Server-Shell"
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "Server default (%s)"
+msgstr "Allgemeine Informationen"
+
 msgid "Server facts. Every field is a string, and is empty rather than absent when the installer has not published it yet."
 msgstr ""
 
@@ -7580,6 +7590,9 @@ msgstr "Name der Speichergruppe"
 #, fuzzy
 msgid "Set failed"
 msgstr "Service-Update fehlgeschlagen"
+
+msgid "Set your display timezone"
+msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -11253,6 +11266,10 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Änderungen speichern?"
 
+#, fuzzy
+#~ msgid "Capone schema"
+#~ msgstr "Standorte"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Überprüfen Sie, ob die Datenbank ausgeführt wird"
 
@@ -11694,10 +11711,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Serial"
 #~ msgstr "Seriennummer"
-
-#, fuzzy
-#~ msgid "Server facts."
-#~ msgstr "Allgemeine Informationen"
 
 #, fuzzy
 #~ msgid "Site Association"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1474,6 +1474,10 @@ msgid "Capone added!"
 msgstr "Nom snapin"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "Emplacements"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "mise à jour a échoué Snapin"
 
@@ -11253,10 +11257,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Sauvegarder les modifications"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "Emplacements"
 
 #~ msgid "Check that database is running"
 #~ msgstr "Vérifiez que la base de données est en cours d'exécution"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1474,10 +1474,6 @@ msgid "Capone added!"
 msgstr "Nom snapin"
 
 #, fuzzy
-msgid "Capone schema"
-msgstr "Emplacements"
-
-#, fuzzy
 msgid "Capone update failed!"
 msgstr "mise à jour a échoué Snapin"
 
@@ -1588,6 +1584,9 @@ msgid "Checking for tasks that can never run..."
 msgstr ""
 
 msgid "Checking if I am the group manager"
+msgstr ""
+
+msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
 msgstr ""
 
 #, fuzzy
@@ -2341,6 +2340,10 @@ msgstr "Nom d'utilisateur"
 #, fuzzy
 msgid "Display With"
 msgstr "Afficher"
+
+#, fuzzy
+msgid "Display timezone"
+msgstr "Nom d'utilisateur"
 
 msgid "Do not list on menu"
 msgstr "Ne pas inscrire sur le menu"
@@ -7254,6 +7257,9 @@ msgstr "Connexion FTP a échoué"
 msgid "SSL Path"
 msgstr "SSL Chemin"
 
+msgid "Save"
+msgstr ""
+
 msgid "Save Changes"
 msgstr "Sauvegarder les modifications"
 
@@ -7469,6 +7475,10 @@ msgstr "serveur Shell"
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "Server default (%s)"
+msgstr "Informations générales"
+
 msgid "Server facts. Every field is a string, and is empty rather than absent when the installer has not published it yet."
 msgstr ""
 
@@ -7578,6 +7588,9 @@ msgstr "Nom du groupe de stockage"
 #, fuzzy
 msgid "Set failed"
 msgstr "mise à jour du service n'a pas"
+
+msgid "Set your display timezone"
+msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -11241,6 +11254,10 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Sauvegarder les modifications"
 
+#, fuzzy
+#~ msgid "Capone schema"
+#~ msgstr "Emplacements"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Vérifiez que la base de données est en cours d'exécution"
 
@@ -11659,10 +11676,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Serial"
 #~ msgstr "Serial System"
-
-#, fuzzy
-#~ msgid "Server facts."
-#~ msgstr "Informations générales"
 
 #, fuzzy
 #~ msgid "Site Association"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1432,10 +1432,6 @@ msgid "Capone added!"
 msgstr "Snapin aggiunto!"
 
 #, fuzzy
-msgid "Capone schema"
-msgstr "sedi"
-
-#, fuzzy
 msgid "Capone update failed!"
 msgstr "Aggiornamento Snapin fallito!"
 
@@ -1545,6 +1541,9 @@ msgstr ""
 
 msgid "Checking if I am the group manager"
 msgstr "Controllare se sono il responsabile del gruppo"
+
+msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
+msgstr ""
 
 msgid "Class"
 msgstr "Classe"
@@ -2273,6 +2272,10 @@ msgstr "Attributo nome utente"
 #, fuzzy
 msgid "Display With"
 msgstr "Display"
+
+#, fuzzy
+msgid "Display timezone"
+msgstr "Attributo nome utente"
 
 msgid "Do not list on menu"
 msgstr "Non elencare nel menu"
@@ -7034,6 +7037,9 @@ msgstr "Connessione FTP non è riuscita"
 msgid "SSL Path"
 msgstr "Percorso SSL"
 
+msgid "Save"
+msgstr ""
+
 msgid "Save Changes"
 msgstr "Salva i cambiamenti"
 
@@ -7243,6 +7249,10 @@ msgstr "Server Shell"
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "Server default (%s)"
+msgstr "Informazione generale"
+
 msgid "Server facts. Every field is a string, and is empty rather than absent when the installer has not published it yet."
 msgstr ""
 
@@ -7350,6 +7360,9 @@ msgstr "Nome gruppo di archiviazione"
 
 msgid "Set failed"
 msgstr "Fallita impostazione"
+
+msgid "Set your display timezone"
+msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -10874,6 +10887,10 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Applicare cambiamenti?"
 
+#, fuzzy
+#~ msgid "Capone schema"
+#~ msgstr "sedi"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Controllare che database è in esecuzione"
 
@@ -11303,10 +11320,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Serial"
 #~ msgstr "Sistema seriale"
-
-#, fuzzy
-#~ msgid "Server facts."
-#~ msgstr "Informazione generale"
 
 #~ msgid "Site Association"
 #~ msgstr "Associazione Sito"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1432,6 +1432,10 @@ msgid "Capone added!"
 msgstr "Snapin aggiunto!"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "sedi"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "Aggiornamento Snapin fallito!"
 
@@ -10886,10 +10890,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Applicare cambiamenti?"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "sedi"
 
 #~ msgid "Check that database is running"
 #~ msgstr "Controllare che database è in esecuzione"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1415,6 +1415,10 @@ msgid "Capone added!"
 msgstr "スナップインを追加しました！"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "ロケーション"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "スナップインの更新に失敗しました！"
 
@@ -10946,10 +10950,6 @@ msgstr ""
 
 #~ msgid "Cannot view from browser"
 #~ msgstr "ブラウザーから表示できません"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "ロケーション"
 
 #~ msgid "Chat is also available on the forums for more realtime help"
 #~ msgstr "よりリアルタイムな支援が必要な場合はフォーラムのチャットも利用できます"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1415,10 +1415,6 @@ msgid "Capone added!"
 msgstr "スナップインを追加しました！"
 
 #, fuzzy
-msgid "Capone schema"
-msgstr "ロケーション"
-
-#, fuzzy
 msgid "Capone update failed!"
 msgstr "スナップインの更新に失敗しました！"
 
@@ -1529,6 +1525,9 @@ msgstr ""
 
 msgid "Checking if I am the group manager"
 msgstr "自身がグループマネージャーか確認しています"
+
+msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
+msgstr ""
 
 msgid "Class"
 msgstr "クラス"
@@ -2256,6 +2255,10 @@ msgstr "グラフ有効"
 #, fuzzy
 msgid "Display With"
 msgstr "表示"
+
+#, fuzzy
+msgid "Display timezone"
+msgstr "グラフ有効"
 
 msgid "Do not list on menu"
 msgstr "メニューに表示しない"
@@ -6992,6 +6995,9 @@ msgstr "FTP 接続に失敗しました"
 msgid "SSL Path"
 msgstr "SSL パス"
 
+msgid "Save"
+msgstr ""
+
 msgid "Save Changes"
 msgstr "変更を保存"
 
@@ -7200,6 +7206,10 @@ msgstr "サーバーシェル"
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "Server default (%s)"
+msgstr "サーバー情報"
+
 msgid "Server facts. Every field is a string, and is empty rather than absent when the installer has not published it yet."
 msgstr ""
 
@@ -7306,6 +7316,9 @@ msgstr "ストレージグループの説明"
 
 msgid "Set failed"
 msgstr "設定に失敗しました"
+
+msgid "Set your display timezone"
+msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -10934,6 +10947,10 @@ msgstr ""
 #~ msgid "Cannot view from browser"
 #~ msgstr "ブラウザーから表示できません"
 
+#, fuzzy
+#~ msgid "Capone schema"
+#~ msgstr "ロケーション"
+
 #~ msgid "Chat is also available on the forums for more realtime help"
 #~ msgstr "よりリアルタイムな支援が必要な場合はフォーラムのチャットも利用できます"
 
@@ -12375,10 +12392,6 @@ msgstr ""
 
 #~ msgid "Serial"
 #~ msgstr "シリアル"
-
-#, fuzzy
-#~ msgid "Server facts."
-#~ msgstr "サーバー情報"
 
 #~ msgid "Server information at a glance."
 #~ msgstr "サーバー情報の概要"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1262,6 +1262,9 @@ msgstr ""
 msgid "Capone added!"
 msgstr ""
 
+msgid "Capone schema"
+msgstr ""
+
 msgid "Capone update failed!"
 msgstr ""
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1262,9 +1262,6 @@ msgstr ""
 msgid "Capone added!"
 msgstr ""
 
-msgid "Capone schema"
-msgstr ""
-
 msgid "Capone update failed!"
 msgstr ""
 
@@ -1360,6 +1357,9 @@ msgid "Checking for tasks that can never run..."
 msgstr ""
 
 msgid "Checking if I am the group manager"
+msgstr ""
+
+msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
 msgstr ""
 
 msgid "Class"
@@ -1991,6 +1991,9 @@ msgid "Display Name Enabled"
 msgstr ""
 
 msgid "Display With"
+msgstr ""
+
+msgid "Display timezone"
 msgstr ""
 
 msgid "Do not list on menu"
@@ -6172,6 +6175,9 @@ msgstr ""
 msgid "SSL Path"
 msgstr ""
 
+msgid "Save"
+msgstr ""
+
 msgid "Save Changes"
 msgstr ""
 
@@ -6359,6 +6365,10 @@ msgstr ""
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
+#, php-format
+msgid "Server default (%s)"
+msgstr ""
+
 msgid "Server facts. Every field is a string, and is empty rather than absent when the installer has not published it yet."
 msgstr ""
 
@@ -6449,6 +6459,9 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr ""
 
 msgid "Set failed"
+msgstr ""
+
+msgid "Set your display timezone"
 msgstr ""
 
 msgid "Setting"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1473,10 +1473,6 @@ msgid "Capone added!"
 msgstr "Nome Snapin"
 
 #, fuzzy
-msgid "Capone schema"
-msgstr "localizações"
-
-#, fuzzy
 msgid "Capone update failed!"
 msgstr "atualização Snapin falhou"
 
@@ -1587,6 +1583,9 @@ msgid "Checking for tasks that can never run..."
 msgstr ""
 
 msgid "Checking if I am the group manager"
+msgstr ""
+
+msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
 msgstr ""
 
 #, fuzzy
@@ -2340,6 +2339,10 @@ msgstr "Nome de usuário"
 #, fuzzy
 msgid "Display With"
 msgstr "Exibição"
+
+#, fuzzy
+msgid "Display timezone"
+msgstr "Nome de usuário"
 
 msgid "Do not list on menu"
 msgstr "Não lista de menus"
@@ -7253,6 +7256,9 @@ msgstr "Conexão FTP falhou"
 msgid "SSL Path"
 msgstr "Caminho SSL"
 
+msgid "Save"
+msgstr ""
+
 msgid "Save Changes"
 msgstr "Salvar alterações"
 
@@ -7468,6 +7474,10 @@ msgstr "Shell servidor"
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "Server default (%s)"
+msgstr "Informação geral"
+
 msgid "Server facts. Every field is a string, and is empty rather than absent when the installer has not published it yet."
 msgstr ""
 
@@ -7577,6 +7587,9 @@ msgstr "Nome do grupo de armazenamento"
 #, fuzzy
 msgid "Set failed"
 msgstr "atualização do Service falhou"
+
+msgid "Set your display timezone"
+msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -11240,6 +11253,10 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Salvar alterações"
 
+#, fuzzy
+#~ msgid "Capone schema"
+#~ msgstr "localizações"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Verifique o banco de dados está em execução"
 
@@ -11658,10 +11675,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Serial"
 #~ msgstr "Serial sistema"
-
-#, fuzzy
-#~ msgid "Server facts."
-#~ msgstr "Informação geral"
 
 #, fuzzy
 #~ msgid "Site Association"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1473,6 +1473,10 @@ msgid "Capone added!"
 msgstr "Nome Snapin"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "localizações"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "atualização Snapin falhou"
 
@@ -11252,10 +11256,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "Salvar alterações"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "localizações"
 
 #~ msgid "Check that database is running"
 #~ msgstr "Verifique o banco de dados está em execução"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1473,6 +1473,10 @@ msgid "Capone added!"
 msgstr "管理单元名称"
 
 #, fuzzy
+msgid "Capone schema"
+msgstr "位置"
+
+#, fuzzy
 msgid "Capone update failed!"
 msgstr "管理单元更新失败"
 
@@ -11252,10 +11256,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Bulk Changes"
 #~ msgstr "保存更改"
-
-#, fuzzy
-#~ msgid "Capone schema"
-#~ msgstr "位置"
 
 #~ msgid "Check that database is running"
 #~ msgstr "检查数据库运行"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1473,10 +1473,6 @@ msgid "Capone added!"
 msgstr "管理单元名称"
 
 #, fuzzy
-msgid "Capone schema"
-msgstr "位置"
-
-#, fuzzy
 msgid "Capone update failed!"
 msgstr "管理单元更新失败"
 
@@ -1587,6 +1583,9 @@ msgid "Checking for tasks that can never run..."
 msgstr ""
 
 msgid "Checking if I am the group manager"
+msgstr ""
+
+msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
 msgstr ""
 
 #, fuzzy
@@ -2340,6 +2339,10 @@ msgstr "用户名"
 #, fuzzy
 msgid "Display With"
 msgstr "显示"
+
+#, fuzzy
+msgid "Display timezone"
+msgstr "用户名"
 
 msgid "Do not list on menu"
 msgstr "不要列出菜单上"
@@ -7253,6 +7256,9 @@ msgstr "FTP连接失败"
 msgid "SSL Path"
 msgstr "SSL通道"
 
+msgid "Save"
+msgstr ""
+
 msgid "Save Changes"
 msgstr "保存更改"
 
@@ -7468,6 +7474,10 @@ msgstr "服务器外壳"
 msgid "Server appears to be offline or unavailable!"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "Server default (%s)"
+msgstr "一般信息"
+
 msgid "Server facts. Every field is a string, and is empty rather than absent when the installer has not published it yet."
 msgstr ""
 
@@ -7577,6 +7587,9 @@ msgstr "存储组名称"
 #, fuzzy
 msgid "Set failed"
 msgstr "服务更新失败"
+
+msgid "Set your display timezone"
+msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -11240,6 +11253,10 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "保存更改"
 
+#, fuzzy
+#~ msgid "Capone schema"
+#~ msgstr "位置"
+
 #~ msgid "Check that database is running"
 #~ msgstr "检查数据库运行"
 
@@ -11658,10 +11675,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Serial"
 #~ msgstr "系统序列"
-
-#, fuzzy
-#~ msgid "Server facts."
-#~ msgstr "一般信息"
 
 #, fuzzy
 #~ msgid "Site Association"

--- a/packages/web/management/other/index.php
+++ b/packages/web/management/other/index.php
@@ -137,6 +137,14 @@ unset($this->stylesheets);
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a href="#" id="tzToggle" class="nav-link" role="button"
+                           data-bs-toggle="modal" data-bs-target="#tzModal"
+                           title="<?= _('Set your display timezone'); ?>"
+                           aria-label="<?= _('Set your display timezone'); ?>">
+                            <i class="far fa-clock"></i>
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="../management/index.php?node=logout"><i class="fas fa-right-from-bracket"></i> <?= _('Logout'); ?></a>
                     </li>
                 </ul>
@@ -227,6 +235,49 @@ if (in_array(strtolower($pageLength), ['search', 'list'])) {
 $apiBase = '/' . ($apiBase === '' ? '' : $apiBase . '/');
 ?>
                 <?= FOGPage::makeInput('apiBase', 'apiBase', '', 'hidden', 'apiBase', $apiBase); ?>
+                <?php
+                // Display-timezone picker. Lives in the shell rather than on a
+                // page of its own because every signed-in user must be able to
+                // reach it, including one holding no role at all -- there is no
+                // self-service node today and adding one would mean widening
+                // the exempt-node list, which is an access-control change this
+                // does not need: the preference route is already reachable by
+                // any authenticated user and can only ever address that user's
+                // own row.
+                //
+                // The zone list comes from the platform's own tzdata, so it
+                // cannot drift from what DateTimeZone will accept back.
+                $tzDefault = (string)self::getSetting('FOG_TZ_INFO');
+if ('' === trim($tzDefault)) {
+    $tzDefault = ini_get('date.timezone') ?: 'UTC';
+}
+$tzList = \DateTimeZone::listIdentifiers();
+?>
+                <div class="modal fade" id="tzModal" tabindex="-1" aria-labelledby="tzModalLabel" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="tzModalLabel"><?= _('Display timezone'); ?></h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?= _('Close'); ?>"></button>
+                            </div>
+                            <div class="modal-body">
+                                <p class="text-body-secondary small">
+                                    <?= _('Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else.'); ?>
+                                </p>
+                                <select class="form-select" id="tzSelect" aria-label="<?= _('Display timezone'); ?>">
+                                    <option value=""><?= sprintf(_('Server default (%s)'), Initiator::e($tzDefault)); ?></option>
+                                    <?php foreach ($tzList as $tzName): ?>
+                                    <option value="<?= Initiator::e($tzName); ?>"><?= Initiator::e($tzName); ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-outline-secondary float-start" data-bs-dismiss="modal"><?= _('Cancel'); ?></button>
+                                <button type="button" class="btn btn-primary" id="tzSave"><?= _('Save'); ?></button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 <?php
         // No-role warning: with deny-by-default a user holding zero roles
         // can reach nothing but the exempt nodes (dashboard, logout), and

--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -215,11 +215,35 @@ abstract class FOGBase
      */
     protected static $HookManager;
     /**
-     * The default timezone for all of fog to use.
+     * The zone stored datetimes are written in and read back as.
+     *
+     * NOT a display setting, whatever the name suggests. niceDate() uses it to
+     * INTERPRET a stored string, and the 34 sites that write a timestamp
+     * produce it through the same call, so this is the zone the database is in.
+     * Changing it therefore re-labels every row that already exists rather
+     * than re-presenting it -- which is why moving storage to UTC is a
+     * migration, not a settings change.
      *
      * @var object
      */
     protected static $TimeZone;
+    /**
+     * The zone datetimes are SHOWN in, resolved once per request.
+     *
+     * Separate from $TimeZone so a user can be shown times in their own zone
+     * without changing what is stored. Null until first use; see
+     * displayTimeZone().
+     *
+     * @var \DateTimeZone|null
+     */
+    private static $_displayTimeZone = null;
+    /**
+     * The user preference holding a viewer's chosen display zone.
+     *
+     * An empty or absent value means "use the install default", which is what
+     * every account has until someone deliberately chooses otherwise.
+     */
+    const TIMEZONE_PREF = 'display.timezone';
     /**
      * The logged in user.
      *
@@ -1786,6 +1810,123 @@ abstract class FOGBase
      *
      * @return \DateTime
      */
+    /**
+     * The zone stored datetimes are written in and interpreted as.
+     *
+     * @return \DateTimeZone
+     */
+    public static function storageTimeZone()
+    {
+        if (empty(self::$TimeZone)) {
+            return new \DateTimeZone('UTC');
+        }
+        try {
+            return new \DateTimeZone(self::$TimeZone);
+        } catch (\Exception $e) {
+            // An unusable name must not take out every page that shows a date.
+            return new \DateTimeZone('UTC');
+        }
+    }
+    /**
+     * The zone datetimes are SHOWN in for whoever is asking.
+     *
+     * The signed-in user's own preference if they have set one, otherwise
+     * FOG_TZ_INFO, which stays the install-wide default. Resolved once per
+     * request and cached: this is consulted for every date on a page, and the
+     * preference is a database read.
+     *
+     * Resolved lazily rather than in setEnv() on purpose -- the acting user is
+     * not known that early, and a lazy read has no ordering to get wrong.
+     *
+     * @return \DateTimeZone
+     */
+    public static function displayTimeZone()
+    {
+        if (null !== self::$_displayTimeZone) {
+            return self::$_displayTimeZone;
+        }
+        self::$_displayTimeZone = self::storageTimeZone();
+        $user = self::$FOGUser;
+        // Matches the house guard used wherever the shell asks the same
+        // question: unset before LoadGlobals has run, and invalid for anyone
+        // not signed in -- a background service, or the login page itself.
+        if (!$user || !$user->isValid()) {
+            return self::$_displayTimeZone;
+        }
+        try {
+            $pref = self::getClass('UserPrefManager')
+                ->fetch((int)$user->get('id'), self::TIMEZONE_PREF);
+        } catch (\Exception $e) {
+            // A preference store that cannot be read is not a reason to stop
+            // rendering dates; the install-wide default still applies.
+            return self::$_displayTimeZone;
+        }
+        if ('' === trim((string)$pref)) {
+            return self::$_displayTimeZone;
+        }
+        try {
+            self::$_displayTimeZone = new \DateTimeZone(trim((string)$pref));
+        } catch (\Exception $e) {
+            // A stored name the platform no longer knows -- a retired zone, or
+            // a tzdata that moved underneath us. Fall back rather than throw.
+        }
+        return self::$_displayTimeZone;
+    }
+    /**
+     * Turns a datetime the VIEWER typed into one the database can be
+     * compared against.
+     *
+     * The inverse of toDisplay(), and it exists so filtering stays honest: a
+     * grid that shows times in the viewer's zone but filters them in the
+     * storage zone answers a different question than the one on screen, and
+     * near midnight it silently returns the wrong day.
+     *
+     * A no-op whenever the two zones are the same, which is every account
+     * that has not chosen a preference.
+     *
+     * @param string $value 'Y-m-d H:i:s' as the viewer means it.
+     *
+     * @return string 'Y-m-d H:i:s' as the database holds it.
+     */
+    public static function displayToStorage($value)
+    {
+        $display = self::displayTimeZone();
+        $storage = self::storageTimeZone();
+        if ($display->getName() === $storage->getName()) {
+            return (string)$value;
+        }
+        try {
+            $date = new \DateTime((string)$value, $display);
+        } catch (\Exception $e) {
+            // Not a date we can read: hand it back untouched rather than
+            // inventing a bound. The caller's own validation still applies.
+            return (string)$value;
+        }
+        return $date->setTimezone($storage)->format('Y-m-d H:i:s');
+    }
+    /**
+     * Reads a stored datetime and returns it in the viewer's zone.
+     *
+     * Interpretation and presentation are two different questions and this is
+     * the only place that answers both: the value is read in the STORAGE zone,
+     * because that is the zone it was written in, then moved to the DISPLAY
+     * zone. Formatting the result gives the same wall-clock time the storer
+     * meant, expressed where the viewer is.
+     *
+     * @param mixed $date The stored value, or a DateTime.
+     *
+     * @return \DateTime
+     */
+    public static function toDisplay($date = 'now')
+    {
+        $out = $date instanceof \DateTime ? clone $date : self::niceDate($date);
+        // A zero or invalid date carries no instant to convert, and shifting
+        // one can push it across a day boundary and change how it renders.
+        if (!self::validDate($out)) {
+            return $out;
+        }
+        return $out->setTimezone(self::displayTimeZone());
+    }
     public static function niceDate($date = 'now', $utc = false)
     {
         /*
@@ -1817,15 +1958,10 @@ abstract class FOGBase
         // if ($date !== 'now' && (!self::validDate($date))) {
         //      $date = 'now';
         // }
-        if ($utc || empty(self::$TimeZone)) {
-            $tz = new \DateTimeZone('UTC');
-        } else {
-            try {
-                $tz = new \DateTimeZone(self::$TimeZone);
-            } catch (\Exception $e) {
-                $tz = new \DateTimeZone('UTC');
-            }
-        }
+        // The STORAGE zone, deliberately: this call interprets a value that
+        // has already been written, and is also what the write sites format
+        // through. Presentation is a separate question -- see toDisplay().
+        $tz = $utc ? new \DateTimeZone('UTC') : self::storageTimeZone();
         //Added try catch to catch when an invalid date is being brought in
         try {
             $niceDate = new \DateTime($date, $tz);
@@ -1850,6 +1986,17 @@ abstract class FOGBase
         if (!$time instanceof \DateTime) {
             $time = self::niceDate($time, $utc);
         }
+        // Everything below this line is OUTPUT, so it happens in the viewer's
+        // zone -- unless the caller asked for UTC explicitly, which is a
+        // request for a specific zone and not a display preference.
+        //
+        // $now moves with it. The "today / yesterday / runs today" branches
+        // compare calendar days, and comparing a day in one zone against a day
+        // in another is how a timestamp ends up labeled "Ran Yesterday" on
+        // the same afternoon it happened.
+        if (!$utc) {
+            $time = self::toDisplay($time);
+        }
         if ($format) {
             if (!self::validDate($time)) {
                 return _('No Data');
@@ -1857,7 +2004,9 @@ abstract class FOGBase
 
             return $time->format($format);
         }
-        $now = self::niceDate('now', $utc);
+        $now = $utc
+            ? self::niceDate('now', true)
+            : self::toDisplay('now');
         // Get difference of the current to supplied.
         $diff = $now->format('U') - $time->format('U');
         $absolute = abs($diff);
@@ -1958,10 +2107,7 @@ abstract class FOGBase
         if (!$format) {
             $format = 'm/d/Y';
         }
-        if (empty(self::$TimeZone)) {
-            self::$TimeZone = 'UTC';
-        }
-        $tz = new \DateTimeZone(self::$TimeZone);
+        $tz = self::storageTimeZone();
 
         return \DateTime::createFromFormat(
             $format,

--- a/packages/web/src/Base/FOGManagerController.php
+++ b/packages/web/src/Base/FOGManagerController.php
@@ -278,6 +278,70 @@ abstract class FOGManagerController extends FOGBase
      *
      * @return array Formatted data in a row based format
      */
+    /**
+     * Re-labels a grid's date cells in the zone the viewer reads in.
+     *
+     * Grid cells are raw stored values -- dataOutput() copies them straight
+     * out of the row unless the column declares a formatter -- so without this
+     * a user's chosen timezone would apply on every form and detail page and
+     * nowhere on the lists, which is where the timestamps people actually read
+     * live. The column types are the ones already computed for the client's
+     * search UI, so nothing extra is derived to do it.
+     *
+     * NOT applied to REST responses. A script reading hostLastDeploy wants one
+     * stable answer, not one that depends on whose token it used; per-caller
+     * values would break consumers silently, and the values carry no zone
+     * marker to disambiguate them. The UI is the human surface and this is a
+     * human preference.
+     *
+     * A no-op whenever the display and storage zones agree, which is every
+     * account that has not chosen a preference.
+     *
+     * @param array $rows  Rows as dataOutput() built them.
+     * @param array $types The per-column search types, keyed as the rows are.
+     *
+     * @return array
+     */
+    public static function displayDates($rows, $types)
+    {
+        if (self::displayTimeZone()->getName()
+            === self::storageTimeZone()->getName()
+        ) {
+            return $rows;
+        }
+        if (class_exists('\\FOG\\Router\\Route')
+            && \FOG\Router\Route::$apiRequest
+        ) {
+            return $rows;
+        }
+        $dateKeys = [];
+        foreach ((array)$types as $key => $type) {
+            if ($type === 'date') {
+                $dateKeys[] = $key;
+            }
+        }
+        if (!$dateKeys) {
+            return $rows;
+        }
+        foreach ($rows as &$row) {
+            foreach ($dateKeys as $key) {
+                if (!isset($row[$key]) || '' === trim((string)$row[$key])) {
+                    continue;
+                }
+                // validDate() keeps the zero date -- "this never happened" --
+                // out of it. Shifting one moves it across a day boundary and
+                // changes how the cell renders for no reason.
+                if (!self::validDate($row[$key])) {
+                    continue;
+                }
+                $row[$key] = self::toDisplay((string)$row[$key])
+                    ->format('Y-m-d H:i:s');
+            }
+        }
+        unset($row);
+
+        return $rows;
+    }
     public static function dataOutput($columns, $data)
     {
         $out = [];
@@ -1131,11 +1195,19 @@ abstract class FOGManagerController extends FOGBase
         // (which use both) worked. Found against the running server; the first
         // cut of the gate rendered the bindings into the SQL text and so could
         // not see it. The gate now also asserts every binding is referenced.
-        $lower = $dates[0] . ' 00:00:00';
+        // Both bounds are converted from the zone the VIEWER is reading in to
+        // the zone the column is stored in. The user picked a day off a
+        // calendar that matches what the grid showed them, so "on 29 August"
+        // has to mean their 29th -- not the server's, which near midnight is a
+        // different day and quietly returns the wrong rows. A no-op for every
+        // account that has not chosen a display zone.
+        $lower = self::displayToStorage($dates[0] . ' 00:00:00');
         // The exclusive upper bound: midnight starting the day AFTER the last
         // date named. One date makes it that date's own midnight, so "=" is
         // the whole of one day and "after" starts at the next.
-        $upper = self::_sbNextDay($between ? $dates[1] : $dates[0]);
+        $upper = self::displayToStorage(
+            self::_sbNextDay($between ? $dates[1] : $dates[0])
+        );
         switch ($condition) {
             case '=':
             case 'between':
@@ -1357,7 +1429,12 @@ abstract class FOGManagerController extends FOGBase
             'truncated' => !$countOnly
                 && self::$_capped
                 && intval($recordsFiltered) > self::MAX_ROWS,
-            'data' => $countOnly ? [] : self::dataOutput($columns, $data),
+            'data' => $countOnly
+                ? []
+                : self::displayDates(
+                    self::dataOutput($columns, $data),
+                    self::searchTypes($table, $columns)
+                ),
             // How each column may be filtered, for the client's search UI.
             // Server-derived because a server-side grid hands the browser one
             // page, and page one is not enough to tell a date column from a

--- a/packages/web/src/Base/FOGPageRender.php
+++ b/packages/web/src/Base/FOGPageRender.php
@@ -404,7 +404,11 @@ trait FOGPageRender
             return _('Never');
         }
 
-        return self::niceDate($value)->format('Y-m-d H:i:s');
+        // toDisplay(), not niceDate(): niceDate reads the value in the zone it
+        // was STORED in and formatting it straight back hands you the same
+        // string you started with, so the viewer's zone would never be applied
+        // anywhere a date is shown on a form.
+        return self::toDisplay($value)->format('Y-m-d H:i:s');
     }
 
     /**

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 392);
-        define('FOG_BCACHE_VER', 334);
+        define('FOG_BCACHE_VER', 335);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4503');
+        define('FOG_VERSION', '1.6.0-beta.4506');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4500');
+        define('FOG_VERSION', '1.6.0-beta.4503');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1401,7 +1401,7 @@ parameters:
 		-
 			message: '#^Calling self\:\:getSetting\(\) outside of class scope\.$#'
 			identifier: outOfClass.self
-			count: 6
+			count: 7
 			path: packages/web/management/other/index.php
 
 		-

--- a/tests/display-timezone-split.test.php
+++ b/tests/display-timezone-split.test.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Storage and display are two different timezones, and the code must not
+ * confuse them.
+ *
+ * FOG_TZ_INFO is not a display setting despite the name: niceDate() uses it to
+ * INTERPRET a stored string, and every site that writes a timestamp formats
+ * through the same call, so it is the zone the database is written in.
+ * Showing a user times in their own zone therefore means converting on the way
+ * OUT, and converting back on the way IN, while leaving writes exactly where
+ * they were.
+ *
+ * Each way of getting that wrong is silent:
+ *
+ *  - niceDate() converting to the display zone would make every NEW timestamp
+ *    land in whichever user happened to trigger it, so two users writing the
+ *    same event would store two different times and neither would look wrong
+ *    on screen. That is data corruption that only shows up in comparisons.
+ *  - formatTime() comparing a time in one zone against 'now' in another makes
+ *    the "today / yesterday / runs today" branches straddle a day boundary, so
+ *    a task that ran this afternoon reads "Ran Yesterday".
+ *  - a grid that SHOWS the viewer's zone but FILTERS in the storage zone
+ *    answers a different question than the one on screen; near midnight it
+ *    returns the wrong day and looks like missing rows.
+ *  - converting REST responses would make a script's answer depend on whose
+ *    token it used, with no zone marker on the value to tell.
+ *
+ * Usage: php tests/display-timezone-split.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+
+$base = file_get_contents($web . '/src/Base/FOGBase.php');
+$manager = file_get_contents($web . '/src/Base/FOGManagerController.php');
+$render = file_get_contents($web . '/src/Base/FOGPageRender.php');
+
+$fails = [];
+
+/**
+ * Isolates one method's body so a match elsewhere in a 3000-line class cannot
+ * stand in for the thing being tested, with its comments stripped so a gate
+ * cannot pass on its own documentation.
+ *
+ * @param string $src  The file contents.
+ * @param string $sig  The method signature to find.
+ * @param string $name What to call it in a failure message.
+ *
+ * @return string
+ */
+function tzMethod($src, $sig, $name)
+{
+    global $fails;
+    $pattern = '#' . preg_quote($sig, '#') . '.*?\n    \}\n#s';
+    if (!preg_match($pattern, $src, $m)) {
+        $fails[] = "$name not found -- the gate cannot see its subject";
+
+        return '';
+    }
+
+    return preg_replace('#^\s*//.*$#m', '', $m[0]);
+}
+
+// ------------------------------------------------- writes do not move
+
+$niceDate = tzMethod(
+    $base,
+    "public static function niceDate(\$date = 'now', \$utc = false)",
+    'FOGBase::niceDate()'
+);
+if ('' !== $niceDate) {
+    if (!preg_match('#self::storageTimeZone\(\)#', $niceDate)) {
+        $fails[] = 'niceDate() does not interpret through storageTimeZone()';
+    }
+    if (preg_match('#displayTimeZone\(\)|toDisplay\(#', $niceDate)) {
+        $fails[] = 'niceDate() reaches for the DISPLAY zone. It is what the '
+            . 'write sites format through, so every new timestamp would be '
+            . 'stored in whichever user triggered it';
+    }
+}
+
+// -------------------------------------------------------- the two zones
+
+foreach (['storageTimeZone', 'displayTimeZone', 'toDisplay', 'displayToStorage'] as $fn) {
+    if (!preg_match('#public static function ' . $fn . '\(#', $base)) {
+        $fails[] = "FOGBase::$fn() is missing";
+    }
+}
+
+$display = tzMethod(
+    $base,
+    'public static function displayTimeZone()',
+    'FOGBase::displayTimeZone()'
+);
+if ('' !== $display) {
+    if (!preg_match('#self::storageTimeZone\(\)#', $display)) {
+        $fails[] = 'displayTimeZone() does not fall back to the install '
+            . 'default; an account with no preference must be unaffected';
+    }
+    if (!preg_match('#self::TIMEZONE_PREF#', $display)) {
+        $fails[] = 'displayTimeZone() does not read the preference key';
+    }
+    // A user-supplied zone name reaching DateTimeZone unguarded is a fatal on
+    // every page that shows a date.
+    if (!preg_match('#catch \(\\\\Exception \$e\)#', $display)) {
+        $fails[] = 'displayTimeZone() does not guard the stored zone name; an '
+            . 'unusable value would throw on every page that shows a date';
+    }
+}
+
+$toDisplay = tzMethod(
+    $base,
+    "public static function toDisplay(\$date = 'now')",
+    'FOGBase::toDisplay()'
+);
+if ('' !== $toDisplay) {
+    if (!preg_match('#setTimezone\(self::displayTimeZone\(\)\)#', $toDisplay)) {
+        $fails[] = 'toDisplay() does not move the value into the display zone';
+    }
+    if (!preg_match('#validDate#', $toDisplay)) {
+        $fails[] = 'toDisplay() does not exempt an invalid/zero date; shifting '
+            . 'one moves it across a day boundary and changes how it renders';
+    }
+}
+
+// ---------------------------------------------------- formatTime output
+
+$format = tzMethod(
+    $base,
+    'public static function formatTime($time, $format = false, $utc = false)',
+    'FOGBase::formatTime()'
+);
+if ('' !== $format) {
+    if (!preg_match('#if \(!\$utc\) \{\s*\$time = self::toDisplay\(\$time\);#s', $format)) {
+        $fails[] = 'formatTime() does not render in the display zone (and an '
+            . 'explicit $utc must still win)';
+    }
+    // $now has to move with $time or the calendar-day comparisons straddle.
+    if (!preg_match("#\\\$now = \\\$utc\s*\?\s*self::niceDate\('now', true\)\s*:\s*self::toDisplay\('now'\);#s", $format)) {
+        $fails[] = "formatTime()'s 'now' is not resolved in the same zone as "
+            . 'the value it is compared against; the today/yesterday branches '
+            . 'would straddle a day boundary';
+    }
+}
+
+$dateOrNever = tzMethod(
+    $render,
+    'protected static function dateOrNever($value)',
+    'FOGPageRender::dateOrNever()'
+);
+if ('' !== $dateOrNever && !preg_match('#self::toDisplay\(\$value\)#', $dateOrNever)) {
+    $fails[] = 'dateOrNever() does not convert; niceDate() formatted straight '
+        . 'back hands you the stored string, so no form date would ever move';
+}
+
+// ------------------------------------------------------------ grid cells
+
+$displayDates = tzMethod(
+    $manager,
+    'public static function displayDates($rows, $types)',
+    'FOGManagerController::displayDates()'
+);
+if ('' !== $displayDates) {
+    if (!preg_match('#Route::\$apiRequest#', $displayDates)) {
+        $fails[] = 'displayDates() does not exempt REST responses; a script '
+            . 'would get a different answer depending on whose token it used';
+    }
+    if (!preg_match('#displayTimeZone\(\)->getName\(\)\s*===\s*self::storageTimeZone\(\)->getName\(\)#s', $displayDates)) {
+        $fails[] = 'displayDates() does not short-circuit when the zones agree, '
+            . 'which is every account that has not set a preference';
+    }
+    if (!preg_match('#validDate#', $displayDates)) {
+        $fails[] = 'displayDates() does not exempt the zero date';
+    }
+}
+if (!preg_match('#self::displayDates\(\s*self::dataOutput\(\$columns, \$data\),#s', $manager)) {
+    $fails[] = 'the grid payload is not passed through displayDates(), so a '
+        . 'chosen timezone would apply everywhere except the lists, which is '
+        . 'where the timestamps people read actually live';
+}
+
+// --------------------------------------------------------- filter bounds
+
+$sbDate = tzMethod(
+    $manager,
+    'private static function _sbDate($col, $condition, $values, &$bindings)',
+    'FOGManagerController::_sbDate()'
+);
+if ('' !== $sbDate) {
+    if (!preg_match("#\\\$lower = self::displayToStorage\(\\\$dates\[0\] \. ' 00:00:00'\);#", $sbDate)) {
+        $fails[] = "the filter's lower bound is not converted from the "
+            . "viewer's zone; the grid would filter a different day than it shows";
+    }
+    if (!preg_match('#\$upper = self::displayToStorage\(#', $sbDate)) {
+        $fails[] = "the filter's upper bound is not converted from the "
+            . "viewer's zone";
+    }
+}
+
+if ($fails) {
+    foreach ($fails as $f) {
+        echo "FAIL: $f\n";
+    }
+    exit(1);
+}
+echo "PASS: storage and display timezones stay separate -- writes, output, "
+    . "grid cells and filter bounds all pinned\n";
+exit(0);

--- a/tests/searchbuilder-filter-clause.test.php
+++ b/tests/searchbuilder-filter-clause.test.php
@@ -87,6 +87,45 @@ abstract class FOGBase
     {
         return self::$types[$table . '.' . $column] ?? '';
     }
+    /**
+     * The zone the viewer reads times in, and the zone the column is stored
+     * in. Equal by default, which is every account that has not chosen a
+     * display timezone -- and in that state the conversion below must be a
+     * no-op, so every existing case still states the clause it always did.
+     *
+     * @var string
+     */
+    public static $displayZone = 'UTC';
+    /**
+     * @var string
+     */
+    public static $storageZone = 'UTC';
+
+    /**
+     * Moves a bound from the viewer's zone to the storage zone.
+     *
+     * @param string $value 'Y-m-d H:i:s' as the viewer means it
+     *
+     * @return string
+     */
+    public static function displayToStorage($value)
+    {
+        if (self::$displayZone === self::$storageZone) {
+            return (string)$value;
+        }
+        try {
+            $date = new \DateTime(
+                (string)$value,
+                new \DateTimeZone(self::$displayZone)
+            );
+        } catch (\Exception $e) {
+            return (string)$value;
+        }
+
+        return $date
+            ->setTimezone(new \DateTimeZone(self::$storageZone))
+            ->format('Y-m-d H:i:s');
+    }
 }
 class DatabaseManager
 {
@@ -588,10 +627,58 @@ $cases[] = [
         . " AND `hostName` LIKE 'lab%' ESCAPE '\\\\'",
 ];
 
+/* -- the viewer's timezone -------------------------------------------- */
+
+/*
+ * A grid that SHOWS times in the viewer's zone has to FILTER in it too. The
+ * user picks a day off a calendar that matches the column they are reading,
+ * so "on the 29th" must mean their 29th; comparing it against the storage
+ * zone's 29th silently returns a different set of rows, and near midnight a
+ * different day entirely.
+ *
+ * Storage here is UTC and the viewer is five hours behind it, so their day
+ * starts at 05:00 UTC and ends at 05:00 UTC the next morning.
+ */
+$cases[] = [
+    'name' => "a day means the VIEWER's day, not the server's",
+    'zones' => ['America/Chicago', 'UTC'],
+    'request' => sbRequest([sbCriterion('deployed', '=', ['2026-08-29'])]),
+    'expect' => "WHERE ((`hostDeployed` >= '2026-08-29 05:00:00'"
+        . " AND `hostDeployed` < '2026-08-30 05:00:00'))",
+];
+
+$cases[] = [
+    'name' => 'before, in the viewer\'s zone',
+    'zones' => ['America/Chicago', 'UTC'],
+    'request' => sbRequest([sbCriterion('deployed', '<', ['2026-08-29'])]),
+    'expect' => "WHERE ((`hostDeployed` >= '1000-01-01 00:00:00'"
+        . " AND `hostDeployed` < '2026-08-29 05:00:00'))",
+];
+
+$cases[] = [
+    'name' => 'after, in the viewer\'s zone',
+    'zones' => ['America/Chicago', 'UTC'],
+    'request' => sbRequest([sbCriterion('deployed', '>', ['2026-08-29'])]),
+    'expect' => "WHERE (`hostDeployed` >= '2026-08-30 05:00:00')",
+];
+
+$cases[] = [
+    'name' => 'no preference set leaves the bounds exactly as typed',
+    'zones' => ['UTC', 'UTC'],
+    'request' => sbRequest([sbCriterion('deployed', '=', ['2026-08-29'])]),
+    'expect' => "WHERE ((`hostDeployed` >= '2026-08-29 00:00:00'"
+        . " AND `hostDeployed` < '2026-08-30 00:00:00'))",
+];
+
 $failures = [];
 $checks = 0;
 foreach ($cases as $case) {
     ++$checks;
+    // Zones default to equal -- the state every account is in until someone
+    // chooses a display timezone -- so an unmarked case states the clause it
+    // always did.
+    FOGBase::$displayZone = $case['zones'][0] ?? 'UTC';
+    FOGBase::$storageZone = $case['zones'][1] ?? 'UTC';
     if (isset($case['assert'])) {
         $problem = $case['assert']();
         if ('' !== $problem) {


### PR DESCRIPTION
## What this does

Dates and times are shown in whatever timezone the signed-in user has chosen — set from a clock icon in the navbar. `FOG_TZ_INFO` stays exactly what it was, the install-wide default.

**An account that has not chosen anything is unaffected in every path.** The conversion short-circuits when the two zones agree, which is every account until someone deliberately picks one.

## The thing that shapes the whole change

`FOG_TZ_INFO` is **not** a display setting today, whatever the name suggests. `niceDate()` uses it to *interpret* a stored string, and all 34 sites that write a timestamp format through the same call — so it is **the zone the database is written in**. Changing it re-labels every row that already exists rather than re-presenting it.

Presenting a different zone therefore means converting on the way out and back on the way in, while leaving writes alone:

| | |
|---|---|
| `storageTimeZone()` | the zone values are written in and read back as. `niceDate()` interprets through it, so a new timestamp still lands in the install's zone rather than in whichever user happened to trigger it |
| `displayTimeZone()` | the viewer's zone: their preference, else the install default. Resolved once per request, guarded so an unusable stored name falls back instead of throwing on every page that shows a date |
| `toDisplay()` / `displayToStorage()` | the two directions |

## Three surfaces

- **Form and detail pages** — `dateOrNever()` and `formatTime()`.
- **Grid cells** — `FOGManagerController::displayDates()`. Grid cells are raw stored values (`dataOutput()` copies them straight out of the row), and the lists are where the timestamps people actually read live. Without this the preference would apply everywhere *except* the lists.
- **The date filter's day bounds** — so a grid that **shows** the viewer's zone also **filters** in it. Otherwise "on the 29th" means the server's 29th, which near midnight is a different day and reads as missing rows.

**REST responses are deliberately not converted.** A script reading `hostLastDeploy` wants one stable answer, not one that depends on whose token it used — and the values carry no zone marker to disambiguate them.

One subtlety worth calling out: `formatTime()`'s `'now'` moves with the value it is compared against. The today / yesterday / runs-today branches compare calendar days, and comparing a day in one zone against a day in another is how something that ran this afternoon ends up labeled *"Ran Yesterday"*.

## Where the picker lives

In the page shell, not on a page of its own, so **every** signed-in user can reach it — including one holding no role at all. That needs no new node and **no access-control change**: the preference route is already reachable by any authenticated user and can only ever address that user's own row.

Saving reloads the page, because dates are rendered server-side and nothing already on screen can be relabeled in place.

## Not in this PR

**Storage stays where it is.** Moving it to UTC is a one-way migration over 40 datetime columns in 22 core tables plus plugin tables, and it changes every date the REST API hands out, so it is a separate release by design. `scheduledTasks` splits cleanly when that happens: `stDateTime` is a unix timestamp and already zone-free, while the cron fields are wall-clock intent and must never be converted.

## Verification

Against an isolated copy of a live database (never the live one):

- with no preference, behavior is **byte-identical** — same rendered string, same filter bounds;
- with one, a value stored `09:00` in the install's zone shows as `15:00` in the viewer's, with the instant unchanged;
- new timestamps still land in the storage zone;
- `formatTime($utc = true)` still means UTC, not the preference;
- zero and empty dates are left alone rather than shifted across a day boundary;
- an unusable stored zone falls back to the default.

The picker itself was driven in a real browser through open → save → reload → re-open → clear, confirming it sends the JSON body the route reads and that choosing "server default" **clears** the preference rather than storing an empty string.

Gates: `tests/display-timezone-split.test.php`, mutation-proved on seven ways of confusing the two zones, plus four new cases in the SearchBuilder gate that go red if a filter bound stops being converted. Full suite 207/207, both PHPStan passes clean.

## Deploying

Redeploy only — no schema change. `FOG_BCACHE_VER` 334 → 335 for the changed JS.
