### PR TITLE
Read a date a human typed in the zone that human is reading

### DIFF
--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -1691,7 +1691,9 @@ class HostManagement extends FOGPage
         if ('' === $sbEnrolled) {
             $sbEnrolled = null;
         } elseif (self::validDate($sbEnrolled)) {
-            $sbEnrolled = self::niceDate($sbEnrolled)->format('Y-m-d H:i:s');
+            // Typed into the form, so read in the viewer's zone.
+            $sbEnrolled = self::viewerDate($sbEnrolled)
+                ->format('Y-m-d H:i:s');
         } else {
             throw new \Exception(
                 _('Secure Boot enrollment date is not a valid date')

--- a/packages/web/src/Audit/ReportWindow.php
+++ b/packages/web/src/Audit/ReportWindow.php
@@ -88,12 +88,15 @@ class ReportWindow extends FOGBase
                 $given[$k] = '';
             }
         }
+        // Both bounds came off a form, so they are read in the VIEWER's
+        // zone. The defaults are not: 'now' and 'now minus a fortnight'
+        // are the server's own clock and have no viewer in them.
         $end = '' === $given['end']
             ? self::niceDate()
-            : self::niceDate($given['end']);
+            : self::viewerDate($given['end']);
         $start = '' === $given['start']
             ? self::niceDate()->modify((string)$default)
-            : self::niceDate($given['start']);
+            : self::viewerDate($given['start']);
         if ($start > $end) {
             [$start, $end] = [$end, $start];
         }

--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -1902,6 +1902,29 @@ abstract class FOGBase
         return self::$_displayTimeZone;
     }
     /**
+     * A datetime the VIEWER typed, as a DateTime the database can be
+     * compared against.
+     *
+     * niceDate() reads a value in the STORAGE zone, which is right for
+     * something that came out of a column and wrong for something somebody
+     * just typed into a form: they typed it while looking at a page rendered
+     * in THEIR zone. Reading it as storage schedules a task, or bounds a
+     * report, at an hour they did not ask for -- silently, and only for the
+     * users who have set a preference, which is the worst possible
+     * distribution for a bug.
+     *
+     * A no-op whenever the two zones are the same, which is every account
+     * that has not chosen one.
+     *
+     * @param string $value as the viewer typed it.
+     *
+     * @return \DateTime
+     */
+    public static function viewerDate($value)
+    {
+        return self::niceDate(self::displayToStorage($value));
+    }
+    /**
      * The current time, in the zone the database is written in.
      *
      * This is what every WRITE must use. formatTime() is its display-side

--- a/packages/web/src/Base/FOGPagePost.php
+++ b/packages/web/src/Base/FOGPagePost.php
@@ -469,7 +469,12 @@ trait FOGPagePost
                 ) {
                     throw new \Exception(_('A scheduled time is required'));
                 }
-                $scheduleDeployTime = self::niceDate($scheduleSingleTime);
+                // The viewer typed this into a picker on a page rendered
+                // in their own zone, so it is read in theirs and not the
+                // install's -- see viewerDate(). The past-time check
+                // below then compares two values that mean the same
+                // thing.
+                $scheduleDeployTime = self::viewerDate($scheduleSingleTime);
                 if ($scheduleDeployTime < self::niceDate()) {
                     throw new \Exception(_('Scheduled time is in the past'));
                 }

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4539');
+        define('FOG_VERSION', '1.6.0-beta.4542');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/tests/run-history-report.test.php
+++ b/tests/run-history-report.test.php
@@ -162,19 +162,26 @@ $t->check(
  * what is pinned here is that this report still goes through it. Pinning
  * only the delegation would leave the rules unguarded; pinning only the
  * class would not notice this report growing its own copy back.
+ *
+ * The two branches of each bound are on DIFFERENT clocks, and that is the
+ * point rather than an inconsistency. A default is the server saying "now"
+ * and "a fortnight before now", which has no viewer in it and so is read in
+ * the storage zone. A supplied bound was typed by somebody reading a page
+ * rendered in THEIR zone, so it is read in that one -- viewerDate(), which
+ * is a no-op for every account that has not chosen a display zone.
  */
 $window = $web . '/src/Audit/ReportWindow.php';
 $t->check('the shared window parser exists', is_readable($window));
 $wsrc = is_readable($window) ? file_get_contents($window) : '';
