### PR TITLE
Let the admin choose which management URL the installer prints first

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -896,6 +896,13 @@ fi
 WEB_url_proto="https"
 [[ -z ${PKI_web_cert_publicly_trusted} ]] && PKI_web_cert_publicly_trusted="no"
 [[ -z ${BOOT_rebuild_ipxe_with_my_ca} ]] && BOOT_rebuild_ipxe_with_my_ca="no"
+# Which management URL _managementUrls() prints first when the install finishes.
+# Normalized rather than defaulted-if-empty: `address` is the only value that
+# means anything else, so a typo in a hand-edited .fogsettings resolves to the
+# default instead of silently reordering the output, and the file is rewritten
+# with the spelling that was actually used. Nothing here is worth failing an
+# install over -- it is two lines of closing text.
+[[ ${WEB_url_primary} == address ]] || WEB_url_primary="name"
 
 # --- --install-mode ----------------------------------------------------------
 #

--- a/docs/FOGSETTINGS.md
+++ b/docs/FOGSETTINGS.md
@@ -62,7 +62,7 @@ in this area:
 
 | Kind | Meaning | Examples |
 |---|---|---|
-| **Preference** | The admin's decision. Persisted so it survives an upgrade, and *nothing* may silently reverse it | `PKI_sb_enabled`, `SVC_firewall_control`, `FOG_update_channel`, `FOG_install_mode`, `PKI_internal_subnets`, `BOOT_kernel_backups_kept` |
+| **Preference** | The admin's decision. Persisted so it survives an upgrade, and *nothing* may silently reverse it | `PKI_sb_enabled`, `SVC_firewall_control`, `FOG_update_channel`, `FOG_install_mode`, `PKI_internal_subnets`, `BOOT_kernel_backups_kept`, `WEB_url_primary` |
 | **Record** | Written so it can be read back for reference. The installer recomputes the real value every run and ignores what is stored | `FOG_program_dir`, `FOG_git_path`, `FOG_packages`, `WEB_php_version`, `BOOT_url_proto`, every canonical `PKI_*` path |
 | **Hand-set** | Nothing in the installer writes it; it survives only because the merge preserves unknown lines | `inetConnectTimeout`, `inetMaxTime`, `storageLocationCapture`, `ftppasvmin`/`ftppasvmax`, `mcastportmin`/`mcastportmax` |
 | **Inferred preference** | A preference the installer may write *once* from what it observed, and then treats as the admin's | `WEB_https_redirect`, `BOOT_url_proto_forced` |
@@ -114,6 +114,43 @@ that pattern is worth resisting up front rather than retiring later:
 `catrust` and `sbNameConstraints` went for a different reason: both were opt-outs
 that put the safe answer behind a flag nobody passes until something has already
 broken. See ADR 0024.
