### PR TITLE
Dark mode: fix the flash, and make the theme a per-user preference

### DIFF
--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -1310,10 +1310,56 @@ class Initiator
         }
     }
 
+    /**
+     * Collapses whitespace in the rendered page, but not where it means
+     * something.
+     *
+     * `/(\s)+/` -> `\1` replaces a whitespace run with its LAST character,
+     * so a newline followed by indentation -- which is every line of a
+     * pretty-printed page -- collapses to a single space and the newline is
+     * gone. Inside three elements that is destructive rather than cosmetic:
+     *
+     *  - <script>: every `//` comment swallows the rest of the block, because
+     *    after the collapse there is no line for it to end at. The pre-paint
+     *    dark-mode script in management/other/index.php was dead this way, so
+     *    the theme was only applied on DOMContentLoaded and every viewer
+     *    following their OS preference got a white flash first.
+     *  - <textarea>: the line breaks a user typed are their data, and this
+     *    rewrote them on the way back to the form.
+     *  - <pre>: the whole point of the element.
+     *
+     * So collapse only the markup between those blocks and pass their
+     * contents through untouched.
+     *
+     * @param string $buffer The rendered page.
+     *
+     * @return string
+     */
     public static function sanitizeOutput(string $buffer): string
     {
+        // DELIM_CAPTURE keeps the matched blocks in the list, at the odd
+        // indexes, so the two halves stay interleaved in order.
+        $parts = preg_split(
+            '#(<(?:script|pre|textarea)\b[^>]*>.*?</(?:script|pre|textarea)>)#is',
+            $buffer,
+            -1,
+            PREG_SPLIT_DELIM_CAPTURE
+        );
+        if (!is_array($parts)) {
+            // A backtrack/recursion limit on a very large page. Returning the
+            // buffer unchanged loses the whitespace saving; rewriting it with
+            // the old expression would lose the script.
+            return $buffer;
+        }
         $search = ['/>\s+</', '/(\s)+/'];
         $replace = ['> <', '\\1'];
-        return preg_replace($search, $replace, $buffer) ?? $buffer;
+        foreach ($parts as $index => $part) {
+            if (1 === $index % 2) {
+                continue;
+            }
+            $parts[$index] = preg_replace($search, $replace, $part) ?? $part;
+        }
+
+        return implode('', $parts);
     }
 }

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -440,10 +440,11 @@ function fogBindTimezonePicker() {
     fogPrefStore('display.timezone', chosen, function(storeErr) {
       if (storeErr) {
         button.prop('disabled', false);
-        // notifyFromAPI, not notify: the latter does not exist here, and
-        // calling it would throw on the one path that exists to report a
-        // failure -- leaving the button disabled with nothing on screen and
-        // only a console error to say why.
+        // notifyFromAPI, not notify: $.notify takes (title, body, type),
+        // and the object-and-options form this used to pass is a different
+        // library's signature -- it rendered "[object Object]" as the title.
+        // notifyFromAPI is also the better answer here because it surfaces
+        // the reason the server actually gave.
         $.notifyFromAPI(storeErr.responseJSON, storeErr);
         return;
       }

--- a/packages/web/management/js/fog/theme.js
+++ b/packages/web/management/js/fog/theme.js
@@ -1,97 +1,166 @@
 /**
- * Dark-mode toggle.
+ * Color theme picker.
  *
- * data-bs-theme on <html> is the single source of truth (Bootstrap 5 / AdminLTE
- * 4 native theming, and FOG's own chrome keys off the same attribute). It is
- * stamped server-side from the fogTheme cookie (see management/other/index.php),
- * or resolved from the OS preference by a pre-paint head script when no cookie
- * is set, so the first paint already matches — there is no light flash on
- * reload. This script only:
- *   - syncs the toggle icon/label with the effective theme on load, and
- *   - flips data-bs-theme live and writes the cookie when the toggle is clicked.
+ * data-bs-theme on <html> is the single source of truth (Bootstrap 5 /
+ * AdminLTE 4 native theming, and FOG's own chrome keys off the same
+ * attribute). It is already correct before this file runs:
  *
- * Themes: 'dark' | 'light'. No cookie => follow the OS via prefers-color-scheme.
+ *   - a forced 'light'/'dark' preference is stamped server-side on <html>
+ *     (management/other/index.php), and
+ *   - an unset preference leaves the attribute off, which the pre-paint
+ *     script in <head> takes as its cue to resolve prefers-color-scheme.
+ *
+ * So this script never decides the FIRST paint. It only keeps the picker in
+ * step, applies a new choice live, and -- in system mode -- follows the OS if
+ * it changes while the page is open.
+ *
+ * Three states, and '' is not 'light': see FOGBase::displayTheme().
+ *
+ * Stored in userPrefs rather than a cookie, because the theme belongs to the
+ * person and not the machine they happen to be sitting at. The login page has
+ * no session and therefore no picker; it follows the system.
  */
 (function () {
     'use strict';
 
-    var COOKIE = 'fogTheme';
-
-    function readCookie(name) {
-        var m = document.cookie.match('(?:^|; )' + name + '=([^;]*)');
-        return m ? decodeURIComponent(m[1]) : null;
-    }
-
-    function writeCookie(name, value) {
-        // One year; path=/ so it applies site-wide; lax is fine for a UI pref.
-        document.cookie = name + '=' + encodeURIComponent(value) +
-            '; path=/; max-age=31536000; samesite=lax';
-    }
+    var PREF = 'display.theme';
+    // Only for adopting a choice made before the preference existed.
+    var LEGACY_COOKIE = 'fogTheme';
 
     function systemPrefersDark() {
         return !!(window.matchMedia &&
             window.matchMedia('(prefers-color-scheme: dark)').matches);
     }
 
-    // The effective theme = explicit cookie choice, else the OS preference.
-    function effectiveIsDark() {
-        var pref = readCookie(COOKIE);
-        if (pref === 'dark') {
-            return true;
+    // The theme actually shown, given a stored preference of '' | light | dark.
+    function effective(pref) {
+        if (pref === 'dark' || pref === 'light') {
+            return pref;
         }
-        if (pref === 'light') {
-            return false;
-        }
-        return systemPrefersDark();
+        return systemPrefersDark() ? 'dark' : 'light';
     }
 
-    function apply(isDark) {
-        // data-bs-theme on <html> is the single source of truth: Bootstrap's
-        // components, AdminLTE, and FOG's own chrome all key off it. Flip it
-        // live so everything recolors together on toggle.
-        document.documentElement.setAttribute(
-            'data-bs-theme',
-            isDark ? 'dark' : 'light'
-        );
+    function apply(pref) {
+        var theme = effective(pref);
+        document.documentElement.setAttribute('data-bs-theme', theme);
 
         // Let interested widgets (e.g. dashboard charts, which cache resolved
         // colors and cannot read CSS variables) recolor themselves live.
         document.dispatchEvent(new CustomEvent('fog:themechange', {
-            detail: { dark: isDark }
+            detail: { dark: theme === 'dark' }
         }));
 
         var toggle = document.getElementById('themeToggle');
         if (!toggle) {
             return;
         }
+        toggle.setAttribute('data-theme-pref', pref);
+
+        // The icon shows the state the user is IN, not the action a click
+        // performs -- with three states there is no single next action, and a
+        // half-filled circle is the only honest icon for "whatever the system
+        // says".
         var icon = toggle.querySelector('i');
         if (icon) {
-            // Show the action the click will perform: sun when dark, moon when light.
-            icon.className = isDark ? 'far fa-sun' : 'far fa-moon';
+            if (pref === 'dark') {
+                icon.className = 'far fa-moon';
+            } else if (pref === 'light') {
+                icon.className = 'far fa-sun';
+            } else {
+                icon.className = 'fas fa-circle-half-stroke';
+            }
         }
-        var label = isDark
-            ? (toggle.getAttribute('data-label-dark') || '')
-            : (toggle.getAttribute('data-label-light') || '');
+        var label = toggle.getAttribute(
+            pref === 'dark'
+                ? 'data-label-dark'
+                : (pref === 'light' ? 'data-label-light' : 'data-label-system')
+        ) || '';
         if (label) {
             toggle.setAttribute('title', label);
             toggle.setAttribute('aria-label', label);
         }
+
+        // Tick the chosen row. invisible rather than d-none so the three rows
+        // keep the same width and the menu does not jump as the tick moves.
+        var items = document.querySelectorAll('[data-theme-choice]');
+        Array.prototype.forEach.call(items, function (item) {
+            var tick = item.querySelector('.theme-choice-tick');
+            if (!tick) {
+                return;
+            }
+            tick.classList.toggle(
+                'invisible',
+                item.getAttribute('data-theme-choice') !== pref
+            );
+        });
+    }
+
+    function readCookie(name) {
+        var m = document.cookie.match('(?:^|; )' + name + '=([^;]*)');
+        return m ? decodeURIComponent(m[1]) : null;
     }
 
     document.addEventListener('DOMContentLoaded', function () {
-        // Sync the toggle with whatever the body actually resolved to.
-        apply(effectiveIsDark());
-
         var toggle = document.getElementById('themeToggle');
         if (!toggle) {
+            // The login page: no session, so no preference to read or write.
+            // The pre-paint script has already resolved the system value.
             return;
         }
-        toggle.addEventListener('click', function (e) {
-            e.preventDefault();
-            var next = document.documentElement
-                .getAttribute('data-bs-theme') !== 'dark';
-            writeCookie(COOKIE, next ? 'dark' : 'light');
-            apply(next);
+
+        var pref = toggle.getAttribute('data-theme-pref') || '';
+
+        // One-time adoption of the choice made when the theme lived in a
+        // cookie. Only when the user has no stored preference yet, so it can
+        // never overwrite a deliberate later choice. The cookie is expired
+        // either way, so this runs at most once per browser.
+        var legacy = readCookie(LEGACY_COOKIE);
+        if (legacy === 'dark' || legacy === 'light') {
+            if (pref === '') {
+                pref = legacy;
+                fogPrefStore(PREF, pref);
+            }
+            document.cookie = LEGACY_COOKIE +
+                '=; path=/; max-age=0; samesite=lax';
+        }
+
+        apply(pref);
+
+        document.querySelectorAll('[data-theme-choice]').forEach(function (item) {
+            item.addEventListener('click', function (e) {
+                e.preventDefault();
+                var chosen = item.getAttribute('data-theme-choice') || '';
+                // Applied before the request rather than after it: the theme
+                // is a client-side attribute flip, so waiting on the network
+                // would only add lag to something that cannot fail visibly.
+                // An empty value clears the preference, which is what "follow
+                // the system" means -- the store deletes the row rather than
+                // holding an empty string.
+                apply(chosen);
+                fogPrefStore(PREF, chosen, function (err) {
+                    if (err) {
+                        $.notifyFromAPI(err.responseJSON, err);
+                    }
+                });
+            });
         });
+
+        // In system mode, follow the OS while the page is open. Without this
+        // a user who flips their desktop to dark at dusk keeps a light FOG
+        // until they navigate, which reads as the setting not working.
+        if (window.matchMedia) {
+            var mq = window.matchMedia('(prefers-color-scheme: dark)');
+            var onChange = function () {
+                if ((toggle.getAttribute('data-theme-pref') || '') === '') {
+                    apply('');
+                }
+            };
+            if (mq.addEventListener) {
+                mq.addEventListener('change', onChange);
+            } else if (mq.addListener) {
+                // Safari < 14.
+                mq.addListener(onChange);
+            }
+        }
     });
 }());

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -2105,6 +2105,9 @@ msgstr ""
 msgid "Daily"
 msgstr "Täglich"
 
+msgid "Dark"
+msgstr ""
+
 msgid "Dashboard"
 msgstr "Dashboard"
 
@@ -4929,6 +4932,10 @@ msgstr "Level muss eine integer sein."
 
 msgid "License"
 msgstr "Lizenz"
+
+#, fuzzy
+msgid "Light"
+msgstr "Mitternacht"
 
 msgid "Line"
 msgstr "Zeile"
@@ -8415,12 +8422,6 @@ msgstr "erfolgreich gelöscht"
 msgid "Supported here: %s."
 msgstr ""
 
-msgid "Switch to dark mode"
-msgstr ""
-
-msgid "Switch to light mode"
-msgstr ""
-
 msgid "Sync finished - "
 msgstr ""
 
@@ -9022,6 +9023,18 @@ msgstr "Die hochgeladene Datei wurde nur teilweise hochgeladen"
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 
+msgid "Theme"
+msgstr ""
+
+msgid "Theme: dark"
+msgstr ""
+
+msgid "Theme: follow system"
+msgstr ""
+
+msgid "Theme: light"
+msgstr ""
+
 msgid "There are"
 msgstr "Es gibt"
 
@@ -9316,9 +9329,6 @@ msgid "To get started please select an item from the menu."
 msgstr "Um zu beginnen, wählen Sie bitte ein Element aus dem Menü."
 
 msgid "Toggle Dropdown"
-msgstr ""
-
-msgid "Toggle dark mode"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -2107,6 +2107,9 @@ msgstr ""
 msgid "Daily"
 msgstr "Daily"
 
+msgid "Dark"
+msgstr ""
+
 msgid "Dashboard"
 msgstr "Dashboard"
 
@@ -4928,6 +4931,10 @@ msgstr "Event must be a string"
 
 msgid "License"
 msgstr "License"
+
+#, fuzzy
+msgid "Light"
+msgstr "Midnight"
 
 msgid "Line"
 msgstr "Line"
@@ -8410,12 +8417,6 @@ msgstr "successfully updated"
 msgid "Supported here: %s."
 msgstr ""
 
-msgid "Switch to dark mode"
-msgstr ""
-
-msgid "Switch to light mode"
-msgstr ""
-
 msgid "Sync finished - "
 msgstr ""
 
@@ -9017,6 +9018,18 @@ msgstr "The uploaded file was only partially uploaded"
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 
+msgid "Theme"
+msgstr ""
+
+msgid "Theme: dark"
+msgstr ""
+
+msgid "Theme: follow system"
+msgstr ""
+
+msgid "Theme: light"
+msgstr ""
+
 msgid "There are"
 msgstr "There are"
 
@@ -9311,9 +9324,6 @@ msgid "To get started please select an item from the menu."
 msgstr ""
 
 msgid "Toggle Dropdown"
-msgstr ""
-
-msgid "Toggle dark mode"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2128,6 +2128,9 @@ msgstr ""
 msgid "Daily"
 msgstr "Diariamente"
 
+msgid "Dark"
+msgstr ""
+
 msgid "Dashboard"
 msgstr ""
 
@@ -5027,6 +5030,10 @@ msgstr "Evento debe ser una cadena"
 #, fuzzy
 msgid "License"
 msgstr "Línea"
+
+#, fuzzy
+msgid "Light"
+msgstr "Medianoche"
 
 msgid "Line"
 msgstr "Línea"
@@ -8588,12 +8595,6 @@ msgstr "actualizado exitosamente"
 msgid "Supported here: %s."
 msgstr ""
 
-msgid "Switch to dark mode"
-msgstr ""
-
-msgid "Switch to light mode"
-msgstr ""
-
 msgid "Sync finished - "
 msgstr ""
 
@@ -9200,6 +9201,18 @@ msgstr "El archivo subido se ha subido sólo parcialmente"
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 
+msgid "Theme"
+msgstr ""
+
+msgid "Theme: dark"
+msgstr ""
+
+msgid "Theme: follow system"
+msgstr ""
+
+msgid "Theme: light"
+msgstr ""
+
 #, fuzzy
 msgid "There are"
 msgstr "Existen"
@@ -9490,9 +9503,6 @@ msgid "To get started please select an item from the menu."
 msgstr ""
 
 msgid "Toggle Dropdown"
-msgstr ""
-
-msgid "Toggle dark mode"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2105,6 +2105,9 @@ msgstr ""
 msgid "Daily"
 msgstr "Täglich"
 
+msgid "Dark"
+msgstr ""
+
 msgid "Dashboard"
 msgstr "Dashboard"
 
@@ -4930,6 +4933,10 @@ msgstr "Level muss eine integer sein."
 
 msgid "License"
 msgstr "Lizenz"
+
+#, fuzzy
+msgid "Light"
+msgstr "Mitternacht"
 
 msgid "Line"
 msgstr "Zeile"
@@ -8416,12 +8423,6 @@ msgstr "erfolgreich gelöscht"
 msgid "Supported here: %s."
 msgstr ""
 
-msgid "Switch to dark mode"
-msgstr ""
-
-msgid "Switch to light mode"
-msgstr ""
-
 msgid "Sync finished - "
 msgstr ""
 
@@ -9023,6 +9024,18 @@ msgstr "Die hochgeladene Datei wurde nur teilweise hochgeladen"
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 
+msgid "Theme"
+msgstr ""
+
+msgid "Theme: dark"
+msgstr ""
+
+msgid "Theme: follow system"
+msgstr ""
+
+msgid "Theme: light"
+msgstr ""
+
 msgid "There are"
 msgstr "Es gibt"
 
@@ -9317,9 +9330,6 @@ msgid "To get started please select an item from the menu."
 msgstr "Um zu beginnen, wählen Sie bitte ein Element aus dem Menü."
 
 msgid "Toggle Dropdown"
-msgstr ""
-
-msgid "Toggle dark mode"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2109,6 +2109,9 @@ msgstr ""
 msgid "Daily"
 msgstr "Tous les jours"
 
+msgid "Dark"
+msgstr ""
+
 msgid "Dashboard"
 msgstr "Tableau de bord"
 
@@ -4930,6 +4933,10 @@ msgstr "Événement doit être une chaîne"
 
 msgid "License"
 msgstr "Licence"
+
+#, fuzzy
+msgid "Light"
+msgstr "Minuit"
 
 msgid "Line"
 msgstr "Ligne"
@@ -8412,12 +8419,6 @@ msgstr "mise à jour réussie"
 msgid "Supported here: %s."
 msgstr ""
 
-msgid "Switch to dark mode"
-msgstr ""
-
-msgid "Switch to light mode"
-msgstr ""
-
 msgid "Sync finished - "
 msgstr ""
 
@@ -9019,6 +9020,18 @@ msgstr "Le fichier n'a été que partiellement téléchargé"
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 
+msgid "Theme"
+msgstr ""
+
+msgid "Theme: dark"
+msgstr ""
+
+msgid "Theme: follow system"
+msgstr ""
+
+msgid "Theme: light"
+msgstr ""
+
 msgid "There are"
 msgstr "Il y a"
 
@@ -9313,9 +9326,6 @@ msgid "To get started please select an item from the menu."
 msgstr ""
 
 msgid "Toggle Dropdown"
-msgstr ""
-
-msgid "Toggle dark mode"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -2048,6 +2048,9 @@ msgstr ""
 msgid "Daily"
 msgstr "Quotidiano"
 
+msgid "Dark"
+msgstr ""
+
 msgid "Dashboard"
 msgstr "scrivania"
 
@@ -4777,6 +4780,10 @@ msgstr "Livello deve essere una stringa"
 
 msgid "License"
 msgstr "Licenza"
+
+#, fuzzy
+msgid "Light"
+msgstr "Mezzanotte"
 
 msgid "Line"
 msgstr "linea"
@@ -8146,12 +8153,6 @@ msgstr "Creato con successo"
 msgid "Supported here: %s."
 msgstr ""
 
-msgid "Switch to dark mode"
-msgstr ""
-
-msgid "Switch to light mode"
-msgstr ""
-
 msgid "Sync finished - "
 msgstr ""
 
@@ -8733,6 +8734,18 @@ msgstr "Il file caricato è stato solo parzialmente caricato"
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 
+msgid "Theme"
+msgstr ""
+
+msgid "Theme: dark"
+msgstr ""
+
+msgid "Theme: follow system"
+msgstr ""
+
+msgid "Theme: light"
+msgstr ""
+
 msgid "There are"
 msgstr "Ci sono"
 
@@ -9020,9 +9033,6 @@ msgid "To get started please select an item from the menu."
 msgstr "Per iniziare, seleziona un elemento dal menu."
 
 msgid "Toggle Dropdown"
-msgstr ""
-
-msgid "Toggle dark mode"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -2032,6 +2032,9 @@ msgstr ""
 msgid "Daily"
 msgstr "毎日"
 
+msgid "Dark"
+msgstr ""
+
 msgid "Dashboard"
 msgstr "ダッシュボード"
 
@@ -4740,6 +4743,10 @@ msgstr "レベルは整数である必要があります"
 
 msgid "License"
 msgstr "ライセンス"
+
+#, fuzzy
+msgid "Light"
+msgstr "午前 0 時"
 
 msgid "Line"
 msgstr "行"
@@ -8090,12 +8097,6 @@ msgstr "削除しました"
 msgid "Supported here: %s."
 msgstr ""
 
-msgid "Switch to dark mode"
-msgstr ""
-
-msgid "Switch to light mode"
-msgstr ""
-
 msgid "Sync finished - "
 msgstr ""
 
@@ -8676,6 +8677,18 @@ msgstr "アップロードしたファイルは一部しかアップロードさ
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 
+msgid "Theme"
+msgstr ""
+
+msgid "Theme: dark"
+msgstr ""
+
+msgid "Theme: follow system"
+msgstr ""
+
+msgid "Theme: light"
+msgstr ""
+
 msgid "There are"
 msgstr "あります"
 
@@ -8963,9 +8976,6 @@ msgid "To get started please select an item from the menu."
 msgstr "開始するにはメニューから項目を選択してください。"
 
 msgid "Toggle Dropdown"
-msgstr ""
-
-msgid "Toggle dark mode"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1796,6 +1796,9 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
+msgid "Dark"
+msgstr ""
+
 msgid "Dashboard"
 msgstr ""
 
@@ -4181,6 +4184,9 @@ msgid "Level must be an integer"
 msgstr ""
 
 msgid "License"
+msgstr ""
+
+msgid "Light"
 msgstr ""
 
 msgid "Line"
@@ -7144,12 +7150,6 @@ msgstr ""
 msgid "Supported here: %s."
 msgstr ""
 
-msgid "Switch to dark mode"
-msgstr ""
-
-msgid "Switch to light mode"
-msgstr ""
-
 msgid "Sync finished - "
 msgstr ""
 
@@ -7677,6 +7677,18 @@ msgstr ""
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 
+msgid "Theme"
+msgstr ""
+
+msgid "Theme: dark"
+msgstr ""
+
+msgid "Theme: follow system"
+msgstr ""
+
+msgid "Theme: light"
+msgstr ""
+
 msgid "There are"
 msgstr ""
 
@@ -7953,9 +7965,6 @@ msgid "To get started please select an item from the menu."
 msgstr ""
 
 msgid "Toggle Dropdown"
-msgstr ""
-
-msgid "Toggle dark mode"
 msgstr ""
 
 msgid "Toggle navigation"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -2108,6 +2108,9 @@ msgstr ""
 msgid "Daily"
 msgstr "Diariamente"
 
+msgid "Dark"
+msgstr ""
+
 msgid "Dashboard"
 msgstr "painel de instrumentos"
 
@@ -4929,6 +4932,10 @@ msgstr "Evento deve ser uma string"
 
 msgid "License"
 msgstr "Licença"
+
+#, fuzzy
+msgid "Light"
+msgstr "meia-noite"
 
 msgid "Line"
 msgstr "Linha"
@@ -8411,12 +8418,6 @@ msgstr "atualizado com sucesso"
 msgid "Supported here: %s."
 msgstr ""
 
-msgid "Switch to dark mode"
-msgstr ""
-
-msgid "Switch to light mode"
-msgstr ""
-
 msgid "Sync finished - "
 msgstr ""
 
@@ -9018,6 +9019,18 @@ msgstr "O arquivo enviado foi apenas parcialmente carregado"
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 
+msgid "Theme"
+msgstr ""
+
+msgid "Theme: dark"
+msgstr ""
+
+msgid "Theme: follow system"
+msgstr ""
+
+msgid "Theme: light"
+msgstr ""
+
 msgid "There are"
 msgstr "tem"
 
@@ -9312,9 +9325,6 @@ msgid "To get started please select an item from the menu."
 msgstr ""
 
 msgid "Toggle Dropdown"
-msgstr ""
-
-msgid "Toggle dark mode"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -2108,6 +2108,9 @@ msgstr ""
 msgid "Daily"
 msgstr "日常"
 
+msgid "Dark"
+msgstr ""
+
 msgid "Dashboard"
 msgstr "仪表板"
 
@@ -4929,6 +4932,10 @@ msgstr "事件必须是字符串"
 
 msgid "License"
 msgstr "执照"
+
+#, fuzzy
+msgid "Light"
+msgstr "午夜"
 
 msgid "Line"
 msgstr "线"
@@ -8411,12 +8418,6 @@ msgstr "成功更新"
 msgid "Supported here: %s."
 msgstr ""
 
-msgid "Switch to dark mode"
-msgstr ""
-
-msgid "Switch to light mode"
-msgstr ""
-
 msgid "Sync finished - "
 msgstr ""
 
@@ -9018,6 +9019,18 @@ msgstr "上传的文件只有部分被上传"
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 
+msgid "Theme"
+msgstr ""
+
+msgid "Theme: dark"
+msgstr ""
+
+msgid "Theme: follow system"
+msgstr ""
+
+msgid "Theme: light"
+msgstr ""
+
 msgid "There are"
 msgstr "有"
 
@@ -9312,9 +9325,6 @@ msgid "To get started please select an item from the menu."
 msgstr ""
 
 msgid "Toggle Dropdown"
-msgstr ""
-
-msgid "Toggle dark mode"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/other/index.php
+++ b/packages/web/management/other/index.php
@@ -43,14 +43,21 @@ $ulang = htmlspecialchars($_SESSION['FOG_LANG'] ?? '', ENT_QUOTES, 'UTF-8');
 
 // Dark mode: Bootstrap 5 / AdminLTE 4 native theming keys off data-bs-theme on
 // <html>, which is the single source of truth for both BS components and FOG's
-// chrome (see fog-default-ui.scss). The per-user preference is persisted in the
-// fogTheme cookie and stamped on <html> below (server-side, on first paint) so
-// there is no light flash before theme.js runs. With no cookie the attribute is
-// left off here and a pre-paint head script resolves the OS preference instead.
-$themePref = filter_input(INPUT_COOKIE, 'fogTheme');
-$bsTheme = ($themePref === 'dark')
-    ? 'dark'
-    : (($themePref === 'light') ? 'light' : '');
+// chrome (see fog-default-ui.scss).
+//
+// The choice is a USER preference, not a device one, so it lives in userPrefs
+// and follows the person to any browser. A forced light/dark is stamped on
+// <html> below, server-side, so it is already correct on the first paint. An
+// unset preference deliberately leaves the attribute OFF -- that absence is
+// what tells the pre-paint script in <head> to resolve prefers-color-scheme
+// itself, in either direction. Emitting 'light' for an unset preference would
+// give a dark-desktop user a light page and no way to tell why.
+//
+// The login page has no session, so displayTheme() returns '' there and the
+// system preference wins. That is the right answer rather than a compromise:
+// there is nobody yet whose preference it could be.
+$themePref = self::displayTheme();
+$bsTheme = $themePref;
 
 // Start output buffering
 ob_start();
@@ -61,10 +68,16 @@ ob_start();
 <html lang="<?= $ulang; ?>"<?= $bsTheme ? ' data-bs-theme="' . $bsTheme . '"' : ''; ?>>
 <head>
     <script nonce="<?= htmlspecialchars(FOG_CSP_NONCE, ENT_QUOTES, 'UTF-8'); ?>">
-    // Native dark mode, no flash: when the user has no explicit fogTheme cookie
-    // choice <html> carries no server-stamped data-bs-theme, so resolve the OS
-    // preference here synchronously (before paint) and set it. The cookie cases
-    // are already stamped server-side; theme.js keeps it in sync afterwards.
+    // Native dark mode, no flash: when the user has no explicit light/dark
+    // preference <html> carries no server-stamped data-bs-theme, so resolve
+    // the OS preference here synchronously (before paint) and set it. A
+    // forced choice is already stamped server-side; theme.js keeps the picker
+    // in sync afterwards and never decides the first paint.
+    //
+    // First in <head>, inline and not deferred, on purpose: anything later --
+    // including a stylesheet above it -- runs after the browser has painted
+    // once, which IS the flash. Pinned by
+    // tests/output-whitespace-significant-blocks.test.php.
     (function () {
         var e = document.documentElement;
         if (!e.hasAttribute('data-bs-theme')) {
@@ -127,14 +140,49 @@ unset($this->stylesheets);
                     </li>
                 </ul>
                 <ul class="navbar-nav ms-auto">
-                    <li class="nav-item">
+                    <li class="nav-item dropdown">
+                        <?php
+                        // A three-state picker, not a toggle: "follow the
+                        // system" is a state a user can choose and return to,
+                        // and a two-way toggle has nowhere to put it. Sat in
+                        // the navbar beside the clock rather than in settings
+                        // because people currently assume FOG is light-only.
+                        //
+                        // data-theme-pref carries the STORED value, which is
+                        // not always the value on <html>: '' means the browser
+                        // resolved it. theme.js needs both to tick the right
+                        // row.
+        ?>
                         <a href="#" id="themeToggle" class="nav-link" role="button"
-                           data-label-dark="<?= _('Switch to light mode'); ?>"
-                           data-label-light="<?= _('Switch to dark mode'); ?>"
-                           title="<?= _('Toggle dark mode'); ?>"
-                           aria-label="<?= _('Toggle dark mode'); ?>">
+                           data-bs-toggle="dropdown" aria-expanded="false"
+                           data-theme-pref="<?= Initiator::e($themePref); ?>"
+                           data-label-system="<?= _('Theme: follow system'); ?>"
+                           data-label-light="<?= _('Theme: light'); ?>"
+                           data-label-dark="<?= _('Theme: dark'); ?>"
+                           title="<?= _('Theme'); ?>"
+                           aria-label="<?= _('Theme'); ?>">
                             <i class="far fa-moon"></i>
                         </a>
+                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="themeToggle">
+                            <li>
+                                <button class="dropdown-item" type="button" data-theme-choice="">
+                                    <i class="fas fa-circle-half-stroke fa-fw me-2"></i><?= _('System'); ?>
+                                    <i class="fas fa-check fa-fw ms-2 theme-choice-tick invisible"></i>
+                                </button>
+                            </li>
+                            <li>
+                                <button class="dropdown-item" type="button" data-theme-choice="light">
+                                    <i class="far fa-sun fa-fw me-2"></i><?= _('Light'); ?>
+                                    <i class="fas fa-check fa-fw ms-2 theme-choice-tick invisible"></i>
+                                </button>
+                            </li>
+                            <li>
+                                <button class="dropdown-item" type="button" data-theme-choice="dark">
+                                    <i class="far fa-moon fa-fw me-2"></i><?= _('Dark'); ?>
+                                    <i class="fas fa-check fa-fw ms-2 theme-choice-tick invisible"></i>
+                                </button>
+                            </li>
+                        </ul>
                     </li>
                     <li class="nav-item">
                         <a href="#" id="tzToggle" class="nav-link" role="button"

--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -245,6 +245,24 @@ abstract class FOGBase
      */
     const TIMEZONE_PREF = 'display.timezone';
     /**
+     * Resolved once per request, same as $_displayTimeZone.
+     *
+     * '' means "follow the operating system", which is not the same as
+     * 'light' -- see displayTheme().
+     *
+     * @var string|null
+     */
+    private static $_displayTheme = null;
+    /**
+     * The user preference holding a viewer's chosen color theme.
+     *
+     * Absent or empty means "follow the operating system". Storing the theme
+     * per USER rather than in a cookie is deliberate: it is a property of the
+     * person, so signing in on another machine or another browser brings it
+     * with you.
+     */
+    const THEME_PREF = 'display.theme';
+    /**
      * The logged in user.
      *
      * @var object
@@ -1926,6 +1944,57 @@ abstract class FOGBase
             return $out;
         }
         return $out->setTimezone(self::displayTimeZone());
+    }
+    /**
+     * The viewer's chosen color theme.
+     *
+     * Three states, and the difference between two of them is the whole
+     * point:
+     *
+     *  - ''      follow the operating system, in EITHER direction. Somebody
+     *            who has never touched the setting and runs a dark desktop
+     *            gets dark. Collapsing this into 'light' would make the
+     *            default wrong for exactly the people who care most.
+     *  - 'light' force light whatever the system says.
+     *  - 'dark'  force dark whatever the system says.
+     *
+     * Only the last two can be answered here at all: '' is resolved by the
+     * browser, because prefers-color-scheme is not something the server can
+     * see. The page shell stamps data-bs-theme on <html> for a forced choice
+     * and leaves the attribute off otherwise, which is the signal its
+     * pre-paint script uses to decide whether to resolve the system
+     * preference itself.
+     *
+     * @return string '' , 'light' or 'dark'.
+     */
+    public static function displayTheme()
+    {
+        if (null !== self::$_displayTheme) {
+            return self::$_displayTheme;
+        }
+        self::$_displayTheme = '';
+        $user = self::$FOGUser;
+        // The same guard displayTimeZone() uses: unset before LoadGlobals has
+        // run, and invalid for anyone not signed in -- the login page has no
+        // session to hold a preference, and falls back to the system.
+        if (!$user || !$user->isValid()) {
+            return self::$_displayTheme;
+        }
+        try {
+            $pref = self::getClass('UserPrefManager')
+                ->fetch((int)$user->get('id'), self::THEME_PREF);
+        } catch (\Exception $e) {
+            // A preference store that cannot be read is not a reason to fail
+            // the render; following the system is the documented default.
+            return self::$_displayTheme;
+        }
+        $pref = trim((string)$pref);
+        // Anything else stored -- a value from a future release, or something
+        // hand-written into the table -- means the same as no opinion.
+        if ('light' === $pref || 'dark' === $pref) {
+            self::$_displayTheme = $pref;
+        }
+        return self::$_displayTheme;
     }
     public static function niceDate($date = 'now', $utc = false)
     {

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 392);
-        define('FOG_BCACHE_VER', 336);
+        define('FOG_BCACHE_VER', 337);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4515');
+        define('FOG_VERSION', '1.6.0-beta.4520');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1387,6 +1387,12 @@ parameters:
 			path: packages/web/management/other/index.php
 
 		-
+			message: '#^Calling self\:\:displayTheme\(\) outside of class scope\.$#'
+			identifier: outOfClass.self
+			count: 1
+			path: packages/web/management/other/index.php
+
+		-
 			message: '#^Calling self\:\:getClass\(\) outside of class scope\.$#'
 			identifier: outOfClass.self
 			count: 1

--- a/tests/output-whitespace-significant-blocks.test.php
+++ b/tests/output-whitespace-significant-blocks.test.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Whitespace collapsing must stop at <script>, <pre> and <textarea>.
+ *
+ * Initiator::sanitizeOutput() shrinks the rendered page by replacing every
+ * whitespace run with its last character. A newline followed by indentation
+ * therefore becomes one space, and the newline is gone. That is harmless
+ * between tags and destructive inside three elements:
+ *
+ *  - <script>: with no line endings left, the first `//` comment swallows
+ *    everything after it. This is not hypothetical -- the pre-paint dark-mode
+ *    script in management/other/index.php was dead for exactly this reason,
+ *    so data-bs-theme was only set on DOMContentLoaded and anyone following
+ *    their OS preference saw the page painted light first.
+ *  - <textarea>: the line breaks are the user's own data.
+ *  - <pre>: the element exists to preserve them.
+ *
+ * The failure is silent in all three cases: the page still renders, the
+ * script still parses, and nothing is logged.
+ *
+ * Usage: php tests/output-whitespace-significant-blocks.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+$initPath = $web . '/commons/init.php';
+$shellPath = $web . '/management/other/index.php';
+
+$fails = [];
+
+/**
+ * Loads sanitizeOutput() as a standalone function.
+ *
+ * init.php cannot be included -- it boots the application -- so lift the one
+ * method out of it and evaluate that. This deliberately reads the real source
+ * rather than a copy: a test with its own copy of the implementation passes
+ * whatever the shipped one does.
+ *
+ * @param string $src The contents of commons/init.php.
+ *
+ * @return callable|null
+ */
+function loadSanitizer($src)
+{
+    if (!preg_match(
+        '/public static function sanitizeOutput\(string \$buffer\): string.*?\n    \}/s',
+        $src,
+        $m
+    )) {
+        return null;
+    }
+    $fn = str_replace(
+        'public static function sanitizeOutput(string $buffer): string',
+        'return function (string $buffer): string',
+        $m[0]
+    ) . ';';
+
+    return eval($fn);
+}
+
+$src = file_get_contents($initPath);
+$sanitize = loadSanitizer($src);
+if (!$sanitize) {
+    $fails[] = 'could not find sanitizeOutput() in commons/init.php';
+} else {
+    // Indentation matters: a bare "\n" run survives the old expression by
+    // accident (the run's last character IS the newline), so a test written
+    // without leading spaces passes against the very bug it is meant to
+    // catch. Every fixture below is indented for that reason.
+    $cases = [
+        'a script keeps its line endings' => [
+            "    <script>\n    // comment\n    var x = 1;\n    </script>",
+            "\n",
+        ],
+        'a textarea keeps the user\'s line breaks' => [
+            "<textarea>line one\n    line two</textarea>",
+            "\n",
+        ],
+        'a pre block keeps its formatting' => [
+            "<pre>a\n  b\n    c</pre>",
+            "\n",
+        ],
+    ];
+    foreach ($cases as $name => $case) {
+        list($input, $needle) = $case;
+        if (false === strpos($sanitize($input), $needle)) {
+            $fails[] = $name . ': line endings were collapsed';
+        }
+    }
+
+    // The saving itself must still happen, or this "fix" is just a revert of
+    // the whitespace collapsing.
+    $plain = $sanitize("<div>\n    <span>hi</span>\n</div>");
+    if (false !== strpos($plain, "\n")) {
+        $fails[] = 'ordinary markup is no longer collapsed';
+    }
+
+    // Markup BETWEEN two protected blocks must still collapse: an
+    // implementation that bails out on the first match would pass every
+    // check above while quietly giving up on the rest of the page.
+    $mixed = $sanitize(
+        "<script>\n  //a\n  x=1;\n</script>\n  <div>\n   y\n  </div>\n"
+        . "  <script>\n  //b\n  z=2;\n</script>"
+    );
+    if (false === strpos($mixed, '<div> y </div>')) {
+        $fails[] = 'markup between two scripts was not collapsed';
+    }
+    if (false === strpos($mixed, "//a\n") || false === strpos($mixed, "//b\n")) {
+        $fails[] = 'a second script on the page lost its line endings';
+    }
+}
+
+// The consumer this was found through. The pre-paint theme script has to be
+// the first thing in <head> -- before any stylesheet, and not deferred --
+// because anything later runs after the browser has already painted.
+$shell = file_get_contents($shellPath);
+if (!preg_match('/<head>\s*(.*?)<meta charset/s', $shell, $m)) {
+    $fails[] = 'could not find the <head> opening in the page shell';
+} else {
+    $head = $m[1];
+    if (false === strpos($head, 'prefers-color-scheme')) {
+        $fails[] = 'the pre-paint theme script is not the first thing in <head>';
+    }
+    if (false !== strpos($head, 'defer') || false !== strpos($head, 'async')) {
+        $fails[] = 'the pre-paint theme script must not be deferred';
+    }
+    if (false !== strpos($head, '<link')) {
+        $fails[] = 'a stylesheet is emitted before the pre-paint theme script';
+    }
+}
+
+// data-bs-theme belongs on <html>: by the time <body> exists the browser may
+// already have painted the background.
+// Matched on the source LINE, not on the rendered tag: the attribute is
+// emitted by a PHP short echo whose own closing tag defeats a `[^>]*` scan.
+$htmlTag = '';
+foreach (preg_split('/\R/', $shell) as $line) {
+    if (0 === strpos(ltrim($line), '<html')) {
+        $htmlTag = $line;
+        break;
+    }
+}
+if (false === strpos($htmlTag, 'data-bs-theme')) {
+    $fails[] = 'data-bs-theme is not stamped on <html>';
+}
+
+foreach ($fails as $fail) {
+    fwrite(STDERR, 'FAIL: ' . $fail . PHP_EOL);
+}
+if ($fails) {
+    fwrite(STDERR, count($fails) . ' failure(s)' . PHP_EOL);
+    exit(1);
+}
+echo 'ok: whitespace-significant blocks survive output sanitizing' . PHP_EOL;
+exit(0);

--- a/tests/output-whitespace-significant-blocks.test.php
+++ b/tests/output-whitespace-significant-blocks.test.php
@@ -122,7 +122,12 @@ if (!preg_match('/<head>\s*(.*?)<meta charset/s', $shell, $m)) {
     if (false === strpos($head, 'prefers-color-scheme')) {
         $fails[] = 'the pre-paint theme script is not the first thing in <head>';
     }
-    if (false !== strpos($head, 'defer') || false !== strpos($head, 'async')) {
+    // Checked on the opening TAG, not on the whole chunk: the comment inside
+    // the script explains why it is not deferred, and a substring search over
+    // the text finds that explanation.
+    if (!preg_match('/<script\b[^>]*>/', $head, $tag)) {
+        $fails[] = 'the pre-paint theme script has no opening tag';
+    } elseif (preg_match('/\b(?:defer|async)\b/', $tag[0])) {
         $fails[] = 'the pre-paint theme script must not be deferred';
     }
     if (false !== strpos($head, '<link')) {

--- a/tests/theme-user-preference.test.php
+++ b/tests/theme-user-preference.test.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * The color theme is a per-USER preference with THREE states.
+ *
+ * The states are '' (follow the operating system, either direction), 'light'
+ * and 'dark'. Every mistake this gate exists to catch is silent -- the page
+ * renders, nothing is logged, and the only symptom is somebody getting the
+ * wrong colors:
+ *
+ *  - collapsing '' into 'light' gives a dark-desktop user a light page and no
+ *    way to tell why. It is the failure this feature exists to prevent, and
+ *    it is one `?:` away at all times.
+ *  - stamping data-bs-theme on <html> for an unset preference defeats the
+ *    pre-paint script, whose whole cue is the attribute's ABSENCE.
+ *  - reading the theme from a cookie again makes it a property of the device,
+ *    so the same person gets different colors on their other machine.
+ *  - accepting an arbitrary stored string would put unvalidated text into an
+ *    HTML attribute.
+ *
+ * Companion to output-whitespace-significant-blocks.test.php, which pins the
+ * no-flash mechanics this preference rides on.
+ *
+ * Usage: php tests/theme-user-preference.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+
+$base = file_get_contents($web . '/src/Base/FOGBase.php');
+$shell = file_get_contents($web . '/management/other/index.php');
+$js = file_get_contents($web . '/management/js/fog/theme.js');
+
+$fails = [];
+
+// --- the server side -----------------------------------------------------
+
+if (false === strpos($base, "const THEME_PREF = 'display.theme';")) {
+    $fails[] = 'FOGBase does not declare THEME_PREF as display.theme';
+}
+if (!preg_match(
+    '/public static function displayTheme\(\).*?\n    \}/s',
+    $base,
+    $m
+)) {
+    $fails[] = 'FOGBase::displayTheme() is missing';
+} else {
+    $fn = $m[0];
+    // The default has to be the empty string. A default of 'light' is the
+    // collapse this whole gate is about, and it reads as harmless.
+    if (!preg_match("/self::\\\$_displayTheme = '';/", $fn)) {
+        $fails[] = 'displayTheme() does not default to the empty string';
+    }
+    // A whitelist, not a two-way branch: anything else stored -- a value from
+    // a future release, or something typed into the table by hand -- has to
+    // mean "no opinion", not "light".
+    if (!preg_match("/'light' === \\\$pref \\|\\| 'dark' === \\\$pref/", $fn)) {
+        $fails[] = 'displayTheme() does not whitelist exactly light and dark';
+    }
+    if (false === strpos($fn, 'THEME_PREF')) {
+        $fails[] = 'displayTheme() does not read the THEME_PREF preference';
+    }
+    // Same guard the rest of the shell uses: no session means no preference,
+    // which is the login page.
+    if (false === strpos($fn, '$user->isValid()')) {
+        $fails[] = 'displayTheme() does not guard on a valid signed-in user';
+    }
+}
+
+// --- the page shell ------------------------------------------------------
+
+if (false === strpos($shell, '$themePref = self::displayTheme();')) {
+    $fails[] = 'the page shell does not read the theme from displayTheme()';
+}
+if (false !== strpos($shell, "filter_input(INPUT_COOKIE, 'fogTheme')")) {
+    $fails[] = 'the page shell still reads the theme from a cookie';
+}
+
+// The attribute must be emitted only for a forced choice. Its absence is the
+// signal the pre-paint script keys off, so an unconditional attribute would
+// silently disable system-following for everyone.
+$htmlTag = '';
+foreach (preg_split('/\R/', $shell) as $line) {
+    if (0 === strpos(ltrim($line), '<html')) {
+        $htmlTag = $line;
+        break;
+    }
+}
+if (false === strpos($htmlTag, '$bsTheme ?')) {
+    $fails[] = 'data-bs-theme is emitted unconditionally on <html>';
+}
+// And the value fed to that test must be the preference itself. A default
+// applied here -- `$themePref ?: 'light'` -- would make the ternary above
+// always true while still looking conditional.
+if (false === strpos($shell, '$bsTheme = $themePref;')) {
+    $fails[] = 'the stamped theme is not the stored preference verbatim';
+}
+
+// Three choices, and one of them must be the empty one.
+preg_match_all('/data-theme-choice="([^"]*)"/', $shell, $choices);
+$offered = $choices[1];
+sort($offered);
+if (['', 'dark', 'light'] !== $offered) {
+    $fails[] = 'the picker does not offer exactly system, light and dark ('
+        . implode(',', $offered) . ')';
+}
+
+// Visible, in the navbar, beside the timezone clock -- not buried in a
+// settings page, because people assume FOG is light-only until they see it.
+if (!preg_match('/navbar-nav ms-auto.*?tzToggle/s', $shell)
+    || !preg_match('/navbar-nav ms-auto.*?themeToggle/s', $shell)
+) {
+    $fails[] = 'the theme picker is not in the navbar beside the clock';
+}
+
+// --- the client side -----------------------------------------------------
+
+// An unset preference must consult the system, not fall back to light.
+if (!preg_match(
+    '/function effective\(pref\).*?systemPrefersDark\(\).*?\n    \}/s',
+    $js
+)) {
+    $fails[] = 'theme.js does not resolve an unset preference from the system';
+}
+if (false === strpos($js, "fogPrefStore(PREF")) {
+    $fails[] = 'theme.js does not persist the choice as a user preference';
+}
+// The legacy cookie may only be EXPIRED. Writing a live value back to it
+// would quietly restore the device-scoped behavior this replaced.
+if (preg_match('/document\.cookie = LEGACY_COOKIE \+\s*\n?\s*\'=\' \+/', $js)) {
+    $fails[] = 'theme.js writes a value back into the legacy cookie';
+}
+if (false === strpos($js, 'max-age=0')) {
+    $fails[] = 'theme.js does not expire the legacy cookie';
+}
+// System mode has to keep following the system while the page is open.
+if (false === strpos($js, "matchMedia('(prefers-color-scheme: dark)')")
+    || false === strpos($js, "addEventListener('change', onChange)")
+) {
+    $fails[] = 'theme.js does not follow the system preference live';
+}
+
+foreach ($fails as $fail) {
+    fwrite(STDERR, 'FAIL: ' . $fail . PHP_EOL);
+}
+if ($fails) {
+    fwrite(STDERR, count($fails) . ' failure(s)' . PHP_EOL);
+    exit(1);
+}
+echo 'ok: the theme is a three-state per-user preference' . PHP_EOL;
+exit(0);


### PR DESCRIPTION
Two commits, in the order the work had to happen: the flash is fixed first, then the preference is added on top of a shell that no longer flashes.

## 1. The FOUC, and what was actually causing it

Not the theme code. `Initiator::sanitizeOutput()` collapses every whitespace run to its **last** character, so a newline followed by indentation — every line of a pretty-printed page — becomes a single space and the newline is gone.

The pre-paint dark-mode script in `management/other/index.php` is indented, so after collapsing it was one line beginning with a `//` comment. The entire function body was commented out and never ran. `data-bs-theme` was therefore only set by `theme.js` on `DOMContentLoaded`, after the browser had already painted.

Same mechanism, two other victims: a `<textarea>` lost the line breaks the user typed, and a `<pre>` lost the formatting that is the element's whole purpose.

Measured on the login page with a dark system preference, via a CDP screencast:

| | before | after |
|---|---|---|
| first painted frame | white, 266ms–338ms | dark, no white frame at any point |
| `data-bs-theme` at the first animation frame | `null`, white body | `dark`, while `readyState` is still `loading` |
| light system preference | light throughout | light throughout |

The two things that were already right and stay right: the attribute is on `<html>`, and the script is inline in `<head>` before any stylesheet and not deferred. Both are now pinned by the gate rather than left to convention.

## 2. The theme as a user preference

The theme lived in a cookie, so it was a property of the device. It now lives in `userPrefs` beside the display timezone.

```
''      follow the operating system, in EITHER direction
'light' force light
'dark'  force dark
```

An unset preference must not collapse into light — a dark-desktop user who has never touched the setting gets dark. `FOGBase::displayTheme()` whitelists exactly `light` and `dark`; anything else stored means no opinion.

A forced choice is stamped on `<html>` server-side. An unset preference deliberately leaves the attribute **off**, and that absence is the cue the pre-paint script uses to resolve `prefers-color-scheme` itself. `theme.js` no longer decides the first paint at all.

The picker is a three-row dropdown in the navbar next to the timezone clock. An existing `fogTheme` cookie is adopted once, only when the account has no stored preference, then expired.

The login page has no session, so it follows the system. That is the right answer rather than a compromise.

## Verification

- **Browser, against the shadow UI lab and the lab database** — 14 checks: unset follows a dark system and a light system with no wrong-colored frame either way; a forced choice applies without a reload, survives a reload stamped server-side, and beats the opposite system setting in both directions; the login page still follows the system with a preference stored; choosing System deletes the row; the legacy cookie is adopted then expired. The written row was read back out of `userPrefs` directly.
- **Mutation-proved gates** — 6 mutations for the sanitizer gate, 7 for the preference gate. Each was applied, run, and confirmed red.
- `sh tests/run-all.sh` — 210 passed, 0 failed.
- Both `phpstan` passes clean.

## Notes

- No route changes, so `OpenAPI::document()` needs no edit — the picker uses the existing `system/userpref/{key}` endpoint.
- `FOG_BCACHE_VER` bumped for the `theme.js` rewrite.
- One baseline entry added for the new `self::displayTheme()` call in the page shell, matching the entries already there for every other `self::` call in that file.