### PR TITLE
Saved grid filters, shareable to a user, a group or a role

### DIFF
--- a/docs/adr/0031-referential-integrity-is-declared-in-the-database.md
+++ b/docs/adr/0031-referential-integrity-is-declared-in-the-database.md
@@ -15,7 +15,7 @@ windowskey 2, ldap 6, oidc 8, capone 2, subnetgroup 1 -- are declared in
 core's map and applied by a step in each plugin's own `schema()` in
 `FOGProject/fog-plugins`.
 
-**93 of the map's 109 relationships are declared.** The other 16 are not
+**101 of the map's 117 relationships are declared.** The other 16 are not
 pending work: they carry action `none`, which the map's docblock defines as a
 decision rather than an omission. Nine are audit rows, which MUST NOT
 constrain the thing they record (ADR 0021, `schema.php` step 341); seven are

--- a/docs/adr/0032-a-saved-filter-is-shared-by-grant-not-by-visibility.md
+++ b/docs/adr/0032-a-saved-filter-is-shared-by-grant-not-by-visibility.md
@@ -1,0 +1,95 @@
+# A saved filter is shared by grant, and a grant is a row per target kind
+
+## Status
+
+accepted, and implemented on `working-1.6` as schema 393 (`savedFilters`),
+394 (the three `savedFilter*Assoc` junctions) and 395 (the eight foreign keys,
+constraint group 8).
+
+## Context
+
+A grid filter that is worth keeping is usually worth handing to somebody. The
+smallest thing that would work is a boolean -- private or everyone -- and the
+smallest thing that would work *well* is what people actually asked for: show
+this to my manager for approval, then to the four people who need it, or to
+the group, or to everyone holding a role.
+
+That is a many-to-many relationship between a filter and three different kinds
+of target, which leaves two shapes:
+
+- one `savedFilterShare` table with a `type` column and a `targetID`; or
+- one junction per target kind.
+
+ADR 0031 is the reason this is written down rather than defaulted. Of the 117
+relationships in the foreign-key map, the 16 that carry action `none` are
+audit rows and **polymorphic columns** -- a column whose parent table is
+chosen by a sibling column, where no constraint is expressible at all. A
+`type`/`targetID` pair is exactly that shape, and it would have added three
+more unconstrainable relationships to a release whose entire point was
+removing them.
+
+## Decision
+
+**Three junction tables**, one each for users, user groups and roles. Every
+one of the eight resulting relationships is a declared foreign key with a
+real action:
+
+| child | parent | on delete | why |
+|---|---|---|---|
+| `savedFilters.sfUserID` | `users` | CASCADE | a private filter belongs to its owner and goes with them |
+| `savedFilters.sfCreatorID` | `users` | SET NULL | a *global* filter outlives whoever wrote it |
+| `savedFilterUserAssoc.*` | `savedFilters`, `users` | CASCADE | a grant to nobody is not a grant |
+| `savedFilterGroupAssoc.*` | `savedFilters`, `userGroups` | CASCADE | as above |
+| `savedFilterRoleAssoc.*` | `savedFilters`, `roles` | CASCADE | as above |
+
+`sfUserID IS NULL` is what makes a filter global: it has no owner, so there is
+no owner for it to be private to. That is also why `sfCreatorID` exists
+separately and is SET NULL rather than CASCADE -- deleting the author of a
+site-wide filter must not delete the filter.
+
+**Creating a global filter takes `savedfilter.create`; creating a private one
+takes nothing beyond being signed in.** A global filter appears in every
+user's picker on that grid, so it is a change to what other people see, and
+that is an access-control decision rather than a column. `savedfilter.edit`
+and `savedfilter.delete` govern the same operations on an existing global
+filter. Sharing to specific users, groups or roles needs no permission of its
+own: those grants are visible only to people the sharer names, and the target
+lists they pick from are already gated by `user.view`, `usergroup.view` and
+`role.view` respectively -- so a user can only share to targets they can
+already enumerate.
+
+**Visibility is resolved in one query, and reported with a precedence.**
+`SavedFilterManager::listFor()` reaches all five paths -- owned, global,
+shared by name, shared to a group I am in, shared to a role I hold -- as OR'd
+arms of a single SELECT rather than a UNION of per-path selects, so a filter
+a user can reach three ways is one row, always. Which of those reasons is
+*reported* follows a fixed order, most deliberate grant first:
+
+    mine > user > group > role > global
+
+so the badge in the picker always describes the most specific reason the user
+can see it. A manager who is also in the group they shared to sees "shared
+with you", not "everyone".
+
+## Consequences
+
+**A filter is never applied on page load.** It is offered in a picker the user
+opens deliberately, applied by a click, shown as a chip naming it, and cleared
+by that chip's `x`. This is the same rule the saved grid layout already
+follows by stripping searches out of the state it persists: a grid that comes
+back short with no visible reason is indistinguishable from a broken grid.
+What IS remembered per user is whether the header search row is *shown* --
+the affordance, never the term.
+
+**Adding a fourth kind of target is a fourth table**, not a new value in a
+type column. That is the cost of this decision and it is the intended one: the
+schema step is nine lines, and the alternative was three relationships that
+the database could never check.
+
+**A per-user dismissal of a filter shared to them is NOT implemented**, and
+"just delete it" is the wrong answer for anything shared to a role -- the user
+is not entitled to delete it, and the share is not theirs to revoke. The shape
+it would take is a fourth junction (`savedFilterDismissAssoc`, filter + user,
+both CASCADE) plus somewhere in the picker to see what you have hidden;
+without that second half it is a trap rather than a feature. It is additive
+against everything above, so nothing here has to change to add it later.

--- a/docs/development/foreign-keys.md
+++ b/docs/development/foreign-keys.md
@@ -603,7 +603,7 @@ half-converted column.
 ## Phase D — plugins, and the direction rule
 
 18 plugin tables ship in `FOGProject/fog-plugins`. All 18 clone cleanly into
-the survey and 25 of the map's 109 relationships live in them.
+the survey and 25 of the map's 117 relationships live in them.
 
 ### Direction is the whole rule
 