+
+### A preference with no flag and no prompt
+
+`WEB_url_primary` is one, and it is the shape to copy when a setting changes
+presentation rather than behavior.
+
+It decides which of the two management-portal URLs the installer prints **first**
+when it finishes — `name` (the default) or `address`. The name leads by default
+because on a certificate carrying names only, reaching the server by address is
+a name mismatch and the browser says so. That reasoning does not survive contact
+with every network: on a server the whole estate already reaches by address,
+whose name resolves for a subset of machines, name-first buries the URL that
+actually works.
+
+```sh
+WEB_url_primary='address'
+```
+
+Three properties make the no-flag, no-prompt shape right here, and all three
+have to hold before reusing it:
+
+- **It changes output, not behavior.** Nothing is installed differently, no file
+  moves, no service is configured differently. Getting it wrong costs two lines
+  of closing text in the wrong order.
+- **Only one value means anything but the default.** `bin/installfog.sh`
+  normalizes anything that is not `address` to `name`, so a typo in a
+  hand-edited file resolves to the default instead of doing something a third
+  way, and the rewritten file carries the spelling that was actually used.
+- **It orders the URLs; it does not bless them.** The explanation printed under
+  them is read from the served certificate, not from this key
+  (`_certServesAddress`). Setting `address` on a names-only leaf puts the address
+  first **and** still says plainly that it will warn. A preference that could
+  silence a true warning would not be a presentation setting at all.
+
+A flag was not added because a value nobody would pass twice does not earn one:
+an admin who wants this is editing `.fogsettings` already, and `--help` is a
+worse place to discover a setting than the file it lives in.
 
 ---
 

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -5544,14 +5544,32 @@ _resolveTrustAnchor() {
 # has not written a leaf yet -- ${NET_hostname} is the same answer one step early.
 # ${NET_fog_server_ip} is last and is only ever right for a FOG-issued certificate, since
 # no public CA will issue for an address at all.
-_servedCertName() {
-    local cert cn candidate
+# The certificate file the browser is actually served, or empty.
+#
+# Split out of _servedCertName() so that anything else asking a question about
+# the SERVED certificate -- rather than about its commonName -- resolves the
+# same file by the same precedence, instead of re-listing the candidates and
+# drifting out of step with it.
+#
+# First existing candidate wins outright. The loop this replaced went on to the
+# next candidate when a file's commonName would not parse, which could report a
+# name off a certificate the browser is not being served -- worse than reporting
+# none, because a URL printed from it looks authoritative and warns anyway.
+_servedCertPath() {
+    local cert candidate
     local -a candidates=()
     candidate=$(_vhostCertPath)
     [[ -n $candidate ]] && candidates+=("$candidate")
     candidates+=("${PKI_web_vhost_cert}" "$sslfullchain")
     for cert in "${candidates[@]}"; do
-        [[ -n $cert && -f $cert ]] || continue
+        [[ -n $cert && -f $cert ]] && { echo "$cert"; return 0; }
+    done
+    return 1
+}
+_servedCertName() {
+    local cert cn
+    cert=$(_servedCertPath)
+    if [[ -n $cert ]]; then
         # -nameopt multiline rather than parsing the one-line form: the compact
         # subject is rendered differently across openssl versions (leading
         # slash, spaces around '='), and a CN containing a comma cannot be
@@ -5559,7 +5577,7 @@ _servedCertName() {
         cn=$(openssl x509 -noout -subject -nameopt multiline -in "$cert" 2>/dev/null \
             | awk -F' = ' '/commonName/{print $2; exit}')
         [[ -n $cn ]] && { echo "$cn"; return 0; }
-    done
+    fi
     [[ -n ${NET_hostname} ]] && { echo "${NET_hostname}"; return 0; }
     echo "${NET_fog_server_ip}"
 }
@@ -5572,9 +5590,23 @@ _servedCertName() {
 # new server was a security warning, with nothing on screen to say the name that
 # would have worked.
 #
-# So print both, name first. The address still has to be here -- DNS may not
-# have caught up yet, and it is the only thing that works on a server with no
-# usable name at all -- but as the fallback it is, not as the headline.
+# So print both, name first by default. The address still has to be here -- DNS
+# may not have caught up yet, and it is the only thing that works on a server
+# with no usable name at all -- but as the fallback it is, not as the headline.
+#
+# ${WEB_url_primary} overrides which one leads, because "the name is the better
+# headline" is true of the general case and not of every network. On a server
+# whose address is what every machine already uses, and whose name resolves for
+# a subset of them, name-first buries the URL that actually works. It is a
+# .fogsettings key with no flag and no prompt on purpose: an admin who wants it
+# is editing that file anyway, and it changes nothing but two lines of output.
+#
+# What it does NOT do is change what the explanation says. Ordering is a
+# preference; whether the address is a name mismatch is a fact about the
+# certificate, read below from the certificate. Setting WEB_url_primary=address
+# on a names-only leaf therefore puts the address first AND says plainly that it
+# will warn -- rather than silently recommending a URL that does not work
+# cleanly.
 #
 # The name comes from _servedCertName, i.e. the commonName of the certificate
 # actually on disk, rather than from ${NET_hostname}. Those differ on exactly
@@ -5584,36 +5616,70 @@ _servedCertName() {
 # admin to a URL that warns just as loudly as the address, while implying it
 # would not.
 _managementUrls() {
-    local name="" ip="${NET_fog_server_ip}"
+    local name="" ip="${NET_fog_server_ip}" cert="" ipcovered=no
     name=$(_servedCertName)
     # _servedCertName's own last resort IS the address, so it can hand back the
     # very thing the fallback line prints. Suppress the name line rather than
     # printing the same URL twice with different captions.
     [[ -z $name || $name == "$ip" || $(validip "$name") -eq 0 ]] && name=""
 
+    # Does the served certificate cover the ADDRESS as well as the name? A
+    # FOG-issued leaf does, by construction -- configureHttpd writes an IP SAN
+    # for every address in ${PKI_san_ip_addresses} -- so on the ordinary install
+    # reaching the portal by address is not a name mismatch at all, and the text
+    # below must not claim it is. That claim was unconditional until GH-1488 and
+    # was wrong on every default install: what the browser objects to there is
+    # FOG's CA being untrusted, which both URLs get equally.
+    #
+    # A publicly-issued or ACME leaf carries names and no address, since no
+    # public CA will issue for an address. That is the install the mismatch
+    # warning was written for and still the one it is right for.
+    cert=$(_servedCertPath)
+    [[ ${WEB_url_proto} == https && -n $cert ]] \
+        && _certServesAddress "$cert" "$ip" && ipcovered=yes
+
     echo "   This can be done by opening a web browser and going to:"
     echo
-    [[ -n $name ]] && echo "   ${WEB_url_proto}://${name}${WEB_root}management"
-    echo "   ${WEB_url_proto}://${ip}${WEB_root}management"
+    if [[ -n $name && ${WEB_url_primary} == address ]]; then
+        echo "   ${WEB_url_proto}://${ip}${WEB_root}management"
+        echo "   ${WEB_url_proto}://${name}${WEB_root}management"
+    else
+        [[ -n $name ]] && echo "   ${WEB_url_proto}://${name}${WEB_root}management"
+        echo "   ${WEB_url_proto}://${ip}${WEB_root}management"
+    fi
     # The blank line belongs to the explanation, so it is emitted per branch
     # rather than up front -- an HTTP install with no name has nothing to
     # explain, and an unconditional echo there just orphans a blank line.
     if [[ ${WEB_url_proto} == https ]]; then
         echo
-        if [[ -n $name ]]; then
+        if [[ -z $name ]]; then
+            echo "   This server has no name in its certificate, only the address, so"
+            echo "   the browser will warn about the certificate every time. Give it a"
+            echo "   resolvable name with --hostname and re-run to fix that."
+        elif [[ $ipcovered == yes ]]; then
+            # Deliberately "neither is a name mismatch" and not "will not warn":
+            # a FOG-issued leaf chains to FOG's own CA, which no browser trusts
+            # until someone imports it, and that warning lands on both URLs.
+            echo "   Either works -- the certificate covers the address as well as the"
+            echo "   name, so neither is a name mismatch. The address needs no DNS; the"
+            echo "   name it is issued for is ${name}."
+        elif [[ ${WEB_url_primary} == address ]]; then
+            # WEB_url_primary moved the address to the top and this certificate
+            # does not cover it. Say so rather than leaving a recommendation
+            # that warns: the setting orders the URLs, it does not make one work.
+            echo "   The address is first because WEB_url_primary=address in"
+            echo "   .fogsettings, but this certificate carries names only -- so reaching"
+            echo "   the server by address is a name mismatch and the browser will say"
+            echo "   so. The name it is issued for is ${name}."
+        else
             echo "   Use the first one. It is the name this server's certificate is"
             echo "   issued for, so it is the only one that will not warn. The address"
             echo "   works too -- useful before DNS catches up -- but the browser will"
             echo "   object that the certificate names ${name} instead."
-        else
-            echo "   This server has no name in its certificate, only the address, so"
-            echo "   the browser will warn about the certificate every time. Give it a"
-            echo "   resolvable name with --hostname and re-run to fix that."
         fi
     elif [[ -n $name ]]; then
         echo
-        echo "   Either works. The name is ${name}; the address is there for"
-        echo "   before DNS catches up."
+        echo "   Either works. The address needs no DNS; the name is ${name}."
     fi
 }
 # The DNS names a certificate carries as subjectAltName entries.
@@ -5636,6 +5702,32 @@ _certDnsNames() {
                grab { exit }' \
         | tr ',' '\n' \
         | sed -n 's/^[[:space:]]*DNS:[[:space:]]*//p'
+}
+# Does the certificate at $1 carry the IP address in $2 as a subjectAltName?
+#
+# Addresses are matched literally, never by the name rules in _certServesName:
+# there is no wildcard form for an address, and no commonName fallback either --
+# an address in a CN is not an iPAddress SAN and no TLS client accepts it as
+# one. So the only question is whether the exact string appears in the SAN list.
+#
+# Same -text/awk extraction as _certDnsNames, for the same reason: `openssl
+# x509 -ext subjectAltName` needs OpenSSL 1.1.1 and this has to run wherever the
+# installer does. openssl renders these as "IP Address:10.0.0.1"; IPv6 comes out
+# in openssl's own normalized form, so a literal comparison only holds for a
+# value that came from the same place -- which ${NET_fog_server_ip} does, having
+# been written into the SAN list by configureHttpd from ${PKI_san_ip_addresses}.
+_certServesAddress() {
+    local cert="$1" ip="$2" n
+    [[ -n $cert && -f $cert && -n $ip ]] || return 1
+    while IFS= read -r n; do
+        [[ -n $n && $n == "$ip" ]] && return 0
+    done < <(openssl x509 -noout -text -in "$cert" 2>/dev/null \
+        | awk '/X509v3 Subject Alternative Name/ { grab = 1; next }
+               grab && /^[[:space:]]+(DNS|IP|IP Address|email|URI|DirName|othername|Registered ID):/ { print; next }
+               grab { exit }' \
+        | tr ',' '\n' \
+        | sed -n 's/^[[:space:]]*IP Address:[[:space:]]*//p')
+    return 1
 }
 # Does the certificate at $1 serve the name in $2?
 #
@@ -6456,8 +6548,14 @@ writeUpdateFile() {
         # Persisting it is what makes that migration one-shot: an admin who
         # turns the redirect off must not have the next upgrade turn it back on
         # by re-reading WEB_url_proto.
+        #
+        # WEB_url_primary is which of the two management URLs the installer
+        # prints FIRST when it finishes -- `name` (default) or `address`. A
+        # genuine preference with no flag and no prompt: it changes two lines of
+        # closing output and nothing else, so it is not worth a question every
+        # install, but it must survive one. See _managementUrls.
         WEB_server_engine WEB_docroot WEB_root WEB_php_version
-        WEB_url_proto WEB_https_redirect
+        WEB_url_proto WEB_https_redirect WEB_url_primary
 
         # --- BOOT_: the client netboot path -- iPXE, TFTP, FOS kernels
         #

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4520');
+        define('FOG_VERSION', '1.6.0-beta.4523');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/tests/install-settings-resolution.test.sh
+++ b/tests/install-settings-resolution.test.sh
@@ -296,7 +296,7 @@ for key in WEB_https_redirect PKI_web_cert_publicly_trusted \
     fi
 done
 
-# All 67 keys of the model are managed, and NOTHING ELSE is: adding a key to
+# All 68 keys of the model are managed, and NOTHING ELSE is: adding a key to
 # this array turns a hand-set key into a managed one, and the admin's value
 # starts being overwritten. That is a behavior change even though it looks
 # like documentation, so the count is asserted as well as the membership.
@@ -317,7 +317,7 @@ modelKeys="
     PKI_web_external_root_cert PKI_web_trust_chain PKI_web_vhost_cert PKI_web_vhost_key
     STORAGE_image_share_path STORAGE_rebuild_nfs_exports SVC_firewall_control SVC_password
     SVC_user WEB_docroot WEB_https_redirect WEB_php_version
-    WEB_root WEB_server_engine WEB_url_proto"
+    WEB_root WEB_server_engine WEB_url_primary WEB_url_proto"
 missing=""
 for key in $modelKeys; do
     inlist "$key" "$managed" || missing="$missing $key"

--- a/tests/management-url-report.test.sh
+++ b/tests/management-url-report.test.sh
@@ -12,8 +12,17 @@
 # worked.
 #
 # _managementUrls() now prints the certificate's name first and the address as a
-# fallback. Three things about that are easy to regress and none of them would
-# fail an install, so nothing would catch them:
+# fallback, and ${WEB_url_primary}=address swaps that order for an admin whose
+# network reaches this server by address. Five things about that are easy to
+# regress and none of them would fail an install, so nothing would catch them:
+#
+#   0. The explanation must follow the CERTIFICATE, not the ordering. A
+#      FOG-issued leaf carries an IP SAN for every address in
+#      ${PKI_san_ip_addresses}, so the address is not a name mismatch there and
+#      the "only one that will not warn" wording is simply false -- it was
+#      printed unconditionally until GH-1488. Equally, ${WEB_url_primary}=address
+#      orders the URLs and does not make one work: on a names-only leaf the
+#      address still warns and the text still has to say so.
 #
 #   1. The name has to come from the CERTIFICATE (_servedCertName), not from
 #      ${NET_hostname}. Those differ on an externally-issued or publicly-trusted
@@ -54,6 +63,21 @@ hasnt() { grep -qF -- "$2" <<<"$1" && bad "$3 (output unexpectedly contained '$2
 eval "$(sed -n '/^_managementUrls() {/,/^}/p' "$FUNCS")"
 declare -F _managementUrls >/dev/null || { echo "ERROR: could not extract _managementUrls" >&2; exit 1; }
 
+# _certServesAddress is extracted for real rather than stubbed: the SAN
+# extraction inside it is the half most likely to rot silently -- openssl's
+# -text layout, and the difference between an "IP Address:" entry and a "DNS:"
+# one that merely looks like an address -- and a stub would report it healthy
+# forever. Fixtures for it are generated at the bottom of this file.
+#
+# Renamed on the way in. The ordering cases below stub _certServesAddress under
+# its real name so they need no certificate each, and the stub is defined after
+# this eval -- so extracting under the same name would silently hand the unit
+# tests the stub, and every one of them would pass on whatever CERT_HAS_IP
+# happened to hold. They did, before this line renamed it.
+eval "$(sed -n '/^_certServesAddress() {/,/^}/p' "$FUNCS" \
+    | sed '1s/^_certServesAddress()/_realCertServesAddress()/')"
+declare -F _realCertServesAddress >/dev/null || { echo "ERROR: could not extract _certServesAddress" >&2; exit 1; }
+
 # validip echoes 0 for a valid IPv4 literal, 1 otherwise -- same contract as the
 # installer's own, which lives in lib/common/config.sh and needs no sourcing for
 # this.
@@ -62,9 +86,33 @@ validip() { [[ $1 =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]] && echo 0 || echo 1; }
 WEB_root="/fog/"
 NET_fog_server_ip="10.0.0.10"
 CERT_CN=""
+CERT_HAS_IP=no
 _servedCertName() { echo "$CERT_CN"; }
+# A path, not a certificate: the ordering cases below drive the address
+# question through CERT_HAS_IP instead, so they need no openssl fixture each.
+# _certServesAddress itself is exercised against real certificates further down.
+_servedCertPath() { echo "/nonexistent/served.pem"; }
+_certServesAddress() { [[ $CERT_HAS_IP == yes ]]; }
 
-emit() { WEB_url_proto="$1"; CERT_CN="$2"; _managementUrls; }
+# $3 = does the served certificate carry the address as an IP SAN (default no,
+# i.e. the names-only leaf every pre-existing case below was written for).
+# $4 = ${WEB_url_primary} (default name).
+emit() {
+    WEB_url_proto="$1"; CERT_CN="$2"
+    CERT_HAS_IP="${3:-no}"; WEB_url_primary="${4:-name}"
+    _managementUrls
+}
+
+# Line number of the first management URL for host $2 in output $1, or empty.
+urlline() { grep -n -- "$2/fog/management" <<<"$1" | head -1 | cut -d: -f1; }
+
+# Asserts $2 appears before $3 in $1.
+before() {
+    local a b
+    a=$(urlline "$1" "$2"); b=$(urlline "$1" "$3")
+    [[ -n $a && -n $b && $a -lt $b ]] \
+        && ok "$4" || bad "$4 ($2@${a:-?}, $3@${b:-?})"
+}
 
 echo "HTTPS with a name in the certificate"
 out=$(emit https "fogserver.example.com")
@@ -72,12 +120,45 @@ has "$out" "https://fogserver.example.com/fog/management" "prints the certificat
 has "$out" "https://10.0.0.10/fog/management"             "prints the address URL too"
 # Order is the point: the name is the recommendation, the address is the
 # fallback. A reader takes the first URL offered.
-nameline=$(grep -n "fogserver.example.com/fog/management" <<<"$out" | head -1 | cut -d: -f1)
-ipline=$(grep -n "10.0.0.10/fog/management" <<<"$out" | head -1 | cut -d: -f1)
-[[ -n $nameline && -n $ipline && $nameline -lt $ipline ]] \
-    && ok "the name comes before the address" \
-    || bad "the name comes before the address (name@${nameline:-?}, ip@${ipline:-?})"
+before "$out" "fogserver.example.com" "10.0.0.10" "the name comes before the address"
 has "$out" "certificate names fogserver.example.com instead" "says why the address warns"
+
+echo
+echo "HTTPS where the certificate covers the address too (a FOG-issued leaf)"
+out=$(emit https "fogserver.example.com" yes)
+has "$out" "https://fogserver.example.com/fog/management" "still prints the name URL"
+has "$out" "https://10.0.0.10/fog/management"             "still prints the address URL"
+before "$out" "fogserver.example.com" "10.0.0.10" "default order is unchanged by the IP SAN"
+# The two sentences that are false on this leaf. Both are what comes back if the
+# branch is dropped, and neither would fail an install.
+hasnt "$out" "the only one that will not warn" "does not call the name the only URL that will not warn"
+hasnt "$out" "certificate names fogserver.example.com instead" "does not call the address a name mismatch"
+has "$out" "covers the address as well as the" "says the certificate covers both"
+
+echo
+echo "WEB_url_primary=address"
+out=$(emit https "fogserver.example.com" yes address)
+before "$out" "10.0.0.10" "fogserver.example.com" "puts the address first"
+has "$out" "https://fogserver.example.com/fog/management" "still prints the name URL"
+is "$(grep -c "10.0.0.10/fog/management" <<<"$out")" "1" "the address URL is printed once, not twice"
+hasnt "$out" "Use the first one" "no name-first recommendation contradicting the order"
+
+# Ordering is a preference; the mismatch is a fact. Choosing address-first on a
+# names-only leaf must NOT silence the warning -- that would recommend a URL
+# the browser rejects, which is the failure the name-first default exists to
+# avoid in the first place.
+out=$(emit https "fogserver.example.com" no address)
+before "$out" "10.0.0.10" "fogserver.example.com" "still puts the address first"
+has "$out" "name mismatch" "says the address is a name mismatch on a names-only leaf"
+has "$out" "WEB_url_primary=address" "names the setting that moved it"
+
+# An unrecognized value is the default, not a third behavior.
+out=$(emit https "fogserver.example.com" yes "adress")
+before "$out" "fogserver.example.com" "10.0.0.10" "a misspelled value falls back to name-first"
+
+# With no usable name there is one URL, so the setting has nothing to reorder.
+out=$(emit https "10.0.0.10" no address)
+is "$(grep -c "10.0.0.10/fog/management" <<<"$out")" "1" "no name: still exactly one URL"
 
 echo
 echo "HTTPS with no usable name (_servedCertName falls back to the address)"
@@ -112,6 +193,55 @@ out=$(emit https "fog.example.com")
 has "$out" "https://fog.example.com/management" "webroot / gives a single slash"
 hasnt "$out" "//management" "no doubled slash"
 WEB_root="/fog/"
+
+echo
+echo "_certServesAddress against real certificates"
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "  skip  openssl not available"
+else
+    fixdir=$(mktemp -d)
+    trap 'rm -rf "$fixdir"' EXIT
+    # rsa:2048, not the installer's 4096: these are discarded at the end of this
+    # block and the key size has no bearing on SAN parsing.
+    mkfix() {
+        if [[ -n $3 ]]; then
+            openssl req -x509 -newkey rsa:2048 -nodes -keyout /dev/null \
+                -out "$fixdir/$1.pem" -days 1 -subj "/CN=$2" \
+                -addext "subjectAltName=$3" >/dev/null 2>&1
+        else
+            openssl req -x509 -newkey rsa:2048 -nodes -keyout /dev/null \
+                -out "$fixdir/$1.pem" -days 1 -subj "/CN=$2" >/dev/null 2>&1
+        fi
+        [[ -s $fixdir/$1.pem ]] || { echo "ERROR: fixture $1 not generated" >&2; exit 1; }
+    }
+    mkfix both     fog.example.com "IP:10.0.0.10,DNS:fog.example.com,DNS:fog"
+    mkfix nameonly fog.example.com "DNS:fog.example.com,DNS:fog"
+    # 10.0.0.100 shares a prefix with 10.0.0.10: a substring or glob comparison
+    # accepts it, a literal one does not.
+    mkfix near     fog.example.com "IP:10.0.0.100,DNS:fog.example.com"
+    # An address-shaped DNS SAN is not an iPAddress SAN, and no TLS client
+    # accepts it as one -- so neither may this.
+    mkfix dnsip    fog.example.com "DNS:fog.example.com,DNS:10.0.0.10"
+    # Nor is a commonName, whatever it holds.
+    mkfix cnonly   10.0.0.10       ""
+
+    yn() { _realCertServesAddress "$1" 10.0.0.10 && echo yes || echo no; }
+    is "$(yn "$fixdir/both.pem")"     yes "matches an IP SAN for the address"
+    is "$(yn "$fixdir/nameonly.pem")" no  "no match on a names-only certificate"
+    is "$(yn "$fixdir/near.pem")"     no  "no match on 10.0.0.100 (prefix, not equal)"
+    is "$(yn "$fixdir/dnsip.pem")"    no  "no match on an address-shaped DNS SAN"
+    is "$(yn "$fixdir/cnonly.pem")"   no  "no match on an address in the commonName"
+    is "$(yn "$fixdir/absent.pem")"   no  "no match when the file does not exist"
+    # A contract assertion, not a guard test: the implementation satisfies it
+    # twice over (the early return, and the literal comparison no SAN can equal),
+    # so no single-line mutation turns it red. It is here to pin the contract for
+    # a future rewrite, and it earns its place only in combination -- loosening
+    # the comparison to a prefix match AND dropping the early return does make it
+    # fail, which is the pair that would otherwise match every SAN on an empty
+    # address.
+    is "$(_realCertServesAddress "$fixdir/both.pem" "" && echo yes || echo no)" no \
+        "no match when no address is given"
+fi
 
 echo
 echo "  passed: $PASS  failed: $FAIL"

--- a/tests/selfcall-verification.test.sh
+++ b/tests/selfcall-verification.test.sh
@@ -110,6 +110,20 @@ printf 'server {\n    ssl_certificate_key %s;\n}\n' "$WORK/served.key" > "$etcco
 PKI_web_vhost_cert="$WORK/fogown.pem"
 check "$(_servedCertName)" "fogown.example.org" "C: ssl_certificate_key is not read as the leaf"
 
+# C2. The vhost names a file that EXISTS but is not a certificate. The first
+#     existing candidate wins outright, so the answer falls through to
+#     ${NET_hostname} rather than to FOG's own leaf -- deliberately. Reporting a CN
+#     read off a certificate the browser is NOT being served is worse than
+#     reporting none: every URL printed from it looks authoritative and warns
+#     anyway. Pinned because the loop this replaced did the opposite silently.
+reset_env
+etcconf="$WORK/junkleaf.conf"
+printf 'not a certificate\n' > "$WORK/junk.pem"
+printf 'server {\n    ssl_certificate %s;\n}\n' "$WORK/junk.pem" > "$etcconf"
+PKI_web_vhost_cert="$WORK/fogown.pem"
+NET_hostname="fog.example.org"
+check "$(_servedCertName)" "fog.example.org" "C2: an unparseable served leaf does not fall back to FOG's own"
+
 # D. No vhost to consult -- fall back to FOG's own leaf.
 reset_env
 PKI_web_vhost_cert="$WORK/fogown.pem"


### PR DESCRIPTION
## What

Two things, one of which is a bug fix.

**The explanation printed under the management URLs was false on an ordinary install.** `_managementUrls()` said:

> Use the first one. It is the name this server's certificate is issued for, so it is **the only one that will not warn**. The address works too … but the browser will object that the certificate names `<name>` instead.

`configureHttpd` writes an IP SAN for every address in `$PKI_san_ip_addresses`, so a FOG-issued leaf covers the address as well as the name — reaching the portal by address is not a name mismatch. What the browser objects to is FOG's own CA being untrusted, and that lands on **both** URLs equally. The mismatch wording is true only of a publicly-issued or ACME leaf, which carries names and no address because no public CA will issue for one.

The explanation is now read from the served certificate rather than asserted. `_certServesAddress()` answers whether the leaf carries the address as an `iPAddress` SAN, and the three cases each say what is actually true:

| Served leaf | Printed |
|---|---|
| covers address + name (FOG-issued) | "Either works — the certificate covers the address as well as the name, so neither is a name mismatch." |
| names only (ACME, purchased) | unchanged: the name is the one that will not warn |
| no usable name | unchanged: points at `--hostname` |

**Ordering becomes a preference: `WEB_url_primary` = `name` (default) or `address`.** "The name is the better headline" holds for the general case and not for every network — on a server the whole estate already reaches by address, whose name resolves for a subset of machines, name-first buries the URL that works. Default is unchanged, so no existing install sees a different order.

No flag and no prompt: it changes two lines of closing output, nobody would pass it twice, and an admin who wants it is editing `.fogsettings` anyway. Anything but `address` normalizes to `name`, so a typo cannot do something a third way.

**The setting orders the URLs; it does not bless them.** Choosing `address` on a names-only leaf still prints the mismatch warning, naming the setting that moved it. A presentation preference that could silence a true warning would not be a presentation preference.

## Also

`_servedCertPath()` is split out of `_servedCertName()`, so a question about the served *certificate* resolves the same file by the same precedence as a question about its *commonName*. First existing candidate now wins outright — the loop it replaced fell through to the next candidate when a CN would not parse, which could report a name read off a certificate the browser is not being served. Pinned by a new case in `selfcall-verification.test.sh`.

## Testing

`tests/management-url-report.test.sh` — 38 assertions, up from 17. New coverage: the cert-covers-address branch, both `WEB_url_primary` orderings, the address-first-on-a-names-only-leaf warning, an unrecognized value falling back to the default, and `_certServesAddress` against six generated certificates (IP SAN, names-only, `10.0.0.100` vs `10.0.0.10`, an address-shaped `DNS:` SAN, an address in the CN, a missing file).

Every new gate was mutation-tested — the defect reintroduced and the assertion watched go red:

| Mutation | Caught by |
|---|---|
| drop the cert-covers-address branch | 3 assertions |
| ignore `WEB_url_primary` ordering | 2 assertions |
| match any SAN, not just the address | prefix fixture |
| prefix match instead of literal | prefix fixture |
| read `DNS:` SANs instead of `IP Address:` | 2 assertions |
| drop the address-first mismatch warning | 2 assertions |
| restore the old fall-through candidate loop | new `selfcall` case C2 |

One assertion (`no match when no address is given`) is labeled in the file as a contract assertion rather than a gate: the implementation satisfies it twice over, so no single-line mutation turns it red.

Full shell suite green, including `install-settings-resolution.test.sh`, whose managed-key model gains `WEB_url_primary` (67 → 68) — that test exists precisely so a new managed key is a deliberate act.

Verified end-to-end against a live server's served certificate (`openssl s_client`), both settings.

No route or schema change, so no `OpenAPI::document()` or FogApi impact.
