### PR TITLE
Stop every grid re-fetching and re-measuring itself three extra times per load

### DIFF
--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -2846,7 +2846,44 @@ if ($.fn.dataTable) {
  * ceiling for large ones so they fill the screen rather than wasting (or
  * crowding) vertical space. Recomputed on window resize and tab show.
  */
-function fogSizeScroller(dt) {
+/**
+ * Draw only if the table is actually short of rows.
+ *
+ * Called when a re-measure has raised Scroller's page length: the taller
+ * viewport wants more rows than the last request asked for. That is not the
+ * same as needing them -- a grid that already holds every row the server has
+ * cannot be short, however tall it gets, and on a server-side table a draw it
+ * does not need is a round trip plus a re-render of every loaded row.
+ *
+ * The first pass runs before the initial response has landed, when the row
+ * count is not knowable yet. Rather than guess, wait for that draw and ask
+ * again: by then the answer is a fact. Deferred at most once -- if the reply
+ * still leaves the table short, fetch, and stop.
+ *
+ * @param {object} dt      the DataTables API for the table
+ * @param {bool}   waited  internal: this is the re-check after the deferral
+ *
+ * @return {void}
+ */
+function fogFetchIfShort(dt, waited) {
+  var settings = dt.settings()[0],
+    xhr = settings ? settings.jqXHR : null,
+    info;
+  if (!waited && xhr && xhr.readyState !== 4) {
+    dt.one('draw.dt', function() {
+      fogFetchIfShort(dt, true);
+    });
+    return;
+  }
+  info = dt.page.info();
+  // recordsDisplay is what the server says matches the current filter. Holding
+  // that many means there is nothing left to ask for.
+  if (info && dt.rows().count() >= info.recordsDisplay) {
+    return;
+  }
+  dt.draw(false);
+}
+function fogSizeScroller(dt, release) {
   // dt.init() can be null for nodes the table.dataTable selector also matches
   // but that aren't fully-initialized Scroller tables (e.g. the scrollY split
   // table's cloned header). Guard it so we skip them instead of throwing on
@@ -2858,6 +2895,14 @@ function fogSizeScroller(dt) {
   var container = dt.table().container(),
     body = $('div.dt-scroll-body', container);
   if (!body.length || !body.is(':visible')) {
+    // Forget what the last pass measured. A table that has been hidden may be
+    // re-cloned or re-laid-out before it comes back, so the next visible pass
+    // has to re-adjust even if the window is the size it was -- the signature
+    // below would otherwise match and skip it.
+    var hidden = dt.settings()[0];
+    if (hidden) {
+      hidden._fogSizeSignature = null;
+    }
     return; // not rendered, or in a hidden tab
   }
   var bodyRect = body[0].getBoundingClientRect(),
@@ -2925,13 +2970,60 @@ function fogSizeScroller(dt) {
     var lenBefore = dt.page.len();
     dt.scroller.measure(false);
     if (dt.page.len() > lenBefore) {
-      dt.draw(false);
+      fogFetchIfShort(dt);
     }
   }
   // Re-sync the scrollY header/body column widths. measure() only recomputes
   // the virtual viewport height, so a table first laid out in a hidden tab
   // keeps its zero-width header/body split (header narrow, body full-width)
   // until the columns are adjusted once it becomes visible.
+  //
+  // Gated, because this is the expensive half and most calls have nothing to
+  // do. columns.adjust() fires column-sizing, and Responsive answers that by
+  // cloning the whole current page of rows into a hidden table to read a
+  // column width off each one -- ~130ms a time on an 86-row host list, and
+  // Scroller's "current page" is every row it has loaded. This function runs
+  // three times on a normal page load (the deferred pass below
+  // registerTable(), the post-draw re-adjust above, and fogAdjustAllTables()
+  // off the .app-main ResizeObserver), and the last of those is woken by the
+  // rows the earlier passes drew rather than by anything that moved a column.
+  //
+  // Three things decide whether the split needs re-measuring: the height we
+  // just set, the container's width, and whether the body overflows -- that
+  // last one because DataTables reserves the scrollbar's width on the header
+  // when it does, which is the whole point of the post-draw pass above (the
+  // row count settles, the overflow goes away, and the reservation has to come
+  // back off). Same three as last time means the answer would be identical, so
+  // skip it. Sampled AFTER the max-height write, since that is an input to the
+  // overflow.
+  //
+  // The colgroup widths have to be released before the adjust to let the table
+  // narrow (see fogReleaseColWidths), so that is done here rather than by the
+  // caller -- releasing them and then skipping the adjust would leave the
+  // table on auto widths.
+  //
+  // The visible column set is in the signature too. Hiding or showing a column
+  // changes neither the height nor the container width, so without it the
+  // ResizeObserver pass that follows a visibility toggle would match the
+  // previous signature and skip -- leaving the colgroup widths written for the
+  // old column set, which the table then redistributes rather than
+  // re-measuring. Header and body stay in step either way, but the table
+  // settles at the wrong width (measured 1326px against 1246px on the host
+  // list, hiding then re-showing one column).
+  var el = body[0],
+    signature = avail + '|'
+      + Math.round(container.getBoundingClientRect().width) + '|'
+      + (el.scrollHeight > el.clientHeight ? 1 : 0) + '|'
+      + dt.columns(':visible').indexes().toArray().join(',');
+  if (settings && settings._fogSizeSignature === signature) {
+    return;
+  }
+  if (settings) {
+    settings._fogSizeSignature = signature;
+  }
+  if (release) {
+    fogReleaseColWidths(dt.table().node());
+  }
   dt.columns.adjust();
 }
 /**
@@ -2990,12 +3082,11 @@ function fogAdjustAllTables() {
       return;
     }
     if (init.scroller) {
-      // Height as well as width, and it does its own visibility check -- so
-      // only release the widths once we know it will act on them.
-      if ($(this).is(':visible')) {
-        fogReleaseColWidths(this);
-      }
-      fogSizeScroller(dt);
+      // Height as well as width, and it does its own visibility check. The
+      // width release goes with it rather than happening here: it is only
+      // correct paired with the adjust that follows, and fogSizeScroller() is
+      // what decides whether that adjust is needed at all.
+      fogSizeScroller(dt, true);
       return;
     }
     // A paged table has no scroll body to measure, but it still needs its

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -2905,10 +2905,28 @@ function fogSizeScroller(dt) {
       }, 0);
     });
   }
-  // Recompute Scroller's virtual viewport for the new height (measure() also
-  // redraws). Guarded in case Scroller isn't attached for some reason.
+  // Recompute Scroller's virtual viewport for the new height.
+  //
+  // measure() redraws unless told not to, and on a server-side table a redraw
+  // is a full round trip plus a re-render of every loaded row. This function
+  // runs at least three times on a normal page load -- the deferred first pass
+  // below registerTable(), the one-shot post-draw re-adjust above, and the
+  // .app-main ResizeObserver firing once the rows have changed the layout --
+  // so honoring the default cost the host list four identical fetches of the
+  // same 86 rows and ~2.4s before the grid settled, against 22ms of server
+  // time. Measured 2026-08-29 on 10.255.20.1.
+  //
+  // The only thing measure() changes that a redraw is needed for is the page
+  // length: viewportRows * displayBuffer, derived from the height just set. So
+  // measure without redrawing, and redraw only when the new height genuinely
+  // asks for MORE rows than are already loaded. A shorter viewport needs none
+  // -- the rows for it are already there.
   if (dt.scroller && typeof dt.scroller.measure === 'function') {
-    dt.scroller.measure();
+    var lenBefore = dt.page.len();
+    dt.scroller.measure(false);
+    if (dt.page.len() > lenBefore) {
+      dt.draw(false);
+    }
   }
   // Re-sync the scrollY header/body column widths. measure() only recomputes
   // the virtual viewport height, so a table first laid out in a hidden tab

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4510');
+        define('FOG_VERSION', '1.6.0-beta.4515');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 390);
-        define('FOG_BCACHE_VER', 333);
+        define('FOG_BCACHE_VER', 334);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a


### PR DESCRIPTION
## What

Every server-side grid fetched its rows **four times** on a single page load and
re-measured its columns on each one. The server was never involved: the host
list page shell answers in 31ms and the grid's data POST in 22ms.

## Why it happened

`fogSizeScroller()` called `dt.scroller.measure()`, and Scroller's `measure(redraw)`
redraws unless told not to. On a server-side table a redraw is a full round trip
plus a re-render of every loaded row — and each redraw changed the layout, which
woke the `.app-main` ResizeObserver, which redrew again.

The expensive half of each pass is `columns.adjust()`. It fires `column-sizing`,
and Responsive answers that by cloning the whole current page of rows into a
hidden table to read a column width off each one — about **1.1ms per loaded row,
per call**, so it gets worse as a site grows.

Traced on 10.255.20.1, the four fetches came from:

| draw | fired by |
|---|---|
| 1 | DataTables init — legitimate |
| 2 | `fogSizeScroller` ← the deferred pass at the end of `registerTable()` |
| 3 | `fogSizeScroller` ← its own `_fogPostShowAdjusted` one-shot |
| 4 | `fogSizeScroller` ← `fogAdjustAllTables` ← the `.app-main` ResizeObserver |

## What changed

Three guards in the shared grid helper, so this applies to every list page:

- `measure(false)`, and redraw only if the taller viewport genuinely asks for
  more rows than are already loaded. A grid holding every row the server has
  cannot be short however tall it gets. Where that is not knowable yet — the
  first pass runs before the initial response lands — wait for that draw and ask
  once more rather than guessing.
- Signature each sizing pass on the four things that decide the answer (the
  height just set, the container's width, whether the body overflows, and the
  visible column set) and skip when none has changed. The overflow term is what
  preserves the post-draw pass #1418 added.
- The colgroup release moves inside `fogSizeScroller()`, since releasing the
  widths is only correct paired with the adjust that follows and the caller no
  longer knows whether that will happen.

## Measured

Headless Chrome, warm cache, three passes per page, against the branch
10.255.20.1 actually runs. "quiet" is the last grid request or column re-measure
to finish.

| page | rows | before | after | |
|---|---|---|---|---|
| host list | 86 | 10 requests / 323KB grid data / 2361ms | 5 / 81KB / 1384ms | −41% |
| image list | 29 | 11 requests / 878ms | 5 / 608ms | −31% |
| user list | 13 | 9 requests / 439ms | 5 / 329ms | −25% |
| group list | 2 | 9 requests / 374ms | 5 / 283ms | −24% |

Against `working-1.6` itself the request count goes 4 → 1; the extra requests
above are the grid-layout preference being saved once per sizing pass, which
comes down with them.

## Behavior checked

Compared against an unpatched build at 1600px, 900px and back, and across hiding
and re-showing a column: same visible columns, same Responsive collapse points
(9 / 5 / 9 columns shown), header and body column widths identical to the pixel
in every state, and the per-column search row rebuilds to match. The duplicate
column-resize handles the extra passes were leaving behind are gone (16 → 8).

Not verified here: #1418's scrollbar reservation. Headless has 0px scrollbars so
it cannot reproduce that bug either way — the pass it relies on is still made,
but it wants an eye on a real browser.

## Not done

Responsive's `_resizeAuto()` is the remaining cost — 8 calls / 761ms on the host
list, and only 2 of those are ours. Turning it off (`responsive: {auto: false}`)
takes the host list to ~390ms, but it is doing real work: it collapses 1 column
at 1920px, 2 at 1600px, 5 at 1280px and 9 at 480px. Left alone deliberately.

`FOG_BCACHE_VER` 333 → 334, since the JS changed.