--- a/packages/web/commons/schema-constraints.php
+++ b/packages/web/commons/schema-constraints.php
@@ -265,6 +265,28 @@ return [
     ['child' => 'capone', 'column' => 'cImageID', 'parent' => 'images', 'pcolumn' => 'imageID', 'class' => 'config', 'action' => 'RESTRICT', 'sentinel' => 0, 'enabled' => true, 'group' => 'capone'],
     ['child' => 'capone', 'column' => 'cOSID', 'parent' => 'os', 'pcolumn' => 'osID', 'class' => 'config', 'action' => 'RESTRICT', 'sentinel' => 0, 'enabled' => true, 'group' => 'capone'],
     ['child' => 'subnetgroup', 'column' => 'sgGroupID', 'parent' => 'groups', 'pcolumn' => 'groupID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 'subnetgroup'],
+    // Group 8: saved grid filters and who they are shared with
+    // (schema 393/394/395).
+    //
+    // Three different actions on purpose. A PRIVATE filter is a satellite of
+    // the user who owns it, so CASCADE. The CREATOR reference is provenance
+    // on a row that may be GLOBAL -- owned by the install rather than by a
+    // person -- so SET NULL: a shared filter must outlive the account that
+    // wrote it. Every grant is a junction and dies with either end.
+    //
+    // The grant tables are three junctions rather than one polymorphic
+    // table precisely so these can exist: a single target column pointing at
+    // users, userGroups or roles could carry no foreign key at all, which is
+    // why ldapUserGrant and oidcUserGrant below are class 'poly', action
+    // 'none'. ADR 0031 exists to shrink that set.
+    ['child' => 'savedFilters', 'column' => 'sfUserID', 'parent' => 'users', 'pcolumn' => 'uId', 'class' => 'satellite', 'action' => 'CASCADE', 'enabled' => true, 'group' => 8],
+    ['child' => 'savedFilters', 'column' => 'sfCreatorID', 'parent' => 'users', 'pcolumn' => 'uId', 'class' => 'config', 'action' => 'SET NULL', 'enabled' => true, 'group' => 8],
+    ['child' => 'savedFilterUserAssoc', 'column' => 'sfuaFilterID', 'parent' => 'savedFilters', 'pcolumn' => 'sfID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 8],
+    ['child' => 'savedFilterUserAssoc', 'column' => 'sfuaUserID', 'parent' => 'users', 'pcolumn' => 'uId', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 8],
+    ['child' => 'savedFilterGroupAssoc', 'column' => 'sfgaFilterID', 'parent' => 'savedFilters', 'pcolumn' => 'sfID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 8],
+    ['child' => 'savedFilterGroupAssoc', 'column' => 'sfgaUserGroupID', 'parent' => 'userGroups', 'pcolumn' => 'ugID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 8],
+    ['child' => 'savedFilterRoleAssoc', 'column' => 'sfraFilterID', 'parent' => 'savedFilters', 'pcolumn' => 'sfID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 8],
+    ['child' => 'savedFilterRoleAssoc', 'column' => 'sfraRoleID', 'parent' => 'roles', 'pcolumn' => 'rID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 8],
     ['child' => 'ldapUserGrant', 'column' => 'lugTargetID', 'parent' => '(lugTargetType)', 'pcolumn' => '-', 'class' => 'poly', 'action' => 'none'],
     ['child' => 'oidcUserGrant', 'column' => 'ougTargetID', 'parent' => '(ougTargetType)', 'pcolumn' => '-', 'class' => 'poly', 'action' => 'none'],
 ];

--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -927,6 +927,43 @@ return [
                 'upModifiedTime' => 'datetime DEFAULT NULL',
             ],
         ],
+        'savedFilters' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `savedFilters` ( `sfID` int(11) NOT NULL AUTO_INCREMENT, `sfUserID` int(11) DEFAULT NULL, `sfCreatorID` int(11) DEFAULT NULL, `sfTable` varchar(128) NOT NULL DEFAULT \'\', `sfName` varchar(64) NOT NULL DEFAULT \'\', `sfValue` longtext DEFAULT NULL, `sfCreatedTime` datetime NOT NULL DEFAULT current_timestamp(), `sfModifiedTime` datetime DEFAULT NULL, PRIMARY KEY (`sfID`), UNIQUE KEY `sfOwnerTableName` (`sfUserID`,`sfTable`,`sfName`), KEY `sfTable` (`sfTable`), KEY `sfCreatorID` (`sfCreatorID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'sfID' => 'int(11) NOT NULL',
+                'sfUserID' => 'int(11) DEFAULT NULL',
+                'sfCreatorID' => 'int(11) DEFAULT NULL',
+                'sfTable' => 'varchar(128) NOT NULL DEFAULT \'\'',
+                'sfName' => 'varchar(64) NOT NULL DEFAULT \'\'',
+                'sfValue' => 'longtext DEFAULT NULL',
+                'sfCreatedTime' => 'datetime NOT NULL DEFAULT current_timestamp()',
+                'sfModifiedTime' => 'datetime DEFAULT NULL',
+            ],
+        ],
+        'savedFilterUserAssoc' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `savedFilterUserAssoc` ( `sfuaID` int(11) NOT NULL AUTO_INCREMENT, `sfuaFilterID` int(11) NOT NULL, `sfuaUserID` int(11) NOT NULL, PRIMARY KEY (`sfuaID`), UNIQUE KEY `sfuaFilterUser` (`sfuaFilterID`,`sfuaUserID`), KEY `sfuaUserID` (`sfuaUserID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'sfuaID' => 'int(11) NOT NULL',
+                'sfuaFilterID' => 'int(11) NOT NULL',
+                'sfuaUserID' => 'int(11) NOT NULL',
+            ],
+        ],
+        'savedFilterGroupAssoc' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `savedFilterGroupAssoc` ( `sfgaID` int(11) NOT NULL AUTO_INCREMENT, `sfgaFilterID` int(11) NOT NULL, `sfgaUserGroupID` int(11) NOT NULL, PRIMARY KEY (`sfgaID`), UNIQUE KEY `sfgaFilterGroup` (`sfgaFilterID`,`sfgaUserGroupID`), KEY `sfgaUserGroupID` (`sfgaUserGroupID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'sfgaID' => 'int(11) NOT NULL',
+                'sfgaFilterID' => 'int(11) NOT NULL',
+                'sfgaUserGroupID' => 'int(11) NOT NULL',
+            ],
+        ],
+        'savedFilterRoleAssoc' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `savedFilterRoleAssoc` ( `sfraID` int(11) NOT NULL AUTO_INCREMENT, `sfraFilterID` int(11) NOT NULL, `sfraRoleID` int(11) NOT NULL, PRIMARY KEY (`sfraID`), UNIQUE KEY `sfraFilterRole` (`sfraFilterID`,`sfraRoleID`), KEY `sfraRoleID` (`sfraRoleID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'sfraID' => 'int(11) NOT NULL',
+                'sfraFilterID' => 'int(11) NOT NULL',
+                'sfraRoleID' => 'int(11) NOT NULL',
+            ],
+        ],
         'userCleanup' => [
             'create' => 'CREATE TABLE IF NOT EXISTS `userCleanup` ( `ucID` int(11) NOT NULL AUTO_INCREMENT, `ucName` varchar(254) NOT NULL DEFAULT \'\', PRIMARY KEY (`ucID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -9617,3 +9617,140 @@ $this->schema[] =
 
         return true;
     };
+// 393
+// Named, saved filters for a grid.
+//
+// Separate from userPrefs on purpose. A preference is one opaque value per
+// (user, key) and every write replaces the whole of it; filters are a LIST
+// that gets added to, renamed and deleted one at a time. Holding that list as
+// a JSON array in a single preference would make every add a read-modify-write
+// of the whole array, so two tabs saving at once would lose one silently --
+// exactly the race the (user, key) upsert exists to avoid for a single value.
+//
+// sfValue is OPAQUE, the same stance as userPrefs.upValue: it holds
+// DataTables' own searchBuilder state, whose shape belongs to DataTables and
+// changes between its major versions. Nothing server-side decides anything on
+// the strength of what is inside it.
+//
+// OWNERSHIP had to be decided now rather than retrofitted:
+//
+//   sfUserID <id>   private to that user, and shareable BY them -- see the
+//                   three grant tables at step 394.
+//   sfUserID NULL   the filter is GLOBAL, owned by the install rather than by
+//                   a person, and offered to everyone on that grid. NULL
+//                   rather than a 0 sentinel so the foreign key at step 395
+//                   can be a real one; 0 has no row in `users`.
+//
+// sfCreatorID records who MADE it and is kept for globals, because "who do I
+// ask about this filter" is otherwise unanswerable, and a column added later
+// would be empty for every filter that already existed. It is SET NULL rather
+// than CASCADE, which is also what makes a global outlive the person who
+// wrote it -- a site-wide filter must not vanish because somebody left.
+//
+// The UNIQUE KEY enforces "one name per grid per owner" for PRIVATE filters
+// only. MySQL does not treat two NULLs as equal in a unique index, so it does
+// NOT constrain global names -- SavedFilterManager::store() checks that case
+// explicitly rather than pretending the index covers it.
+//
+// Column widths are set by that index, not by taste: it is
+// int + varchar(128) + varchar(64) in utf8mb3, which is 4 + 386 + 193 = 583
+// bytes and fits under InnoDB's 767-byte prefix limit on the older row
+// formats FOG still supports. Two varchar(190) columns -- the userPrefs width
+// -- would come to 1148 and only work on DYNAMIC.
+$this->schema[] = [
+    "CREATE TABLE IF NOT EXISTS `savedFilters` ( "
+    . "`sfID` int(11) NOT NULL AUTO_INCREMENT, "
+    . "`sfUserID` int(11) DEFAULT NULL, "
+    . "`sfCreatorID` int(11) DEFAULT NULL, "
+    . "`sfTable` varchar(128) NOT NULL DEFAULT '', "
+    . "`sfName` varchar(64) NOT NULL DEFAULT '', "
+    // Nullable for the same reason userPrefs.upValue is: a TEXT column cannot
+    // portably carry a literal DEFAULT, so NOT NULL with no default would
+    // error 1364 on a strict server for any INSERT that omitted it.
+    . "`sfValue` longtext DEFAULT NULL, "
+    . "`sfCreatedTime` datetime NOT NULL DEFAULT current_timestamp(), "
+    . "`sfModifiedTime` datetime DEFAULT NULL, "
+    . "PRIMARY KEY (`sfID`), "
+    . "UNIQUE KEY `sfOwnerTableName` (`sfUserID`,`sfTable`,`sfName`), "
+    . "KEY `sfTable` (`sfTable`), "
+    . "KEY `sfCreatorID` (`sfCreatorID`) "
+    // One line: the collation gate reads the CREATE statement line by line,
+    // so splitting CHARSET from COLLATE reads to it as a bare charset.
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC",
+];
+// 394
+// Who a filter is shared with, when it is shared with somebody specific.
+//
+// Global is the blunt instrument: it puts an entry in every single user's
+// picker on that grid, so it takes a permission nobody holds by default.
+// These three tables are the narrow version, which needs no permission at
+// all -- sharing a filter you own with a named colleague, group or role is
+// ordinary collaboration, not an administrative act, and it can only ADD one
+// named entry to the picker of somebody you could already name.
+//
+// THREE junction tables rather than one polymorphic grant table with a
+// target type. FOG has both shapes: the plugin grant tables (ldapUserGrant,
+// oidcUserGrant) are polymorphic and are recorded in the constraint map as
+// class 'poly', action 'none' -- meaning the database cannot enforce them at
+// all, because a column pointing at three different parents cannot carry a
+// foreign key. ADR 0031 exists to shrink that set, not grow it. Three tables
+// cost more DDL once and every reference in them is declared and enforced.
+//
+// The UNIQUE KEY on each makes a re-share a no-op rather than a duplicate,
+// which matters because the share editor sends the whole target list.
+//
+// Note what is NOT here: an approval state. "Share it with my manager, who
+// approves it" is a conversation, and the model that supports it is simply
+// that the share list is editable -- share with one person, then widen to
+// the groups and roles that need it. Encoding approval as a column would
+// mean a filter that exists but cannot be used, which is a workflow nobody
+// asked for.
+$this->schema[] = [
+    "CREATE TABLE IF NOT EXISTS `savedFilterUserAssoc` ( "
+    . "`sfuaID` int(11) NOT NULL AUTO_INCREMENT, "
+    . "`sfuaFilterID` int(11) NOT NULL, "
+    . "`sfuaUserID` int(11) NOT NULL, "
+    . "PRIMARY KEY (`sfuaID`), "
+    . "UNIQUE KEY `sfuaFilterUser` (`sfuaFilterID`,`sfuaUserID`), "
+    . "KEY `sfuaUserID` (`sfuaUserID`) "
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC",
+    "CREATE TABLE IF NOT EXISTS `savedFilterGroupAssoc` ( "
+    . "`sfgaID` int(11) NOT NULL AUTO_INCREMENT, "
+    . "`sfgaFilterID` int(11) NOT NULL, "
+    . "`sfgaUserGroupID` int(11) NOT NULL, "
+    . "PRIMARY KEY (`sfgaID`), "
+    . "UNIQUE KEY `sfgaFilterGroup` (`sfgaFilterID`,`sfgaUserGroupID`), "
+    . "KEY `sfgaUserGroupID` (`sfgaUserGroupID`) "
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC",
+    "CREATE TABLE IF NOT EXISTS `savedFilterRoleAssoc` ( "
+    . "`sfraID` int(11) NOT NULL AUTO_INCREMENT, "
+    . "`sfraFilterID` int(11) NOT NULL, "
+    . "`sfraRoleID` int(11) NOT NULL, "
+    . "PRIMARY KEY (`sfraID`), "
+    . "UNIQUE KEY `sfraFilterRole` (`sfraFilterID`,`sfraRoleID`), "
+    . "KEY `sfraRoleID` (`sfraRoleID`) "
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC",
+];
+// 395
+// The foreign keys for the four tables steps 393 and 394 just created, per
+// ADR 0031.
+//
+// Group 8, and like group 7 it has nothing to migrate: tables created empty
+// one step earlier cannot hold an orphan, so there is no sweep to sequence
+// before the flip.
+//
+// Three actions, chosen separately:
+//
+//  - savedFilters.sfUserID CASCADE. A private filter is a satellite of its
+//    owner and means nothing without them.
+//  - savedFilters.sfCreatorID SET NULL. Provenance on a row that may belong
+//    to the whole install; a shared filter must outlive its author.
+//  - every grant column CASCADE. A share is meaningless once either end of
+//    it is gone, and leaving the row would silently offer a filter to a
+//    group id that has since been reused.
+$this->schema[] =
+    function () {
+        \FOG\Db\SchemaReconciler::applyConstraints(8);
+
+        return true;
+    };

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -406,6 +406,67 @@ function fogPrefFetch(key, cb) {
 }
 
 /**
+ * The preference key for one of a grid's affordances.
+ *
+ * Namespaced under the grid's own layout key so two tables cannot collide,
+ * and suffixed so an affordance cannot collide with the layout itself.
+ *
+ * @param {object} dt   the DataTables API for the table
+ * @param {string} name the affordance
+ *
+ * @return {string} the key, or '' when the table has no id to key on
+ */
+function fogAffordanceKey(dt, name) {
+  var base = fogStateKey(dt.settings()[0]);
+  return base ? base + '.' + name : '';
+}
+
+/**
+ * Remembers whether one of a grid's affordances is showing.
+ *
+ * Deliberately a BOOLEAN and never a filter term. Restoring "the search row
+ * is open" shows an empty row; restoring what was typed in it would show a
+ * short grid with no visible reason, which is the failure the layout state
+ * avoids by stripping searches entirely.
+ *
+ * @param {object}  dt   the DataTables API for the table
+ * @param {string}  name the affordance
+ * @param {boolean} on   whether it is showing
+ *
+ * @return {void}
+ */
+function fogAffordanceStore(dt, name, on) {
+  var key = fogAffordanceKey(dt, name);
+  if (!key) {
+    return;
+  }
+  // An empty value clears the preference, so "off" leaves no row behind --
+  // the same convention the rest of the store uses for "no opinion".
+  fogPrefStore(key, on ? '1' : '');
+}
+
+/**
+ * Reads one affordance back and applies it.
+ *
+ * @param {object}   dt    the DataTables API for the table
+ * @param {string}   name  the affordance
+ * @param {function} apply receives true when it was left showing
+ *
+ * @return {void}
+ */
+function fogAffordanceRestore(dt, name, apply) {
+  var key = fogAffordanceKey(dt, name);
+  if (!key) {
+    return;
+  }
+  fogPrefFetch(key, function(err, value) {
+    if (!err && value === '1') {
+      apply();
+    }
+  });
+}
+
+/**
  * Display-timezone picker in the navbar.
  *
  * Reads and writes the same preference store the grid layouts use, so a chosen
@@ -554,8 +615,29 @@ var shouldReAuth,
     enabled: false,
     text: '<i class="fas fa-magnifying-glass-chart"></i> Column search',
     action: function(e, dt) {
-      $(dt.table().container()).toggleClass('fog-colsearch-on');
+      var on = $(dt.table().container())
+        .toggleClass('fog-colsearch-on')
+        .hasClass('fog-colsearch-on');
       fogColumnSearchSync(dt);
+      // WHETHER THE ROW IS SHOWN, never what is typed in it. The row is an
+      // affordance -- "I like filtering from the headers" -- and remembering
+      // that is not the same as remembering a question somebody asked once.
+      // The terms are still cleared when the row closes, and still stripped
+      // from the saved layout; see fogStripStateSearch().
+      fogAffordanceStore(dt, 'searchrow', on);
+    }
+  },
+  // Named, saved filters. A separate control from the Filter panel next to
+  // it: that one BUILDS a filter, this one remembers the ones worth keeping
+  // and hands them out. Everything about it lives in fog.filters.js -- the
+  // toolbar only needs to know how to open it.
+  savedFiltersButton = {
+    name: 'savedfilters',
+    text: '<i class="far fa-bookmark"></i> Saved filters',
+    action: function(e, dt) {
+      if (window.fogSavedFilters) {
+        window.fogSavedFilters.open(dt);
+      }
     }
   },
   exportButtons = [
@@ -589,6 +671,7 @@ var shouldReAuth,
       text: '<i class="fas fa-print"></i> Print'
     },
     searchBuilderButton,
+    savedFiltersButton,
     columnSearchButton,
     {
       extend: 'colvis',
@@ -623,6 +706,7 @@ var shouldReAuth,
       text: '<i class="fas fa-print"></i> Print'
     },
     searchBuilderButton,
+    savedFiltersButton,
     columnSearchButton,
     {
       extend: 'colvis',
@@ -3560,6 +3644,7 @@ $.fn.registerTable = function(onSelect, opts) {
         text: '<i class="far fa-square"></i> Deselect All'
       },
       searchBuilderButton,
+      savedFiltersButton,
       columnSearchButton,
       {
         text: '<i class="fas fa-arrows-rotate"></i> Refresh',
@@ -3699,6 +3784,14 @@ $.fn.registerTable = function(onSelect, opts) {
     fogColumnSearchRow(api, types);
     fogColumnSearchRestore(api);
     api.buttons('colsearch:name').enable();
+    // Only once. This handler runs on every response, and re-applying would
+    // fight a user who closed the row and then changed a page.
+    if (!settings._fogAffordancesDone) {
+      settings._fogAffordancesDone = true;
+      fogAffordanceRestore(api, 'searchrow', function() {
+        $(api.table().container()).addClass('fog-colsearch-on');
+      });
+    }
   });
 
   var table = $(this).DataTable(opts);

--- a/packages/web/management/js/fog/fog.filters.js
+++ b/packages/web/management/js/fog/fog.filters.js
@@ -1,0 +1,580 @@
+/**
+ * Named, saved grid filters.
+ *
+ * A filter someone SAVED and then PICKED is a different thing from a filter
+ * silently restored on their behalf. The layout state deliberately drops
+ * searches on the way out (fogStripStateSearch in fog.common.js) because a
+ * restored filter looks exactly like missing data -- you open Hosts, see 4 of
+ * 4000, and nothing on screen says why. Everything here is built around
+ * keeping that distinction true:
+ *
+ *   - NOTHING is ever applied on page load. The list is fetched when the user
+ *     opens the picker, and applied only when they click Apply.
+ *   - while a filter is applied there is a CHIP next to the toolbar naming
+ *     it, with an x that clears it in one click. Not a dropdown that quietly
+ *     stays selected.
+ *
+ * Sharing: a filter is private until its owner shares it. It can go to named
+ * users, to user groups, to roles, or -- for somebody holding
+ * savedfilter.create -- to everyone. Sharing needs no permission because it
+ * can only add one named entry to the picker of somebody the sharer could
+ * already name; "everyone" is the one case that is an administrative act.
+ */
+(function () {
+    'use strict';
+
+    var MODAL_ID = 'fogFilterModal';
+
+    function api(path) {
+        return (window.fogApiBase ? fogApiBase() : '/fog/') + path;
+    }
+
+    /**
+     * The grid this table's filters belong to.
+     *
+     * Deliberately the same key the saved LAYOUT uses: it already answers
+     * "which grid is this", including the part that is not the DOM id -- FOG
+     * builds most grids as #dataTable, so the host list and the image list
+     * would otherwise share one set of filters.
+     */
+    function tableKey(dt) {
+        return window.fogStateKey ? fogStateKey(dt.settings()[0]) : '';
+    }
+
+    /** Text node, never innerHTML: a filter name is somebody else's input. */
+    function el(tag, className, text) {
+        var node = document.createElement(tag);
+        if (className) {
+            node.className = className;
+        }
+        if (text !== undefined && text !== null) {
+            node.textContent = text;
+        }
+        return node;
+    }
+
+    // ---------------------------------------------------------------- chip
+
+    /**
+     * The "a filter is on" indicator.
+     *
+     * Lives in the table's own container so a page with two grids gets two
+     * chips, and is REMOVED rather than hidden when nothing is applied --
+     * an empty chip element sitting in the layout is one CSS mistake away
+     * from being invisible while claiming to be the visible indicator.
+     */
+    function chipHost(dt) {
+        var container = dt.table().container();
+        var host = container.querySelector('.fog-filter-chip-host');
+        if (!host) {
+            host = el('div', 'fog-filter-chip-host mb-2');
+            container.insertBefore(host, container.firstChild);
+        }
+        return host;
+    }
+
+    function clearChip(dt) {
+        var host = dt.table().container()
+            .querySelector('.fog-filter-chip-host');
+        if (host) {
+            host.innerHTML = '';
+        }
+    }
+
+    function showChip(dt, name) {
+        var host = chipHost(dt);
+        var chip = el('span', 'badge bg-primary d-inline-flex align-items-center gap-2');
+        var close = el('button', 'btn-close btn-close-white');
+        host.innerHTML = '';
+        chip.appendChild(el('i', 'fas fa-filter'));
+        chip.appendChild(el('span', null, name));
+        close.setAttribute('type', 'button');
+        close.setAttribute('aria-label', 'Clear filter');
+        close.setAttribute('title', 'Clear this filter');
+        close.addEventListener('click', function () {
+            clearFilter(dt);
+        });
+        chip.appendChild(close);
+        host.appendChild(chip);
+    }
+
+    // ------------------------------------------------------------- applying
+
+    function applyFilter(dt, filter) {
+        var details;
+        try {
+            details = JSON.parse(filter.value || '{}');
+        } catch (e) {
+            $.notify('Filter', 'That saved filter could not be read.', 'error');
+            return;
+        }
+        dt.searchBuilder.rebuild(details);
+        showChip(dt, filter.name);
+    }
+
+    function clearFilter(dt) {
+        // rebuild({}) is SearchBuilder's own reset. Clearing the chip first
+        // would leave the rows filtered with nothing on screen to say so if
+        // the rebuild threw.
+        dt.searchBuilder.rebuild({});
+        clearChip(dt);
+    }
+
+    // -------------------------------------------------------------- fetching
+
+    function loadFilters(dt, done) {
+        $.ajax({
+            url: api('system/savedfilters'),
+            data: { table: tableKey(dt) },
+            global: false,
+            success: function (res) {
+                done(null, res || {});
+            },
+            error: function (xhr) {
+                done(xhr, {});
+            }
+        });
+    }
+
+    function loadTargets(done) {
+        $.ajax({
+            url: api('system/savedfiltertargets'),
+            global: false,
+            success: function (res) { done(res || {}); },
+            error: function () { done({}); }
+        });
+    }
+
+    // ---------------------------------------------------------------- modal
+
+    function modal() {
+        var node = document.getElementById(MODAL_ID);
+        if (node) {
+            return node;
+        }
+        node = el('div', 'modal fade');
+        node.id = MODAL_ID;
+        node.setAttribute('tabindex', '-1');
+        node.innerHTML =
+            '<div class="modal-dialog modal-lg">'
+            + '<div class="modal-content">'
+            + '<div class="modal-header">'
+            + '<h5 class="modal-title">Saved filters</h5>'
+            + '<button type="button" class="btn-close" data-bs-dismiss="modal"'
+            + ' aria-label="Close"></button>'
+            + '</div>'
+            + '<div class="modal-body"><div class="fog-filter-body"></div></div>'
+            + '<div class="modal-footer">'
+            + '<button type="button" class="btn btn-outline-secondary float-start"'
+            + ' data-bs-dismiss="modal">Close</button>'
+            + '</div>'
+            + '</div></div>';
+        document.body.appendChild(node);
+        return node;
+    }
+
+    /** A checkbox list of share targets, or nothing when the caller sees none. */
+    function targetList(legend, items, selected) {
+        var wrap;
+        var box;
+        if (!items || !items.length) {
+            return null;
+        }
+        wrap = el('div', 'col-md-4');
+        wrap.appendChild(el('div', 'fw-semibold small mb-1', legend));
+        box = el('div', 'border rounded p-2 overflow-auto');
+        box.style.maxHeight = '10rem';
+        items.forEach(function (item) {
+            var row = el('div', 'form-check');
+            var input = el('input', 'form-check-input');
+            var label = el('label', 'form-check-label', item.name);
+            var id = 'fogshare-' + legend.toLowerCase() + '-' + item.id;
+            input.type = 'checkbox';
+            input.value = String(item.id);
+            input.id = id;
+            input.checked = (selected || []).indexOf(item.id) !== -1;
+            label.setAttribute('for', id);
+            row.appendChild(input);
+            row.appendChild(label);
+            box.appendChild(row);
+        });
+        wrap.appendChild(box);
+        return wrap;
+    }
+
+    function checkedIds(scope, legend) {
+        return Array.prototype.map.call(
+            scope.querySelectorAll(
+                '[id^="fogshare-' + legend.toLowerCase() + '-"]:checked'
+            ),
+            function (input) { return parseInt(input.value, 10); }
+        );
+    }
+
+    /**
+     * Why this filter is visible to the caller, in one badge.
+     *
+     * The wording names the ROUTE and not the target -- "via a group you are
+     * in" rather than the group's name -- because the group and role lists
+     * are permission-gated (a user may share to a group they cannot
+     * enumerate), and naming them here would hand back exactly what that gate
+     * withholds.
+     */
+    function sourceBadge(filter) {
+        var by = filter.sharedBy ? ' by ' + filter.sharedBy : '';
+        switch (filter.source) {
+        case 'user':
+            return el('span', 'badge bg-info ms-2', 'Shared with you' + by);
+        case 'group':
+            return el(
+                'span', 'badge bg-info ms-2',
+                'Shared with a group you are in' + by
+            );
+        case 'role':
+            return el(
+                'span', 'badge bg-info ms-2',
+                'Shared with a role you hold' + by
+            );
+        default:
+            return el('span', 'badge bg-secondary ms-2', 'Everyone');
+        }
+    }
+
+    /**
+     * Draws the picker.
+     *
+     * Rebuilt from the server's answer every time it opens rather than kept
+     * in sync: it is opened by hand, rarely, and a stale share list is the
+     * one thing here that would silently mislead.
+     */
+    function render(dt, body, data, targets) {
+        var filters = data.filters || [];
+        var current;
+
+        body.innerHTML = '';
+
+        if (!filters.length) {
+            body.appendChild(
+                el('p', 'text-body-secondary',
+                    'No saved filters for this grid yet. Build a filter with'
+                    + ' the Filter button, then save it here.')
+            );
+        } else {
+            filters.forEach(function (filter) {
+                var row = el('div', 'd-flex align-items-center gap-2 border-bottom py-2');
+                var name = el('div', 'flex-grow-1');
+                var apply = el('button', 'btn btn-sm btn-primary', 'Apply');
+                name.appendChild(el('span', 'fw-semibold', filter.name));
+                // One badge, never several: the server has already picked
+                // the most specific reason this row is visible (see
+                // SavedFilterManager::listFor), so a filter that arrives by
+                // three routes at once still reads as one explanation.
+                if (filter.source && filter.source !== 'mine') {
+                    name.appendChild(sourceBadge(filter));
+                }
+                apply.type = 'button';
+                apply.addEventListener('click', function () {
+                    applyFilter(dt, filter);
+                    bootstrap.Modal.getInstance(modal()).hide();
+                });
+                row.appendChild(name);
+
+                if (filter.mine || (filter.global && data.mayShareGlobally)) {
+                    row.appendChild(shareButton(dt, filter, targets));
+                    row.appendChild(renameButton(dt, filter));
+                    row.appendChild(deleteButton(dt, filter));
+                }
+                row.appendChild(apply);
+                body.appendChild(row);
+            });
+        }
+
+        // ---- save the filter that is on the table right now ----
+        current = dt.searchBuilder.getDetails();
+        body.appendChild(el('h6', 'mt-4', 'Save the current filter'));
+        if (!current || !current.criteria || !current.criteria.length) {
+            body.appendChild(
+                el('p', 'text-body-secondary small',
+                    'Nothing is filtered right now. Build a filter with the'
+                    + ' Filter button and come back.')
+            );
+            return;
+        }
+        body.appendChild(saveForm(dt, data, targets, current));
+    }
+
+    function saveForm(dt, data, targets, current) {
+        var form = el('div');
+        var nameRow = el('div', 'input-group mb-3');
+        var input = el('input', 'form-control');
+        var save = el('button', 'btn btn-primary', 'Save');
+        var shares = el('div', 'row g-3');
+        var globalRow;
+
+        input.type = 'text';
+        input.maxLength = 64;
+        input.placeholder = 'Name this filter';
+        nameRow.appendChild(input);
+        nameRow.appendChild(save);
+        form.appendChild(nameRow);
+
+        form.appendChild(
+            el('div', 'fw-semibold small mb-1', 'Share it with (optional)')
+        );
+        [
+            ['Users', targets.users],
+            ['Groups', targets.groups],
+            ['Roles', targets.roles]
+        ].forEach(function (pair) {
+            var list = targetList(pair[0], pair[1], []);
+            if (list) {
+                shares.appendChild(list);
+            }
+        });
+        if (!shares.children.length) {
+            shares.appendChild(
+                el('div', 'text-body-secondary small',
+                    'You do not have permission to list users, groups or'
+                    + ' roles, so this filter can only be private.')
+            );
+        }
+        form.appendChild(shares);
+
+        if (data.mayShareGlobally) {
+            globalRow = el('div', 'form-check mt-3');
+            globalRow.innerHTML =
+                '<input class="form-check-input" type="checkbox"'
+                + ' id="fogFilterGlobal">'
+                + '<label class="form-check-label" for="fogFilterGlobal">'
+                + 'Share with everyone on this server</label>';
+            form.appendChild(globalRow);
+        }
+
+        save.type = 'button';
+        save.addEventListener('click', function () {
+            var name = (input.value || '').trim();
+            var globalBox = document.getElementById('fogFilterGlobal');
+            if (!name) {
+                input.focus();
+                return;
+            }
+            save.disabled = true;
+            $.ajax({
+                url: api('system/savedfilters'),
+                type: 'POST',
+                contentType: 'application/json',
+                global: false,
+                data: JSON.stringify({
+                    table: tableKey(dt),
+                    name: name,
+                    value: JSON.stringify(current),
+                    global: !!(globalBox && globalBox.checked)
+                }),
+                success: function (res) {
+                    var saved = (res.filters || []).filter(function (f) {
+                        return f.name === name;
+                    })[0];
+                    var picked = {
+                        users: checkedIds(form, 'Users'),
+                        groups: checkedIds(form, 'Groups'),
+                        roles: checkedIds(form, 'Roles')
+                    };
+                    // The share list is a second call on purpose: the save
+                    // endpoint upserts by name, so it has no id to give back
+                    // until the row exists. Nothing is lost if this one fails
+                    // -- the filter is already saved, just not yet shared.
+                    if (saved && (picked.users.length || picked.groups.length
+                        || picked.roles.length)) {
+                        $.ajax({
+                            url: api('system/savedfilter/' + saved.id),
+                            type: 'PUT',
+                            contentType: 'application/json',
+                            global: false,
+                            data: JSON.stringify({ shares: picked })
+                        });
+                    }
+                    // Applied immediately: the filter is already ON the table,
+                    // so this only names it -- and the chip is what tells the
+                    // user the save worked.
+                    if (saved) {
+                        showChip(dt, saved.name);
+                    }
+                    bootstrap.Modal.getInstance(modal()).hide();
+                    $.notify('Filter', 'Saved.', 'success');
+                },
+                error: function (xhr) {
+                    save.disabled = false;
+                    $.notifyFromAPI(xhr.responseJSON, xhr);
+                }
+            });
+        });
+
+        return form;
+    }
+
+    function renameButton(dt, filter) {
+        var button = el('button', 'btn btn-sm btn-outline-secondary', 'Rename');
+        button.type = 'button';
+        button.addEventListener('click', function () {
+            var name = window.prompt('New name for this filter', filter.name);
+            if (name === null) {
+                return;
+            }
+            name = name.trim();
+            if (!name || name === filter.name) {
+                return;
+            }
+            $.ajax({
+                url: api('system/savedfilter/' + filter.id),
+                type: 'PUT',
+                contentType: 'application/json',
+                global: false,
+                data: JSON.stringify({ name: name }),
+                success: function () { open(dt); },
+                error: function (xhr) {
+                    $.notifyFromAPI(xhr.responseJSON, xhr);
+                }
+            });
+        });
+        return button;
+    }
+
+    function deleteButton(dt, filter) {
+        // btn-danger and on the LEFT of the row's controls, per the house
+        // rule: destroying something takes deliberate travel.
+        var button = el('button', 'btn btn-sm btn-danger', 'Delete');
+        button.type = 'button';
+        button.addEventListener('click', function () {
+            if (!window.confirm('Delete the filter "' + filter.name + '"?')) {
+                return;
+            }
+            $.ajax({
+                url: api('system/savedfilter/' + filter.id),
+                type: 'DELETE',
+                global: false,
+                success: function () { open(dt); },
+                error: function (xhr) {
+                    $.notifyFromAPI(xhr.responseJSON, xhr);
+                }
+            });
+        });
+        return button;
+    }
+
+    function shareButton(dt, filter, targets) {
+        var button = el('button', 'btn btn-sm btn-outline-secondary', 'Share');
+        button.type = 'button';
+        button.addEventListener('click', function () {
+            $.ajax({
+                url: api('system/savedfilter/' + filter.id),
+                global: false,
+                success: function (res) {
+                    shareEditor(dt, filter, targets, res.shares || {
+                        users: [], groups: [], roles: []
+                    });
+                },
+                error: function (xhr) {
+                    $.notifyFromAPI(xhr.responseJSON, xhr);
+                }
+            });
+        });
+        return button;
+    }
+
+    function shareEditor(dt, filter, targets, selected) {
+        var body = modal().querySelector('.fog-filter-body');
+        var shares = el('div', 'row g-3');
+        var save = el('button', 'btn btn-primary mt-3', 'Save sharing');
+        var back = el('button', 'btn btn-outline-secondary mt-3 me-2', 'Back');
+
+        body.innerHTML = '';
+        body.appendChild(el('h6', null, 'Share "' + filter.name + '"'));
+        [
+            ['Users', targets.users, selected.users],
+            ['Groups', targets.groups, selected.groups],
+            ['Roles', targets.roles, selected.roles]
+        ].forEach(function (spec) {
+            var list = targetList(spec[0], spec[1], spec[2]);
+            if (list) {
+                shares.appendChild(list);
+            }
+        });
+        if (!shares.children.length) {
+            shares.appendChild(
+                el('div', 'text-body-secondary small',
+                    'You do not have permission to list users, groups or roles.')
+            );
+        }
+        body.appendChild(shares);
+        back.type = 'button';
+        back.addEventListener('click', function () { open(dt); });
+        save.type = 'button';
+        save.addEventListener('click', function () {
+            save.disabled = true;
+            $.ajax({
+                url: api('system/savedfilter/' + filter.id),
+                type: 'PUT',
+                contentType: 'application/json',
+                global: false,
+                // Always sent, even when everything is unticked: an empty list
+                // means "shared with nobody" and has to be able to say so.
+                data: JSON.stringify({
+                    shares: {
+                        users: checkedIds(body, 'Users'),
+                        groups: checkedIds(body, 'Groups'),
+                        roles: checkedIds(body, 'Roles')
+                    }
+                }),
+                success: function () {
+                    $.notify('Filter', 'Sharing updated.', 'success');
+                    open(dt);
+                },
+                error: function (xhr) {
+                    save.disabled = false;
+                    $.notifyFromAPI(xhr.responseJSON, xhr);
+                }
+            });
+        });
+        body.appendChild(back);
+        body.appendChild(save);
+    }
+
+    function open(dt) {
+        var node = modal();
+        var body = node.querySelector('.fog-filter-body');
+        body.innerHTML = '';
+        body.appendChild(el('p', 'text-body-secondary', 'Loading...'));
+        bootstrap.Modal.getOrCreateInstance(node).show();
+        loadFilters(dt, function (err, data) {
+            if (err) {
+                body.innerHTML = '';
+                body.appendChild(
+                    el('p', 'text-danger',
+                        'Your saved filters could not be loaded.')
+                );
+                return;
+            }
+            loadTargets(function (targets) {
+                render(dt, body, data, targets);
+            });
+        });
+    }
+
+    window.fogSavedFilters = {
+        open: open,
+        clear: clearFilter,
+        /**
+         * Drops the chip when the filter behind it is gone.
+         *
+         * SearchBuilder is cleared from several places -- its own panel, the
+         * Reset button, a rebuild -- and a chip left behind would name a
+         * filter that is no longer applied, which is worse than no chip.
+         */
+        sync: function (dt) {
+            var details = dt.searchBuilder.getDetails();
+            if (!details || !details.criteria || !details.criteria.length) {
+                clearChip(dt);
+            }
+        }
+    };
+}());

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -329,6 +329,13 @@ msgstr ""
 msgid "A filename is required!"
 msgstr "Ein Gruppenname ist erforderlich!"
 
+msgid "A filter needs a grid and a name"
+msgstr ""
+
+#, fuzzy
+msgid "A filter needs a name"
+msgstr "Bitte geben Sie einen gültigen Hostnamen ein"
+
 #, fuzzy
 msgid "A group already exists with this name!"
 msgstr "Eine Gruppe mit diesem Namen ist bereits vorhanden!"
@@ -2255,6 +2262,10 @@ msgid "Delete a %s"
 msgstr "Löschen fehlgeschlagen"
 
 #, fuzzy
+msgid "Delete a saved filter"
+msgstr "Ausgewählte löschen"
+
+#, fuzzy
 msgid "Delete associated hosts"
 msgstr "Ausgewählte löschen"
 
@@ -2480,6 +2491,9 @@ msgstr "Gruppeneinstellungen Module"
 msgid "Editing Global LDAP Settings"
 msgstr "Gruppeneinstellungen Module"
 
+msgid "Either half may be sent, or both. ABSENT IS NOT EMPTY: a body with no \"shares\" key leaves the share list alone, while one carrying empty lists means \"shared with nobody\" and clears it. The whole list is replaced rather than added to. Sharing needs no permission -- it can only add one named entry to the picker of somebody you could already name -- but editing a GLOBAL filter requires savedfilter.edit."
+msgstr ""
+
 msgid "Email"
 msgstr "E-Mail"
 
@@ -2635,6 +2649,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "Keine Datei wurde hochgeladen"
+
+msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
 msgstr ""
@@ -5844,6 +5861,9 @@ msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
 msgid "No storagegroups assigned to this snapin"
 msgstr "Die zugewiesene Image Speichergruppe ist nicht gültig."
 
+msgid "No such filter"
+msgstr ""
+
 msgid "No such object."
 msgstr ""
 
@@ -5959,6 +5979,10 @@ msgstr "(empfohlen)"
 msgid "Not reported"
 msgstr "(empfohlen)"
 
+#, fuzzy
+msgid "Not signed in"
+msgstr "Nicht synchronisieren"
+
 msgid "Not syncing"
 msgstr "Nicht synchronisieren"
 
@@ -6066,6 +6090,10 @@ msgid "Off - direct membership only"
 msgstr ""
 
 #, fuzzy
+msgid "Offered to every user on this grid."
+msgstr "Dies ist nicht die primäre Gruppe"
+
+#, fuzzy
 msgid "Old key must be a string"
 msgstr "Alter Schlüsselname muss eine Zeichenfolge sein."
 
@@ -6103,6 +6131,10 @@ msgstr "Eine oder mehrere MACs sind mit einem Host verknüpft"
 
 msgid "One preference."
 msgstr ""
+
+#, fuzzy
+msgid "One saved filter."
+msgstr "Drucker-Update fehlgeschlagen!"
 
 msgid "Online"
 msgstr ""
@@ -6894,6 +6926,10 @@ msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
+msgid "Read one saved filter"
+msgstr "Ausgewählte löschen"
+
+#, fuzzy
 msgid "Real Time"
 msgstr "Datum und Zeit"
 
@@ -7020,6 +7056,9 @@ msgid "Removing this group would leave no user with administrator access."
 msgstr ""
 
 msgid "Removing this role would leave no user with administrator access."
+msgstr ""
+
+msgid "Rename a filter, or change who it is shared with"
 msgstr ""
 
 #, fuzzy
@@ -7278,6 +7317,10 @@ msgstr ""
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
+#, fuzzy
+msgid "Save a filter"
+msgstr "Drucker-Update fehlgeschlagen!"
+
 msgid "Save completed but no valid ID was assigned (insertId=0). Possible duplicate-key update or missing auto-increment."
 msgstr ""
 
@@ -7287,9 +7330,15 @@ msgstr ""
 msgid "Save the site before setting catch-all"
 msgstr ""
 
+msgid "Saved filters for one grid"
+msgstr ""
+
 #, fuzzy
 msgid "Saving data for"
 msgstr "Speichern von Daten für %s Objekt"
+
+msgid "Saving over a name you already used replaces that filter rather than adding a second one, which is what a Save button is expected to do. A private save never touches a global of the same name and the other way round. global:true requires savedfilter.create and answers 403 without it; everything else needs only a session. Values are capped at 64KB and refused rather than truncated."
+msgstr ""
 
 msgid "Schedule"
 msgstr "Zeitplan"
@@ -8693,6 +8742,13 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That filter is too large to save"
+msgstr "konnte nicht gespeichert werden"
+
+msgid "That grid name is too long"
+msgstr ""
+
+#, fuzzy
 msgid "That group is already defined for this provider!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
 
@@ -8711,6 +8767,9 @@ msgid "That is the recommended state. Restore it only to issue a new intermediat
 msgstr ""
 
 msgid "That is the signed chain staged by the installer; the default boot file is unsigned and a Secure Boot client will refuse it"
+msgstr ""
+
+msgid "That name is too long"
 msgstr ""
 
 #, fuzzy
@@ -8850,6 +8909,27 @@ msgstr ""
 msgid "The file itself."
 msgstr ""
 
+msgid "The filter state, opaque. It is DataTables SearchBuilder's own serialization and the server does not interpret it."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was deleted."
+msgstr "Keine Datei wurde hochgeladen"
+
+msgid "The filter was saved; the full list is returned."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was updated."
+msgstr "Keine Datei wurde hochgeladen"
+
+msgid "The filters visible to the caller."
+msgstr ""
+
+#, fuzzy
+msgid "The grid key."
+msgstr "Fehler beim Erstellen eines Tasks"
+
 #, fuzzy
 msgid "The identity provider could not be reached"
 msgstr "Temporäre Datei konnte nicht gelesen werden."
@@ -8977,6 +9057,10 @@ msgid "The same rules in prose, for a client reading this at runtime."
 msgstr ""
 
 #, fuzzy
+msgid "The saved filter."
+msgstr "Drucker-Update fehlgeschlagen!"
+
+#, fuzzy
 msgid "The selected site no longer exists"
 msgstr "läuft nicht mehr"
 
@@ -8985,6 +9069,9 @@ msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
 msgstr "Die Einstellungen wirken sich in der Regel auf alle Hosts aus."
+
+msgid "The share targets the caller may see."
+msgstr ""
 
 #, fuzzy
 msgid "The sign-in could not be verified"
@@ -9074,6 +9161,10 @@ msgstr "Es gibt offene Slots,"
 
 msgid "There is a host in a tasking"
 msgstr "Es gibt einen Host in einer Aufgabe"
+
+#, fuzzy
+msgid "There is no filter to save"
+msgstr "konnte nicht gespeichert werden"
 
 msgid "There is nothing to replicate"
 msgstr "Es gibt nichts zu replizieren"
@@ -9919,12 +10010,18 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
+msgid "Username of whoever created it, on filters the caller does not own. Empty when the creator's account has since been deleted."
+msgstr ""
+
 #, fuzzy
 msgid "Username was blank"
 msgstr "Benutzername"
 
 msgid "Users"
 msgstr "Benutzer"
+
+msgid "Users, user groups and roles as id/name pairs. Each section is gated on that entity's own view permission -- user.view, usergroup.view, role.view -- and comes back EMPTY rather than 403 when the caller lacks it, so this route discloses nothing they could not already list. A caller holding none of the three can still save private filters; there is simply nobody they may name."
+msgstr ""
 
 msgid "Using the group match function"
 msgstr "Verwenden der Gruppenübereinstimmungsfunktion,"
@@ -10043,6 +10140,12 @@ msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has 
 msgstr ""
 
 msgid "Who"
+msgstr ""
+
+msgid "Who a filter can be shared with"
+msgstr ""
+
+msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
 msgstr ""
 
 msgid "Width must be 650 pixels."
@@ -10166,6 +10269,12 @@ msgstr ""
 msgid "You do not have permission to view API tokens."
 msgstr ""
 
+msgid "You may not change a filter shared with everyone"
+msgstr ""
+
+msgid "You may not save a filter for everyone"
+msgstr ""
+
 msgid "You may use _, ., -, or a space between."
 msgstr ""
 
@@ -10178,6 +10287,9 @@ msgstr "Sie müssen mindestens eine Speichergruppe haben"
 #, fuzzy
 msgid "You must select an action to perform"
 msgstr "Sie müssen eine Aktion auswählen, die ausgeführt werden soll"
+
+msgid "You own it, so you may rename, re-share or delete it."
+msgstr ""
 
 msgid "You were logged out due to inactivity."
 msgstr ""
@@ -10192,6 +10304,9 @@ msgid "Your session has ended. Sign in again."
 msgstr ""
 
 msgid "Your stored preferences"
+msgstr ""
+
+msgid "Yours, always. A global one requires savedfilter.delete. Every share of it goes with it, by foreign key."
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
@@ -10884,6 +10999,9 @@ msgstr ""
 #, fuzzy
 msgid "settings"
 msgstr "Einstellungen"
+
+msgid "shares is null unless you own the filter: being shared WITH one does not entitle you to see who else it went to. A filter that does not exist and one belonging to somebody else both answer 404, deliberately, so an id cannot be used to probe for other people's filters."
+msgstr ""
 
 msgid "short"
 msgstr ""
@@ -11882,9 +12000,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "has failed to destroy"
 #~ msgstr "konnte nicht zerstört werden"
-
-#~ msgid "has failed to save"
-#~ msgstr "konnte nicht gespeichert werden"
 
 #, fuzzy
 #~ msgid "multicast tasks!"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -334,6 +334,13 @@ msgstr ""
 msgid "A filename is required!"
 msgstr "An image name is required!"
 
+msgid "A filter needs a grid and a name"
+msgstr ""
+
+#, fuzzy
+msgid "A filter needs a name"
+msgstr "Please enter a valid hostname"
+
 #, fuzzy
 msgid "A group already exists with this name!"
 msgstr "An image already exists with this name!"
@@ -2257,6 +2264,10 @@ msgid "Delete a %s"
 msgstr "Delete file data"
 
 #, fuzzy
+msgid "Delete a saved filter"
+msgstr "Delete Selected"
+
+#, fuzzy
 msgid "Delete associated hosts"
 msgstr "Delete Selected"
 
@@ -2482,6 +2493,9 @@ msgstr "Update Settings"
 msgid "Editing Global LDAP Settings"
 msgstr "Update Settings"
 
+msgid "Either half may be sent, or both. ABSENT IS NOT EMPTY: a body with no \"shares\" key leaves the share list alone, while one carrying empty lists means \"shared with nobody\" and clears it. The whole list is replaced rather than added to. Sharing needs no permission -- it can only add one named entry to the picker of somebody you could already name -- but editing a GLOBAL filter requires savedfilter.edit."
+msgstr ""
+
 msgid "Email"
 msgstr "Email"
 
@@ -2636,6 +2650,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "No file was uploaded"
+
+msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
 msgstr ""
@@ -5842,6 +5859,9 @@ msgstr "An image already exists with this name!"
 msgid "No storagegroups assigned to this snapin"
 msgstr "The image storage group assigned is not valid"
 
+msgid "No such filter"
+msgstr ""
+
 msgid "No such object."
 msgstr ""
 
@@ -5956,6 +5976,10 @@ msgstr ""
 msgid "Not reported"
 msgstr "Inventory"
 
+#, fuzzy
+msgid "Not signed in"
+msgstr "Installed Plugins"
+
 msgid "Not syncing"
 msgstr ""
 
@@ -6063,6 +6087,10 @@ msgid "Off - direct membership only"
 msgstr ""
 
 #, fuzzy
+msgid "Offered to every user on this grid."
+msgstr " | This is not the primary group"
+
+#, fuzzy
 msgid "Old key must be a string"
 msgstr "Event must be a string"
 
@@ -6100,6 +6128,10 @@ msgstr "Error, Is an image associated with this host"
 
 msgid "One preference."
 msgstr ""
+
+#, fuzzy
+msgid "One saved filter."
+msgstr "Printer update failed!"
 
 msgid "Online"
 msgstr ""
@@ -6891,6 +6923,10 @@ msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
+msgid "Read one saved filter"
+msgstr "Delete Selected"
+
+#, fuzzy
 msgid "Real Time"
 msgstr "Host Update Failed"
 
@@ -7017,6 +7053,9 @@ msgid "Removing this group would leave no user with administrator access."
 msgstr ""
 
 msgid "Removing this role would leave no user with administrator access."
+msgstr ""
+
+msgid "Rename a filter, or change who it is shared with"
 msgstr ""
 
 #, fuzzy
@@ -7275,6 +7314,10 @@ msgstr ""
 msgid "Save Changes"
 msgstr "Save Changes"
 
+#, fuzzy
+msgid "Save a filter"
+msgstr "Printer update failed!"
+
 msgid "Save completed but no valid ID was assigned (insertId=0). Possible duplicate-key update or missing auto-increment."
 msgstr ""
 
@@ -7284,9 +7327,15 @@ msgstr ""
 msgid "Save the site before setting catch-all"
 msgstr ""
 
+msgid "Saved filters for one grid"
+msgstr ""
+
 #, fuzzy
 msgid "Saving data for"
 msgstr "Saving data for %s object"
+
+msgid "Saving over a name you already used replaces that filter rather than adding a second one, which is what a Save button is expected to do. A private save never touches a global of the same name and the other way round. global:true requires savedfilter.create and answers 403 without it; everything else needs only a session. Values are capped at 64KB and refused rather than truncated."
+msgstr ""
 
 msgid "Schedule"
 msgstr "Schedule"
@@ -8688,6 +8737,13 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That filter is too large to save"
+msgstr "has failed to save"
+
+msgid "That grid name is too long"
+msgstr ""
+
+#, fuzzy
 msgid "That group is already defined for this provider!"
 msgstr "An image already exists with this name!"
 
@@ -8706,6 +8762,9 @@ msgid "That is the recommended state. Restore it only to issue a new intermediat
 msgstr ""
 
 msgid "That is the signed chain staged by the installer; the default boot file is unsigned and a Secure Boot client will refuse it"
+msgstr ""
+
+msgid "That name is too long"
 msgstr ""
 
 #, fuzzy
@@ -8845,6 +8904,27 @@ msgstr ""
 msgid "The file itself."
 msgstr ""
 
+msgid "The filter state, opaque. It is DataTables SearchBuilder's own serialization and the server does not interpret it."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was deleted."
+msgstr "No file was uploaded"
+
+msgid "The filter was saved; the full list is returned."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was updated."
+msgstr "No file was uploaded"
+
+msgid "The filters visible to the caller."
+msgstr ""
+
+#, fuzzy
+msgid "The grid key."
+msgstr "Failed to create task"
+
 #, fuzzy
 msgid "The identity provider could not be reached"
 msgstr "Could not read temp file"
@@ -8972,6 +9052,10 @@ msgid "The same rules in prose, for a client reading this at runtime."
 msgstr ""
 
 #, fuzzy
+msgid "The saved filter."
+msgstr "Printer update failed!"
+
+#, fuzzy
 msgid "The selected site no longer exists"
 msgstr " no longer exists"
 
@@ -8979,6 +9063,9 @@ msgid "The server refuses to activate this plugin, or the plugin declares no sch
 msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
+msgstr ""
+
+msgid "The share targets the caller may see."
 msgstr ""
 
 #, fuzzy
@@ -9069,6 +9156,10 @@ msgstr "There are open slots, but"
 
 msgid "There is a host in a tasking"
 msgstr "There is a host in a tasking"
+
+#, fuzzy
+msgid "There is no filter to save"
+msgstr "has failed to save"
 
 msgid "There is nothing to replicate"
 msgstr "There is nothing to replicate"
@@ -9914,12 +10005,18 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
+msgid "Username of whoever created it, on filters the caller does not own. Empty when the creator's account has since been deleted."
+msgstr ""
+
 #, fuzzy
 msgid "Username was blank"
 msgstr "Username"
 
 msgid "Users"
 msgstr "Users"
+
+msgid "Users, user groups and roles as id/name pairs. Each section is gated on that entity's own view permission -- user.view, usergroup.view, role.view -- and comes back EMPTY rather than 403 when the caller lacks it, so this route discloses nothing they could not already list. A caller holding none of the three can still save private filters; there is simply nobody they may name."
+msgstr ""
 
 msgid "Using the group match function"
 msgstr ""
@@ -10037,6 +10134,12 @@ msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has 
 msgstr ""
 
 msgid "Who"
+msgstr ""
+
+msgid "Who a filter can be shared with"
+msgstr ""
+
+msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
 msgstr ""
 
 msgid "Width must be 650 pixels."
@@ -10161,6 +10264,12 @@ msgstr ""
 msgid "You do not have permission to view API tokens."
 msgstr ""
 
+msgid "You may not change a filter shared with everyone"
+msgstr ""
+
+msgid "You may not save a filter for everyone"
+msgstr ""
+
 msgid "You may use _, ., -, or a space between."
 msgstr ""
 
@@ -10173,6 +10282,9 @@ msgstr "You must have at least one Storage Group"
 #, fuzzy
 msgid "You must select an action to perform"
 msgstr "You must specify the alias and port"
+
+msgid "You own it, so you may rename, re-share or delete it."
+msgstr ""
 
 msgid "You were logged out due to inactivity."
 msgstr ""
@@ -10187,6 +10299,9 @@ msgid "Your session has ended. Sign in again."
 msgstr ""
 
 msgid "Your stored preferences"
+msgstr ""
+
+msgid "Yours, always. A global one requires savedfilter.delete. Every share of it goes with it, by foreign key."
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
@@ -10875,6 +10990,9 @@ msgstr ""
 #, fuzzy
 msgid "settings"
 msgstr "Settings"
+
+msgid "shares is null unless you own the filter: being shared WITH one does not entitle you to see who else it went to. A filter that does not exist and one belonging to somebody else both answer 404, deliberately, so an id cannot be used to probe for other people's filters."
+msgstr ""
 
 msgid "short"
 msgstr ""
@@ -11832,9 +11950,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "has failed to destroy"
 #~ msgstr "has failed to be destroyed"
-
-#~ msgid "has failed to save"
-#~ msgstr "has failed to save"
 
 #, fuzzy
 #~ msgid "multicast tasks!"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -332,6 +332,13 @@ msgstr ""
 msgid "A filename is required!"
 msgstr "Se requiere un nombre de imagen!"
 
+msgid "A filter needs a grid and a name"
+msgstr ""
+
+#, fuzzy
+msgid "A filter needs a name"
+msgstr "Por favor introduce un nombre de sesión"
+
 #, fuzzy
 msgid "A group already exists with this name!"
 msgstr "Una imagen ya existe con este nombre!"
@@ -2283,6 +2290,10 @@ msgid "Delete a %s"
 msgstr "Eliminar los datos del archivo"
 
 #, fuzzy
+msgid "Delete a saved filter"
+msgstr "Eliminar seleccionado"
+
+#, fuzzy
 msgid "Delete associated hosts"
 msgstr "Eliminar seleccionado"
 
@@ -2515,6 +2526,9 @@ msgstr "Descripción del Grupo"
 msgid "Editing Global LDAP Settings"
 msgstr "Descripción del Grupo"
 
+msgid "Either half may be sent, or both. ABSENT IS NOT EMPTY: a body with no \"shares\" key leaves the share list alone, while one carrying empty lists means \"shared with nobody\" and clears it. The whole list is replaced rather than added to. Sharing needs no permission -- it can only add one named entry to the picker of somebody you could already name -- but editing a GLOBAL filter requires savedfilter.edit."
+msgstr ""
+
 #, fuzzy
 msgid "Email"
 msgstr "Diariamente"
@@ -2671,6 +2685,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "Ningún archivo fue subido"
+
+msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
 msgstr ""
@@ -5966,6 +5983,9 @@ msgstr "Una imagen ya existe con este nombre!"
 msgid "No storagegroups assigned to this snapin"
 msgstr "Marque aquí para ver los grupos no asignado esta imagen"
 
+msgid "No such filter"
+msgstr ""
+
 msgid "No such object."
 msgstr ""
 
@@ -6083,6 +6103,10 @@ msgstr ""
 msgid "Not reported"
 msgstr "ID de inventario"
 
+#, fuzzy
+msgid "Not signed in"
+msgstr "Instalador inteligente (recomendado)"
+
 msgid "Not syncing"
 msgstr ""
 
@@ -6189,6 +6213,9 @@ msgstr ""
 msgid "Off - direct membership only"
 msgstr ""
 
+msgid "Offered to every user on this grid."
+msgstr ""
+
 #, fuzzy
 msgid "Old key must be a string"
 msgstr "Evento debe ser una cadena"
@@ -6227,6 +6254,10 @@ msgstr "Error, es una imagen asociada con este anfitrión"
 
 msgid "One preference."
 msgstr ""
+
+#, fuzzy
+msgid "One saved filter."
+msgstr "actualización de la impresora ha fallado!"
 
 msgid "Online"
 msgstr ""
@@ -7032,6 +7063,10 @@ msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
+msgid "Read one saved filter"
+msgstr "Eliminar seleccionado"
+
+#, fuzzy
 msgid "Real Time"
 msgstr "Tiempo de actividad del sistema"
 
@@ -7161,6 +7196,9 @@ msgid "Removing this group would leave no user with administrator access."
 msgstr ""
 
 msgid "Removing this role would leave no user with administrator access."
+msgstr ""
+
+msgid "Rename a filter, or change who it is shared with"
 msgstr ""
 
 #, fuzzy
@@ -7422,6 +7460,10 @@ msgstr ""
 msgid "Save Changes"
 msgstr "Guardar cambios"
 
+#, fuzzy
+msgid "Save a filter"
+msgstr "actualización de la impresora ha fallado!"
+
 msgid "Save completed but no valid ID was assigned (insertId=0). Possible duplicate-key update or missing auto-increment."
 msgstr ""
 
@@ -7431,9 +7473,15 @@ msgstr ""
 msgid "Save the site before setting catch-all"
 msgstr ""
 
+msgid "Saved filters for one grid"
+msgstr ""
+
 #, fuzzy
 msgid "Saving data for"
 msgstr "Guardar los datos de %s objeto"
+
+msgid "Saving over a name you already used replaces that filter rather than adding a second one, which is what a Save button is expected to do. A private save never touches a global of the same name and the other way round. global:true requires savedfilter.create and answers 403 without it; everything else needs only a session. Values are capped at 64KB and refused rather than truncated."
+msgstr ""
 
 msgid "Schedule"
 msgstr "Programar"
@@ -8872,6 +8920,13 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That filter is too large to save"
+msgstr "no ha logrado ahorrar"
+
+msgid "That grid name is too long"
+msgstr ""
+
+#, fuzzy
 msgid "That group is already defined for this provider!"
 msgstr "Una imagen ya existe con este nombre!"
 
@@ -8890,6 +8945,9 @@ msgid "That is the recommended state. Restore it only to issue a new intermediat
 msgstr ""
 
 msgid "That is the signed chain staged by the installer; the default boot file is unsigned and a Secure Boot client will refuse it"
+msgstr ""
+
+msgid "That name is too long"
 msgstr ""
 
 #, fuzzy
@@ -9027,6 +9085,27 @@ msgstr ""
 msgid "The file itself."
 msgstr ""
 
+msgid "The filter state, opaque. It is DataTables SearchBuilder's own serialization and the server does not interpret it."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was deleted."
+msgstr "Ningún archivo fue subido"
+
+msgid "The filter was saved; the full list is returned."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was updated."
+msgstr "Ningún archivo fue subido"
+
+msgid "The filters visible to the caller."
+msgstr ""
+
+#, fuzzy
+msgid "The grid key."
+msgstr "No se pudo crear la tarea"
+
 #, fuzzy
 msgid "The identity provider could not be reached"
 msgstr "No se pudo leer el archivo temporal"
@@ -9155,6 +9234,10 @@ msgstr ""
 msgid "The same rules in prose, for a client reading this at runtime."
 msgstr ""
 
+#, fuzzy
+msgid "The saved filter."
+msgstr "actualización de la impresora ha fallado!"
+
 msgid "The selected site no longer exists"
 msgstr ""
 
@@ -9162,6 +9245,9 @@ msgid "The server refuses to activate this plugin, or the plugin declares no sch
 msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
+msgstr ""
+
+msgid "The share targets the caller may see."
 msgstr ""
 
 #, fuzzy
@@ -9254,6 +9340,10 @@ msgstr "Existen"
 
 msgid "There is a host in a tasking"
 msgstr "Hay una gran cantidad en una tarea"
+
+#, fuzzy
+msgid "There is no filter to save"
+msgstr "no ha logrado ahorrar"
 
 msgid "There is nothing to replicate"
 msgstr ""
@@ -10096,6 +10186,9 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
+msgid "Username of whoever created it, on filters the caller does not own. Empty when the creator's account has since been deleted."
+msgstr ""
+
 #, fuzzy
 msgid "Username was blank"
 msgstr "Nombre de usuario"
@@ -10103,6 +10196,9 @@ msgstr "Nombre de usuario"
 #, fuzzy
 msgid "Users"
 msgstr "Usuario"
+
+msgid "Users, user groups and roles as id/name pairs. Each section is gated on that entity's own view permission -- user.view, usergroup.view, role.view -- and comes back EMPTY rather than 403 when the caller lacks it, so this route discloses nothing they could not already list. A caller holding none of the three can still save private filters; there is simply nobody they may name."
+msgstr ""
 
 msgid "Using the group match function"
 msgstr ""
@@ -10219,6 +10315,12 @@ msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has 
 msgstr ""
 
 msgid "Who"
+msgstr ""
+
+msgid "Who a filter can be shared with"
+msgstr ""
+
+msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
 msgstr ""
 
 msgid "Width must be 650 pixels."
@@ -10343,6 +10445,12 @@ msgstr ""
 msgid "You do not have permission to view API tokens."
 msgstr ""
 
+msgid "You may not change a filter shared with everyone"
+msgstr ""
+
+msgid "You may not save a filter for everyone"
+msgstr ""
+
 msgid "You may use _, ., -, or a space between."
 msgstr ""
 
@@ -10357,6 +10465,9 @@ msgstr "Debe tener al menos un grupo de almacenamiento"
 msgid "You must select an action to perform"
 msgstr "Debe especificar el alias y el puerto"
 
+msgid "You own it, so you may rename, re-share or delete it."
+msgstr ""
+
 msgid "You were logged out due to inactivity."
 msgstr ""
 
@@ -10370,6 +10481,9 @@ msgid "Your session has ended. Sign in again."
 msgstr ""
 
 msgid "Your stored preferences"
+msgstr ""
+
+msgid "Yours, always. A global one requires savedfilter.delete. Every share of it goes with it, by foreign key."
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
@@ -11057,6 +11171,9 @@ msgstr ""
 #, fuzzy
 msgid "settings"
 msgstr "Configuración Tecla"
+
+msgid "shares is null unless you own the filter: being shared WITH one does not entitle you to see who else it went to. A filter that does not exist and one belonging to somebody else both answer 404, deliberately, so an id cannot be used to probe for other people's filters."
+msgstr ""
 
 msgid "short"
 msgstr ""
@@ -12006,9 +12123,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "has failed to destroy"
 #~ msgstr "ha dejado de ser destruido"
-
-#~ msgid "has failed to save"
-#~ msgstr "no ha logrado ahorrar"
 
 #, fuzzy
 #~ msgid "multicast tasks!"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -329,6 +329,13 @@ msgstr ""
 msgid "A filename is required!"
 msgstr "Ein Gruppenname ist erforderlich!"
 
+msgid "A filter needs a grid and a name"
+msgstr ""
+
+#, fuzzy
+msgid "A filter needs a name"
+msgstr "Bitte geben Sie einen gültigen Hostnamen ein"
+
 #, fuzzy
 msgid "A group already exists with this name!"
 msgstr "Eine Gruppe mit diesem Namen ist bereits vorhanden!"
@@ -2255,6 +2262,10 @@ msgid "Delete a %s"
 msgstr "Löschen fehlgeschlagen"
 
 #, fuzzy
+msgid "Delete a saved filter"
+msgstr "Ausgewählte löschen"
+
+#, fuzzy
 msgid "Delete associated hosts"
 msgstr "Ausgewählte löschen"
 
@@ -2480,6 +2491,9 @@ msgstr "Gruppeneinstellungen Module"
 msgid "Editing Global LDAP Settings"
 msgstr "Gruppeneinstellungen Module"
 
+msgid "Either half may be sent, or both. ABSENT IS NOT EMPTY: a body with no \"shares\" key leaves the share list alone, while one carrying empty lists means \"shared with nobody\" and clears it. The whole list is replaced rather than added to. Sharing needs no permission -- it can only add one named entry to the picker of somebody you could already name -- but editing a GLOBAL filter requires savedfilter.edit."
+msgstr ""
+
 msgid "Email"
 msgstr "E-Mail"
 
@@ -2635,6 +2649,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "Keine Datei wurde hochgeladen"
+
+msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
 msgstr ""
@@ -5845,6 +5862,9 @@ msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
 msgid "No storagegroups assigned to this snapin"
 msgstr "Die zugewiesene Image Speichergruppe ist nicht gültig."
 
+msgid "No such filter"
+msgstr ""
+
 msgid "No such object."
 msgstr ""
 
@@ -5960,6 +5980,10 @@ msgstr "(empfohlen)"
 msgid "Not reported"
 msgstr "(empfohlen)"
 
+#, fuzzy
+msgid "Not signed in"
+msgstr "Nicht synchronisieren"
+
 msgid "Not syncing"
 msgstr "Nicht synchronisieren"
 
@@ -6067,6 +6091,10 @@ msgid "Off - direct membership only"
 msgstr ""
 
 #, fuzzy
+msgid "Offered to every user on this grid."
+msgstr "Dies ist nicht die primäre Gruppe"
+
+#, fuzzy
 msgid "Old key must be a string"
 msgstr "Alter Schlüsselname muss eine Zeichenfolge sein."
 
@@ -6104,6 +6132,10 @@ msgstr "Eine oder mehrere MACs sind mit einem Host verknüpft"
 
 msgid "One preference."
 msgstr ""
+
+#, fuzzy
+msgid "One saved filter."
+msgstr "Drucker-Update fehlgeschlagen!"
 
 msgid "Online"
 msgstr ""
@@ -6895,6 +6927,10 @@ msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
+msgid "Read one saved filter"
+msgstr "Ausgewählte löschen"
+
+#, fuzzy
 msgid "Real Time"
 msgstr "Datum und Zeit"
 
@@ -7021,6 +7057,9 @@ msgid "Removing this group would leave no user with administrator access."
 msgstr ""
 
 msgid "Removing this role would leave no user with administrator access."
+msgstr ""
+
+msgid "Rename a filter, or change who it is shared with"
 msgstr ""
 
 #, fuzzy
@@ -7279,6 +7318,10 @@ msgstr ""
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
+#, fuzzy
+msgid "Save a filter"
+msgstr "Drucker-Update fehlgeschlagen!"
+
 msgid "Save completed but no valid ID was assigned (insertId=0). Possible duplicate-key update or missing auto-increment."
 msgstr ""
 
@@ -7288,9 +7331,15 @@ msgstr ""
 msgid "Save the site before setting catch-all"
 msgstr ""
 
+msgid "Saved filters for one grid"
+msgstr ""
+
 #, fuzzy
 msgid "Saving data for"
 msgstr "Speichern von Daten für %s Objekt"
+
+msgid "Saving over a name you already used replaces that filter rather than adding a second one, which is what a Save button is expected to do. A private save never touches a global of the same name and the other way round. global:true requires savedfilter.create and answers 403 without it; everything else needs only a session. Values are capped at 64KB and refused rather than truncated."
+msgstr ""
 
 msgid "Schedule"
 msgstr "Zeitplan"
@@ -8694,6 +8743,13 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That filter is too large to save"
+msgstr "konnte nicht gespeichert werden"
+
+msgid "That grid name is too long"
+msgstr ""
+
+#, fuzzy
 msgid "That group is already defined for this provider!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
 
@@ -8712,6 +8768,9 @@ msgid "That is the recommended state. Restore it only to issue a new intermediat
 msgstr ""
 
 msgid "That is the signed chain staged by the installer; the default boot file is unsigned and a Secure Boot client will refuse it"
+msgstr ""
+
+msgid "That name is too long"
 msgstr ""
 
 #, fuzzy
@@ -8851,6 +8910,27 @@ msgstr ""
 msgid "The file itself."
 msgstr ""
 
+msgid "The filter state, opaque. It is DataTables SearchBuilder's own serialization and the server does not interpret it."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was deleted."
+msgstr "Keine Datei wurde hochgeladen"
+
+msgid "The filter was saved; the full list is returned."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was updated."
+msgstr "Keine Datei wurde hochgeladen"
+
+msgid "The filters visible to the caller."
+msgstr ""
+
+#, fuzzy
+msgid "The grid key."
+msgstr "Fehler beim Erstellen eines Tasks"
+
 #, fuzzy
 msgid "The identity provider could not be reached"
 msgstr "Temporäre Datei konnte nicht gelesen werden."
@@ -8978,6 +9058,10 @@ msgid "The same rules in prose, for a client reading this at runtime."
 msgstr ""
 
 #, fuzzy
+msgid "The saved filter."
+msgstr "Drucker-Update fehlgeschlagen!"
+
+#, fuzzy
 msgid "The selected site no longer exists"
 msgstr "läuft nicht mehr"
 
@@ -8986,6 +9070,9 @@ msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
 msgstr "Die Einstellungen wirken sich in der Regel auf alle Hosts aus."
+
+msgid "The share targets the caller may see."
+msgstr ""
 
 #, fuzzy
 msgid "The sign-in could not be verified"
@@ -9075,6 +9162,10 @@ msgstr "Es gibt offene Slots,"
 
 msgid "There is a host in a tasking"
 msgstr "Es gibt einen Host in einer Aufgabe"
+
+#, fuzzy
+msgid "There is no filter to save"
+msgstr "konnte nicht gespeichert werden"
 
 msgid "There is nothing to replicate"
 msgstr "Es gibt nichts zu replizieren"
@@ -9920,12 +10011,18 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
+msgid "Username of whoever created it, on filters the caller does not own. Empty when the creator's account has since been deleted."
+msgstr ""
+
 #, fuzzy
 msgid "Username was blank"
 msgstr "Benutzername"
 
 msgid "Users"
 msgstr "Benutzer"
+
+msgid "Users, user groups and roles as id/name pairs. Each section is gated on that entity's own view permission -- user.view, usergroup.view, role.view -- and comes back EMPTY rather than 403 when the caller lacks it, so this route discloses nothing they could not already list. A caller holding none of the three can still save private filters; there is simply nobody they may name."
+msgstr ""
 
 msgid "Using the group match function"
 msgstr "Verwenden der Gruppenübereinstimmungsfunktion,"
@@ -10044,6 +10141,12 @@ msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has 
 msgstr ""
 
 msgid "Who"
+msgstr ""
+
+msgid "Who a filter can be shared with"
+msgstr ""
+
+msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
 msgstr ""
 
 msgid "Width must be 650 pixels."
@@ -10167,6 +10270,12 @@ msgstr ""
 msgid "You do not have permission to view API tokens."
 msgstr ""
 
+msgid "You may not change a filter shared with everyone"
+msgstr ""
+
+msgid "You may not save a filter for everyone"
+msgstr ""
+
 msgid "You may use _, ., -, or a space between."
 msgstr ""
 
@@ -10179,6 +10288,9 @@ msgstr "Sie müssen mindestens eine Speichergruppe haben"
 #, fuzzy
 msgid "You must select an action to perform"
 msgstr "Sie müssen eine Aktion auswählen, die ausgeführt werden soll"
+
+msgid "You own it, so you may rename, re-share or delete it."
+msgstr ""
 
 msgid "You were logged out due to inactivity."
 msgstr ""
@@ -10193,6 +10305,9 @@ msgid "Your session has ended. Sign in again."
 msgstr ""
 
 msgid "Your stored preferences"
+msgstr ""
+
+msgid "Yours, always. A global one requires savedfilter.delete. Every share of it goes with it, by foreign key."
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
@@ -10885,6 +11000,9 @@ msgstr ""
 #, fuzzy
 msgid "settings"
 msgstr "Einstellungen"
+
+msgid "shares is null unless you own the filter: being shared WITH one does not entitle you to see who else it went to. A filter that does not exist and one belonging to somebody else both answer 404, deliberately, so an id cannot be used to probe for other people's filters."
+msgstr ""
 
 msgid "short"
 msgstr ""
@@ -11883,9 +12001,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "has failed to destroy"
 #~ msgstr "konnte nicht zerstört werden"
-
-#~ msgid "has failed to save"
-#~ msgstr "konnte nicht gespeichert werden"
 
 #, fuzzy
 #~ msgid "multicast tasks!"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -335,6 +335,13 @@ msgstr ""
 msgid "A filename is required!"
 msgstr "Un nom de l'image est nécessaire!"
 
+msgid "A filter needs a grid and a name"
+msgstr ""
+
+#, fuzzy
+msgid "A filter needs a name"
+msgstr "S'il vous plaît entrer un nom d'hôte valide"
+
 #, fuzzy
 msgid "A group already exists with this name!"
 msgstr "Une image existe déjà avec ce nom!"
@@ -2259,6 +2266,10 @@ msgid "Delete a %s"
 msgstr "Supprimer les données de fichiers"
 
 #, fuzzy
+msgid "Delete a saved filter"
+msgstr "Supprimer sélectionnée"
+
+#, fuzzy
 msgid "Delete associated hosts"
 msgstr "Supprimer sélectionnée"
 
@@ -2484,6 +2495,9 @@ msgstr "hôte description de"
 msgid "Editing Global LDAP Settings"
 msgstr "hôte description de"
 
+msgid "Either half may be sent, or both. ABSENT IS NOT EMPTY: a body with no \"shares\" key leaves the share list alone, while one carrying empty lists means \"shared with nobody\" and clears it. The whole list is replaced rather than added to. Sharing needs no permission -- it can only add one named entry to the picker of somebody you could already name -- but editing a GLOBAL filter requires savedfilter.edit."
+msgstr ""
+
 msgid "Email"
 msgstr "Email"
 
@@ -2638,6 +2652,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "Aucun fichier a été téléchargé"
+
+msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
 msgstr ""
@@ -5844,6 +5861,9 @@ msgstr "Une image existe déjà avec ce nom!"
 msgid "No storagegroups assigned to this snapin"
 msgstr "Le groupe de stockage d'images attribuée est non valable"
 
+msgid "No such filter"
+msgstr ""
+
 msgid "No such object."
 msgstr ""
 
@@ -5958,6 +5978,10 @@ msgstr ""
 msgid "Not reported"
 msgstr "Inventaire"
 
+#, fuzzy
+msgid "Not signed in"
+msgstr "Plugins installés"
+
 msgid "Not syncing"
 msgstr ""
 
@@ -6065,6 +6089,10 @@ msgid "Off - direct membership only"
 msgstr ""
 
 #, fuzzy
+msgid "Offered to every user on this grid."
+msgstr " | Cela ne veut pas le groupe principal"
+
+#, fuzzy
 msgid "Old key must be a string"
 msgstr "Événement doit être une chaîne"
 
@@ -6102,6 +6130,10 @@ msgstr "Erreur, est une image associée à cet hôte"
 
 msgid "One preference."
 msgstr ""
+
+#, fuzzy
+msgid "One saved filter."
+msgstr "mise à jour de l'imprimante a échoué!"
 
 msgid "Online"
 msgstr ""
@@ -6893,6 +6925,10 @@ msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
+msgid "Read one saved filter"
+msgstr "Supprimer sélectionnée"
+
+#, fuzzy
 msgid "Real Time"
 msgstr "Mise à jour de l'hôte a échoué"
 
@@ -7019,6 +7055,9 @@ msgid "Removing this group would leave no user with administrator access."
 msgstr ""
 
 msgid "Removing this role would leave no user with administrator access."
+msgstr ""
+
+msgid "Rename a filter, or change who it is shared with"
 msgstr ""
 
 #, fuzzy
@@ -7277,6 +7316,10 @@ msgstr ""
 msgid "Save Changes"
 msgstr "Sauvegarder les modifications"
 
+#, fuzzy
+msgid "Save a filter"
+msgstr "mise à jour de l'imprimante a échoué!"
+
 msgid "Save completed but no valid ID was assigned (insertId=0). Possible duplicate-key update or missing auto-increment."
 msgstr ""
 
@@ -7286,9 +7329,15 @@ msgstr ""
 msgid "Save the site before setting catch-all"
 msgstr ""
 
+msgid "Saved filters for one grid"
+msgstr ""
+
 #, fuzzy
 msgid "Saving data for"
 msgstr "Enregistrement des données pour %s l'objet"
+
+msgid "Saving over a name you already used replaces that filter rather than adding a second one, which is what a Save button is expected to do. A private save never touches a global of the same name and the other way round. global:true requires savedfilter.create and answers 403 without it; everything else needs only a session. Values are capped at 64KB and refused rather than truncated."
+msgstr ""
 
 msgid "Schedule"
 msgstr "Programme"
@@ -8690,6 +8739,13 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That filter is too large to save"
+msgstr "n'a pas réussi à sauver"
+
+msgid "That grid name is too long"
+msgstr ""
+
+#, fuzzy
 msgid "That group is already defined for this provider!"
 msgstr "Une image existe déjà avec ce nom!"
 
@@ -8708,6 +8764,9 @@ msgid "That is the recommended state. Restore it only to issue a new intermediat
 msgstr ""
 
 msgid "That is the signed chain staged by the installer; the default boot file is unsigned and a Secure Boot client will refuse it"
+msgstr ""
+
+msgid "That name is too long"
 msgstr ""
 
 #, fuzzy
@@ -8847,6 +8906,27 @@ msgstr ""
 msgid "The file itself."
 msgstr ""
 
+msgid "The filter state, opaque. It is DataTables SearchBuilder's own serialization and the server does not interpret it."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was deleted."
+msgstr "Aucun fichier a été téléchargé"
+
+msgid "The filter was saved; the full list is returned."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was updated."
+msgstr "Aucun fichier a été téléchargé"
+
+msgid "The filters visible to the caller."
+msgstr ""
+
+#, fuzzy
+msgid "The grid key."
+msgstr "Impossible de créer la tâche"
+
 #, fuzzy
 msgid "The identity provider could not be reached"
 msgstr "Impossible de lire le fichier temporaire"
@@ -8974,6 +9054,10 @@ msgid "The same rules in prose, for a client reading this at runtime."
 msgstr ""
 
 #, fuzzy
+msgid "The saved filter."
+msgstr "mise à jour de l'imprimante a échoué!"
+
+#, fuzzy
 msgid "The selected site no longer exists"
 msgstr " n'existe plus"
 
@@ -8981,6 +9065,9 @@ msgid "The server refuses to activate this plugin, or the plugin declares no sch
 msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
+msgstr ""
+
+msgid "The share targets the caller may see."
 msgstr ""
 
 #, fuzzy
@@ -9071,6 +9158,10 @@ msgstr "Il y a des fentes ouvertes, mais"
 
 msgid "There is a host in a tasking"
 msgstr "Il y a une foule dans un tasking"
+
+#, fuzzy
+msgid "There is no filter to save"
+msgstr "n'a pas réussi à sauver"
 
 msgid "There is nothing to replicate"
 msgstr "Il n'y a rien à répliquer"
@@ -9916,12 +10007,18 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
+msgid "Username of whoever created it, on filters the caller does not own. Empty when the creator's account has since been deleted."
+msgstr ""
+
 #, fuzzy
 msgid "Username was blank"
 msgstr "Nom d'utilisateur"
 
 msgid "Users"
 msgstr "Utilisateurs"
+
+msgid "Users, user groups and roles as id/name pairs. Each section is gated on that entity's own view permission -- user.view, usergroup.view, role.view -- and comes back EMPTY rather than 403 when the caller lacks it, so this route discloses nothing they could not already list. A caller holding none of the three can still save private filters; there is simply nobody they may name."
+msgstr ""
 
 msgid "Using the group match function"
 msgstr ""
@@ -10039,6 +10136,12 @@ msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has 
 msgstr ""
 
 msgid "Who"
+msgstr ""
+
+msgid "Who a filter can be shared with"
+msgstr ""
+
+msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
 msgstr ""
 
 msgid "Width must be 650 pixels."
@@ -10163,6 +10266,12 @@ msgstr ""
 msgid "You do not have permission to view API tokens."
 msgstr ""
 
+msgid "You may not change a filter shared with everyone"
+msgstr ""
+
+msgid "You may not save a filter for everyone"
+msgstr ""
+
 msgid "You may use _, ., -, or a space between."
 msgstr ""
 
@@ -10175,6 +10284,9 @@ msgstr "Vous devez avoir au moins un groupe de stockage"
 #, fuzzy
 msgid "You must select an action to perform"
 msgstr "Vous devez spécifier l'alias et le port"
+
+msgid "You own it, so you may rename, re-share or delete it."
+msgstr ""
 
 msgid "You were logged out due to inactivity."
 msgstr ""
@@ -10189,6 +10301,9 @@ msgid "Your session has ended. Sign in again."
 msgstr ""
 
 msgid "Your stored preferences"
+msgstr ""
+
+msgid "Yours, always. A global one requires savedfilter.delete. Every share of it goes with it, by foreign key."
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
@@ -10877,6 +10992,9 @@ msgstr ""
 #, fuzzy
 msgid "settings"
 msgstr "Paramètres"
+
+msgid "shares is null unless you own the filter: being shared WITH one does not entitle you to see who else it went to. A filter that does not exist and one belonging to somebody else both answer 404, deliberately, so an id cannot be used to probe for other people's filters."
+msgstr ""
 
 msgid "short"
 msgstr ""
@@ -11838,9 +11956,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "has failed to destroy"
 #~ msgstr "n'a pas réussi à détruire"
-
-#~ msgid "has failed to save"
-#~ msgstr "n'a pas réussi à sauver"
 
 #, fuzzy
 #~ msgid "multicast tasks!"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -330,6 +330,13 @@ msgstr ""
 msgid "A filename is required!"
 msgstr "È richiesto un nome di gruppo!"
 
+msgid "A filter needs a grid and a name"
+msgstr ""
+
+#, fuzzy
+msgid "A filter needs a name"
+msgstr "Si prega di inserire un nome host valido"
+
 msgid "A group already exists with this name!"
 msgstr "Esiste già un gruppo con questo nome!"
 
@@ -2195,6 +2202,10 @@ msgid "Delete a %s"
 msgstr "Cancellare i file"
 
 #, fuzzy
+msgid "Delete a saved filter"
+msgstr "Cancella selezionato"
+
+#, fuzzy
 msgid "Delete associated hosts"
 msgstr "Cancella selezionato"
 
@@ -2416,6 +2427,9 @@ msgstr "Impostazioni modulo del gruppo"
 msgid "Editing Global LDAP Settings"
 msgstr "Impostazioni modulo del gruppo"
 
+msgid "Either half may be sent, or both. ABSENT IS NOT EMPTY: a body with no \"shares\" key leaves the share list alone, while one carrying empty lists means \"shared with nobody\" and clears it. The whole list is replaced rather than added to. Sharing needs no permission -- it can only add one named entry to the picker of somebody you could already name -- but editing a GLOBAL filter requires savedfilter.edit."
+msgstr ""
+
 msgid "Email"
 msgstr "E-mail"
 
@@ -2569,6 +2583,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "Nessun file è stato caricato"
+
+msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
 msgstr ""
@@ -5662,6 +5679,9 @@ msgstr "Un host già esiste con questo nome!"
 msgid "No storagegroups assigned to this snapin"
 msgstr "Il gruppo di archiviazione immagine assegnato non è valido"
 
+msgid "No such filter"
+msgstr ""
+
 msgid "No such object."
 msgstr ""
 
@@ -5772,6 +5792,10 @@ msgstr "Consigliato"
 msgid "Not reported"
 msgstr "Consigliato"
 
+#, fuzzy
+msgid "Not signed in"
+msgstr "Non sincronizzo"
+
 msgid "Not syncing"
 msgstr "Non sincronizzo"
 
@@ -5877,6 +5901,10 @@ msgstr ""
 msgid "Off - direct membership only"
 msgstr ""
 
+#, fuzzy
+msgid "Offered to every user on this grid."
+msgstr "Questo non è il gruppo primario"
+
 msgid "Old key must be a string"
 msgstr "Vecchia chiave deve essere una stringa"
 
@@ -5913,6 +5941,10 @@ msgstr "Uno o più MAC sono associati a questo host"
 
 msgid "One preference."
 msgstr ""
+
+#, fuzzy
+msgid "One saved filter."
+msgstr "Aggiornamento della stampante non è riuscito!"
 
 msgid "Online"
 msgstr ""
@@ -6684,6 +6716,10 @@ msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
+msgid "Read one saved filter"
+msgstr "Cancella selezionato"
+
+#, fuzzy
 msgid "Real Time"
 msgstr "Data e Ora"
 
@@ -6807,6 +6843,9 @@ msgid "Removing this group would leave no user with administrator access."
 msgstr ""
 
 msgid "Removing this role would leave no user with administrator access."
+msgstr ""
+
+msgid "Rename a filter, or change who it is shared with"
 msgstr ""
 
 #, fuzzy
@@ -7057,6 +7096,10 @@ msgstr ""
 msgid "Save Changes"
 msgstr "Salva i cambiamenti"
 
+#, fuzzy
+msgid "Save a filter"
+msgstr "Aggiornamento della stampante non è riuscito!"
+
 msgid "Save completed but no valid ID was assigned (insertId=0). Possible duplicate-key update or missing auto-increment."
 msgstr ""
 
@@ -7066,8 +7109,14 @@ msgstr ""
 msgid "Save the site before setting catch-all"
 msgstr ""
 
+msgid "Saved filters for one grid"
+msgstr ""
+
 msgid "Saving data for"
 msgstr "Salvataggio dei dati per"
+
+msgid "Saving over a name you already used replaces that filter rather than adding a second one, which is what a Save button is expected to do. A private save never touches a global of the same name and the other way round. global:true requires savedfilter.create and answers 403 without it; everything else needs only a session. Values are capped at 64KB and refused rather than truncated."
+msgstr ""
 
 msgid "Schedule"
 msgstr "Programmazione"
@@ -8408,6 +8457,13 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That filter is too large to save"
+msgstr "fallito il salvataggio"
+
+msgid "That grid name is too long"
+msgstr ""
+
+#, fuzzy
 msgid "That group is already defined for this provider!"
 msgstr "Un host già esiste con questo nome!"
 
@@ -8426,6 +8482,9 @@ msgid "That is the recommended state. Restore it only to issue a new intermediat
 msgstr ""
 
 msgid "That is the signed chain staged by the installer; the default boot file is unsigned and a Secure Boot client will refuse it"
+msgstr ""
+
+msgid "That name is too long"
 msgstr ""
 
 #, fuzzy
@@ -8564,6 +8623,27 @@ msgstr ""
 msgid "The file itself."
 msgstr ""
 
+msgid "The filter state, opaque. It is DataTables SearchBuilder's own serialization and the server does not interpret it."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was deleted."
+msgstr "Nessun file è stato caricato"
+
+msgid "The filter was saved; the full list is returned."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was updated."
+msgstr "Nessun file è stato caricato"
+
+msgid "The filters visible to the caller."
+msgstr ""
+
+#, fuzzy
+msgid "The grid key."
+msgstr "Impossibile creare un'attività"
+
 #, fuzzy
 msgid "The identity provider could not be reached"
 msgstr "Impossibile leggere il file temporaneo"
@@ -8690,6 +8770,10 @@ msgid "The same rules in prose, for a client reading this at runtime."
 msgstr ""
 
 #, fuzzy
+msgid "The saved filter."
+msgstr "Aggiornamento della stampante non è riuscito!"
+
+#, fuzzy
 msgid "The selected site no longer exists"
 msgstr "non è più in esecuzione"
 
@@ -8698,6 +8782,9 @@ msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
 msgstr "Le impostazioni tendono ad essere le impostazioni globali che influenzano tutti gli host"
+
+msgid "The share targets the caller may see."
+msgstr ""
 
 #, fuzzy
 msgid "The sign-in could not be verified"
@@ -8783,6 +8870,10 @@ msgstr "Ci sono slot aperti"
 
 msgid "There is a host in a tasking"
 msgstr "C'è un host con un compito"
+
+#, fuzzy
+msgid "There is no filter to save"
+msgstr "fallito il salvataggio"
 
 msgid "There is nothing to replicate"
 msgstr "Non c'è nulla da replicare"
@@ -9604,12 +9695,18 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
+msgid "Username of whoever created it, on filters the caller does not own. Empty when the creator's account has since been deleted."
+msgstr ""
+
 #, fuzzy
 msgid "Username was blank"
 msgstr "Nome utente"
 
 msgid "Users"
 msgstr "utenti"
+
+msgid "Users, user groups and roles as id/name pairs. Each section is gated on that entity's own view permission -- user.view, usergroup.view, role.view -- and comes back EMPTY rather than 403 when the caller lacks it, so this route discloses nothing they could not already list. A caller holding none of the three can still save private filters; there is simply nobody they may name."
+msgstr ""
 
 msgid "Using the group match function"
 msgstr "Utilizzo della funzione di corrispondenza gruppo"
@@ -9722,6 +9819,12 @@ msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has 
 msgstr ""
 
 msgid "Who"
+msgstr ""
+
+msgid "Who a filter can be shared with"
+msgstr ""
+
+msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
 msgstr ""
 
 msgid "Width must be 650 pixels."
@@ -9842,6 +9945,12 @@ msgstr ""
 msgid "You do not have permission to view API tokens."
 msgstr ""
 
+msgid "You may not change a filter shared with everyone"
+msgstr ""
+
+msgid "You may not save a filter for everyone"
+msgstr ""
+
 msgid "You may use _, ., -, or a space between."
 msgstr ""
 
@@ -9853,6 +9962,9 @@ msgstr "È necessario disporre di almeno un gruppo di archiviazione"
 
 msgid "You must select an action to perform"
 msgstr "È necessario selezionare un'azione da eseguire"
+
+msgid "You own it, so you may rename, re-share or delete it."
+msgstr ""
 
 msgid "You were logged out due to inactivity."
 msgstr ""
@@ -9867,6 +9979,9 @@ msgid "Your session has ended. Sign in again."
 msgstr ""
 
 msgid "Your stored preferences"
+msgstr ""
+
+msgid "Yours, always. A global one requires savedfilter.delete. Every share of it goes with it, by foreign key."
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
@@ -10523,6 +10638,9 @@ msgstr ""
 #, fuzzy
 msgid "settings"
 msgstr "impostazioni"
+
+msgid "shares is null unless you own the filter: being shared WITH one does not entitle you to see who else it went to. A filter that does not exist and one belonging to somebody else both answer 404, deliberately, so an id cannot be used to probe for other people's filters."
+msgstr ""
 
 msgid "short"
 msgstr ""
@@ -11481,9 +11599,6 @@ msgstr ""
 
 #~ msgid "has failed to destroy"
 #~ msgstr "è fallita la distruzione"
-
-#~ msgid "has failed to save"
-#~ msgstr "fallito il salvataggio"
 
 #, fuzzy
 #~ msgid "multicast tasks!"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -322,6 +322,13 @@ msgstr "\"snapinfiles[]\" マルチパートフィールドを使用して、1 �
 msgid "A filename is required!"
 msgstr "名前は必須です！"
 
+msgid "A filter needs a grid and a name"
+msgstr ""
+
+#, fuzzy
+msgid "A filter needs a name"
+msgstr "ホスト名を入力してください"
+
 msgid "A group already exists with this name!"
 msgstr "この名前のグループは既に存在します！"
 
@@ -2179,6 +2186,10 @@ msgid "Delete a %s"
 msgstr "削除に失敗しました"
 
 #, fuzzy
+msgid "Delete a saved filter"
+msgstr "ファイルを削除"
+
+#, fuzzy
 msgid "Delete associated hosts"
 msgstr "選択したホストを削除"
 
@@ -2399,6 +2410,9 @@ msgstr "グループモジュール設定"
 msgid "Editing Global LDAP Settings"
 msgstr "グループモジュール設定"
 
+msgid "Either half may be sent, or both. ABSENT IS NOT EMPTY: a body with no \"shares\" key leaves the share list alone, while one carrying empty lists means \"shared with nobody\" and clears it. The whole list is replaced rather than added to. Sharing needs no permission -- it can only add one named entry to the picker of somebody you could already name -- but editing a GLOBAL filter requires savedfilter.edit."
+msgstr ""
+
 msgid "Email"
 msgstr "メール"
 
@@ -2552,6 +2566,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "ファイルはアップロードされませんでした"
+
+msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
 msgstr ""
@@ -5624,6 +5641,10 @@ msgstr "このイメージを削除できる有効なマスターノードがあ
 msgid "No storagegroups assigned to this snapin"
 msgstr "割り当てられたイメージのストレージグループが無効です"
 
+#, fuzzy
+msgid "No such filter"
+msgstr "サイトがありません"
+
 msgid "No such object."
 msgstr ""
 
@@ -5733,6 +5754,10 @@ msgstr "保護されていません"
 msgid "Not reported"
 msgstr "保護されていません"
 
+#, fuzzy
+msgid "Not signed in"
+msgstr "同期していません"
+
 msgid "Not syncing"
 msgstr "同期していません"
 
@@ -5839,6 +5864,10 @@ msgstr ""
 msgid "Off - direct membership only"
 msgstr ""
 
+#, fuzzy
+msgid "Offered to every user on this grid."
+msgstr "このグループ内のすべてのホストでこの項目をクリアします。"
+
 msgid "Old key must be a string"
 msgstr "古いキーは文字列である必要があります"
 
@@ -5875,6 +5904,10 @@ msgstr "1 つ以上の MAC アドレスがホストに関連付けられてい�
 
 msgid "One preference."
 msgstr ""
+
+#, fuzzy
+msgid "One saved filter."
+msgstr "サイトの更新に失敗しました！"
 
 msgid "Online"
 msgstr ""
@@ -6651,6 +6684,10 @@ msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
+msgid "Read one saved filter"
+msgstr "関連付けを削除"
+
+#, fuzzy
 msgid "Real Time"
 msgstr "日時"
 
@@ -6773,6 +6810,9 @@ msgid "Removing this group would leave no user with administrator access."
 msgstr ""
 
 msgid "Removing this role would leave no user with administrator access."
+msgstr ""
+
+msgid "Rename a filter, or change who it is shared with"
 msgstr ""
 
 msgid "Rename or remove one of them."
@@ -7015,6 +7055,10 @@ msgstr ""
 msgid "Save Changes"
 msgstr "変更を保存"
 
+#, fuzzy
+msgid "Save a filter"
+msgstr "サイトの更新に失敗しました！"
+
 msgid "Save completed but no valid ID was assigned (insertId=0). Possible duplicate-key update or missing auto-increment."
 msgstr "保存は完了しましたが、有効な ID が割り当てられませんでした（insertId=0）。重複キーによる更新、または自動採番が設定されていない可能性があります。"
 
@@ -7025,8 +7069,14 @@ msgstr "Initrd を保存"
 msgid "Save the site before setting catch-all"
 msgstr ""
 
+msgid "Saved filters for one grid"
+msgstr ""
+
 msgid "Saving data for"
 msgstr "次のデータを保存しています:"
+
+msgid "Saving over a name you already used replaces that filter rather than adding a second one, which is what a Save button is expected to do. A private save never touches a global of the same name and the other way round. global:true requires savedfilter.create and answers 403 without it; everything else needs only a session. Values are capped at 64KB and refused rather than truncated."
+msgstr ""
 
 msgid "Schedule"
 msgstr "スケジュール"
@@ -8349,6 +8399,13 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That filter is too large to save"
+msgstr "保存に失敗しました"
+
+msgid "That grid name is too long"
+msgstr ""
+
+#, fuzzy
 msgid "That group is already defined for this provider!"
 msgstr "このグループは既にサブネットグループで使用されています。"
 
@@ -8367,6 +8424,9 @@ msgid "That is the recommended state. Restore it only to issue a new intermediat
 msgstr ""
 
 msgid "That is the signed chain staged by the installer; the default boot file is unsigned and a Secure Boot client will refuse it"
+msgstr ""
+
+msgid "That name is too long"
 msgstr ""
 
 #, fuzzy
@@ -8504,6 +8564,27 @@ msgstr ""
 msgid "The file itself."
 msgstr ""
 
+msgid "The filter state, opaque. It is DataTables SearchBuilder's own serialization and the server does not interpret it."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was deleted."
+msgstr "ファイルはアップロードされませんでした"
+
+msgid "The filter was saved; the full list is returned."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was updated."
+msgstr "ファイルはアップロードされませんでした"
+
+msgid "The filters visible to the caller."
+msgstr ""
+
+#, fuzzy
+msgid "The grid key."
+msgstr "タスクの作成に失敗しました"
+
 #, fuzzy
 msgid "The identity provider could not be reached"
 msgstr "強制終了できませんでした"
@@ -8632,6 +8713,10 @@ msgid "The same rules in prose, for a client reading this at runtime."
 msgstr ""
 
 #, fuzzy
+msgid "The saved filter."
+msgstr "サイトの更新に失敗しました！"
+
+#, fuzzy
 msgid "The selected site no longer exists"
 msgstr "選択したプリンターを追加"
 
@@ -8640,6 +8725,9 @@ msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
 msgstr "これらの設定は通常グローバル設定であり、すべてのホストに影響します。"
+
+msgid "The share targets the caller may see."
+msgstr ""
 
 #, fuzzy
 msgid "The sign-in could not be verified"
@@ -8726,6 +8814,10 @@ msgstr "空きスロットがあります"
 
 msgid "There is a host in a tasking"
 msgstr "タスク実行中のホストがあります"
+
+#, fuzzy
+msgid "There is no filter to save"
+msgstr "保存に失敗しました"
 
 msgid "There is nothing to replicate"
 msgstr "レプリケーションする項目はありません"
@@ -9549,12 +9641,18 @@ msgstr "ユーザー名は 3 文字以上で指定してください"
 msgid "Username must end with a number or letter."
 msgstr "ユーザー名は英数字またはアンダースコアで開始する必要があります"
 
+msgid "Username of whoever created it, on filters the caller does not own. Empty when the creator's account has since been deleted."
+msgstr ""
+
 #, fuzzy
 msgid "Username was blank"
 msgstr "ユーザー名"
 
 msgid "Users"
 msgstr "ユーザー"
+
+msgid "Users, user groups and roles as id/name pairs. Each section is gated on that entity's own view permission -- user.view, usergroup.view, role.view -- and comes back EMPTY rather than 403 when the caller lacks it, so this route discloses nothing they could not already list. A caller holding none of the three can still save private filters; there is simply nobody they may name."
+msgstr ""
 
 msgid "Using the group match function"
 msgstr "グループ照合機能を使用しています"
@@ -9666,6 +9764,12 @@ msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has 
 msgstr ""
 
 msgid "Who"
+msgstr ""
+
+msgid "Who a filter can be shared with"
+msgstr ""
+
+msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
 msgstr ""
 
 msgid "Width must be 650 pixels."
@@ -9786,6 +9890,12 @@ msgstr "少なくとも 1 つのグループを関連付ける必要がありま
 msgid "You do not have permission to view API tokens."
 msgstr "少なくとも 1 つのグループを関連付ける必要があります"
 
+msgid "You may not change a filter shared with everyone"
+msgstr ""
+
+msgid "You may not save a filter for everyone"
+msgstr ""
+
 msgid "You may use _, ., -, or a space between."
 msgstr ""
 
@@ -9797,6 +9907,9 @@ msgstr "少なくとも 1 つのストレージグループが必要です"
 
 msgid "You must select an action to perform"
 msgstr "実行する操作を選択してください"
+
+msgid "You own it, so you may rename, re-share or delete it."
+msgstr ""
 
 msgid "You were logged out due to inactivity."
 msgstr ""
@@ -9811,6 +9924,9 @@ msgid "Your session has ended. Sign in again."
 msgstr ""
 
 msgid "Your stored preferences"
+msgstr ""
+
+msgid "Yours, always. A global one requires savedfilter.delete. Every share of it goes with it, by foreign key."
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
@@ -10470,6 +10586,9 @@ msgstr "このノードはオンラインではないようです"
 msgid "settings"
 msgstr "設定"
 
+msgid "shares is null unless you own the filter: being shared WITH one does not entitle you to see who else it went to. A filter that does not exist and one belonging to somebody else both answer 404, deliberately, so an id cannot be used to probe for other people's filters."
+msgstr ""
+
 msgid "short"
 msgstr ""
 
@@ -11096,9 +11215,6 @@ msgstr ""
 
 #~ msgid "Delete all PM tasks?"
 #~ msgstr "すべての電源管理タスクを削除しますか？"
-
-#~ msgid "Delete files"
-#~ msgstr "ファイルを削除"
 
 #~ msgid "Delete hosts within"
 #~ msgstr "含まれるホストを削除"
@@ -12012,9 +12128,6 @@ msgstr ""
 
 #~ msgid "No rule selected"
 #~ msgstr "ルールが選択されていません"
-
-#~ msgid "No site"
-#~ msgstr "サイトがありません"
 
 #~ msgid "No valid Image defined for this host"
 #~ msgstr "このホストに有効なイメージが定義されていません"
@@ -12971,9 +13084,6 @@ msgstr ""
 
 #~ msgid "has failed to destroy"
 #~ msgstr "削除に失敗しました"
-
-#~ msgid "has failed to save"
-#~ msgstr "保存に失敗しました"
 
 #~ msgid "help with any aspect of FOG"
 #~ msgstr "FOG に関するあらゆるサポート"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -298,6 +298,12 @@ msgstr ""
 msgid "A filename is required!"
 msgstr ""
 
+msgid "A filter needs a grid and a name"
+msgstr ""
+
+msgid "A filter needs a name"
+msgstr ""
+
 msgid "A group already exists with this name!"
 msgstr ""
 
@@ -1923,6 +1929,9 @@ msgstr ""
 msgid "Delete a %s"
 msgstr ""
 
+msgid "Delete a saved filter"
+msgstr ""
+
 msgid "Delete associated hosts"
 msgstr ""
 
@@ -2113,6 +2122,9 @@ msgstr ""
 msgid "Editing Global LDAP Settings"
 msgstr ""
 
+msgid "Either half may be sent, or both. ABSENT IS NOT EMPTY: a body with no \"shares\" key leaves the share list alone, while one carrying empty lists means \"shared with nobody\" and clears it. The whole list is replaced rather than added to. Sharing needs no permission -- it can only add one named entry to the picker of somebody you could already name -- but editing a GLOBAL filter requires savedfilter.edit."
+msgstr ""
+
 msgid "Email"
 msgstr ""
 
@@ -2253,6 +2265,9 @@ msgid "Every configured multicast port is already in use"
 msgstr ""
 
 msgid "Every file was uploaded."
+msgstr ""
+
+msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
 msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
@@ -4959,6 +4974,9 @@ msgstr ""
 msgid "No storagegroups assigned to this snapin"
 msgstr ""
 
+msgid "No such filter"
+msgstr ""
+
 msgid "No such object."
 msgstr ""
 
@@ -5058,6 +5076,9 @@ msgstr ""
 msgid "Not reported"
 msgstr ""
 
+msgid "Not signed in"
+msgstr ""
+
 msgid "Not syncing"
 msgstr ""
 
@@ -5148,6 +5169,9 @@ msgstr ""
 msgid "Off - direct membership only"
 msgstr ""
 
+msgid "Offered to every user on this grid."
+msgstr ""
+
 msgid "Old key must be a string"
 msgstr ""
 
@@ -5182,6 +5206,9 @@ msgid "One or more macs are associated with a host"
 msgstr ""
 
 msgid "One preference."
+msgstr ""
+
+msgid "One saved filter."
 msgstr ""
 
 msgid "Online"
@@ -5860,6 +5887,9 @@ msgstr ""
 msgid "Read one of your preferences"
 msgstr ""
 
+msgid "Read one saved filter"
+msgstr ""
+
 msgid "Real Time"
 msgstr ""
 
@@ -5970,6 +6000,9 @@ msgid "Removing this group would leave no user with administrator access."
 msgstr ""
 
 msgid "Removing this role would leave no user with administrator access."
+msgstr ""
+
+msgid "Rename a filter, or change who it is shared with"
 msgstr ""
 
 msgid "Rename or remove one of them."
@@ -6193,6 +6226,9 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
+msgid "Save a filter"
+msgstr ""
+
 msgid "Save completed but no valid ID was assigned (insertId=0). Possible duplicate-key update or missing auto-increment."
 msgstr ""
 
@@ -6202,7 +6238,13 @@ msgstr ""
 msgid "Save the site before setting catch-all"
 msgstr ""
 
+msgid "Saved filters for one grid"
+msgstr ""
+
 msgid "Saving data for"
+msgstr ""
+
+msgid "Saving over a name you already used replaces that filter rather than adding a second one, which is what a Save button is expected to do. A private save never touches a global of the same name and the other way round. global:true requires savedfilter.create and answers 403 without it; everything else needs only a session. Values are capped at 64KB and refused rather than truncated."
 msgstr ""
 
 msgid "Schedule"
@@ -7373,6 +7415,12 @@ msgstr ""
 msgid "Text to match against the id and name. A few classes match more: host also on MAC, storagenode on node hostname, setting on value."
 msgstr ""
 
+msgid "That filter is too large to save"
+msgstr ""
+
+msgid "That grid name is too long"
+msgstr ""
+
 msgid "That group is already defined for this provider!"
 msgstr ""
 
@@ -7389,6 +7437,9 @@ msgid "That is the recommended state. Restore it only to issue a new intermediat
 msgstr ""
 
 msgid "That is the signed chain staged by the installer; the default boot file is unsigned and a Secure Boot client will refuse it"
+msgstr ""
+
+msgid "That name is too long"
 msgstr ""
 
 msgid "That session has already started"
@@ -7515,6 +7566,24 @@ msgstr ""
 msgid "The file itself."
 msgstr ""
 
+msgid "The filter state, opaque. It is DataTables SearchBuilder's own serialization and the server does not interpret it."
+msgstr ""
+
+msgid "The filter was deleted."
+msgstr ""
+
+msgid "The filter was saved; the full list is returned."
+msgstr ""
+
+msgid "The filter was updated."
+msgstr ""
+
+msgid "The filters visible to the caller."
+msgstr ""
+
+msgid "The grid key."
+msgstr ""
+
 msgid "The identity provider could not be reached"
 msgstr ""
 
@@ -7634,6 +7703,9 @@ msgstr ""
 msgid "The same rules in prose, for a client reading this at runtime."
 msgstr ""
 
+msgid "The saved filter."
+msgstr ""
+
 msgid "The selected site no longer exists"
 msgstr ""
 
@@ -7641,6 +7713,9 @@ msgid "The server refuses to activate this plugin, or the plugin declares no sch
 msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
+msgstr ""
+
+msgid "The share targets the caller may see."
 msgstr ""
 
 msgid "The sign-in could not be verified"
@@ -7721,6 +7796,9 @@ msgid "There are open slots"
 msgstr ""
 
 msgid "There is a host in a tasking"
+msgstr ""
+
+msgid "There is no filter to save"
 msgstr ""
 
 msgid "There is nothing to replicate"
@@ -8460,10 +8538,16 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
+msgid "Username of whoever created it, on filters the caller does not own. Empty when the creator's account has since been deleted."
+msgstr ""
+
 msgid "Username was blank"
 msgstr ""
 
 msgid "Users"
+msgstr ""
+
+msgid "Users, user groups and roles as id/name pairs. Each section is gated on that entity's own view permission -- user.view, usergroup.view, role.view -- and comes back EMPTY rather than 403 when the caller lacks it, so this route discloses nothing they could not already list. A caller holding none of the three can still save private filters; there is simply nobody they may name."
 msgstr ""
 
 msgid "Using the group match function"
@@ -8574,6 +8658,12 @@ msgstr ""
 msgid "Who"
 msgstr ""
 
+msgid "Who a filter can be shared with"
+msgstr ""
+
+msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
+msgstr ""
+
 msgid "Width must be 650 pixels."
 msgstr ""
 
@@ -8680,6 +8770,12 @@ msgstr ""
 msgid "You do not have permission to view API tokens."
 msgstr ""
 
+msgid "You may not change a filter shared with everyone"
+msgstr ""
+
+msgid "You may not save a filter for everyone"
+msgstr ""
+
 msgid "You may use _, ., -, or a space between."
 msgstr ""
 
@@ -8690,6 +8786,9 @@ msgid "You must have at least one Storage Group"
 msgstr ""
 
 msgid "You must select an action to perform"
+msgstr ""
+
+msgid "You own it, so you may rename, re-share or delete it."
 msgstr ""
 
 msgid "You were logged out due to inactivity."
@@ -8705,6 +8804,9 @@ msgid "Your session has ended. Sign in again."
 msgstr ""
 
 msgid "Your stored preferences"
+msgstr ""
+
+msgid "Yours, always. A global one requires savedfilter.delete. Every share of it goes with it, by foreign key."
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
@@ -9307,6 +9409,9 @@ msgid "server does not appear to be online"
 msgstr ""
 
 msgid "settings"
+msgstr ""
+
+msgid "shares is null unless you own the filter: being shared WITH one does not entitle you to see who else it went to. A filter that does not exist and one belonging to somebody else both answer 404, deliberately, so an id cannot be used to probe for other people's filters."
 msgstr ""
 
 msgid "short"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -334,6 +334,13 @@ msgstr ""
 msgid "A filename is required!"
 msgstr "Um nome de imagem é necessário!"
 
+msgid "A filter needs a grid and a name"
+msgstr ""
+
+#, fuzzy
+msgid "A filter needs a name"
+msgstr "Por favor insira um nome de host válido"
+
 #, fuzzy
 msgid "A group already exists with this name!"
 msgstr "Uma imagem já existe com este nome!"
@@ -2258,6 +2265,10 @@ msgid "Delete a %s"
 msgstr "Apagar dados de arquivo"
 
 #, fuzzy
+msgid "Delete a saved filter"
+msgstr "Delete Selected"
+
+#, fuzzy
 msgid "Delete associated hosts"
 msgstr "Delete Selected"
 
@@ -2483,6 +2494,9 @@ msgstr "anfitrião Descrição"
 msgid "Editing Global LDAP Settings"
 msgstr "anfitrião Descrição"
 
+msgid "Either half may be sent, or both. ABSENT IS NOT EMPTY: a body with no \"shares\" key leaves the share list alone, while one carrying empty lists means \"shared with nobody\" and clears it. The whole list is replaced rather than added to. Sharing needs no permission -- it can only add one named entry to the picker of somebody you could already name -- but editing a GLOBAL filter requires savedfilter.edit."
+msgstr ""
+
 msgid "Email"
 msgstr "O email"
 
@@ -2637,6 +2651,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "Nenhum arquivo foi transferido"
+
+msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
 msgstr ""
@@ -5843,6 +5860,9 @@ msgstr "Uma imagem já existe com este nome!"
 msgid "No storagegroups assigned to this snapin"
 msgstr "O grupo de armazenamento de imagens atribuído não é válido"
 
+msgid "No such filter"
+msgstr ""
+
 msgid "No such object."
 msgstr ""
 
@@ -5957,6 +5977,10 @@ msgstr ""
 msgid "Not reported"
 msgstr "Inventário"
 
+#, fuzzy
+msgid "Not signed in"
+msgstr "Plugins instalados"
+
 msgid "Not syncing"
 msgstr ""
 
@@ -6064,6 +6088,10 @@ msgid "Off - direct membership only"
 msgstr ""
 
 #, fuzzy
+msgid "Offered to every user on this grid."
+msgstr " | Este não é o grupo primário"
+
+#, fuzzy
 msgid "Old key must be a string"
 msgstr "Evento deve ser uma string"
 
@@ -6101,6 +6129,10 @@ msgstr "Erro, é uma imagem associada com este anfitrião"
 
 msgid "One preference."
 msgstr ""
+
+#, fuzzy
+msgid "One saved filter."
+msgstr "atualização da impressora falhou!"
 
 msgid "Online"
 msgstr ""
@@ -6892,6 +6924,10 @@ msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
+msgid "Read one saved filter"
+msgstr "Delete Selected"
+
+#, fuzzy
 msgid "Real Time"
 msgstr "Anfitrião Update Failed"
 
@@ -7018,6 +7054,9 @@ msgid "Removing this group would leave no user with administrator access."
 msgstr ""
 
 msgid "Removing this role would leave no user with administrator access."
+msgstr ""
+
+msgid "Rename a filter, or change who it is shared with"
 msgstr ""
 
 #, fuzzy
@@ -7276,6 +7315,10 @@ msgstr ""
 msgid "Save Changes"
 msgstr "Salvar alterações"
 
+#, fuzzy
+msgid "Save a filter"
+msgstr "atualização da impressora falhou!"
+
 msgid "Save completed but no valid ID was assigned (insertId=0). Possible duplicate-key update or missing auto-increment."
 msgstr ""
 
@@ -7285,9 +7328,15 @@ msgstr ""
 msgid "Save the site before setting catch-all"
 msgstr ""
 
+msgid "Saved filters for one grid"
+msgstr ""
+
 #, fuzzy
 msgid "Saving data for"
 msgstr "Salvando dados para %s objeto"
+
+msgid "Saving over a name you already used replaces that filter rather than adding a second one, which is what a Save button is expected to do. A private save never touches a global of the same name and the other way round. global:true requires savedfilter.create and answers 403 without it; everything else needs only a session. Values are capped at 64KB and refused rather than truncated."
+msgstr ""
 
 msgid "Schedule"
 msgstr "Cronograma"
@@ -8689,6 +8738,13 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That filter is too large to save"
+msgstr "não foi capaz de salvar"
+
+msgid "That grid name is too long"
+msgstr ""
+
+#, fuzzy
 msgid "That group is already defined for this provider!"
 msgstr "Uma imagem já existe com este nome!"
 
@@ -8707,6 +8763,9 @@ msgid "That is the recommended state. Restore it only to issue a new intermediat
 msgstr ""
 
 msgid "That is the signed chain staged by the installer; the default boot file is unsigned and a Secure Boot client will refuse it"
+msgstr ""
+
+msgid "That name is too long"
 msgstr ""
 
 #, fuzzy
@@ -8846,6 +8905,27 @@ msgstr ""
 msgid "The file itself."
 msgstr ""
 
+msgid "The filter state, opaque. It is DataTables SearchBuilder's own serialization and the server does not interpret it."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was deleted."
+msgstr "Nenhum arquivo foi transferido"
+
+msgid "The filter was saved; the full list is returned."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was updated."
+msgstr "Nenhum arquivo foi transferido"
+
+msgid "The filters visible to the caller."
+msgstr ""
+
+#, fuzzy
+msgid "The grid key."
+msgstr "Falha ao criar tarefa"
+
 #, fuzzy
 msgid "The identity provider could not be reached"
 msgstr "Não foi possível ler arquivo temporário"
@@ -8973,6 +9053,10 @@ msgid "The same rules in prose, for a client reading this at runtime."
 msgstr ""
 
 #, fuzzy
+msgid "The saved filter."
+msgstr "atualização da impressora falhou!"
+
+#, fuzzy
 msgid "The selected site no longer exists"
 msgstr " não existe mais"
 
@@ -8980,6 +9064,9 @@ msgid "The server refuses to activate this plugin, or the plugin declares no sch
 msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
+msgstr ""
+
+msgid "The share targets the caller may see."
 msgstr ""
 
 #, fuzzy
@@ -9070,6 +9157,10 @@ msgstr "Há slots abertos, mas"
 
 msgid "There is a host in a tasking"
 msgstr "Há uma série de tarefas"
+
+#, fuzzy
+msgid "There is no filter to save"
+msgstr "não foi capaz de salvar"
 
 msgid "There is nothing to replicate"
 msgstr "Não há nada para replicar"
@@ -9915,12 +10006,18 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
+msgid "Username of whoever created it, on filters the caller does not own. Empty when the creator's account has since been deleted."
+msgstr ""
+
 #, fuzzy
 msgid "Username was blank"
 msgstr "Nome de usuário"
 
 msgid "Users"
 msgstr "usuários"
+
+msgid "Users, user groups and roles as id/name pairs. Each section is gated on that entity's own view permission -- user.view, usergroup.view, role.view -- and comes back EMPTY rather than 403 when the caller lacks it, so this route discloses nothing they could not already list. A caller holding none of the three can still save private filters; there is simply nobody they may name."
+msgstr ""
 
 msgid "Using the group match function"
 msgstr ""
@@ -10038,6 +10135,12 @@ msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has 
 msgstr ""
 
 msgid "Who"
+msgstr ""
+
+msgid "Who a filter can be shared with"
+msgstr ""
+
+msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
 msgstr ""
 
 msgid "Width must be 650 pixels."
@@ -10162,6 +10265,12 @@ msgstr ""
 msgid "You do not have permission to view API tokens."
 msgstr ""
 
+msgid "You may not change a filter shared with everyone"
+msgstr ""
+
+msgid "You may not save a filter for everyone"
+msgstr ""
+
 msgid "You may use _, ., -, or a space between."
 msgstr ""
 
@@ -10174,6 +10283,9 @@ msgstr "Você deve ter pelo menos um grupo de armazenamento"
 #, fuzzy
 msgid "You must select an action to perform"
 msgstr "Você deve especificar o alias e porta"
+
+msgid "You own it, so you may rename, re-share or delete it."
+msgstr ""
 
 msgid "You were logged out due to inactivity."
 msgstr ""
@@ -10188,6 +10300,9 @@ msgid "Your session has ended. Sign in again."
 msgstr ""
 
 msgid "Your stored preferences"
+msgstr ""
+
+msgid "Yours, always. A global one requires savedfilter.delete. Every share of it goes with it, by foreign key."
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
@@ -10876,6 +10991,9 @@ msgstr ""
 #, fuzzy
 msgid "settings"
 msgstr "Configurações"
+
+msgid "shares is null unless you own the filter: being shared WITH one does not entitle you to see who else it went to. A filter that does not exist and one belonging to somebody else both answer 404, deliberately, so an id cannot be used to probe for other people's filters."
+msgstr ""
 
 msgid "short"
 msgstr ""
@@ -11837,9 +11955,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "has failed to destroy"
 #~ msgstr "falhou para ser destruído"
-
-#~ msgid "has failed to save"
-#~ msgstr "não foi capaz de salvar"
 
 #, fuzzy
 #~ msgid "multicast tasks!"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -334,6 +334,13 @@ msgstr ""
 msgid "A filename is required!"
 msgstr "图像名是必需的！"
 
+msgid "A filter needs a grid and a name"
+msgstr ""
+
+#, fuzzy
+msgid "A filter needs a name"
+msgstr "请输入一个有效的主机名"
+
 #, fuzzy
 msgid "A group already exists with this name!"
 msgstr "图像已经存在具有此名称！"
@@ -2258,6 +2265,10 @@ msgid "Delete a %s"
 msgstr "删除的文件数据"
 
 #, fuzzy
+msgid "Delete a saved filter"
+msgstr "删除所选"
+
+#, fuzzy
 msgid "Delete associated hosts"
 msgstr "删除所选"
 
@@ -2483,6 +2494,9 @@ msgstr "主机描述"
 msgid "Editing Global LDAP Settings"
 msgstr "主机描述"
 
+msgid "Either half may be sent, or both. ABSENT IS NOT EMPTY: a body with no \"shares\" key leaves the share list alone, while one carrying empty lists means \"shared with nobody\" and clears it. The whole list is replaced rather than added to. Sharing needs no permission -- it can only add one named entry to the picker of somebody you could already name -- but editing a GLOBAL filter requires savedfilter.edit."
+msgstr ""
+
 msgid "Email"
 msgstr "电子邮件"
 
@@ -2637,6 +2651,9 @@ msgstr ""
 #, fuzzy
 msgid "Every file was uploaded."
 msgstr "没有文件被上传"
+
+msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
 msgstr ""
@@ -5843,6 +5860,9 @@ msgstr "图像已经存在具有此名称！"
 msgid "No storagegroups assigned to this snapin"
 msgstr "分配图像存储组无效"
 
+msgid "No such filter"
+msgstr ""
+
 msgid "No such object."
 msgstr ""
 
@@ -5957,6 +5977,10 @@ msgstr ""
 msgid "Not reported"
 msgstr "库存"
 
+#, fuzzy
+msgid "Not signed in"
+msgstr "已安装的插件"
+
 msgid "Not syncing"
 msgstr ""
 
@@ -6064,6 +6088,10 @@ msgid "Off - direct membership only"
 msgstr ""
 
 #, fuzzy
+msgid "Offered to every user on this grid."
+msgstr "|这不是主要组"
+
+#, fuzzy
 msgid "Old key must be a string"
 msgstr "事件必须是字符串"
 
@@ -6101,6 +6129,10 @@ msgstr "错误，与此主机关联的图像"
 
 msgid "One preference."
 msgstr ""
+
+#, fuzzy
+msgid "One saved filter."
+msgstr "打印机更新失败！"
 
 msgid "Online"
 msgstr ""
@@ -6892,6 +6924,10 @@ msgid "Read one of your preferences"
 msgstr ""
 
 #, fuzzy
+msgid "Read one saved filter"
+msgstr "删除所选"
+
+#, fuzzy
 msgid "Real Time"
 msgstr "主机更新失败"
 
@@ -7018,6 +7054,9 @@ msgid "Removing this group would leave no user with administrator access."
 msgstr ""
 
 msgid "Removing this role would leave no user with administrator access."
+msgstr ""
+
+msgid "Rename a filter, or change who it is shared with"
 msgstr ""
 
 #, fuzzy
@@ -7276,6 +7315,10 @@ msgstr ""
 msgid "Save Changes"
 msgstr "保存更改"
 
+#, fuzzy
+msgid "Save a filter"
+msgstr "打印机更新失败！"
+
 msgid "Save completed but no valid ID was assigned (insertId=0). Possible duplicate-key update or missing auto-increment."
 msgstr ""
 
@@ -7285,9 +7328,15 @@ msgstr ""
 msgid "Save the site before setting catch-all"
 msgstr ""
 
+msgid "Saved filters for one grid"
+msgstr ""
+
 #, fuzzy
 msgid "Saving data for"
 msgstr "保存数据%s对象"
+
+msgid "Saving over a name you already used replaces that filter rather than adding a second one, which is what a Save button is expected to do. A private save never touches a global of the same name and the other way round. global:true requires savedfilter.create and answers 403 without it; everything else needs only a session. Values are capped at 64KB and refused rather than truncated."
+msgstr ""
 
 msgid "Schedule"
 msgstr "时间表"
@@ -8689,6 +8738,13 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That filter is too large to save"
+msgstr "未能保存"
+
+msgid "That grid name is too long"
+msgstr ""
+
+#, fuzzy
 msgid "That group is already defined for this provider!"
 msgstr "图像已经存在具有此名称！"
 
@@ -8707,6 +8763,9 @@ msgid "That is the recommended state. Restore it only to issue a new intermediat
 msgstr ""
 
 msgid "That is the signed chain staged by the installer; the default boot file is unsigned and a Secure Boot client will refuse it"
+msgstr ""
+
+msgid "That name is too long"
 msgstr ""
 
 #, fuzzy
@@ -8846,6 +8905,27 @@ msgstr ""
 msgid "The file itself."
 msgstr ""
 
+msgid "The filter state, opaque. It is DataTables SearchBuilder's own serialization and the server does not interpret it."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was deleted."
+msgstr "没有文件被上传"
+
+msgid "The filter was saved; the full list is returned."
+msgstr ""
+
+#, fuzzy
+msgid "The filter was updated."
+msgstr "没有文件被上传"
+
+msgid "The filters visible to the caller."
+msgstr ""
+
+#, fuzzy
+msgid "The grid key."
+msgstr "无法创建任务"
+
 #, fuzzy
 msgid "The identity provider could not be reached"
 msgstr "无法读取临时文件"
@@ -8973,6 +9053,10 @@ msgid "The same rules in prose, for a client reading this at runtime."
 msgstr ""
 
 #, fuzzy
+msgid "The saved filter."
+msgstr "打印机更新失败！"
+
+#, fuzzy
 msgid "The selected site no longer exists"
 msgstr "不复存在"
 
@@ -8980,6 +9064,9 @@ msgid "The server refuses to activate this plugin, or the plugin declares no sch
 msgstr ""
 
 msgid "The settings tend to be global which affects all hosts."
+msgstr ""
+
+msgid "The share targets the caller may see."
 msgstr ""
 
 #, fuzzy
@@ -9070,6 +9157,10 @@ msgstr "有开口槽，但"
 
 msgid "There is a host in a tasking"
 msgstr "有在一个任务的主机"
+
+#, fuzzy
+msgid "There is no filter to save"
+msgstr "未能保存"
 
 msgid "There is nothing to replicate"
 msgstr "没有什么可以复制"
@@ -9915,12 +10006,18 @@ msgstr ""
 msgid "Username must end with a number or letter."
 msgstr ""
 
+msgid "Username of whoever created it, on filters the caller does not own. Empty when the creator's account has since been deleted."
+msgstr ""
+
 #, fuzzy
 msgid "Username was blank"
 msgstr "用户名"
 
 msgid "Users"
 msgstr "用户"
+
+msgid "Users, user groups and roles as id/name pairs. Each section is gated on that entity's own view permission -- user.view, usergroup.view, role.view -- and comes back EMPTY rather than 403 when the caller lacks it, so this route discloses nothing they could not already list. A caller holding none of the three can still save private filters; there is simply nobody they may name."
+msgstr ""
 
 msgid "Using the group match function"
 msgstr ""
@@ -10038,6 +10135,12 @@ msgid "Whichever route is used, MokManager -- the blue enrollment screen -- has 
 msgstr ""
 
 msgid "Who"
+msgstr ""
+
+msgid "Who a filter can be shared with"
+msgstr ""
+
+msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
 msgstr ""
 
 msgid "Width must be 650 pixels."
@@ -10162,6 +10265,12 @@ msgstr ""
 msgid "You do not have permission to view API tokens."
 msgstr ""
 
+msgid "You may not change a filter shared with everyone"
+msgstr ""
+
+msgid "You may not save a filter for everyone"
+msgstr ""
+
 msgid "You may use _, ., -, or a space between."
 msgstr ""
 
@@ -10174,6 +10283,9 @@ msgstr "您必须至少有一个存储组"
 #, fuzzy
 msgid "You must select an action to perform"
 msgstr "您必须指定别名和端口"
+
+msgid "You own it, so you may rename, re-share or delete it."
+msgstr ""
 
 msgid "You were logged out due to inactivity."
 msgstr ""
@@ -10188,6 +10300,9 @@ msgid "Your session has ended. Sign in again."
 msgstr ""
 
 msgid "Your stored preferences"
+msgstr ""
+
+msgid "Yours, always. A global one requires savedfilter.delete. Every share of it goes with it, by foreign key."
 msgstr ""
 
 msgid "a service account: it may hold API tokens and can never sign in to this interface"
@@ -10876,6 +10991,9 @@ msgstr ""
 #, fuzzy
 msgid "settings"
 msgstr "设置"
+
+msgid "shares is null unless you own the filter: being shared WITH one does not entitle you to see who else it went to. A filter that does not exist and one belonging to somebody else both answer 404, deliberately, so an id cannot be used to probe for other people's filters."
+msgstr ""
 
 msgid "short"
 msgstr ""
@@ -11837,9 +11955,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "has failed to destroy"
 #~ msgstr "未能被销毁"
-
-#~ msgid "has failed to save"
-#~ msgstr "未能保存"
 
 #, fuzzy
 #~ msgid "multicast tasks!"

--- a/packages/web/src/Auth/Authorization.php
+++ b/packages/web/src/Auth/Authorization.php
@@ -244,6 +244,22 @@ class Authorization extends FOGBase
         // is no object here for an object permission to be about.
         'userprefs' => null,
         'userpref' => null,
+        // Saved grid filters. null for the same reason as userpref: the
+        // acting user comes from the session and the path has no place to put
+        // a different one, so every read and write is already scoped to the
+        // caller by the manager.
+        //
+        // The privileged case -- saving a filter for EVERYONE -- is checked
+        // inside the handler against savedfilter.*, because "global" is a
+        // property of the request body rather than of the route. A single
+        // route-level permission would have to be the strictest of the two
+        // cases, which would take private filters away from everybody.
+        'savedfilters' => null,
+        'savedfilter' => null,
+        // Gated per section inside the handler against user.view,
+        // usergroup.view and role.view, so it can disclose nothing the caller
+        // could not already list.
+        'savedfiltertargets' => null,
         // The API description, and its swagger.json alias. Public for the
         // same reason status/info are: a client should be able to discover
         // what it is talking to before it has credentials. Both expose only
@@ -470,6 +486,22 @@ class Authorization extends FOGBase
             // folded into edit.
             'apitoken' => ['view', 'create', 'edit', 'delete'],
             'usergroup' => ['view', 'create', 'edit', 'delete'],
+            // GLOBAL saved grid filters only.
+            //
+            // The node governs the shared namespace, not filters in general.
+            // Anybody signed in may create, rename, delete and SHARE their
+            // own filters without holding anything here: those reach only the
+            // people they name, the route derives the owner from the session,
+            // and requiring a grant would silently remove the feature from
+            // everyone on upgrade until roles were edited.
+            //
+            // A global filter is different in kind: it appears in every
+            // user's picker on that grid, so somebody has to be trusted with
+            // it. Split three ways for the same reason apitoken is --
+            // removing a filter the whole site has built a habit around is a
+            // bigger act than adding one, and 'view' is absent because
+            // everyone can already see a global filter by definition.
+            'savedfilter' => ['create', 'edit', 'delete'],
             'role' => ['view', 'create', 'edit', 'delete'],
             // Sites came in from the site plugin. The node keeps the name
             // the plugin registered so grants written against it survive

--- a/packages/web/src/Base/Page.php
+++ b/packages/web/src/Base/Page.php
@@ -198,6 +198,10 @@ class Page extends FOGBase
         'js/input-mask/jquery.inputmask.date.extensions.js',
         'js/fog/bootstrap-csrf.js',
         'js/fog/fog.common.js',
+        // After fog.common.js: it registers window.fogSavedFilters, which the
+        // grid toolbar's Filters button calls. Authenticated list only -- the
+        // login page has no grids and no session to own a filter.
+        'js/fog/fog.filters.js',
         'js/fog/theme.js'
     ];
     /**

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4527');
+        define('FOG_VERSION', '1.6.0-beta.4533');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -94,8 +94,8 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 392);
-        define('FOG_BCACHE_VER', 337);
+        define('FOG_SCHEMA', 395);
+        define('FOG_BCACHE_VER', 338);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4523');
+        define('FOG_VERSION', '1.6.0-beta.4527');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Items/SavedFilter.php
+++ b/packages/web/src/Items/SavedFilter.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * One named, saved grid filter
+ *
+ * PHP version 7.4+
+ *
+ * @category SavedFilter
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Items;
+
+use FOG\Base\FOGController;
+
+/**
+ * One named, saved grid filter.
+ *
+ * The value is OPAQUE, the same stance as UserPref: it holds DataTables'
+ * searchBuilder state, whose shape belongs to DataTables and changes between
+ * its major versions. Nothing server-side decides anything on the strength of
+ * what is inside it.
+ *
+ * OWNERSHIP: a null userID means the filter is GLOBAL -- offered to everyone
+ * on that grid. Any other value makes it private to that user. creatorID
+ * records who wrote it and survives for globals, so a shared filter still has
+ * an author to ask about after its owner has moved on.
+ *
+ * @category SavedFilter
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SavedFilter extends FOGController
+{
+    /**
+     * The largest filter that will be stored, in bytes.
+     *
+     * A SearchBuilder state with a dozen rules runs to a couple of kilobytes.
+     * The cap is here because the value arrives from a browser: an unbounded
+     * write is a way to fill a disk quietly, not a feature anybody asked for.
+     * Matches UserPref::MAX_VALUE_BYTES for the same reason.
+     *
+     * @var int
+     */
+    const MAX_VALUE_BYTES = 65536;
+    /**
+     * The longest name that will be stored, in bytes.
+     *
+     * Matches the varchar(64) column, which is sized by the UNIQUE index it
+     * sits in rather than by taste -- see schema step 393. A longer name is
+     * refused rather than truncated, because two names cut to the same 64
+     * bytes would collide on that index and overwrite each other.
+     *
+     * @var int
+     */
+    const MAX_NAME_BYTES = 64;
+    /**
+     * The longest grid key that will be stored, in bytes.
+     *
+     * Matches the varchar(128) column, same index and same reasoning.
+     *
+     * @var int
+     */
+    const MAX_TABLE_BYTES = 128;
+    /**
+     * The saved filters table
+     *
+     * @var string
+     */
+    protected $databaseTable = 'savedFilters';
+    /**
+     * The table fields and common names
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'sfID',
+        'userID' => 'sfUserID',
+        'creatorID' => 'sfCreatorID',
+        'table' => 'sfTable',
+        'name' => 'sfName',
+        'value' => 'sfValue',
+        'createdTime' => 'sfCreatedTime',
+        'modifiedTime' => 'sfModifiedTime'
+    ];
+    /**
+     * The required fields
+     *
+     * userID is NOT required: a null means the filter is global, and that is
+     * a state the table is designed to hold rather than a missing value.
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'table',
+        'name'
+    ];
+}

--- a/packages/web/src/Managers/SavedFilterManager.php
+++ b/packages/web/src/Managers/SavedFilterManager.php
@@ -1,0 +1,568 @@
+<?php
+/**
+ * Saved grid filter manager class.
+ *
+ * PHP version 7.4+
+ *
+ * @category SavedFilterManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Managers;
+
+use FOG\Base\FOGManagerController;
+use FOG\Items\SavedFilter;
+
+/**
+ * Saved grid filter manager class.
+ *
+ * Access control is structural, the same shape UserPrefManager uses. Every
+ * mutating method takes the acting user's id and will only touch a row whose
+ * sfUserID matches it. Reaching a GLOBAL row (sfUserID IS NULL) additionally
+ * requires an explicit $mayManageGlobal, which ONLY the route layer sets, and
+ * only after asking Authorization. So no call in this class can be talked
+ * into editing somebody else's private filter whatever it is handed, and the
+ * privileged case cannot be reached by accident.
+ *
+ * There are three ways to SEE a filter and only one way to CHANGE it. A user
+ * sees their own, every global one, and any shared with them directly, with
+ * a group they are in, or with a role they hold. Being shared with confers
+ * no write access at all: rename, re-share and delete stay with the owner.
+ *
+ * @category SavedFilterManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SavedFilterManager extends FOGManagerController
+{
+    /**
+     * Everything the given user may SEE for one grid.
+     *
+     * Their own filters plus every global one. Ordered globals last so the
+     * picker can group them without the client having to sort, and by name
+     * within each group.
+     *
+     * @param int    $userID The user asking.
+     * @param string $table  The grid key.
+     *
+     * @return array
+     */
+    public function listFor($userID, $table)
+    {
+        $userID = (int)$userID;
+        $table = (string)$table;
+        if ($userID < 1 || '' === $table) {
+            return [];
+        }
+        $rows = self::$DB
+            ->query(
+                'SELECT f.`sfID`, f.`sfUserID`, f.`sfName`, f.`sfValue`,'
+                . ' f.`sfModifiedTime`, c.`uName` AS `creatorName`,'
+                // How this row REACHED the caller, so the picker can label it.
+                // Computed here rather than inferred client-side because only
+                // the server knows the caller's groups and roles. A row can
+                // arrive by several paths at once -- that is the normal case
+                // for a manager who is also in the group they shared to -- so
+                // each path is reported and the precedence is applied below.
+                . ' EXISTS (SELECT 1 FROM `savedFilterUserAssoc`'
+                . ' WHERE `sfuaFilterID` = f.`sfID`'
+                . ' AND `sfuaUserID` = :uid6) AS `viaUser`,'
+                . ' EXISTS (SELECT 1 FROM `savedFilterGroupAssoc` g'
+                . ' JOIN `userGroupMembers` m'
+                . ' ON m.`ugmGroupID` = g.`sfgaUserGroupID`'
+                . ' WHERE g.`sfgaFilterID` = f.`sfID`'
+                . ' AND m.`ugmUserID` = :uid7) AS `viaGroup`,'
+                . ' EXISTS (SELECT 1 FROM `savedFilterRoleAssoc` o'
+                . ' JOIN `roleUserAssoc` r'
+                . ' ON r.`ruaRoleID` = o.`sfraRoleID`'
+                . ' WHERE o.`sfraFilterID` = f.`sfID`'
+                . ' AND r.`ruaUserID` = :uid8) AS `viaRole`'
+                . ' FROM `savedFilters` f'
+                . ' LEFT JOIN `users` c ON c.`uID` = f.`sfCreatorID`'
+                . ' WHERE f.`sfTable` = :table AND ('
+                // Mine.
+                . ' f.`sfUserID` = :uid'
+                // Everybody's.
+                . ' OR f.`sfUserID` IS NULL'
+                // Shared with me by name.
+                . ' OR f.`sfID` IN ('
+                . ' SELECT `sfuaFilterID` FROM `savedFilterUserAssoc`'
+                . ' WHERE `sfuaUserID` = :uid2)'
+                // Shared with a group I am in.
+                . ' OR f.`sfID` IN ('
+                . ' SELECT a.`sfgaFilterID` FROM `savedFilterGroupAssoc` a'
+                . ' JOIN `userGroupMembers` m'
+                . ' ON m.`ugmGroupID` = a.`sfgaUserGroupID`'
+                . ' WHERE m.`ugmUserID` = :uid3)'
+                // Shared with a role I hold.
+                . ' OR f.`sfID` IN ('
+                . ' SELECT a.`sfraFilterID` FROM `savedFilterRoleAssoc` a'
+                . ' JOIN `roleUserAssoc` r'
+                . ' ON r.`ruaRoleID` = a.`sfraRoleID`'
+                . ' WHERE r.`ruaUserID` = :uid4)'
+                . ' )'
+                . ' ORDER BY (f.`sfUserID` = :uid5) DESC,'
+                . ' (f.`sfUserID` IS NULL) ASC, f.`sfName` ASC',
+                [],
+                [
+                    ':table' => $table,
+                    ':uid' => $userID,
+                    ':uid2' => $userID,
+                    ':uid3' => $userID,
+                    ':uid4' => $userID,
+                    ':uid5' => $userID,
+                    ':uid6' => $userID,
+                    ':uid7' => $userID,
+                    ':uid8' => $userID
+                ]
+            )
+            ->fetch('', 'fetch_all')
+            ->get();
+
+        $filters = [];
+        foreach ((array)$rows as $row) {
+            $mine = null !== $row['sfUserID']
+                && (int)$row['sfUserID'] === $userID;
+            // Most deliberate grant first. Owning it beats being named
+            // beats being in a group beats holding a role beats being
+            // everybody -- so the label a user sees always describes the
+            // most specific reason they can see it, and one filter reaching
+            // them three ways still reads as one row with one explanation.
+            // The row itself is already unique: every arm above is an OR
+            // inside a single SELECT, not a UNION.
+            if ($mine) {
+                $source = 'mine';
+            } elseif ($row['viaUser']) {
+                $source = 'user';
+            } elseif ($row['viaGroup']) {
+                $source = 'group';
+            } elseif ($row['viaRole']) {
+                $source = 'role';
+            } else {
+                $source = 'global';
+            }
+            $filters[] = [
+                'id' => (int)$row['sfID'],
+                'name' => (string)$row['sfName'],
+                // Two flags rather than the owner's id. The client needs to
+                // know which rows it may rename or delete (mine), and which
+                // are the site-wide ones (global) so it can label them. The
+                // owner's id would be a gratuitous disclosure and the client
+                // has no use for it.
+                'mine' => $mine,
+                'global' => null === $row['sfUserID'],
+                'source' => $source,
+                // Who made it, so "Shared with you" can say by whom. Only
+                // for rows the caller did not make: on their own rows it is
+                // themselves, and on a global one the useful fact is that it
+                // is global. Absent when the creator's account is gone --
+                // sfCreatorID is SET NULL, deliberately, so a filter survives
+                // the person who wrote it.
+                'sharedBy' => $mine
+                    ? ''
+                    : (string)($row['creatorName'] ?? ''),
+                'value' => (string)($row['sfValue'] ?? ''),
+                'modified' => (string)($row['sfModifiedTime'] ?? '')
+            ];
+        }
+
+        return $filters;
+    }
+
+    /**
+     * Who one filter is shared with.
+     *
+     * Owner-only: being shared WITH a filter does not entitle you to see who
+     * else it went to.
+     *
+     * @param int  $id              The filter.
+     * @param int  $userID          The acting user.
+     * @param bool $mayManageGlobal Whether the caller holds the permission.
+     *
+     * @return array|null users/groups/roles as id lists, or null if not yours
+     */
+    public function shares($id, $userID, $mayManageGlobal = false)
+    {
+        list($ok) = $this->_reachable($id, $userID, $mayManageGlobal);
+        if (!$ok) {
+            return null;
+        }
+        $id = (int)$id;
+        $out = [];
+        $sets = [
+            'users' => ['savedFilterUserAssoc', 'sfuaFilterID', 'sfuaUserID'],
+            'groups' => [
+                'savedFilterGroupAssoc', 'sfgaFilterID', 'sfgaUserGroupID'
+            ],
+            'roles' => ['savedFilterRoleAssoc', 'sfraFilterID', 'sfraRoleID']
+        ];
+        foreach ($sets as $key => $spec) {
+            list($table, $filterCol, $targetCol) = $spec;
+            $rows = self::$DB
+                ->query(
+                    sprintf(
+                        'SELECT `%s` FROM `%s` WHERE `%s` = :id',
+                        $targetCol,
+                        $table,
+                        $filterCol
+                    ),
+                    [],
+                    [':id' => $id]
+                )
+                ->fetch('', 'fetch_all')
+                ->get();
+            $out[$key] = array_map(
+                'intval',
+                array_column((array)$rows, $targetCol)
+            );
+        }
+
+        return $out;
+    }
+
+    /**
+     * Replaces who a filter is shared with.
+     *
+     * The whole list is sent and the whole list is replaced, rather than
+     * add/remove calls: the share editor shows a set of checkboxes, and
+     * "what is ticked now" is the only state either side can agree on
+     * without a per-row conflict story.
+     *
+     * Deleting first and inserting after is safe here because both statements
+     * are scoped to one filter that only this caller may reach.
+     *
+     * @param int   $id              The filter.
+     * @param int   $userID          The acting user.
+     * @param array $targets         users/groups/roles as id lists.
+     * @param bool  $mayManageGlobal Whether the caller holds the permission.
+     *
+     * @return array [bool ok, string error]
+     */
+    public function setShares(
+        $id,
+        $userID,
+        array $targets,
+        $mayManageGlobal = false
+    ) {
+        list($ok, $error) = $this->_reachable($id, $userID, $mayManageGlobal);
+        if (!$ok) {
+            return [false, $error];
+        }
+        $id = (int)$id;
+        $sets = [
+            'users' => [
+                'savedFilterUserAssoc', 'sfuaFilterID', 'sfuaUserID',
+                'users', 'uId'
+            ],
+            'groups' => [
+                'savedFilterGroupAssoc', 'sfgaFilterID', 'sfgaUserGroupID',
+                'userGroups', 'ugID'
+            ],
+            'roles' => [
+                'savedFilterRoleAssoc', 'sfraFilterID', 'sfraRoleID',
+                'roles', 'rID'
+            ]
+        ];
+        foreach ($sets as $key => $spec) {
+            list($table, $filterCol, $targetCol, $parent, $parentCol) = $spec;
+            $wanted = array_values(array_unique(array_filter(array_map(
+                'intval',
+                (array)($targets[$key] ?? [])
+            ))));
+            self::$DB->query(
+                sprintf('DELETE FROM `%s` WHERE `%s` = :id', $table, $filterCol),
+                [],
+                [':id' => $id]
+            );
+            if (!$wanted) {
+                continue;
+            }
+            // Filtered against the parent table before inserting. The foreign
+            // key added at schema 395 would refuse an unknown id anyway, but
+            // it refuses the whole statement -- so one stale checkbox in a
+            // stale browser tab would lose every other share in the same
+            // save. Dropping the unknown ids keeps the rest of the intent.
+            $placeholders = [];
+            $binds = [];
+            foreach ($wanted as $index => $value) {
+                $placeholders[] = ':t' . $index;
+                $binds[':t' . $index] = $value;
+            }
+            $live = self::$DB
+                ->query(
+                    sprintf(
+                        'SELECT `%s` FROM `%s` WHERE `%s` IN (%s)',
+                        $parentCol,
+                        $parent,
+                        $parentCol,
+                        implode(',', $placeholders)
+                    ),
+                    [],
+                    $binds
+                )
+                ->fetch('', 'fetch_all')
+                ->get();
+            $live = array_map('intval', array_column((array)$live, $parentCol));
+            foreach ($live as $value) {
+                self::$DB->query(
+                    sprintf(
+                        'INSERT IGNORE INTO `%s` (`%s`, `%s`)'
+                        . ' VALUES (:id, :target)',
+                        $table,
+                        $filterCol,
+                        $targetCol
+                    ),
+                    [],
+                    [':id' => $id, ':target' => $value]
+                );
+            }
+        }
+
+        return [true, ''];
+    }
+
+    /**
+     * Reads one filter, if this user may see it.
+     *
+     * @param int $id     The filter.
+     * @param int $userID The user asking.
+     *
+     * @return array|null
+     */
+    public function fetch($id, $userID)
+    {
+        $id = (int)$id;
+        $userID = (int)$userID;
+        if ($id < 1 || $userID < 1) {
+            return null;
+        }
+        $row = self::$DB
+            ->query(
+                'SELECT `sfID`, `sfUserID`, `sfTable`, `sfName`, `sfValue`'
+                . ' FROM `savedFilters`'
+                . ' WHERE `sfID` = :id'
+                . ' AND (`sfUserID` = :uid OR `sfUserID` IS NULL)',
+                [],
+                [':id' => $id, ':uid' => $userID]
+            )
+            ->fetch()
+            ->get();
+
+        return $row ? (array)$row : null;
+    }
+
+    /**
+     * Creates a filter, or replaces the value of one with the same name.
+     *
+     * Saving over a name you already used is the operation people expect from
+     * a Save button, so this is an upsert rather than a create -- but only
+     * within the owner the caller is allowed to write to. Saving a private
+     * filter never touches a global of the same name, and vice versa.
+     *
+     * @param int    $userID          The acting user.
+     * @param string $table           The grid key.
+     * @param string $name            The filter's name.
+     * @param string $value           The opaque filter state.
+     * @param bool   $global          Save it for everyone.
+     * @param bool   $mayManageGlobal Whether the caller holds the permission.
+     *
+     * @return array [bool ok, string error]
+     */
+    public function store(
+        $userID,
+        $table,
+        $name,
+        $value,
+        $global = false,
+        $mayManageGlobal = false
+    ) {
+        $userID = (int)$userID;
+        $table = trim((string)$table);
+        $name = trim((string)$name);
+        $value = (string)$value;
+        if ($userID < 1) {
+            return [false, _('Not signed in')];
+        }
+        if ('' === $table || '' === $name) {
+            return [false, _('A filter needs a grid and a name')];
+        }
+        if (strlen($name) > SavedFilter::MAX_NAME_BYTES) {
+            return [false, _('That name is too long')];
+        }
+        if (strlen($table) > SavedFilter::MAX_TABLE_BYTES) {
+            return [false, _('That grid name is too long')];
+        }
+        if ('' === $value) {
+            return [false, _('There is no filter to save')];
+        }
+        if (strlen($value) > SavedFilter::MAX_VALUE_BYTES) {
+            return [false, _('That filter is too large to save')];
+        }
+        if ($global && !$mayManageGlobal) {
+            return [false, _('You may not save a filter for everyone')];
+        }
+
+        // The UNIQUE index covers the private case. It does NOT cover the
+        // global one: MySQL does not treat two NULLs as equal in a unique
+        // index, so (NULL, 'hosts', 'Broken') can be inserted twice and the
+        // picker would then show two identically named entries. Find the
+        // existing row explicitly instead of relying on an upsert that only
+        // half works.
+        $existing = self::$DB
+            ->query(
+                'SELECT `sfID` FROM `savedFilters`'
+                . ' WHERE `sfTable` = :table AND `sfName` = :name'
+                . ($global ? ' AND `sfUserID` IS NULL' : ' AND `sfUserID` = :uid'),
+                [],
+                $global
+                    ? [':table' => $table, ':name' => $name]
+                    : [':table' => $table, ':name' => $name, ':uid' => $userID]
+            )
+            ->fetch()
+            ->get();
+
+        if ($existing && !empty($existing['sfID'])) {
+            return [
+                (bool)self::$DB->query(
+                    'UPDATE `savedFilters`'
+                    . ' SET `sfValue` = :val, `sfModifiedTime` = NOW()'
+                    . ' WHERE `sfID` = :id',
+                    [],
+                    [':val' => $value, ':id' => (int)$existing['sfID']]
+                ),
+                ''
+            ];
+        }
+
+        return [
+            (bool)self::$DB->query(
+                'INSERT INTO `savedFilters`'
+                . ' (`sfUserID`, `sfCreatorID`, `sfTable`, `sfName`,'
+                . ' `sfValue`, `sfModifiedTime`)'
+                . ' VALUES (:owner, :creator, :table, :name, :val, NOW())',
+                [],
+                [
+                    // NULL, not 0: 0 has no row in users, so the foreign key
+                    // added at schema 394 would refuse it.
+                    ':owner' => $global ? null : $userID,
+                    ':creator' => $userID,
+                    ':table' => $table,
+                    ':name' => $name,
+                    ':val' => $value
+                ]
+            ),
+            ''
+        ];
+    }
+
+    /**
+     * Renames a filter.
+     *
+     * @param int    $id              The filter.
+     * @param int    $userID          The acting user.
+     * @param string $name            The new name.
+     * @param bool   $mayManageGlobal Whether the caller holds the permission.
+     *
+     * @return array [bool ok, string error]
+     */
+    public function rename($id, $userID, $name, $mayManageGlobal = false)
+    {
+        $name = trim((string)$name);
+        if ('' === $name) {
+            return [false, _('A filter needs a name')];
+        }
+        if (strlen($name) > SavedFilter::MAX_NAME_BYTES) {
+            return [false, _('That name is too long')];
+        }
+        list($ok, $error) = $this->_reachable($id, $userID, $mayManageGlobal);
+        if (!$ok) {
+            return [false, $error];
+        }
+
+        return [
+            (bool)self::$DB->query(
+                'UPDATE `savedFilters`'
+                . ' SET `sfName` = :name, `sfModifiedTime` = NOW()'
+                . ' WHERE `sfID` = :id',
+                [],
+                [':name' => $name, ':id' => (int)$id]
+            ),
+            ''
+        ];
+    }
+
+    /**
+     * Deletes a filter.
+     *
+     * @param int  $id              The filter.
+     * @param int  $userID          The acting user.
+     * @param bool $mayManageGlobal Whether the caller holds the permission.
+     *
+     * @return array [bool ok, string error]
+     */
+    public function remove($id, $userID, $mayManageGlobal = false)
+    {
+        list($ok, $error) = $this->_reachable($id, $userID, $mayManageGlobal);
+        if (!$ok) {
+            return [false, $error];
+        }
+
+        return [
+            (bool)self::$DB->query(
+                'DELETE FROM `savedFilters` WHERE `sfID` = :id',
+                [],
+                [':id' => (int)$id]
+            ),
+            ''
+        ];
+    }
+
+    /**
+     * Whether this user may MUTATE this filter.
+     *
+     * The one place the two ownership rules are written down, so rename and
+     * remove cannot drift apart. A row that does not exist and a row that
+     * belongs to somebody else are answered identically: the alternative
+     * turns the id into an oracle for which filters other people have.
+     *
+     * @param int  $id              The filter.
+     * @param int  $userID          The acting user.
+     * @param bool $mayManageGlobal Whether the caller holds the permission.
+     *
+     * @return array [bool ok, string error]
+     */
+    private function _reachable($id, $userID, $mayManageGlobal)
+    {
+        $id = (int)$id;
+        $userID = (int)$userID;
+        if ($id < 1 || $userID < 1) {
+            return [false, _('No such filter')];
+        }
+        $row = self::$DB
+            ->query(
+                'SELECT `sfUserID` FROM `savedFilters` WHERE `sfID` = :id',
+                [],
+                [':id' => $id]
+            )
+            ->fetch()
+            ->get();
+        if (!$row) {
+            return [false, _('No such filter')];
+        }
+        if (null === $row['sfUserID']) {
+            return $mayManageGlobal
+                ? [true, '']
+                : [false, _('You may not change a filter shared with everyone')];
+        }
+        if ((int)$row['sfUserID'] !== $userID) {
+            return [false, _('No such filter')];
+        }
+
+        return [true, ''];
+    }
+}

--- a/packages/web/src/Router/OpenAPI.php
+++ b/packages/web/src/Router/OpenAPI.php
@@ -2310,6 +2310,107 @@ class OpenAPI extends FOGBase
      *
      * @return array
      */
+    /**
+     * The {id} path parameter shared by the saved-filter item operations.
+     *
+     * @return array
+     */
+    /**
+     * An id/name list, as the share-target route returns.
+     *
+     * @return array
+     */
+    private static function _namedIdList()
+    {
+        return [
+            'type' => 'array',
+            'items' => [
+                'type' => 'object',
+                'properties' => [
+                    'id' => ['type' => 'integer'],
+                    'name' => ['type' => 'string']
+                ]
+            ]
+        ];
+    }
+    private static function _filterIdParam()
+    {
+        return [
+            [
+                'name' => 'id',
+                'in' => 'path',
+                'required' => true,
+                'description' => _('The saved filter.'),
+                'schema' => ['type' => 'integer']
+            ]
+        ];
+    }
+    /**
+     * One saved filter as the list operation returns it.
+     *
+     * @return array
+     */
+    private static function _savedFilterSchema()
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'id' => ['type' => 'integer'],
+                'name' => ['type' => 'string'],
+                'mine' => [
+                    'type' => 'boolean',
+                    'description' => _('You own it, so you may rename, '
+                        . 're-share or delete it.')
+                ],
+                'global' => [
+                    'type' => 'boolean',
+                    'description' => _('Offered to every user on this grid.')
+                ],
+                'source' => [
+                    'type' => 'string',
+                    'enum' => ['mine', 'user', 'group', 'role', 'global'],
+                    'description' => _('Why the caller can see it, most '
+                        . 'specific grant first. A filter reachable several '
+                        . 'ways is still returned once and reports only the '
+                        . 'most specific reason.')
+                ],
+                'sharedBy' => [
+                    'type' => 'string',
+                    'description' => _('Username of whoever created it, on '
+                        . 'filters the caller does not own. Empty when the '
+                        . 'creator\'s account has since been deleted.')
+                ],
+                'value' => [
+                    'type' => 'string',
+                    'description' => _('The filter state, opaque. It is '
+                        . 'DataTables SearchBuilder\'s own serialization and '
+                        . 'the server does not interpret it.')
+                ],
+                'modified' => ['type' => 'string']
+            ]
+        ];
+    }
+    /**
+     * The share-target lists, as sent and as returned.
+     *
+     * @return array
+     */
+    private static function _shareTargetsSchema()
+    {
+        $ids = [
+            'type' => 'array',
+            'items' => ['type' => 'integer']
+        ];
+
+        return [
+            'type' => 'object',
+            'properties' => [
+                'users' => $ids,
+                'groups' => $ids,
+                'roles' => $ids
+            ]
+        ];
+    }
     private static function _prefKeyParam()
     {
         return [
@@ -2475,6 +2576,219 @@ class OpenAPI extends FOGBase
                     self::_prefKeyParam(),
                     [],
                     'ClearPref'
+                )
+            ],
+            '/system/savedfilters' => [
+                'get' => self::_op(
+                    '',
+                    'savedfilters',
+                    _('Saved filters for one grid'),
+                    _('Every filter the CALLING user may see on that grid: '
+                        . 'their own, every global one, and any shared with '
+                        . 'them by name, through a user group, or through a '
+                        . 'role. There is no user in the path and no way to '
+                        . 'name one. mayShareGlobally reports whether the '
+                        . 'caller holds savedfilter.create, so a client can '
+                        . 'omit the "everyone" option rather than offer it '
+                        . 'and fail on save.'),
+                    $json(
+                        [
+                            'type' => 'object',
+                            'properties' => [
+                                'table' => ['type' => 'string'],
+                                'filters' => [
+                                    'type' => 'array',
+                                    'items' => self::_savedFilterSchema()
+                                ],
+                                'mayShareGlobally' => ['type' => 'boolean'],
+                                'msg' => ['type' => 'string']
+                            ]
+                        ],
+                        _('The filters visible to the caller.')
+                    ),
+                    [
+                        [
+                            'name' => 'table',
+                            'in' => 'query',
+                            'required' => true,
+                            'description' => _('The grid key.'),
+                            'schema' => [
+                                'type' => 'string',
+                                'maxLength' => 128
+                            ]
+                        ]
+                    ],
+                    [],
+                    'ListSavedFilters'
+                ),
+                'post' => self::_op(
+                    '',
+                    'savedfilters',
+                    _('Save a filter'),
+                    _('Saving over a name you already used replaces that '
+                        . 'filter rather than adding a second one, which is '
+                        . 'what a Save button is expected to do. A private '
+                        . 'save never touches a global of the same name and '
+                        . 'the other way round. global:true requires '
+                        . 'savedfilter.create and answers 403 without it; '
+                        . 'everything else needs only a session. Values are '
+                        . 'capped at 64KB and refused rather than truncated.'),
+                    $json(
+                        [
+                            'type' => 'object',
+                            'properties' => [
+                                'filters' => [
+                                    'type' => 'array',
+                                    'items' => self::_savedFilterSchema()
+                                ],
+                                'msg' => ['type' => 'string']
+                            ]
+                        ],
+                        _('The filter was saved; the full list is returned.')
+                    ),
+                    [],
+                    [
+                        'required' => true,
+                        'content' => [
+                            'application/json' => [
+                                'schema' => [
+                                    'type' => 'object',
+                                    'required' => ['table', 'name', 'value'],
+                                    'properties' => [
+                                        'table' => ['type' => 'string'],
+                                        'name' => ['type' => 'string'],
+                                        'value' => ['type' => 'string'],
+                                        'global' => ['type' => 'boolean']
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
+                    'SaveFilter'
+                )
+            ],
+            '/system/savedfilter/{id}' => [
+                'get' => self::_op(
+                    '',
+                    'savedfilter',
+                    _('Read one saved filter'),
+                    _('shares is null unless you own the filter: being '
+                        . 'shared WITH one does not entitle you to see who '
+                        . 'else it went to. A filter that does not exist and '
+                        . 'one belonging to somebody else both answer 404, '
+                        . 'deliberately, so an id cannot be used to probe for '
+                        . 'other people\'s filters.'),
+                    $json(
+                        [
+                            'type' => 'object',
+                            'properties' => [
+                                'id' => ['type' => 'integer'],
+                                'name' => ['type' => 'string'],
+                                'value' => ['type' => 'string'],
+                                'global' => ['type' => 'boolean'],
+                                'shares' => array_merge(
+                                    self::_shareTargetsSchema(),
+                                    ['nullable' => true]
+                                ),
+                                'msg' => ['type' => 'string']
+                            ]
+                        ],
+                        _('One saved filter.')
+                    ),
+                    self::_filterIdParam(),
+                    [],
+                    'GetSavedFilter'
+                ),
+                'put' => self::_op(
+                    '',
+                    'savedfilter',
+                    _('Rename a filter, or change who it is shared with'),
+                    _('Either half may be sent, or both. ABSENT IS NOT '
+                        . 'EMPTY: a body with no "shares" key leaves the '
+                        . 'share list alone, while one carrying empty lists '
+                        . 'means "shared with nobody" and clears it. The '
+                        . 'whole list is replaced rather than added to. '
+                        . 'Sharing needs no permission -- it can only add one '
+                        . 'named entry to the picker of somebody you could '
+                        . 'already name -- but editing a GLOBAL filter '
+                        . 'requires savedfilter.edit.'),
+                    $json(
+                        [
+                            'type' => 'object',
+                            'properties' => [
+                                'id' => ['type' => 'integer'],
+                                'msg' => ['type' => 'string']
+                            ]
+                        ],
+                        _('The filter was updated.')
+                    ),
+                    self::_filterIdParam(),
+                    [
+                        'required' => true,
+                        'content' => [
+                            'application/json' => [
+                                'schema' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'name' => ['type' => 'string'],
+                                        'shares' => self::_shareTargetsSchema()
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
+                    'UpdateSavedFilter'
+                ),
+                'delete' => self::_op(
+                    '',
+                    'savedfilter',
+                    _('Delete a saved filter'),
+                    _('Yours, always. A global one requires '
+                        . 'savedfilter.delete. Every share of it goes with '
+                        . 'it, by foreign key.'),
+                    $json(
+                        [
+                            'type' => 'object',
+                            'properties' => [
+                                'id' => ['type' => 'integer'],
+                                'msg' => ['type' => 'string']
+                            ]
+                        ],
+                        _('The filter was deleted.')
+                    ),
+                    self::_filterIdParam(),
+                    [],
+                    'DeleteSavedFilter'
+                )
+            ],
+            '/system/savedfiltertargets' => [
+                'get' => self::_op(
+                    '',
+                    'savedfiltertargets',
+                    _('Who a filter can be shared with'),
+                    _('Users, user groups and roles as id/name pairs. Each '
+                        . 'section is gated on that entity\'s own view '
+                        . 'permission -- user.view, usergroup.view, '
+                        . 'role.view -- and comes back EMPTY rather than 403 '
+                        . 'when the caller lacks it, so this route discloses '
+                        . 'nothing they could not already list. A caller '
+                        . 'holding none of the three can still save private '
+                        . 'filters; there is simply nobody they may name.'),
+                    $json(
+                        [
+                            'type' => 'object',
+                            'properties' => [
+                                'users' => self::_namedIdList(),
+                                'groups' => self::_namedIdList(),
+                                'roles' => self::_namedIdList(),
+                                'msg' => ['type' => 'string']
+                            ]
+                        ],
+                        _('The share targets the caller may see.')
+                    ),
+                    [],
+                    [],
+                    'ListShareTargets'
                 )
             ],
             '/system/export' => [

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -1402,6 +1402,34 @@ class Route extends FOGBase
             [__CLASS__, 'userpref'],
             'userpref'
         )->map(
+            // The CALLER's saved filters for one grid, and saving a new one.
+            // Like userpref above there is no user in the path: the id comes
+            // from the session, and the manager filters every read and write
+            // on it. Saving a GLOBAL filter is the one privileged operation
+            // and is checked inside the handler, because it is a property of
+            // the request body rather than of the route.
+            'GET|POST',
+            '/system/savedfilters',
+            [__CLASS__, 'savedfilters'],
+            'savedfilters'
+        )->map(
+            'GET|PUT|DELETE',
+            '/system/savedfilter/[i:id]',
+            [__CLASS__, 'savedfilter'],
+            'savedfilter'
+        )->get(
+            // Who a filter can be shared WITH. A separate route rather than a
+            // reuse of /user, /usergroup and /role because it returns id and
+            // name only, and because it answers all three in one request --
+            // the share editor needs every list before it can draw anything.
+            //
+            // Each section is gated on that entity's own view permission and
+            // omitted when the caller lacks it, so this route discloses
+            // nothing they could not already list.
+            '/system/savedfiltertargets',
+            [__CLASS__, 'savedfiltertargets'],
+            'savedfiltertargets'
+        )->map(
             'GET|POST',
             '/[search|unisearch]/[*:item]/[i:limit]?',
             [__CLASS__, 'unisearch'],
@@ -2121,6 +2149,263 @@ class Route extends FOGBase
             ),
             'msg' => _('success')
         ];
+    }
+    /**
+     * The permission that governs GLOBAL saved filters.
+     *
+     * Private filters, and filters shared with named people, need no
+     * permission at all: they reach only the person who made them and the
+     * people they named, and the route derives the actor from the session.
+     * A GLOBAL filter puts an entry in EVERY user's picker on that grid, so
+     * it is the one operation that is an administrative act.
+     *
+     * @param string $action create, edit or delete.
+     *
+     * @return bool
+     */
+    private static function _mayManageGlobalFilters($action)
+    {
+        return Authorization::can('savedfilter.' . $action);
+    }
+    /**
+     * Lists the caller's saved filters for one grid, or saves one.
+     *
+     * @return void
+     */
+    public static function savedfilters()
+    {
+        $userID = (int)self::$FOGUser->get('id');
+        if ($userID < 1) {
+            // Same fail-closed stance as userpref(): unreachable, because the
+            // router authenticates first, but acting as user 0 would pool
+            // every anonymous write into one shared pile.
+            self::sendResponse(
+                HTTPResponseCodes::HTTP_UNAUTHORIZED,
+                json_encode(['error' => _('No user in session')])
+            );
+
+            return;
+        }
+        $manager = self::getClass('SavedFilterManager');
+        $method = strtoupper(self::$reqmethod ?: 'GET');
+        if ('GET' === $method) {
+            self::$data = [
+                'table' => (string)filter_input(INPUT_GET, 'table'),
+                'filters' => $manager->listFor(
+                    $userID,
+                    (string)filter_input(INPUT_GET, 'table')
+                ),
+                // So the client knows whether to offer the "everyone" option
+                // at all, rather than offering it and failing on save.
+                'mayShareGlobally' => self::_mayManageGlobalFilters('create'),
+                'msg' => _('success')
+            ];
+
+            return;
+        }
+        $body = self::_jsonBody();
+        $global = !empty($body['global']);
+        list($ok, $error) = $manager->store(
+            $userID,
+            (string)($body['table'] ?? ''),
+            (string)($body['name'] ?? ''),
+            (string)($body['value'] ?? ''),
+            $global,
+            self::_mayManageGlobalFilters('create')
+        );
+        if (!$ok) {
+            self::sendResponse(
+                $global && !self::_mayManageGlobalFilters('create')
+                    ? HTTPResponseCodes::HTTP_FORBIDDEN
+                    : HTTPResponseCodes::HTTP_BAD_REQUEST,
+                json_encode(['error' => $error])
+            );
+
+            return;
+        }
+        self::$data = [
+            'filters' => $manager->listFor(
+                $userID,
+                (string)($body['table'] ?? '')
+            ),
+            'msg' => _('success')
+        ];
+    }
+    /**
+     * Reads, renames, re-shares or deletes one saved filter.
+     *
+     * @param int $id the filter
+     *
+     * @return void
+     */
+    public static function savedfilter($id)
+    {
+        $userID = (int)self::$FOGUser->get('id');
+        if ($userID < 1) {
+            self::sendResponse(
+                HTTPResponseCodes::HTTP_UNAUTHORIZED,
+                json_encode(['error' => _('No user in session')])
+            );
+
+            return;
+        }
+        $manager = self::getClass('SavedFilterManager');
+        $method = strtoupper(self::$reqmethod ?: 'GET');
+        if ('GET' === $method) {
+            $filter = $manager->fetch((int)$id, $userID);
+            if (!$filter) {
+                self::sendResponse(
+                    HTTPResponseCodes::HTTP_NOT_FOUND,
+                    json_encode(['error' => _('No such filter')])
+                );
+
+                return;
+            }
+            self::$data = [
+                'id' => (int)$filter['sfID'],
+                'name' => (string)$filter['sfName'],
+                'value' => (string)($filter['sfValue'] ?? ''),
+                'global' => null === $filter['sfUserID'],
+                // null when the caller does not own it. Being shared WITH a
+                // filter does not entitle you to see who else it went to.
+                'shares' => $manager->shares(
+                    (int)$id,
+                    $userID,
+                    self::_mayManageGlobalFilters('edit')
+                ),
+                'msg' => _('success')
+            ];
+
+            return;
+        }
+        if ('DELETE' === $method) {
+            list($ok, $error) = $manager->remove(
+                (int)$id,
+                $userID,
+                self::_mayManageGlobalFilters('delete')
+            );
+            if (!$ok) {
+                self::_filterDenied($error);
+
+                return;
+            }
+            self::$data = ['id' => (int)$id, 'msg' => _('success')];
+
+            return;
+        }
+        $body = self::_jsonBody();
+        $mayGlobal = self::_mayManageGlobalFilters('edit');
+        // A PUT may carry either half, or both. Absent is not empty: a body
+        // with no `shares` key must leave the share list alone, while one
+        // carrying an empty list means "shared with nobody" and has to clear
+        // it. Reading them the same way would make renaming a filter silently
+        // unshare it.
+        if (array_key_exists('name', $body)) {
+            list($ok, $error) = $manager->rename(
+                (int)$id,
+                $userID,
+                (string)$body['name'],
+                $mayGlobal
+            );
+            if (!$ok) {
+                self::_filterDenied($error);
+
+                return;
+            }
+        }
+        if (array_key_exists('shares', $body)) {
+            list($ok, $error) = $manager->setShares(
+                (int)$id,
+                $userID,
+                (array)$body['shares'],
+                $mayGlobal
+            );
+            if (!$ok) {
+                self::_filterDenied($error);
+
+                return;
+            }
+        }
+        self::$data = ['id' => (int)$id, 'msg' => _('success')];
+    }
+    /**
+     * The users, groups and roles a filter can be shared with.
+     *
+     * Each section is gated on that entity's own view permission and omitted
+     * entirely when the caller lacks it, so this route can disclose nothing
+     * they could not already list through /user, /usergroup or /role. A
+     * caller who holds none of the three gets three empty lists and can still
+     * save private filters -- there is simply nobody they may name.
+     *
+     * @return void
+     */
+    public static function savedfiltertargets()
+    {
+        $sets = [
+            'users' => ['user.view', 'users', 'uId', 'uName'],
+            'groups' => ['usergroup.view', 'userGroups', 'ugID', 'ugName'],
+            'roles' => ['role.view', 'roles', 'rID', 'rName']
+        ];
+        $out = [];
+        foreach ($sets as $key => $spec) {
+            list($perm, $table, $idCol, $nameCol) = $spec;
+            $out[$key] = [];
+            if (!Authorization::can($perm)) {
+                continue;
+            }
+            $rows = self::$DB
+                ->query(
+                    sprintf(
+                        'SELECT `%s`, `%s` FROM `%s` ORDER BY `%s` ASC',
+                        $idCol,
+                        $nameCol,
+                        $table,
+                        $nameCol
+                    )
+                )
+                ->fetch('', 'fetch_all')
+                ->get();
+            foreach ((array)$rows as $row) {
+                $out[$key][] = [
+                    'id' => (int)$row[$idCol],
+                    'name' => (string)$row[$nameCol]
+                ];
+            }
+        }
+        self::$data = $out + ['msg' => _('success')];
+    }
+    /**
+     * Answers a refused filter mutation.
+     *
+     * 404 and 403 say different things and the manager already decided which:
+     * "no such filter" covers both a row that is absent and one belonging to
+     * somebody else, deliberately, so that an id cannot be used to probe for
+     * other people's filters. Only the global case is a true 403, and it is
+     * safe to admit because the filter is visible to the caller anyway.
+     *
+     * @param string $error the manager's message
+     *
+     * @return void
+     */
+    private static function _filterDenied($error)
+    {
+        self::sendResponse(
+            false === stripos($error, 'everyone')
+                ? HTTPResponseCodes::HTTP_NOT_FOUND
+                : HTTPResponseCodes::HTTP_FORBIDDEN,
+            json_encode(['error' => $error])
+        );
+    }
+    /**
+     * The request body, decoded, for the routes that take JSON.
+     *
+     * @return array
+     */
+    private static function _jsonBody()
+    {
+        $decoded = json_decode((string)file_get_contents('php://input'), true);
+
+        return is_array($decoded) ? $decoded : [];
     }
     /**
      * Reads, writes or clears one preference of the calling user's.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -129,7 +129,7 @@ parameters:
 		-
 			message: '#^Variable \$this might not be defined\.$#'
 			identifier: variable.undefined
-			count: 362
+			count: 365
 			path: packages/web/commons/schema.php
 
 		-

--- a/tests/foreign-key-map.test.php
+++ b/tests/foreign-key-map.test.php
@@ -325,6 +325,15 @@ $expected = [
     'multicastSessionsAssoc.tID',
     // Group 7
     'userPrefs.upUserID',
+    // Group 8
+    'savedFilters.sfUserID',
+    'savedFilters.sfCreatorID',
+    'savedFilterUserAssoc.sfuaFilterID',
+    'savedFilterUserAssoc.sfuaUserID',
+    'savedFilterGroupAssoc.sfgaFilterID',
+    'savedFilterGroupAssoc.sfgaUserGroupID',
+    'savedFilterRoleAssoc.sfraFilterID',
+    'savedFilterRoleAssoc.sfraRoleID',
     // Plugin groups, named for the plugin rather than numbered. Each
     // lands in that plugin's own repo, in an appended step of its
     // manager's schema(); see fog-plugins tests/foreign-keys.test.php,

--- a/tests/saved-filters.test.php
+++ b/tests/saved-filters.test.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Saved grid filters: the four things that fail SILENTLY if they drift.
+ *
+ * None of these shows up as an error. A filter applied on page load looks
+ * like a grid that lost rows; a filter listed three times looks like three
+ * filters; a global filter saved without the permission looks like it worked;
+ * a remembered search TERM looks like a short grid with no visible cause.
+ *
+ *  1. listFor() reaches every share path from ONE select, so a filter that a
+ *     user can see by several routes at once is still one row. The moment it
+ *     becomes a UNION of per-path selects the picker starts repeating itself.
+ *  2. The provenance precedence is most-specific-first. The badge a user sees
+ *     has to describe the most deliberate grant, or "shared with you by your
+ *     manager" silently becomes "everyone".
+ *  3. Nothing is ever applied on load. The whole design rests on it: the
+ *     saved state of a grid carries no search, and a filter is applied only
+ *     by a click that the user can see and undo with the chip's x.
+ *  4. Saving a filter FOR EVERYONE takes savedfilter.create. It is an access
+ *     control decision, not a column: a global filter appears in every user's
+ *     picker.
+ *
+ * Usage: php tests/saved-filters.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+
+$manager = file_get_contents($web . '/src/Managers/SavedFilterManager.php');
+$route = file_get_contents($web . '/src/Router/Route.php');
+$authz = file_get_contents($web . '/src/Auth/Authorization.php');
+$js = file_get_contents($web . '/management/js/fog/fog.filters.js');
+$common = file_get_contents($web . '/management/js/fog/fog.common.js');
+
+$fails = [];
+
+/**
+ * One named method's body, so an assertion cannot pass on a comment or on an
+ * unrelated method further down the file.
+ *
+ * @param string $src  the file
+ * @param string $name the method
+ *
+ * @return string
+ */
+function sf_body($src, $name)
+{
+    if (!preg_match(
+        '/function ' . preg_quote($name, '/') . '\(.*?\n    \}/s',
+        $src,
+        $m
+    )) {
+        return '';
+    }
+
+    return $m[0];
+}
+
+/**
+ * The same body with its // comments removed.
+ *
+ * Without this the UNION check below fails on the comment EXPLAINING that
+ * there is no union -- a gate passing (or failing) on its own documentation
+ * rather than on the code it guards.
+ *
+ * @param string $body the method body
+ *
+ * @return string
+ */
+function sf_code($body)
+{
+    return preg_replace('#^\s*//.*$#m', '', $body);
+}
+
+// --- 1. one select, not a union ------------------------------------------
+
+$listFor = sf_body($manager, 'listFor');
+if ('' === $listFor) {
+    $fails[] = 'SavedFilterManager::listFor() not found';
+} else {
+    if (false !== stripos(sf_code($listFor), 'union')) {
+        $fails[] = 'listFor() uses UNION -- a filter reachable by several'
+            . ' share paths will be listed once per path';
+    }
+    if (1 !== preg_match_all('/SELECT `sfID`|SELECT f\.`sfID`/', $listFor)) {
+        $fails[] = 'listFor() no longer builds exactly one row-returning'
+            . ' select over savedFilters';
+    }
+    // The three share paths, each an OR arm of that one select.
+    foreach (
+        [
+            'savedFilterUserAssoc' => 'direct',
+            'savedFilterGroupAssoc' => 'group',
+            'savedFilterRoleAssoc' => 'role'
+        ] as $table => $what
+    ) {
+        if (false === strpos($listFor, $table)) {
+            $fails[] = "listFor() no longer reads the $what share table"
+                . " ($table)";
+        }
+    }
+}
+
+// --- 2. precedence, most specific first ----------------------------------
+
+if ('' !== $listFor) {
+    if (!preg_match_all(
+        "/\\\$source = '(mine|user|group|role|global)'/",
+        $listFor,
+        $m
+    )) {
+        $fails[] = 'listFor() no longer reports a share source';
+    } elseif ($m[1] !== ['mine', 'user', 'group', 'role', 'global']) {
+        $fails[] = 'listFor() reports sources in the order '
+            . implode(' > ', $m[1])
+            . ' -- it must be mine > user > group > role > global, most'
+            . ' deliberate grant first';
+    }
+    // The order above is only meaningful if the tests are a fall-through
+    // chain: separate ifs would let a later one overwrite an earlier one.
+    if (!preg_match(
+        "/if \(\\\$mine\) \{.*?\} elseif \(\\\$row\['viaUser'\]\).*?"
+        . "\} elseif \(\\\$row\['viaGroup'\]\).*?"
+        . "\} elseif \(\\\$row\['viaRole'\]\).*?\} else \{/s",
+        $listFor
+    )) {
+        $fails[] = 'listFor() no longer picks the source with a single'
+            . ' if/elseif fall-through, so a less specific grant can win';
+    }
+}
+
+// --- 3. nothing is applied on load ---------------------------------------
+
+// The definition itself is excluded; what is counted is call sites.
+$calls = preg_match_all(
+    '/(?<!function )applyFilter\(dt, filter\)/',
+    $js,
+    $m,
+    PREG_OFFSET_CAPTURE
+);
+if (1 !== $calls) {
+    $fails[] = 'fog.filters.js applies a filter from ' . $calls
+        . ' places -- there must be exactly one, the Apply button';
+} else {
+    $before = substr($js, max(0, $m[0][0][1] - 200), 200);
+    if (false === strpos($before, "addEventListener('click'")) {
+        $fails[] = 'the one applyFilter() call is no longer inside a click'
+            . ' handler, so a filter can be applied without the user asking';
+    }
+}
+foreach (['DOMContentLoaded', '$(document).ready', 'doPageLoad'] as $onload) {
+    if (false !== strpos($js, $onload)) {
+        $fails[] = "fog.filters.js registers $onload -- this file must do"
+            . ' nothing at all until the toolbar button is clicked';
+    }
+}
+
+// --- 4. the affordance is a boolean, never a term ------------------------
+
+$store = sf_body($common, 'fogAffordanceStore');
+if ('' === $store) {
+    $fails[] = 'fogAffordanceStore() not found';
+} elseif (!preg_match("/fogPrefStore\(key, on \? '1' : ''\)/", $store)) {
+    $fails[] = 'fogAffordanceStore() no longer writes a plain boolean -- the'
+        . ' search row is remembered as SHOWN, never as what was typed in it';
+}
+
+// --- 5. a global filter takes savedfilter.create -------------------------
+
+$gate = sf_body($route, '_mayManageGlobalFilters');
+if ('' === $gate) {
+    $fails[] = 'Route::_mayManageGlobalFilters() not found';
+} elseif (false === strpos($gate, "Authorization::can('savedfilter.'")) {
+    $fails[] = '_mayManageGlobalFilters() no longer consults Authorization';
+}
+$handler = sf_body($route, 'savedfilters');
+if ('' === $handler) {
+    $fails[] = 'Route::savedfilters() not found';
+} else {
+    // Anchored on the store() CALL, not on a count of mentions: the handler
+    // names the permission three times (to advertise it, to enforce it, and
+    // to pick the status code), so a count of two still passed with the one
+    // that actually enforces it replaced by `true`.
+    if (!preg_match(
+        '/\$manager->store\(.*?self::_mayManageGlobalFilters\(\'create\'\)'
+        . '\s*\);/s',
+        $handler
+    )) {
+        $fails[] = 'Route::savedfilters() no longer passes the caller\'s'
+            . ' global-filter permission to store(), so a global filter can'
+            . ' be saved by anybody';
+    }
+    if (false === strpos(
+        $handler,
+        "'mayShareGlobally' => self::_mayManageGlobalFilters('create')"
+    )) {
+        $fails[] = 'Route::savedfilters() no longer tells the client whether'
+            . ' it may offer the "everyone" option';
+    }
+    if (false === strpos($handler, 'HTTP_FORBIDDEN')) {
+        $fails[] = 'Route::savedfilters() no longer answers 403 when a global'
+            . ' filter is refused';
+    }
+}
+$store = sf_body($manager, 'store');
+if ('' === $store) {
+    $fails[] = 'SavedFilterManager::store() not found';
+} elseif (!preg_match('/\$mayManageGlobal\b/', $store)) {
+    $fails[] = 'SavedFilterManager::store() no longer takes the caller\'s'
+        . ' global-filter permission, so the route is the only guard';
+}
+if (false === strpos($authz, "'savedfilter' => [")) {
+    $fails[] = 'Authorization::coreRegistry() no longer registers the'
+        . ' savedfilter permission node, so nobody can be granted it';
+}
+
+// --- report ---------------------------------------------------------------
+
+if ($fails) {
+    fwrite(STDERR, "FAIL saved-filters\n");
+    foreach ($fails as $fail) {
+        fwrite(STDERR, '  - ' . $fail . "\n");
+    }
+    exit(1);
+}
+
+echo "PASS saved-filters\n";
+exit(0);


### PR DESCRIPTION
A filter worth building twice is worth keeping, and a filter worth keeping is
usually worth handing to somebody. This adds named, saved SearchBuilder
filters per grid, with sharing.

## The two rules it is built around

- **Nothing is ever applied on page load.** A filter is offered in a picker
  the user opens deliberately, applied by a click, shown as a chip naming it,
  and cleared by that chip's `x`. A grid that comes back short with no visible
  reason is indistinguishable from a broken grid — which is exactly why the
  saved layout already strips searches out of the state it persists.
- **The header search row is remembered as SHOWN, never as what was typed in
  it.** The affordance is a preference; the question somebody asked once is
  not.

## Sharing

Three junction tables — users, user groups, roles — not a `type`/`targetID`
pair. ADR 0031 records polymorphic columns as the one place no constraint is
expressible, and a type column would have added three more of them to a
release whose point was removing them. All eight relationships are declared
foreign keys (constraint group 8): a private filter CASCADEs with its owner,
and `sfCreatorID` is SET NULL so a global filter outlives whoever wrote it.

**Visibility resolves in one SELECT with OR'd arms**, not a UNION of per-path
selects, so a filter a user can reach three ways at once is one row, always.
Which reason is *reported* follows a fixed precedence, most deliberate grant
first:

    mine > user > group > role > global

The picker shows one badge, so a manager who is also in the group they shared
to sees "Shared with you by …", not "Everyone".

## Access control

| operation | takes |
|---|---|
| create / rename / delete / share **your own** filter | nothing beyond being signed in |
| create a filter **for everyone** | `savedfilter.create` |
| rename / delete an existing global filter | `savedfilter.edit` / `savedfilter.delete` |

A global filter appears in every user's picker on that grid, so it changes
what other people see — an access-control decision rather than a column.
Private sharing needs no permission of its own: the grants reach only the
people they name, and the target lists are already gated by `user.view`,
`usergroup.view` and `role.view`, so nobody can share to a target they cannot
already enumerate. `savedfilter` has no `view` verb, because everyone can see
a global filter by definition.

Reasoning in `docs/adr/0032-a-saved-filter-is-shared-by-grant-not-by-visibility.md`.

## Schema

393 (`savedFilters`), 394 (the three `savedFilter*Assoc` junctions), 395 (the
eight constraints). `FOG_SCHEMA` and `FOG_BCACHE_VER` bumped.

## Verification

Run against a **throwaway container copy** of a real database, never the live
one, through a shadow tree in a real browser:

- the chip appears on save, names the filter, and its `x` clears the filter in
  one click;
- a saved filter is **not** applied on the next page load (86 rows before and
  after; no chip);
- applying it from the picker reproduces the exact row count the ad hoc filter
  gave;
- sharing writes the junction rows, and removing one grant at a time walks the
  reported source `user → group → role → global` with **one** row throughout;
- an account holding `host.view`/`user.view` and no `savedfilter.*` is
  answered **403** on a global filter, is told `mayShareGlobally: false`, is
  offered no "everyone" option, and can still save a private filter (200);
- the header search row survives a reload while its **terms** do not.

`tests/saved-filters.test.php` pins the four invariants that fail silently.
Every one of its twelve assertions was proved by mutation — the check goes red
when the thing it guards is broken, including one it originally did not
(counting mentions of the permission passed while the enforcing call site was
replaced with `true`).

`phpstan` both passes clean; `tests/run-all.sh` 211 passed.

## Not in this change

- **Restoring the Filter PANEL open.** It was built and reverted: the panel is
  a DataTables Buttons *collection*, and the vendored extension calls
  `this.popover(...)` without a `background` option, so a collection always
  lays a click-catching backdrop over the page. Restoring it on load would dim
  the grid and swallow the first click of every visit, and the only way around
  it is to reimplement the extension's own action. The header search row has
  no such problem, which is why it is here and this is not.
- **Per-user dismissal of a filter shared to you.** "Just delete it" is the
  wrong answer for anything shared to a role — you are not entitled to delete
  it and the share is not yours to revoke. It is a fourth junction plus
  somewhere to see what you have hidden; additive against everything here.

## Downstream

None. No route class was added or removed, so FogApi's hardcoded class list is
unaffected.

## Unrelated, noticed while testing

DataTables SearchBuilder gives its panel the class `dropdown-menu` with no
`[data-bs-toggle]` sibling, so Bootstrap's dropdown keydown data-api throws
`Cannot read properties of undefined (reading 'parentNode')` on Escape pressed
inside the panel. Pre-existing, from the vendored bundle, and harmless — the
panel still closes. Not touched here.
