### PR TITLE
Bind the column search row once DataTables has built its wrapper

### DIFF
--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -3800,31 +3800,53 @@ $.fn.registerTable = function(onSelect, opts) {
   // rebuilt -- which it is on every draw, and again whenever a column is
   // shown or hidden. 'input' rather than 'change' so typing filters as you go;
   // debounced because each keystroke is a server round trip.
+  //
+  // Deferred, and that is the whole point of the function: with server-side
+  // data DataTables does not build the wrapper until the first response has
+  // arrived, so at the moment DataTable() returns, table().container() is
+  // still null. Binding there binds to an EMPTY jQuery set -- silently, since
+  // .on() on nothing is not an error -- and the result is a search row that
+  // renders, accepts typing, and filters nothing.
+  //
+  // Called twice on purpose. Straight away covers registerTable() being
+  // re-run over an already-initialized table (retrieve:true), where the
+  // container exists and no further init event will ever fire; on init.dt
+  // covers the normal first run. The .off() makes the overlap harmless.
   var columnSearchTimer = null;
-  $(table.table().container())
-    .off('.fogcolsearch')
-    .on('change.fogcolsearch', 'select.fog-colsearch-mode', function() {
-      fogColumnSearchApply(table, $(this).closest('div.fog-colsearch'));
-    })
-    .on('change.fogcolsearch', 'input.fog-colsearch-input[type="date"]', function() {
-      fogColumnSearchApply(table, $(this).closest('div.fog-colsearch'));
-    })
-    .on('input.fogcolsearch', 'input.fog-colsearch-input[type="text"]', function() {
-      var group = $(this).closest('div.fog-colsearch');
-      clearTimeout(columnSearchTimer);
-      columnSearchTimer = setTimeout(function() {
-        fogColumnSearchApply(table, group);
-      }, 400);
-    })
-    .on('keydown.fogcolsearch', 'input.fog-colsearch-input', function(e) {
-      if (e.which !== 13) {
-        return;
-      }
-      // Enter means "now", not "also submit the form this table sits in".
-      e.preventDefault();
-      clearTimeout(columnSearchTimer);
-      fogColumnSearchApply(table, $(this).closest('div.fog-colsearch'));
-    });
+  function fogBindColumnSearch() {
+    var container = table.table().container();
+    if (!container) {
+      return;
+    }
+    $(container)
+      .off('.fogcolsearch')
+      .on('change.fogcolsearch', 'select.fog-colsearch-mode', function() {
+        fogColumnSearchApply(table, $(this).closest('div.fog-colsearch'));
+      })
+      .on('change.fogcolsearch', 'input.fog-colsearch-input[type="date"]', function() {
+        fogColumnSearchApply(table, $(this).closest('div.fog-colsearch'));
+      })
+      .on('input.fogcolsearch', 'input.fog-colsearch-input[type="text"]', function() {
+        var group = $(this).closest('div.fog-colsearch');
+        clearTimeout(columnSearchTimer);
+        columnSearchTimer = setTimeout(function() {
+          fogColumnSearchApply(table, group);
+        }, 400);
+      })
+      .on('keydown.fogcolsearch', 'input.fog-colsearch-input', function(e) {
+        if (e.which !== 13) {
+          return;
+        }
+        // Enter means "now", not "also submit the form this table sits in".
+        e.preventDefault();
+        clearTimeout(columnSearchTimer);
+        fogColumnSearchApply(table, $(this).closest('div.fog-colsearch'));
+      });
+  }
+  fogBindColumnSearch();
+  $(this)
+    .off('init.dt.fogcolsearch')
+    .on('init.dt.fogcolsearch', fogBindColumnSearch);
 
   // A hidden column's box has to go with it, and the remaining boxes have to
   // re-line-up: the header only carries cells for visible columns, so every

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4542');
+        define('FOG_VERSION', '1.6.0-beta.4546');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 395);
-        define('FOG_BCACHE_VER', 338);
+        define('FOG_BCACHE_VER', 339);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/tests/column-search-binds-after-the-wrapper-exists.test.php
+++ b/tests/column-search-binds-after-the-wrapper-exists.test.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * The per-column search row must actually be wired to the table.
+ *
+ * DataTables does not build its wrapper until it has data. On a server-side
+ * grid -- which is every list page in FOG -- the first response has not
+ * arrived when `$(this).DataTable(opts)` returns, so `table().container()` is
+ * still null at that instant and only becomes an element later.
+ *
+ * Delegating the search-row handlers off that null binds them to an EMPTY
+ * jQuery set. `.on()` against nothing is not an error, so there is no console
+ * message and no failed request: the row renders, the boxes accept typing,
+ * the condition dropdowns work, and not one keystroke ever reaches
+ * `column().search()`. That shipped, and reads as the feature being broken
+ * rather than as a wiring bug, because every visible part of it is present.
+ *
+ * Two things are pinned, and one alone is not enough. Without the deferral
+ * the binding happens too early; without the init hookup a deferred binding
+ * that finds no container simply never happens at all.
+ *
+ * Usage: php tests/column-search-binds-after-the-wrapper-exists.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$js = file_get_contents(
+    $root . '/packages/web/management/js/fog/fog.common.js'
+);
+
+$fails = [];
+
+// The binding lives inside a function that reads the container itself, so
+// that it can be run again once there is one. Anchored on the whole head
+// rather than on the name: a function that no longer re-reads the container
+// is the same bug wearing the right identifier.
+if (!preg_match(
+    '#function fogBindColumnSearch\(\) \{\s*'
+    . 'var container = table\.table\(\)\.container\(\);#s',
+    $js
+)) {
+    $fails[] = 'the column-search binding does not re-read the container, so '
+        . 'it cannot be deferred past a container that did not exist yet';
+}
+
+// Nothing may bind the namespace straight off a fresh init: that is the
+// original defect, and it is a one-line edit away at all times.
+if (preg_match(
+    '#\$\(table\.table\(\)\.container\(\)\)\s*\.off\(\'\.fogcolsearch\'\)#s',
+    $js
+)) {
+    $fails[] = 'the search-row handlers are delegated off '
+        . 'table().container() directly, which is null until the first '
+        . 'server-side response and so binds them to nothing';
+}
+
+// And it has to be re-run when the table finishes coming up, or the first
+// call -- the one that finds no container -- is the only one there is.
+if (!preg_match(
+    "#\\.on\\('init\\.dt\\.fogcolsearch', fogBindColumnSearch\\)#",
+    $js
+)) {
+    $fails[] = 'fogBindColumnSearch() is not re-run on init.dt, so on a '
+        . 'server-side grid it runs exactly once, before there is anything '
+        . 'to bind to';
+}
+
+if ($fails) {
+    foreach ($fails as $f) {
+        echo "FAIL: $f\n";
+    }
+    exit(1);
+}
+echo "PASS: the column search row is bound once the wrapper exists\n";
+exit(0);


