### PR TITLE
Stop offering to remove a storage node from its group

### DIFF
--- a/packages/web/lib/pages/storagegroupmanagement.page.php
+++ b/packages/web/lib/pages/storagegroupmanagement.page.php
@@ -670,12 +670,33 @@ class StorageGroupManagement extends FOGPage
     public function storagegroupStoragenodes()
     {
         // Storage Node Associations
+        //
+        // No Remove here, and the help block says why. A node's group is a
+        // column on the node (nfsGroupMembers.ngmGroupID), not a link row, so
+        // there is nothing to dissociate -- only somewhere else to point it.
+        // Removing used to write ngmGroupID = 0, which left the node in no
+        // group at all: invisible in every group, still in the storage node
+        // list, and unreachable by getOptimalStorageNode() and
+        // getMasterStorageNode(), both of which start from a group. Schema
+        // step 388 declares the column RESTRICT, so that write is now refused
+        // by the database as well as by StorageGroup::removeNode().
+        //
+        // Adding is the move: addNode() rewrites ngmGroupID in one step and
+        // never passes through a group-less state, so a node is taken from
+        // whatever group it was in by adding it to this one.
         $this->renderAssocTab(
             'storagegroup-storagenode',
             _('Storage Group Storage Node Associations'),
             _('Storage Node Name'),
             'storagenode',
-            'btn btn-primary float-end'
+            'btn btn-primary float-end',
+            _('A storage node always belongs to exactly one storage group.'
+            . ' Adding a node here MOVES it into this group from wherever it'
+            . ' is now; a group with no nodes left is fine. To take a node out'
+            . ' of this group, add it to the group it should be in instead.'),
+            '',
+            '',
+            false
         );
 
         $props = ' method="post" action="'

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -1274,6 +1274,17 @@ $.registerGeneralTab = function(opts) {
 //                    per-row toggle commit. For tabs whose side panel must
 //                    refresh once the association save lands (host-snapin's run
 //                    order). Passed through as $.checkItemUpdate's done callback.
+// opts.allowRemove - optional; default true. Pass false for a tab whose
+//                    membership is a single-valued property of the row rather
+//                    than a link row, so it can be repointed but not broken --
+//                    a storage node's group. There are TWO ways to remove on a
+//                    normal tab and hiding the button only closes one: an
+//                    already-associated checkbox, when unticked, posts the same
+//                    confirmdel/remitems on its own. So this also renders such
+//                    a checkbox disabled. The matching renderAssocTab()
+//                    argument suppresses the button and its confirm modal, and
+//                    the two must agree -- a tab that hides the button while
+//                    leaving the checkbox live still offers the operation.
 // Returns the DataTable API instance.
 $.registerAssociationTab = function(opts) {
   opts = opts || {};
@@ -1284,14 +1295,20 @@ $.registerAssociationTab = function(opts) {
     removeBtn = $('#' + slug + '-remove'),
     deleteModal = $('#' + item + 'DelModal'),
     deleteConfirm = $('#confirm' + item + 'DeleteModal'),
+    allowRemove = opts.allowRemove !== false,
     columns = opts.columns || [{data: 'mainLink'}, {data: 'association'}],
     checkboxRender = opts.checkboxRender || function(row) {
-      var checkval = row.association === 'associated' ? ' checked' : '';
+      var associated = row.association === 'associated',
+        checkval = associated ? ' checked' : '',
+        // Ticking still works -- that is the repoint. Unticking is what has
+        // no meaning, and it is a live commit path, not just a display state.
+        lockval = (associated && !allowRemove) ? ' disabled' : '';
       return '<div class="form-check">'
         + '<input type="checkbox" class="associated" name="associate[]" id="'
         + slug + '-associate-' + row.id
         + '" value="' + row.id + '"'
         + checkval
+        + lockval
         + '/>'
         + '</div>';
     },

--- a/packages/web/management/js/fog/storagegroup/fog.storagegroup.edit.js
+++ b/packages/web/management/js/fog/storagegroup/fog.storagegroup.edit.js
@@ -294,10 +294,17 @@
     // STORAGE NODE TAB
 
     // Storage Node Associations
+    // allowRemove: false -- a node's group is a column on the node, not a link
+    // row, so it can be moved but not unset. Adding it to another group is the
+    // move; StorageGroup::removeNode() throws and the database refuses the
+    // write besides. Without this the checkbox of an already-associated node
+    // would still post confirmdel when unticked, which is a second removal
+    // path the hidden button does not close.
     var storagegroupStoragenodesTable = $.registerAssociationTab({
         slug: 'storagegroup-storagenode',
         item: 'storagenode',
         sub: 'getStoragenodesList',
+        allowRemove: false,
         afterCommit: function() {
             setTimeout(storagegroupStoragenodeMasterSelectorUpdate, 1000);
         }

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -443,6 +443,9 @@ msgstr "Speichergruppe gelöscht"
 msgid "A storage node already exists with this name!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
 
+msgid "A storage node always belongs to exactly one storage group. Adding a node here MOVES it into this group from wherever it is now; a group with no nodes left is fine. To take a node out of this group, add it to the group it should be in instead."
+msgstr ""
+
 msgid "A storage node must belong to a storage group. Add it to the group you want it in instead; that moves it, and a group with no nodes left is fine."
 msgstr ""
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -448,6 +448,9 @@ msgstr "Storage Group deleted"
 msgid "A storage node already exists with this name!"
 msgstr "An image already exists with this name!"
 
+msgid "A storage node always belongs to exactly one storage group. Adding a node here MOVES it into this group from wherever it is now; a group with no nodes left is fine. To take a node out of this group, add it to the group it should be in instead."
+msgstr ""
+
 msgid "A storage node must belong to a storage group. Add it to the group you want it in instead; that moves it, and a group with no nodes left is fine."
 msgstr ""
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -445,6 +445,9 @@ msgstr "Nombre del grupo de almacenamiento"
 msgid "A storage node already exists with this name!"
 msgstr "Una imagen ya existe con este nombre!"
 
+msgid "A storage node always belongs to exactly one storage group. Adding a node here MOVES it into this group from wherever it is now; a group with no nodes left is fine. To take a node out of this group, add it to the group it should be in instead."
+msgstr ""
+
 msgid "A storage node must belong to a storage group. Add it to the group you want it in instead; that moves it, and a group with no nodes left is fine."
 msgstr ""
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -443,6 +443,9 @@ msgstr "Speichergruppe gelöscht"
 msgid "A storage node already exists with this name!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
 
+msgid "A storage node always belongs to exactly one storage group. Adding a node here MOVES it into this group from wherever it is now; a group with no nodes left is fine. To take a node out of this group, add it to the group it should be in instead."
+msgstr ""
+
 msgid "A storage node must belong to a storage group. Add it to the group you want it in instead; that moves it, and a group with no nodes left is fine."
 msgstr ""
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -449,6 +449,9 @@ msgstr "Groupe de stockage supprimé"
 msgid "A storage node already exists with this name!"
 msgstr "Une image existe déjà avec ce nom!"
 
+msgid "A storage node always belongs to exactly one storage group. Adding a node here MOVES it into this group from wherever it is now; a group with no nodes left is fine. To take a node out of this group, add it to the group it should be in instead."
+msgstr ""
+
 msgid "A storage node must belong to a storage group. Add it to the group you want it in instead; that moves it, and a group with no nodes left is fine."
 msgstr ""
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -438,6 +438,9 @@ msgstr "Storage Group cancellato"
 msgid "A storage node already exists with this name!"
 msgstr "Un host già esiste con questo nome!"
 
+msgid "A storage node always belongs to exactly one storage group. Adding a node here MOVES it into this group from wherever it is now; a group with no nodes left is fine. To take a node out of this group, add it to the group it should be in instead."
+msgstr ""
+
 msgid "A storage node must belong to a storage group. Add it to the group you want it in instead; that moves it, and a group with no nodes left is fine."
 msgstr ""
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -426,6 +426,9 @@ msgstr "グループを選択してください。"
 msgid "A storage node already exists with this name!"
 msgstr "この名前のロールは既に存在します！"
 
+msgid "A storage node always belongs to exactly one storage group. Adding a node here MOVES it into this group from wherever it is now; a group with no nodes left is fine. To take a node out of this group, add it to the group it should be in instead."
+msgstr ""
+
 msgid "A storage node must belong to a storage group. Add it to the group you want it in instead; that moves it, and a group with no nodes left is fine."
 msgstr ""
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -388,6 +388,9 @@ msgstr ""
 msgid "A storage node already exists with this name!"
 msgstr ""
 
+msgid "A storage node always belongs to exactly one storage group. Adding a node here MOVES it into this group from wherever it is now; a group with no nodes left is fine. To take a node out of this group, add it to the group it should be in instead."
+msgstr ""
+
 msgid "A storage node must belong to a storage group. Add it to the group you want it in instead; that moves it, and a group with no nodes left is fine."
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -448,6 +448,9 @@ msgstr "Grupo de armazenamento excluído"
 msgid "A storage node already exists with this name!"
 msgstr "Uma imagem já existe com este nome!"
 
+msgid "A storage node always belongs to exactly one storage group. Adding a node here MOVES it into this group from wherever it is now; a group with no nodes left is fine. To take a node out of this group, add it to the group it should be in instead."
+msgstr ""
+
 msgid "A storage node must belong to a storage group. Add it to the group you want it in instead; that moves it, and a group with no nodes left is fine."
 msgstr ""
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -448,6 +448,9 @@ msgstr "存储组中删除"
 msgid "A storage node already exists with this name!"
 msgstr "图像已经存在具有此名称！"
 
+msgid "A storage node always belongs to exactly one storage group. Adding a node here MOVES it into this group from wherever it is now; a group with no nodes left is fine. To take a node out of this group, add it to the group it should be in instead."
+msgstr ""
+
 msgid "A storage node must belong to a storage group. Add it to the group you want it in instead; that moves it, and a group with no nodes left is fine."
 msgstr ""
 

--- a/packages/web/src/Base/FOGPageRender.php
+++ b/packages/web/src/Base/FOGPageRender.php
@@ -61,6 +61,18 @@ trait FOGPageRender
      *                          to renderAssocCreate(), which has always taken
      *                          one; without this pass-through a tab could only
      *                          reach it by calling that helper itself.
+     * @param bool   $allowRemove whether the association can be broken at all.
+     *                          Defaults true, which is every many-to-many tab:
+     *                          a link row exists or it does not, and removing
+     *                          it is meaningful. Pass false where membership is
+     *                          a single-valued property of the row rather than
+     *                          a link -- a storage node's group is a column on
+     *                          the node, so there is no association to delete,
+     *                          only one to repoint, and "remove" would have to
+     *                          invent a group-less state that cannot be stored.
+     *                          Suppresses the Remove button and the confirm
+     *                          modal it opens, so the tab stops offering an
+     *                          operation the model has no way to perform.
      *
      * @return void
      */
@@ -72,7 +84,8 @@ trait FOGPageRender
         $sendClass = 'btn btn-primary float-end',
         $helpBlock = '',
         $createNode = '',
-        $noun = ''
+        $noun = '',
+        $allowRemove = true
     ) {
         $this->headerData = [
             $colHeader,
@@ -95,12 +108,14 @@ trait FOGPageRender
             $sendClass,
             $props
         );
-        $buttons .= self::makeButton(
-            "$tabSlug-remove",
-            _('Remove selected'),
-            'btn btn-danger float-start',
-            $props
-        );
+        if ($allowRemove) {
+            $buttons .= self::makeButton(
+                "$tabSlug-remove",
+                _('Remove selected'),
+                'btn btn-danger float-start',
+                $props
+            );
+        }
 
         $createModal = '';
         if ($createNode !== '') {
@@ -128,7 +143,9 @@ trait FOGPageRender
         $this->render(12, "$tabSlug-table", $buttons);
         echo '</div>';
         echo '<div class="card-footer">';
-        echo $this->assocDelModal($delItem);
+        // Without the button there is nothing to open this, and the confirm
+        // modal's own Remove would post the same confirmdel if it were reached.
+        echo $allowRemove ? $this->assocDelModal($delItem) : '';
         echo $createModal;
         echo '</div>';
         echo '</div>';

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 392);
-        define('FOG_BCACHE_VER', 334);
+        define('FOG_BCACHE_VER', 335);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4506');
+        define('FOG_VERSION', '1.6.0-beta.4510');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/tests/storagenode-group-is-not-removable.test.sh
+++ b/tests/storagenode-group-is-not-removable.test.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+#
+# A storage node's group cannot be removed, only repointed.
+#
+#   tests/storagenode-group-is-not-removable.test.sh
+#
+# nfsGroupMembers.ngmGroupID is a COLUMN on the node, not a link row. Every
+# other association tab in FOG is a genuine many-to-many where removing means
+# deleting a row; this one has nothing to delete, only somewhere else to point.
+# Removing used to write ngmGroupID = 0, which left the node in a group that
+# has never existed: invisible in every group, still in the storage node list,
+# and unreachable by getOptimalStorageNode() and getMasterStorageNode(), which
+# both start from a group. So the node could never be selected for any work
+# again, and nothing said so. One such row was found on a live server.
+#
+# Schema step 388 declares the column ON DELETE RESTRICT and
+# StorageGroup::removeNode() throws, so the write is refused twice over. This
+# gate is about the third layer: the UI must stop OFFERING the operation.
+#
+# THE HALF THAT IS EASY TO MISS, and the reason this test exists rather than a
+# comment: there are TWO removal paths on an association tab, and hiding the
+# button closes only one. An already-associated checkbox posts
+# confirmdel/remitems on its own when unticked, through $.checkItemUpdate. A
+# tab that hides the button and leaves the checkbox live still offers the
+# operation, and looks correct in a screenshot.
+#
+# Both halves are RUN here rather than grepped -- renderAssocTab() against a
+# stub page, and the real default checkboxRender lifted out of fog.common.js
+# and called. A grep for "allowRemove" passes just as happily when the flag is
+# read and then ignored.
+#
+# Needs node for the JavaScript half, which skips on its own when node is
+# absent, the same way apidocs-request-snippets.test.sh does. The PHP half
+# always runs.
+#
+# Exit status 0 = pass, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+WEB="$REPO/packages/web"
+RENDER="$WEB/src/Base/FOGPageRender.php"
+PAGE="$WEB/lib/pages/storagegroupmanagement.page.php"
+COMMON="$WEB/management/js/fog/fog.common.js"
+EDIT="$WEB/management/js/fog/storagegroup/fog.storagegroup.edit.js"
+
+for f in "$RENDER" "$PAGE" "$COMMON" "$EDIT"; do
+    [[ -f $f ]] || { echo "ERROR: $f not found" >&2; exit 1; }
+done
+
+PASS=0
+FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# 1. renderAssocTab(), executed. The trait is used by a stub page that supplies
+#    the seven things the method reaches for, so what is asserted is the markup
+#    the method really emits rather than the shape of its source.
+# ---------------------------------------------------------------------------
+php_out=$(WEB="$WEB" php -d error_reporting=E_ALL <<'PHPEOF'
+<?php
+$web = getenv('WEB');
+if (!function_exists('_')) {
+    function _($s) { return $s; }
+}
+// The trait's own file, loaded alone. Its `use` imports resolve lazily, and
+// nothing this test calls reaches any of them.
+require $web . '/src/Base/FOGPageRender.php';
+
+class StubObj
+{
+    public function get($k) { return 42; }
+}
+class StubPage
+{
+    use FOG\Base\FOGPageRender;
+
+    public $obj;
+    public $headerData = [];
+    public $attributes = [];
+
+    public function __construct() { $this->obj = new StubObj(); }
+
+    public static function makeButton($id, $label, $class, $props = '')
+    {
+        return '<button id="' . $id . '">' . $label . '</button>';
+    }
+    public static function makeTabUpdateURL($slug, $id) { return 'URL'; }
+    public static function renderAssocCreate($a, $b, $c, $d, $e = '') { return ''; }
+    public function assocDelModal($item = '') { return '<div id="' . $item . 'DelModal"></div>'; }
+    public function render($cols, $id, $buttons) { echo '<table id="' . $id . '">' . $buttons . '</table>'; }
+
+    // renderAssocTab is protected; this test is the caller.
+    public function callIt($allowRemove)
+    {
+        ob_start();
+        $this->renderAssocTab(
+            'storagegroup-storagenode',
+            'Title',
+            'Header',
+            'storagenode',
+            'btn btn-primary float-end',
+            '',
+            '',
+            '',
+            $allowRemove
+        );
+        return ob_get_clean();
+    }
+}
+
+$page = new StubPage();
+$with = $page->callIt(true);
+$without = $page->callIt(false);
+
+$checks = [
+    // The default must be unchanged: every other tab in FOG relies on it.
+    'default still renders the Remove button'
+        => false !== strpos($with, 'storagegroup-storagenode-remove'),
+    'default still renders the confirm modal'
+        => false !== strpos($with, 'storagenodeDelModal'),
+    // The point of the flag.
+    'allowRemove=false renders NO Remove button'
+        => false === strpos($without, 'storagegroup-storagenode-remove'),
+    'allowRemove=false renders NO confirm modal'
+        => false === strpos($without, 'storagenodeDelModal'),
+    // ...without gutting the tab: adding is how a node is moved.
+    'allowRemove=false still renders the Add button'
+        => false !== strpos($without, 'storagegroup-storagenode-send'),
+    'allowRemove=false still renders the table'
+        => false !== strpos($without, 'storagegroup-storagenode-table'),
+];
+foreach ($checks as $what => $result) {
+    echo ($result ? 'PASS' : 'FAIL'), ': ', $what, "\n";
+}
+PHPEOF
+)
+php_status=$?
+echo "$php_out"
+if [[ $php_status -ne 0 ]]; then
+    bad "the renderAssocTab harness ran cleanly"
+fi
+while IFS= read -r line; do
+    case "$line" in
+        PASS:*) PASS=$((PASS + 1)) ;;
+        FAIL:*) FAIL=$((FAIL + 1)) ;;
+    esac
+done <<< "$php_out"
+
+# ---------------------------------------------------------------------------
+# 2. The storage group page must pass the flag. This is the USE, and on its own
+#    it would be a weak assertion -- section 1 is what proves the flag does
+#    anything. Anchored on the whole call so a reordered argument list fails
+#    here rather than silently passing false to $noun.
+# ---------------------------------------------------------------------------
+if perl -0777 -ne 'exit(/renderAssocTab\(\s*'"'"'storagegroup-storagenode'"'"'.*?\n\s*false\s*\n\s*\);/s ? 0 : 1)' "$PAGE"; then
+    ok "storagegroupmanagement passes allowRemove=false as the last argument"
+else
+    bad "storagegroupmanagement passes allowRemove=false as the last argument"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. The JavaScript half, executed. The default checkboxRender is lifted out of
+#    fog.common.js verbatim and called, because the failure being guarded is a
+#    behavior of that function and not the presence of a word in the file.
+# ---------------------------------------------------------------------------
+if ! command -v node >/dev/null 2>&1; then
+    echo "SKIP: node is not installed; the JavaScript half did not run"
+else
+    node_out=$(COMMON="$COMMON" EDIT="$EDIT" node <<'NODEEOF'
+const fs = require('fs');
+const src = fs.readFileSync(process.env.COMMON, 'utf8');
+
+// Lift the default checkboxRender out of $.registerAssociationTab. Running the
+// whole factory would need jQuery, DataTables and Common; this is the function
+// under test and it is self-contained.
+const m = src.match(
+  /checkboxRender = opts\.checkboxRender \|\| (function \(row\) \{[\s\S]*?\n    \}),\n/
+) || src.match(
+  /checkboxRender = opts\.checkboxRender \|\| (function\(row\) \{[\s\S]*?\n    \}),\n/
+);
+if (!m) {
+  console.log('FAIL: the default checkboxRender could not be located in fog.common.js');
+  process.exit(0);
+}
+
+function build(allowRemove) {
+  const slug = 'storagegroup-storagenode';
+  // eslint-disable-next-line no-new-func
+  return new Function('allowRemove', 'slug', 'return (' + m[1] + ');')(allowRemove, slug);
+}
+
+const assoc = {id: 7, association: 'associated'};
+const notAssoc = {id: 8, association: 'dissociated'};
+
+const openTicked   = build(true)(assoc);
+const openUnticked = build(true)(notAssoc);
+const lockTicked   = build(false)(assoc);
+const lockUnticked = build(false)(notAssoc);
+
+const checks = [
+  // Unchanged for every other tab.
+  ['a normal tab leaves an associated checkbox live, so it can still be unticked',
+    !/disabled/.test(openTicked)],
+  ['a normal tab leaves an unassociated checkbox live',
+    !/disabled/.test(openUnticked)],
+  ['a normal tab still marks an associated row checked',
+    /checked/.test(openTicked)],
+  // The fix.
+  ['allowRemove=false disables an ASSOCIATED checkbox, closing the untick path',
+    /disabled/.test(lockTicked)],
+  ['allowRemove=false leaves an UNASSOCIATED checkbox live, so a node can still be moved in',
+    !/disabled/.test(lockUnticked)],
+  // The plumbing $.checkItemUpdate needs must survive in both.
+  ['the locked cell still carries input.associated with the row id',
+    /class="associated"/.test(lockTicked) && /value="7"/.test(lockTicked)],
+];
+for (const [what, result] of checks) {
+  console.log((result ? 'PASS' : 'FAIL') + ': ' + what);
+}
+
+// The page must actually ask for it.
+const edit = fs.readFileSync(process.env.EDIT, 'utf8');
+const asked = /slug:\s*'storagegroup-storagenode'[\s\S]{0,400}?allowRemove:\s*false/.test(edit);
+console.log((asked ? 'PASS' : 'FAIL')
+  + ': fog.storagegroup.edit.js passes allowRemove:false on the storagenode tab');
+NODEEOF
+)
+    echo "$node_out"
+    while IFS= read -r line; do
+        case "$line" in
+            PASS:*) PASS=$((PASS + 1)) ;;
+            FAIL:*) FAIL=$((FAIL + 1)) ;;
+        esac
+    done <<< "$node_out"
+fi
+
+echo
+echo "$PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Problem

A storage node's group is `nfsGroupMembers.ngmGroupID` — a **column on the node**, not a link row. Every other association tab in FOG is a genuine many-to-many where removing means deleting a row. This one has nothing to delete, only somewhere else to point.

Removing wrote `ngmGroupID = 0` and left the node there: in a group that has never existed, invisible in every group, still listed under Storage Management, and unreachable by `getOptimalStorageNode()` and `getMasterStorageNode()` — both of which start from a group. The node could never be selected for any work again, and nothing said so.

One such row was found on a live server, left behind by lab testing (`fognode1.lan`). It was also the reason `fk_nfsGroupMembers_ngmGroupID` was the single core constraint that server refused to apply.

## What was already in place

- `StorageGroup::removeNode()` throws rather than writing the sentinel.
- Schema step 388 declares the column `ON DELETE RESTRICT`, so the database refuses it too.

So the write was already refused twice over. What remained was that the **UI still offered it** — a red "Remove selected" button whose only possible outcome was an error toast.

## The half that is easy to miss

There are **two** removal paths on an association tab, and hiding the button closes only one. An already-associated checkbox posts the same `confirmdel`/`remitems` by itself when unticked, via `$.checkItemUpdate`. A tab that hides the button and leaves the checkbox live still offers the operation — and looks correct in a screenshot.

Both are closed here.

## The change

`renderAssocTab()` and `$.registerAssociationTab()` gain a matching `allowRemove` flag, **defaulting true**, so every other association tab in the application is untouched. Passing false:

- suppresses the Remove button and the confirm modal it opens;
- renders an *associated* row's checkbox `disabled`.

An *unassociated* row's checkbox stays live, because adding a node to a group is how a node is **moved**: `addNode()` repoints `ngmGroupID` in one step and never passes through the group-less state. The tab's new help block says exactly that.

## Test

`tests/storagenode-group-is-not-removable.test.sh` **runs** both halves rather than grepping for the flag — `renderAssocTab()` against a stub page, and the real default `checkboxRender` lifted out of `fog.common.js` and called. A grep for `allowRemove` passes just as happily when the flag is read and then ignored.

Seven mutations were each verified to fail it:

| Mutation | Gate that caught it |
|---|---|
| un-guard the Remove button (restores the bug) | renders NO Remove button |
| un-guard the confirm modal | renders NO confirm modal |
| drop `allowRemove: false` from the storagegroup JS | the JS passes the flag |
| drop the `false` argument from the page call | the page passes the flag |
| drop `lockval` from the checkbox | disables an associated checkbox |
| disable the checkbox unconditionally | leaves an unassociated checkbox live |
| drop `class="associated"` | locked cell still carries the commit plumbing |

Full suite 207 passed / 0 failed; both phpstan passes clean; us-spelling clean.

`FOG_BCACHE_VER` 334 → 335, since `fog.common.js` changed.

## Not ported to dev-branch

1.5.x has no foreign keys and no `renderAssocTab`/`registerAssociationTab` factory, so neither the constraint nor the shared flag exists there. Changing `removeNode()` on the stable line would be a behavior change without the schema that motivates it.