-// Both bounds, anchored as whole expressions. A substring search for
-// `self::niceDate()` is satisfied by the START branch alone, so swapping
-// only the END branch to PHP's clock -- which is exactly the half-shifted
-// window the lab found -- would pass it.
+// Both bounds, anchored as whole expressions including BOTH branches. A
+// substring search for `self::niceDate()` is satisfied by one branch alone,
+// so swapping only the other to PHP's clock -- which is exactly the
+// half-shifted window the lab found -- would pass it.
 $t->check(
-    'the END bound is built with niceDate(), FOG\'s clock',
+    'the END bound is FOG\'s clock by default, the viewer\'s when given',
     1 === preg_match(
         "/\\\$end = '' === \\\$given\['end'\]\s*\?\s*self::niceDate\(\)"
-        . "\s*:\s*self::niceDate\(\\\$given\['end'\]\);/",
+        . "\s*:\s*self::viewerDate\(\\\$given\['end'\]\);/",
         $wsrc
     )
 );
@@ -183,7 +190,7 @@ $t->check(
     1 === preg_match(
         "/\\\$start = '' === \\\$given\['start'\]\s*\?\s*"
         . "self::niceDate\(\)->modify\(.*?\)\s*:\s*"
-        . "self::niceDate\(\\\$given\['start'\]\);/s",
+        . "self::viewerDate\(\\\$given\['start'\]\);/s",
         $wsrc
     )
 );

--- a/tests/typed-dates-are-read-in-the-viewers-zone.test.php
+++ b/tests/typed-dates-are-read-in-the-viewers-zone.test.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * A datetime somebody TYPED is in their zone, not the install's.
+ *
+ * niceDate() reads a value in the STORAGE zone. That is right for a value
+ * that came out of a column and wrong for one that came off a form: the
+ * viewer typed it while looking at a page rendered in THEIR zone, so reading
+ * it as storage silently moves it by the offset between the two.
+ *
+ * It bites only the users who have set a display preference, which is the
+ * worst possible distribution for a bug -- most people never see it, the
+ * ones who do get a task scheduled hours from when they asked, and there is
+ * nothing on screen or in a log to say why.
+ *
+ * The companion gate is stored-times-use-the-storage-zone.test.php, which
+ * covers the other direction: a value on its way IN must not be formatted
+ * through the viewer's zone.
+ *
+ * Usage: php tests/typed-dates-are-read-in-the-viewers-zone.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+
+$fails = [];
+
+/**
+ * One named method's body.
+ *
+ * @param string $src  the file
+ * @param string $name the method
+ *
+ * @return string
+ */
+function vz_body($src, $name)
+{
+    if (!preg_match(
+        '/function ' . preg_quote($name, '/') . '\(.*?\n    \}/s',
+        $src,
+        $m
+    )) {
+        return '';
+    }
+
+    return $m[0];
+}
+
+// --- the helper itself ---------------------------------------------------
+
+$base = file_get_contents($web . '/src/Base/FOGBase.php');
+$viewer = vz_body($base, 'viewerDate');
+if ('' === $viewer) {
+    $fails[] = 'FOGBase::viewerDate() not found';
+} elseif (false === strpos($viewer, 'self::displayToStorage(')) {
+    $fails[] = 'viewerDate() no longer converts from the display zone, which'
+        . ' makes it an alias for niceDate() and the distinction disappears';
+}
+
+// --- every form-supplied datetime goes through it ------------------------
+
+// Each is a value a person typed into the web UI. The pairing is what the
+// gate is really about: the SOURCE is request input, and the READER must be
+// viewerDate(). Anchored on the whole statement, so a changed reader shows
+// up as a failure rather than as a grep that still matches somewhere else.
+$typed = [
+    'src/Base/FOGPagePost.php' => [
+        'the scheduled start time of a task' =>
+            '$scheduleDeployTime = self::viewerDate($scheduleSingleTime);',
+    ],
+    'src/Audit/ReportWindow.php' => [
+        'the end of a report window' => ': self::viewerDate($given[\'end\']);',
+        'the start of a report window' =>
+            ': self::viewerDate($given[\'start\']);',
+    ],
+    'lib/pages/hostmanagement.page.php' => [
+        'the Secure Boot enrollment date' =>
+            '$sbEnrolled = self::viewerDate($sbEnrolled)',
+    ],
+];
+foreach ($typed as $file => $cases) {
+    $src = file_get_contents($web . '/' . $file);
+    foreach ($cases as $what => $needle) {
+        if (false === strpos($src, $needle)) {
+            $fails[] = "$what ($file) is no longer read with viewerDate(), so"
+                . ' a viewer with a display zone gets a value they did not'
+                . ' type';
+        }
+    }
+}
+
+// --- and the machine-supplied one deliberately does NOT ------------------
+
+// The fog-client posts this. There is no viewer in a client check-in, so
+// converting it from a display zone would be inventing an offset out of
+// whoever happened to be signed in somewhere else.
+$track = file_get_contents($web . '/src/Client/UserTrack.php');
+if (false !== strpos($track, 'viewerDate(')) {
+    $fails[] = 'UserTrack reads the CLIENT-supplied date through'
+        . ' viewerDate() -- a client check-in has no viewer, and the zone it'
+        . ' arrives in is a separate open question';
+}
+
+// --- report ---------------------------------------------------------------
+
+if ($fails) {
+    fwrite(STDERR, "FAIL typed-dates-are-read-in-the-viewers-zone\n");
+    foreach ($fails as $fail) {
+        fwrite(STDERR, '  - ' . $fail . "\n");
+    }
+    exit(1);
+}
+
+echo "PASS typed-dates-are-read-in-the-viewers-zone\n";
+exit(0);


