### PR TITLE
Answer the lockout guard from the users table, not from a scoped read

### DIFF
--- a/packages/web/src/Auth/Authorization.php
+++ b/packages/web/src/Auth/Authorization.php
@@ -2112,13 +2112,27 @@ class Authorization extends FOGBase
             'USER_TYPES_FILTER',
             ['types' => &$types]
         );
-        $allUsers = array_map('intval', (array)Route::getIds('user'));
-        $special = (count($types)
-            ? array_map(
-                'intval',
-                (array)Route::getIds('user', ['type' => $types])
-            )
-            : []);
+        // Read the users table directly rather than through Route::getIds(),
+        // for the reason rolesHolding() and _externalUsers() do and for one
+        // more that is specific to this read: ids() carries the CALLER'S
+        // object scope when it is serving a request, and `user` is a scoped
+        // node. A request with no signed-in user is bounded to nothing at
+        // all -- scopedObjectWhere() answers '1=0' -- so this read came back
+        // EMPTY, and a guard that can see no users concludes no
+        // administrator would remain and refuses.
+        //
+        // That is not hypothetical: the OIDC callback applies the provider's
+        // groups before the session exists, so any sign-in whose group
+        // mapping removed a role or a group membership refused itself with
+        // "This would leave no account able to administer FOG." A
+        // site-scoped administrator hit the same thing from the other
+        // direction -- they see only their own sites' users, which is right
+        // for a list and wrong for this question.
+        //
+        // A lockout guard asks about the WHOLE install, so it must never be
+        // answered through one caller's view of it.
+        $allUsers = self::_userIDs();
+        $special = (count($types) ? self::_userIDs($types) : []);
         $exclude = array_map(
             'intval',
             (array)($changes['excludeUsers'] ?? [])
@@ -2244,6 +2258,40 @@ class Authorization extends FOGBase
             }
         }
         return false;
