### PR TITLE
A stored timestamp is in the install's zone, not the viewer's

### DIFF
--- a/packages/web/lib/pages/imagemanagement.page.php
+++ b/packages/web/lib/pages/imagemanagement.page.php
@@ -1947,7 +1947,7 @@ class ImageManagement extends FOGPage
             ->set('stateID', null)
             ->set('sessclients', $sessioncount)
             ->set('isDD', $Image->get('imageTypeID'))
-            ->set('starttime', self::formatTime('now', 'Y-m-d H:i:s'))
+            ->set('starttime', self::storageNow())
             ->set('interface', $StorageNode->get('interface'))
             ->set('logpath', $Image->get('path'))
             ->set('storagegroupID', $StorageGroup->get('id'))

--- a/packages/web/lib/pages/snapinmanagement.page.php
+++ b/packages/web/lib/pages/snapinmanagement.page.php
@@ -1260,7 +1260,7 @@ class SnapinManagement extends FOGPage
                         $insert_values[] = [
                             $this->obj->get('file'),
                             'Snapin',
-                            self::formatTime('now', 'Y-m-d H:i:s'),
+                            self::storageNow(),
                             self::getQueuedState(),
                             self::$FOGUser->get('name'),
                             $storagegroupID

--- a/packages/web/lib/pages/usermanagement.page.php
+++ b/packages/web/lib/pages/usermanagement.page.php
@@ -1464,7 +1464,7 @@ class UserManagement extends FOGPage
                     'title' => _('API Token Created'),
                     'token' => $token,
                     'name' => $name,
-                    'created' => self::formatTime('now', 'Y-m-d H:i:s')
+                    'created' => self::storageNow()
                 ]
             )
         );

--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -1863,14 +1863,25 @@ abstract class FOGBase
         if (null !== self::$_displayTimeZone) {
             return self::$_displayTimeZone;
         }
-        self::$_displayTimeZone = self::storageTimeZone();
+        $storage = self::storageTimeZone();
         $user = self::$FOGUser;