### PR DESCRIPTION
## The bug

`niceDate()` reads a value in the **storage** zone. That is correct for a value that came out of a column, and wrong for one a human just typed into a form — they typed it while looking at a page rendered in **their** zone, so reading it as storage silently moves it by the difference between the two.

`displayToStorage()` has existed since the display/storage split (#1484) for exactly this, and had one caller: grid date filtering. Three human-typed dates skipped it.

| Where | What it did |
|---|---|
| `FOGPagePost::` scheduled single-run task | a task asked for at 09:00 was scheduled for 14:00 |
| `ReportWindow::` start and end | the report ran over a window other than the one drawn |
| `HostManagement::` Secure Boot enrollment date | stored an hour nobody entered |

Only users who have set a display zone are affected, which is the worst possible distribution for a bug — it cannot be reproduced by whoever is looking at the default install.

## The fix

`FOGBase::viewerDate()` names the conversion, so a call site says which of the two kinds of value it is holding. It is a no-op for every account that has not chosen a display zone.

Deliberately **not** converted:

- the **defaults** in a report window — `now` and `now minus a fortnight` are the server's own clock and have no viewer in them;
- `Client/UserTrack.php`'s check-in date — a machine reporting its own time to a server, with no browser and no viewer anywhere in it.

## Verification

Runtime, against a real stored preference on a throwaway database rather than by reading the code: with the viewer in `UTC` and the install in `America/Chicago`, `viewerDate('2026-08-30 14:00:00')` returns `09:00:00` and `niceDate()` on the same string still returns `14:00:00`.

`tests/typed-dates-are-read-in-the-viewers-zone.test.php` anchors each fixed site on its whole statement, and asserts `UserTrack` does *not* use `viewerDate(`. Six mutations, six caught:

```
caught:        viewerDate() becomes an alias for niceDate()
caught:        the scheduled start time goes back to the storage zone
caught:        a report window's end goes back
caught:        a report window's start goes back
caught:        the Secure Boot enrollment date goes back
caught:        the CLIENT-supplied date is wrongly display-converted
```

`tests/run-history-report.test.php` pinned `niceDate()` on both report bounds; it now pins the refined rule — default branch on the server's clock, supplied branch on the viewer's — with both branches still anchored as whole expressions, so swapping one alone still fails it.

Both PHPStan passes clean, `tests/run-all.sh` 214 passed 0 failed.

## Still open, not fixed here

The cron schedule fields (`scheduleCronMin` / `scheduleCronHour`) are typed by a viewer and evaluated by the scheduler in the storage zone. Converting a cron expression across zones is not an offset — DST makes some local hours ambiguous and others nonexistent — so it is flagged rather than papered over.