+    }
+    /**
+     * Every user id, or only those of the given uType values.
+     *
+     * Owns its SQL for the reason given at the head of adminExistsGiven():
+     * the routed read is scoped to whoever is asking, and this question is
+     * about the install rather than about the caller.
+     *
+     * @param array $types uType values to restrict to; all users when empty
+     *
+     * @return array user ids
+     */
+    private static function _userIDs(array $types = [])
+    {
+        $sql = 'SELECT `uID` FROM `users`';
+        $params = [];
+        if (count($types)) {
+            $names = [];
+            foreach (array_values($types) as $index => $type) {
+                $name = sprintf('type%d', $index);
+                $names[] = ':' . $name;
+                $params[$name] = (int)$type;
+            }
+            $sql .= ' WHERE `uType` IN (' . implode(',', $names) . ')';
+        }
+        $rows = self::$DB
+            ->query($sql, [], $params)
+            ->fetch(\PDO::FETCH_ASSOC, 'fetch_all')
+            ->get();
+        $ids = [];
+        foreach ((array)$rows as $row) {
+            $ids[] = (int)$row['uID'];
+        }
+        return $ids;
     }
     /**
      * The user ids whose identity is owned by an external provider, after

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4523');
+        define('FOG_VERSION', '1.6.0-beta.4526');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/phpstan-tests-baseline.neon
+++ b/phpstan-tests-baseline.neon
@@ -319,6 +319,12 @@ parameters:
 			path: tests/imaging-notify-events.test.php
 
 		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/lockout-guard-is-unscoped.test.php
+
+		-
 			message: '#^Access to an undefined static property FOG\\Route\:\:\$rows\.$#'
 			identifier: staticProperty.notFound
 			count: 3

--- a/tests/lockout-guard-is-unscoped.test.php
+++ b/tests/lockout-guard-is-unscoped.test.php
@@ -1,0 +1,329 @@
+<?php
+/**
+ * The lockout guard asks about the WHOLE install, never about the caller.
+ *
+ * Authorization::adminExistsGiven() decides whether an operation would
+ * leave nobody able to administer FOG. It used to count users with
+ * Route::getIds('user'), and that read is not neutral: when it is serving
+ * a request, ids() bolts the CALLER'S object scope onto the query, and
+ * `user` is a site-scoped node. A request with no signed-in user is
+ * bounded to nothing at all -- scopedObjectWhere() answers the deny-all
+ * fragment '1=0' -- so the guard counted zero users, concluded no
+ * administrator would remain, and refused.
+ *
+ * That is not a corner case. The OIDC callback applies the provider's
+ * group mappings BEFORE the session exists, so any sign-in whose mapping
+ * dropped a role or a group membership refused itself:
+ *
+ *     {"error":"This would leave no account able to administer FOG."}
+ *
+ * and the account could never sign in again. A site-scoped administrator
+ * reached the same wrong answer from the other side, seeing only their own
+ * sites' users.
+ *
+ * The failure is silent in the direction that matters -- a guard that
+ * cannot see anybody refuses everything, and the message it prints names
+ * the wrong cause -- so this pins both halves: the count comes from the
+ * users table directly, and the guard still refuses a change that really
+ * would lock the install out.
+ *
+ * DB-free by the same means as site-scope-lists.test.php.
+ *
+ * Usage: php tests/lockout-guard-is-unscoped.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+use FOG\Auth\Authorization;
+
+$root = dirname(__DIR__);
+$webroot = $root . '/packages/web';
+$init = $webroot . '/commons/init.php';
+if (!is_readable($init)) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+
+$tmp = sys_get_temp_dir() . '/fog-lockout-guard-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
+register_shutdown_function(
+    function () use ($tmp) {
+        if (!is_dir($tmp)) {
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($tmp, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $f) {
+            $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+        }
+        @rmdir($tmp);
+    }
+);
+
+if (!defined('FOG_CACHE_DIR')) {
+    define('FOG_CACHE_DIR', $tmp . '/cache');
+}
+if (!defined('FOG_LOG_DIR')) {
+    define('FOG_LOG_DIR', $tmp . '/log');
+}
+if (!defined('FOG_PLUGIN_DIR')) {
+    define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+}
+
+require_once $init;
+new Initiator();
+
+$fails = [];
+$checks = 0;
+
+function check($label, $cond, array &$fails, &$checks)
+{
+    $checks++;
+    if (!$cond) {
+        $fails[] = $label;
+    }
+}
+
+/** Minimal stand-in for PDODB; see site-scope-lists.test.php for rationale. */
+class FakeDB
+{
+    public $error = false;
+    public $log = [];
+    private $_responder;
+    private $_result;
+
+    public function __construct(callable $responder)
+    {
+        $this->_responder = $responder;
+    }
+
+    public function query($sql, $a = [], $params = [])
+    {
+        $this->log[] = $sql;
+        $this->_result = call_user_func($this->_responder, $sql, $params);
+        return $this;
+    }
+
+    public function fetch($mode = null, $type = '')
+    {
+        return $this;
+    }
+
+    public function get($field = '')
+    {
+        return $this->_result;
+    }
+}
+
+/** A hook manager with nothing registered, which is the stock install. */
+class QuietHookManager
+{
+    public function processEvent($event, $arguments = [])
+    {
+        return;
+    }
+}
+
+$dbProp = new \ReflectionProperty(\FOG\Base\FOGBase::class, 'DB');
+$dbProp->setAccessible(true);
+$hookProp = new \ReflectionProperty(\FOG\Base\FOGBase::class, 'HookManager');
+$hookProp->setAccessible(true);
+
+/*
+ * One administrator (user 1, through role 1) and one ordinary user. Any
+ * table the guard reads and this scenario does not name answers empty, so
+ * a read that starts going somewhere new shows up as a wrong answer rather
+ * than as a silently absent row.
+ */
+$db = new FakeDB(
+    function ($sql, $params) {
+        if (false !== strpos($sql, 'FROM `users`')) {
+            return [['uID' => 1], ['uID' => 2]];
+        }
+        if (false !== strpos($sql, 'FROM `roleUserAssoc`')) {
+            return [['ruaRoleID' => 1, 'ruaUserID' => 1]];
+        }
+        if (false !== strpos($sql, 'FROM `rolePermissions`')) {
+            return [['rpRoleID' => 1]];
+        }
+        return [];
+    }
+);
+$dbProp->setValue(null, $db);
+$hookProp->setValue(null, new QuietHookManager());
+
+/**
+ * adminExistsGiven(), or the error it died with.
+ *
+ * Wrapped because the read this test exists to keep out does not merely
+ * answer wrongly here -- Route needs a booted router to answer at all, so
+ * reintroducing it turns the guard into a fatal. Reported as a failed
+ * check rather than left to kill the run, so the output names the cause.
+ *
+ * @param array $changes the proposed changes
+ *
+ * @return bool|string the answer, or the error message
+ */
+function guard(array $changes)
+{
+    try {
+        return Authorization::adminExistsGiven($changes);
+    } catch (\Throwable $e) {
+        return 'threw: ' . $e->getMessage();
+    }
+}
+
+/*
+ * 1. The guard sees the administrator.
+ */
+check(
+    'adminExistsGiven() cannot see the administrator in the users table',
+    true === guard([]),
+    $fails,
+    $checks
+);
+
+/*
+ * 2. It counted them by reading the table, and read nothing site-shaped on
+ *    the way. Checking the queries and not just the boolean is the point:
+ *    a routed read answers correctly for a caller who happens to be
+ *    unbounded, so the boolean alone passes on the very install where the
+ *    bug does not bite and fails on the customer's.
+ */
+$sawUsersTable = false;
+$sawScope = false;
+foreach ($db->log as $sql) {
+    if (preg_match('#SELECT\s+`uID`\s+FROM\s+`users`#', $sql)) {
+        $sawUsersTable = true;
+    }
+    if (false !== strpos($sql, 'siteUserMembers')
+        || false !== strpos($sql, '1=0')
+    ) {
+        $sawScope = true;
+    }
+}
+check(
+    'adminExistsGiven() no longer reads the users table directly',
+    $sawUsersTable,
+    $fails,
+    $checks
+);
+check(
+    'adminExistsGiven() carried a site boundary into its own count',
+    !$sawScope,
+    $fails,
+    $checks
+);
+
+/*
+ * 3. And it still refuses. A guard that answers "yes, somebody remains" to
+ *    everything is the same defect wearing the other face, so the negative
+ *    cases matter as much as the positive one.
+ */
+check(
+    'deleting the only administrator is no longer refused',
+    false === guard(['excludeUsers' => [1]]),
+    $fails,
+    $checks
+);
+check(
+    'deleting the role holding * is no longer refused',
+    false === guard(['removeRoles' => [1]]),
+    $fails,
+    $checks
+);
+check(
+    'stripping * from the only role holding it is no longer refused',
+    false === guard(['rolePermissions' => [1 => []]]),
+    $fails,
+    $checks
+);
+
+/*
+ * 4. The source-level half. The reads above can only be checked for what
+ *    they DID; this checks what the method may not do at all, so a future
+ *    edit that reintroduces a routed read is caught even if the scenario
+ *    it is exercised under happens to be unbounded.
+ */
+$authFile = $webroot . '/src/Auth/Authorization.php';
+$src = methodSource($authFile, 'adminExistsGiven');
+if (null === $src) {
+    $fails[] = 'Authorization::adminExistsGiven() is missing';
+} else {
+    check(
+        'adminExistsGiven() reads through Route again; a routed read carries'
+        . ' the caller\'s object scope, and a userless request is scoped to'
+        . ' nothing',
+        false === strpos($src, 'Route::'),
+        $fails,
+        $checks
+    );
+}
+
+/**
+ * Source text of one method, comments and whitespace stripped.
+ *
+ * Comments go first so the prose above a method -- which names the symbols
+ * this test searches for -- cannot satisfy the search on its own. Same
+ * helper as break-glass-auth-sources.test.php.
+ *
+ * @param string $file   path to read
+ * @param string $method method name to find
+ *
+ * @return string|null code of the body, or null if not found
+ */
+function methodSource($file, $method)
+{
+    $t = token_get_all(file_get_contents($file));
+    $n = count($t);
+    for ($i = 0; $i < $n; $i++) {
+        if (!is_array($t[$i]) || T_FUNCTION !== $t[$i][0]) {
+            continue;
+        }
+        $j = $i + 1;
+        while ($j < $n && is_array($t[$j]) && T_WHITESPACE === $t[$j][0]) {
+            $j++;
+        }
+        if ($j >= $n || !is_array($t[$j]) || $t[$j][1] !== $method) {
+            continue;
+        }
+        $depth = 0;
+        $src = '';
+        $started = false;
+        for ($k = $j; $k < $n; $k++) {
+            $c = $t[$k];
+            if (is_array($c)
+                && in_array($c[0], [T_COMMENT, T_DOC_COMMENT], true)
+            ) {
+                continue;
+            }
+            if (!is_array($c)) {
+                if ('{' === $c) {
+                    $depth++;
+                    $started = true;
+                } elseif ('}' === $c) {
+                    if (0 === --$depth && $started) {
+                        return preg_replace('#\s+#', '', $src);
+                    }
+                }
+            }
+            if ($started) {
+                $src .= is_array($c) ? $c[1] : $c;
+            }
+        }
+        return preg_replace('#\s+#', '', $src);
+    }
+    return null;
+}
+
+if (count($fails)) {
+    fwrite(STDERR, "FAIL (" . count($fails) . " of $checks checks)\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+fwrite(STDOUT, "PASS ($checks checks)\n");
+exit(0);


### PR DESCRIPTION
## The bug

An OIDC sign-in could refuse itself, on an install with plenty of administrators:

```
{"error":"This would leave no account able to administer FOG."}
```

and the account then had no way in through the provider at all.

`Authorization::adminExistsGiven()` — the shared decision behind every lockout guard —
counted users with `Route::getIds('user')`. That read is not neutral. When `ids()` is
serving a request it bolts the **caller's** object scope onto the query, and `user` is a
site-scoped node (`SiteScope::$_nodes`). A request with no signed-in user is bounded to
nothing at all: `Authorization::scopedObjectWhere('user', …)` answers the deny-all
fragment `1=0`. So the guard's user list came back empty, it concluded no administrator
would remain, and it refused.

The OIDC callback applies the provider's group mappings *before* the session exists
(`OIDCFlow::_applyGrants()` → `_syncTargets()` → `User::save()` → `assocSetter()` →
`Route::deletemass()`), so any sign-in whose mapping removed a role or a user-group
membership tripped it. A site-scoped administrator reached the same wrong answer from
the other direction, seeing only their own sites' users.

Fails closed, which is the right direction for a guard and the wrong one here: the
message names a cause that is not true, and nothing is logged beyond the `guard.lastadmin`
audit row the refusal itself writes.

## The fix

`adminExistsGiven()` reads the `users` table directly, through a new private
`_userIDs()`. That joins `rolesHolding()`, `_externalUsers()` and `_apiOnlyUsers()`,
which already own their SQL for the same reason: a lockout guard asks a question about
the **whole install**, so it must never be answered through one caller's view of it.

Nothing else in the guard changes — membership, group membership and group roles were
already read as raw SQL.

## Verification

Reproduced against a live 1.6 install under a **request** SAPI (`php-cgi`). The CLI
binary cannot see this at all: `Route::_requestScopeWhere()` short-circuits on
`PHP_SAPI === 'cli'`, which is why a CLI probe answers "allowed" on the very install
where the browser is refused.

| | before | after |
|---|---|---|
| `scopedObjectWhere('user', …)` for a userless request | `1=0` | `1=0` (unchanged) |
| `Route::getIds('user')` | `[]` | `[]` (unchanged) |
| `adminExistsGiven([])` | `false` | `true` |
| the guard on the sign-in's own membership delete | denied | allowed |

And it still refuses what it should — delete the last administrator, delete the role
holding `*`, strip `*` from that role, leave no locally-authenticating administrator:
all still `false`.

`tests/lockout-guard-is-unscoped.test.php` (new, DB-free, 7 checks) pins both halves:
the count comes from the users table and carries no site predicate, and the negative
cases still refuse. It fails **six of its seven checks** with the routed read put back,
which is how it was checked rather than assumed.

Full suite green (214 test files), both `phpstan` passes clean — one baseline entry
added for the new test file's `new Initiator()`, matching every other test.

## Notes

- No route changed, so `OpenAPI::document()` is unaffected.
- Not a `dev-branch` issue: neither the object-scope layer nor these guards exist there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