-        // Matches the house guard used wherever the shell asks the same
-        // question: unset before LoadGlobals has run, and invalid for anyone
-        // not signed in -- a background service, or the login page itself.
-        if (!$user || !$user->isValid()) {
-            return self::$_displayTimeZone;
+        // NOTHING is cached until the answer is one worth keeping.
+        //
+        // FOG_TZ_INFO arrives in setEnv(), which runs INSIDE LoadGlobals --
+        // and LoadGlobals formats a date before it gets there. Caching the
+        // answer on that first call pinned the whole request to
+        // storageTimeZone()'s own fallback of UTC, whatever FOG_TZ_INFO said,
+        // which on an America/Chicago install put every rendered date five
+        // hours out and (through the write sites this method used to reach)
+        // stored them that way too.
+        //
+        // So the empty case answers and returns without remembering. The
+        // cache exists for the DATABASE read below, which is the only
+        // expensive part and cannot happen before there is a user anyway.
+        if (empty(self::$TimeZone) || !$user || !$user->isValid()) {
+            return $storage;
         }
+        self::$_displayTimeZone = $storage;
         try {
             $pref = self::getClass('UserPrefManager')
                 ->fetch((int)$user->get('id'), self::TIMEZONE_PREF);
@@ -1889,6 +1900,26 @@ abstract class FOGBase
             // a tzdata that moved underneath us. Fall back rather than throw.
         }
         return self::$_displayTimeZone;
+    }
+    /**
+     * The current time, in the zone the database is written in.
+     *
+     * This is what every WRITE must use. formatTime() is its display-side
+     * counterpart and converts to the VIEWER's zone -- correct for something
+     * on a page, wrong for something about to be stored, because it makes the
+     * value depend on who happened to be signed in when the row was made.
+     *
+     * The two were the same function until a display zone existed at all, so
+     * the write sites were written against formatTime() and were harmless
+     * right up until they were not.
+     *
+     * @param string $format any format DateTime understands.
+     *
+     * @return string
+     */
+    public static function storageNow($format = 'Y-m-d H:i:s')
+    {
+        return self::niceDate('now')->format($format);
     }
     /**
      * Turns a datetime the VIEWER typed into one the database can be

--- a/packages/web/src/Base/FOGController.php
+++ b/packages/web/src/Base/FOGController.php
@@ -794,7 +794,7 @@ abstract class FOGController extends FOGBase
 
                     case 'createdTime':
                         if (!($val && self::validDate($val))) {
-                            $val = self::formatTime('now', 'Y-m-d H:i:s');
+                            $val = self::storageNow();
                         }
                         break;
                 }

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -2064,7 +2064,7 @@ abstract class FOGPage extends FOGBase
                         $insert_values[] = [
                             $pathItem,
                             $this->childClass,
-                            self::formatTime('now', 'Y-m-d H:i:s'),
+                            self::storageNow(),
                             self::getQueuedState(),
                             self::$FOGUser->get('name'),
                             $storagegroupID

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4536');
+        define('FOG_VERSION', '1.6.0-beta.4539');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4533');
+        define('FOG_VERSION', '1.6.0-beta.4536');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Items/APIToken.php
+++ b/packages/web/src/Items/APIToken.php
@@ -397,7 +397,7 @@ class APIToken extends FOGController
             return;
         }
         $this
-            ->set('lastUsed', self::formatTime('now', 'Y-m-d H:i:s'))
+            ->set('lastUsed', self::storageNow())
             ->save();
     }
 }

--- a/packages/web/src/Items/Host.php
+++ b/packages/web/src/Items/Host.php
@@ -1486,7 +1486,7 @@ class Host extends FOGController
             if ($TaskType->id == 14) {
                 $Task
                     ->set('stateID', self::getProgressState())
-                    ->set('checkInTime', self::formatTime('now', 'Y-m-d H:i:s'))
+                    ->set('checkInTime', self::storageNow())
                     ->save();
             }
             if ($wol || $TaskType->id == 14) {

--- a/packages/web/src/Items/Image.php
+++ b/packages/web/src/Items/Image.php
@@ -299,7 +299,7 @@ class Image extends FOGController
             self::getClass('FileDeleteQueue')
                 ->set('path', $this->get('path'))
                 ->set('pathtype', 'Image')
-                ->set('createdTime', self::formatTime('now', 'Y-m-d H:i:s'))
+                ->set('createdTime', self::storageNow())
                 ->set('stateID', self::getQueuedState())
                 ->set('createdBy', self::$FOGUser->get('name'))
                 ->set('storagegroupID', $storagegroupID)

--- a/packages/web/src/Items/Snapin.php
+++ b/packages/web/src/Items/Snapin.php
@@ -182,7 +182,7 @@ class Snapin extends FOGController
             self::getClass('FileDeleteQueue')
                 ->set('path', $this->get('file'))
                 ->set('pathtype', 'Snapin')
-                ->set('createdTime', self::formatTime('now', 'Y-m-d H:i:s'))
+                ->set('createdTime', self::storageNow())
                 ->set('stateID', self::getQueuedState())
                 ->set('createdBy', self::$FOGUser->get('name'))
                 ->set('storagegroupID', $storagegroupID)

--- a/packages/web/src/Items/Task.php
+++ b/packages/web/src/Items/Task.php
@@ -310,7 +310,7 @@ class Task extends TaskType
                     '',
                     [
                         'clients' => 0,
-                        'completetime' => self::formatTime('now', 'Y-m-d H:i:s'),
+                        'completetime' => self::storageNow(),
                         'stateID' => self::getCancelledState()
                     ]
                 );

--- a/packages/web/src/Managers/FileDeleteQueueManager.php
+++ b/packages/web/src/Managers/FileDeleteQueueManager.php
@@ -54,7 +54,7 @@ class FileDeleteQueueManager extends FOGManagerController
             $findWhere,
             '',
             [
-                'completedTime' => self::formatTime('now', 'Y-m-d H:i:s'),
+                'completedTime' => self::storageNow(),
                 'stateID' => $canceled
             ]
         );
@@ -81,7 +81,7 @@ class FileDeleteQueueManager extends FOGManagerController
             $findWhere,
             '',
             [
-                'completedTime' => self::formatTime('now', 'Y-m-d H:i:s'),
+                'completedTime' => self::storageNow(),
                 'stateID' => $completed
             ]
         );

--- a/packages/web/src/Managers/SnapinTaskManager.php
+++ b/packages/web/src/Managers/SnapinTaskManager.php
@@ -70,7 +70,7 @@ class SnapinTaskManager extends FOGManagerController
             '',
             [
                 'stateID' => $canceled,
-                'complete'=> self::formatTime('now', 'Y-m-d H:i:s')
+                'complete'=> self::storageNow()
             ]
         );
         $hostTasksToCancel = [];

--- a/packages/web/src/Service/FileDeleter.php
+++ b/packages/web/src/Service/FileDeleter.php
@@ -317,7 +317,7 @@ class FileDeleter extends FOGService
                     }
                 }
                 $Task
-                    ->set('completedTime', self::formatTime('now', 'Y-m-d H:i:s'))
+                    ->set('completedTime', self::storageNow())
                     ->set('stateID', self::getCompleteState())
                     ->save();
             }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1917,7 +1917,7 @@ parameters:
 		-
 			message: '#^Result of \|\| is always false\.$#'
 			identifier: booleanOr.alwaysFalse
-			count: 1
+			count: 2
 			path: packages/web/src/Base/FOGBase.php
 
 		-

--- a/tests/stored-times-use-the-storage-zone.test.php
+++ b/tests/stored-times-use-the-storage-zone.test.php
@@ -34,22 +34,30 @@ $fails = [];
 // nothing puts 'Y-m-d H:i:s' on a page. The Ymd_His ones are filenames and
 // are deliberately left alone -- a backup named in the viewer's zone is not
 // a stored timestamp.
+// git ls-files rather than a directory walk, so the check covers exactly the
+// COMMITTED tree. A walk sees whatever else is lying in the working copy --
+// the plugin sources, which live in their own repository and are present on a
+// developer's box and absent in CI. That difference is a floor the two
+// environments disagree about, which is a gate that passes in one place and
+// fails in the other for no reason to do with the code.
 $hits = [];
 $scanned = 0;
-$rii = new \RecursiveIteratorIterator(
-    new \RecursiveDirectoryIterator($web, \FilesystemIterator::SKIP_DOTS)
-);
-foreach ($rii as $file) {
-    $path = $file->getPathname();
-    if ('php' !== strtolower($file->getExtension())
-        || false !== strpos($path, '/vendor/')
-    ) {
-        continue;
+chdir($root);
+$files = array_filter(
+    explode("\n", (string)shell_exec('git ls-files "packages/web/*.php"')),
+    function ($f) {
+        return '' !== $f
+            && is_readable($f)
+            && 0 !== strpos($f, 'packages/web/vendor/');
     }
+);
+foreach ($files as $file) {
     $scanned++;
-    $src = file_get_contents($path);
-    if (false !== strpos($src, "formatTime('now', 'Y-m-d H:i:s')")) {
-        $hits[] = str_replace($root . '/', '', $path);
+    if (false !== strpos(
+        file_get_contents($file),
+        "formatTime('now', 'Y-m-d H:i:s')"
+    )) {
+        $hits[] = $file;
     }
 }
 if ($hits) {
@@ -58,7 +66,7 @@ if ($hits) {
 }
 // Below this and the scan is not scanning anything, so a clean result above
 // would mean nothing at all.
-if ($scanned < 400) {
+if ($scanned < 300) {
     $fails[] = "the scan reached only $scanned php files; the check above"
         . ' proves nothing';
 }

--- a/tests/stored-times-use-the-storage-zone.test.php
+++ b/tests/stored-times-use-the-storage-zone.test.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * A stored timestamp is in the INSTALL's zone. A displayed one is in the
+ * VIEWER's. Confusing the two is silent and it corrupts data.
+ *
+ * The two were the same function until there was a display zone at all, so
+ * every write site in this codebase was written against formatTime() and was
+ * harmless right up until it was not. Two things went wrong the moment a
+ * display zone existed:
+ *
+ *  1. formatTime() converts to the VIEWER's zone. Used to produce a value
+ *     that is then STORED -- which is what FOGController::save() does for
+ *     every model's createdTime -- it makes a shared row's timestamp depend
+ *     on who happened to be signed in when it was written.
+ *  2. displayTimeZone() cached its answer on first call, and LoadGlobals
+ *     formats a date BEFORE setEnv() loads FOG_TZ_INFO. So the cache was
+ *     primed with storageTimeZone()'s own UTC fallback and the whole request
+ *     ran in UTC whatever the setting said. On the lab server that put 676
+ *     audit rows five hours ahead of the history rows beside them, with
+ *     nothing logged and nothing on screen to say so.
+ *
+ * Usage: php tests/stored-times-use-the-storage-zone.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+
+$fails = [];
+
+// --- 1. no write site formats 'now' through the display side -------------
+
+// This exact spelling is always a value on its way into a datetime column;
+// nothing puts 'Y-m-d H:i:s' on a page. The Ymd_His ones are filenames and
+// are deliberately left alone -- a backup named in the viewer's zone is not
+// a stored timestamp.
+$hits = [];
+$scanned = 0;
+$rii = new \RecursiveIteratorIterator(
+    new \RecursiveDirectoryIterator($web, \FilesystemIterator::SKIP_DOTS)
+);
+foreach ($rii as $file) {
+    $path = $file->getPathname();
+    if ('php' !== strtolower($file->getExtension())
+        || false !== strpos($path, '/vendor/')
+    ) {
+        continue;
+    }
+    $scanned++;
+    $src = file_get_contents($path);
+    if (false !== strpos($src, "formatTime('now', 'Y-m-d H:i:s')")) {
+        $hits[] = str_replace($root . '/', '', $path);
+    }
+}
+if ($hits) {
+    $fails[] = 'these format the current time through the DISPLAY zone and'
+        . ' then store it -- use storageNow(): ' . implode(', ', $hits);
+}
+// Below this and the scan is not scanning anything, so a clean result above
+// would mean nothing at all.
+if ($scanned < 400) {
+    $fails[] = "the scan reached only $scanned php files; the check above"
+        . ' proves nothing';
+}
+
+$base = file_get_contents($web . '/src/Base/FOGBase.php');
+$controller = file_get_contents($web . '/src/Base/FOGController.php');
+
+/**
+ * One named method's body.
+ *
+ * @param string $src  the file
+ * @param string $name the method
+ *
+ * @return string
+ */
+function sz_body($src, $name)
+{
+    if (!preg_match(
+        '/function ' . preg_quote($name, '/') . '\(.*?\n    \}/s',
+        $src,
+        $m
+    )) {
+        return '';
+    }
+
+    return $m[0];
+}
+
+// --- 2. the storage clock really is the storage clock --------------------
+
+$now = sz_body($base, 'storageNow');
+if ('' === $now) {
+    $fails[] = 'FOGBase::storageNow() not found';
+} else {
+    if (false === strpos($now, "niceDate('now')")) {
+        $fails[] = 'storageNow() no longer reads the clock through'
+            . ' niceDate(), which is the only thing that uses the STORAGE'
+            . ' zone';
+    }
+    if (false !== strpos($now, 'toDisplay')
+        || false !== strpos($now, 'displayTimeZone')
+    ) {
+        $fails[] = 'storageNow() reaches the display zone, which is exactly'
+            . ' what it exists to avoid';
+    }
+}
+
+// --- 3. the display zone is not cached before it is knowable -------------
+
+$display = sz_body($base, 'displayTimeZone');
+if ('' === $display) {
+    $fails[] = 'FOGBase::displayTimeZone() not found';
+} else {
+    if (!preg_match(
+        '/if \(empty\(self::\$TimeZone\).*?\) \{\s*\n\s*return \$storage;/s',
+        $display
+    )) {
+        $fails[] = 'displayTimeZone() no longer returns WITHOUT caching while'
+            . ' FOG_TZ_INFO is still unloaded -- caching there pins the whole'
+            . ' request to the UTC fallback';
+    }
+    // The guard is only worth anything if it comes before the assignment.
+    $guard = strpos($display, 'empty(self::$TimeZone)');
+    $cache = strpos($display, 'self::$_displayTimeZone = $storage');
+    if (false === $guard || false === $cache || $guard > $cache) {
+        $fails[] = 'displayTimeZone() caches before it checks whether'
+            . ' FOG_TZ_INFO has been loaded';
+    }
+}
+
+// --- 4. the auto-filled createdTime is a stored value --------------------
+
+$save = sz_body($controller, 'save');
+if ('' === $save) {
+    $fails[] = 'FOGController::save() not found';
+} elseif (!preg_match(
+    "/case 'createdTime':.*?self::storageNow\(\)/s",
+    $save
+)) {
+    $fails[] = "FOGController::save()'s createdTime auto-fill no longer uses"
+        . ' storageNow(), so every model\'s created date follows whoever'
+        . ' happened to write the row';
+}
+
+// --- report ---------------------------------------------------------------
+
+if ($fails) {
+    fwrite(STDERR, "FAIL stored-times-use-the-storage-zone\n");
+    foreach ($fails as $fail) {
+        fwrite(STDERR, '  - ' . $fail . "\n");
+    }
+    exit(1);
+}
+
+echo "PASS stored-times-use-the-storage-zone\n";
+exit(0);