### PR DESCRIPTION
## The bug

The per-column search row renders, accepts typing, and filters nothing. Reported from the host list: *"The column search is open and I can type in it, but when type something nothing happens."*

DataTables does not build its wrapper until it has data. On a server-side grid — every list page in FOG — the first response has not arrived when `$(this).DataTable(opts)` returns, so `table().container()` is **still null** at that instant and only becomes an element later.

The handlers were delegated off that null. `.on()` against an empty jQuery set is not an error, so there is no console message, no failed request, and no missing markup — the row is there, the condition dropdowns work, the boxes take text, and not one keystroke reaches `column().search()`.

## How it was confirmed

Not inferred from the source. jQuery's own `.on()` was hooked before the page scripts ran:

```
{ types: 'change.fogcolsearch',  len: 0, tag: 'NONE' }
{ types: 'change.fogcolsearch',  len: 0, tag: 'NONE' }
{ types: 'input.fogcolsearch',   len: 0, tag: 'NONE' }
{ types: 'keydown.fogcolsearch', len: 0, tag: 'NONE' }
```

All four bound against a set of length 0. Sweeping every element in the finished page for a `.fogcolsearch` namespace found none, while a probe handler delegated off the same container fired on every keystroke — so the container and the event bubbling were fine, and only the binding moment was wrong. Hooking `$.fn.DataTable` at definition time showed why: at `registerTable`'s call site the API context is valid (`ctxLen: 1`) and `table().container()` returns `null`.

## The fix

The binding moves into a function that reads the container itself, called straight away and again on `init.dt`:

- **straight away** covers `registerTable()` being re-run over an already-initialized table (`retrieve: true`), where the container exists and no init event will ever fire again;
- **`init.dt`** covers the normal first run.

The existing `.off('.fogcolsearch')` makes the overlap harmless.

## Verification

In a browser against a real grid of 86 hosts:

| Step | Rows shown |
|---|---|
| unfiltered | 86 |
| typed `pc11` (condition `contains`) | 5 |
| condition changed to `starts` | 5 |
| box cleared | 86 |
| filtered, then the row hidden | 5 → 86 |

Handlers now present on the container: `change`, `input`, `keydown`. A request fires on typing and `column(0).search()` reads `contains<US>pc11`.

`tests/column-search-binds-after-the-wrapper-exists.test.php` pins both halves — the deferral and the `init.dt` re-run — because either alone still leaves the row dead. Three mutations, three caught:

```
caught:  the binding goes back to the bare container, as shipped
caught:  the container is captured once instead of re-read
caught:  the init.dt re-run is dropped
```

`FOG_BCACHE_VER` bumped to 339, since this is a JavaScript change.

Regression from b9904c377; the search row has never filtered on a server-side grid.