### PR DESCRIPTION
Found while scanning for the UTC-storage-boundary proposal, and measured on the
lab server before it was touched. Two defects, both silent, both created the
moment a display timezone existed at all (#1484).

## 1. Thirteen write sites format the current time through the display zone

`formatTime()` converts to the **viewer's** zone. Right for a date on a page,
wrong for a date about to be stored — and thirteen sites used it to produce a
value that goes straight into a datetime column, `FOGController::save()`'s
`createdTime` auto-fill among them. That one is *every model's created date*, so
a user who had chosen a display zone was stamping their own zone into rows
everybody else reads.

Adds `FOGBase::storageNow()` — what a write site should have been calling all
along — and moves all thirteen onto it. The `Ymd_His` stamps are deliberately
left: those are filenames, not stored timestamps.

## 2. `displayTimeZone()` cached before `FOG_TZ_INFO` was loaded

`LoadGlobals` formats a date *before* `setEnv()` loads the setting, so the cache
was primed with `storageTimeZone()`'s own UTC fallback and the whole request
then ran in UTC whatever the setting said.

Measured on the lab server (`America/Chicago`, schema 392):

```
local NOW()=2026-08-29 20:28:32   UTC=2026-08-30 01:28:32

auditLog.alCreatedTime   datetime    676  2026-08-30 01:05:19  UTC
history.hTime            timestamp  1817  2026-08-29 21:41:24  server local
```

676 audit rows sitting five hours ahead of the history rows beside them, with
nothing logged and nothing on screen to say so.

The cache is not the problem — it exists for the preference lookup, which is a
database read, and that cannot happen before there is a user anyway. So the fix
is to answer and return **without remembering** while `FOG_TZ_INFO` is still
unloaded:

```
before LoadGlobals: cached=NULL
after  LoadGlobals: cached=NULL  GLOBALS[TimeZone]='America/Chicago'
```

## Verification

Against a throwaway container copy of a real database, deliberately set up with
**three different zones** so a value written in the wrong one is unmistakable:
`FOG_TZ_INFO` = `America/Chicago`, the database server itself on UTC, and the
signed-in viewer's display preference set to UTC.

| audit rows | stored value |
|---|---|
| written before the fix | `2026-08-30 01:13:29` (UTC — the viewer's zone leaked in) |
| written after it, same UTC preference still in force | `2026-08-29 20:32:13` (America/Chicago — the install's zone) |

`tests/stored-times-use-the-storage-zone.test.php` pins both halves. All four
mutations were proved to make it fail: a write site reverted to the display
clock, the `createdTime` auto-fill reverted, `storageNow()` routed through
`toDisplay()`, and the cache moved back above the guard.

`phpstan` both passes clean (one baseline `count` bumped 1→2, not regenerated);
`tests/run-all.sh` 213 passed, 0 failed.

## Not fixed here

`NOW()` used **server-side** in SQL (`userPrefs`, `savedFilters`, four plugin
managers) still reads the *database server's* zone, which differs from
`FOG_TZ_INFO` whenever the database is not on the web box. That is a second
clock rather than a leak, and it is one of the things the UTC-storage boundary
work has to settle — it belongs in that proposal, not in a regression fix.

## Downstream

None. No route, class list or schema change.
