### PR TITLE
Give management grids the column visibility button they already save

### DIFF
--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -3646,6 +3646,17 @@ $.fn.registerTable = function(onSelect, opts) {
       searchBuilderButton,
       savedFiltersButton,
       columnSearchButton,
+      // Which columns are showing has been SAVED per user since the layout
+      // work -- it rides in the same state as column order, page length and
+      // sort -- but nothing on a management grid ever let anyone change it.
+      // The control existed only on the export and report toolbars, so the
+      // preference could be restored and never set. Same definition as those
+      // two, deliberately: three copies of one button that behaved
+      // differently would be worse than the gap.
+      {
+        extend: 'colvis',
+        text: '<i class="fas fa-table-columns"></i> Column Visibility'
+      },
       {
         text: '<i class="fas fa-arrows-rotate"></i> Refresh',
         action: function(e, dt, node, config) {

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4552');
+        define('FOG_VERSION', '1.6.0-beta.4555');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 395);
-        define('FOG_BCACHE_VER', 339);
+        define('FOG_BCACHE_VER', 340);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/tests/every-grid-toolbar-can-change-columns.test.php
+++ b/tests/every-grid-toolbar-can-change-columns.test.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * A management grid must offer the column-visibility control it saves.
+ *
+ * Which columns are showing persists per user -- it rides in the same saved
+ * state as column order, page length and sort, and it survives a browser
+ * with no localStorage at all, so it is genuinely the preference store and
+ * not the browser. What was missing was any way to SET it: the colvis button
+ * was defined on the export toolbar and the report toolbar and left out of
+ * registerTable()'s own defaults, which is the toolbar every host, image,
+ * user, snapin and group list uses.
+ *
+ * A saved preference with no control to change it is worse than no feature:
+ * the state is restored on every load, so a layout that ever went wrong --
+ * through an older release, a shared account, a hand-edited preference --
+ * could not be put right from the UI.
+ *
+ * All three toolbars are pinned, because the defect was one of them being
+ * different from the other two.
+ *
+ * Usage: php tests/every-grid-toolbar-can-change-columns.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$js = file_get_contents(
+    $root . '/packages/web/management/js/fog/fog.common.js'
+);
+
+$fails = [];
+
+// Every toolbar is a `buttons` array holding columnSearchButton; the colvis
+// entry has to be in the SAME array, so the two are anchored together rather
+// than counted separately across the file.
+if (!preg_match_all(
+    "#columnSearchButton,\s*(?://[^\n]*\n\s*)*\{\s*extend: 'colvis'#",
+    $js,
+    $m
+)) {
+    $fails[] = 'no toolbar offers a colvis button next to the column search';
+} elseif (count($m[0]) < 3) {
+    $fails[] = sprintf(
+        'only %d of the three toolbars (export, report, registerTable) '
+        . 'offers a colvis button; a grid that saves which columns are '
+        . 'showing but cannot change them restores a layout nobody can fix',
+        count($m[0])
+    );
+}
+
+// And the saving half, which is what makes the button worth having. If
+// visibility stopped being part of the saved state the button would still
+// work and the choice would evaporate on the next page load.
+if (false === strpos($js, 'stateSave: true')) {
+    $fails[] = 'stateSave is off, so a column choice would not survive a '
+        . 'page load';
+}
+
+if ($fails) {
+    foreach ($fails as $f) {
+        echo "FAIL: $f\n";
+    }
+    exit(1);
+}
+echo "PASS: all three grid toolbars can change column visibility\n";
+exit(0);


### PR DESCRIPTION
## The gap

Which columns are showing has persisted per user since the saved-layout work. Verified, not assumed — hiding a column, then logging in from a **brand-new browser profile with no localStorage at all**, still showed it hidden:

```
visit 1 visibility:        11111111111
after hiding col 3:        11101111111
visit 2 (fresh load):      11101111111
brand new browser profile: 11101111111
```

So it is genuinely the preference store, not the browser. What was missing is any way to *set* it. The colvis button is defined on the export toolbar and the report toolbar, and left out of `registerTable()`'s own defaults — which is the toolbar every host, image, user, snapin, group and task list uses.

A saved preference with no control to change it is worse than no feature: the state is restored on every load, so a layout that ever went wrong — an older release, a shared account, a hand-edited preference — could not be put right from the UI at all.

## The change

One entry in `registerTable()`'s `buttons` array, identical to the two that already exist. Three copies of one button that behaved differently would be worse than the gap.

`FOG_BCACHE_VER` bumped to 340.

## Verification

In a browser against the host list:

| Step | Visibility |
|---|---|
| initial | `11111111111` |
| hide "Primary MAC" via the new button | `10111111111` |
| reload the page | `10111111111` |
| show it again | `11111111111` |

The dropdown lists all eleven columns.

`tests/every-grid-toolbar-can-change-columns.test.php` pins all three toolbars together, because the defect was one of them differing from the other two, and pins `stateSave` as well — the button is only worth having if the choice survives a page load. Three mutations, three caught:

```
caught:  the registerTable toolbar loses its colvis button again
caught:  the report toolbar loses its colvis button
caught:  the layout stops being saved
```

## Found while testing, NOT fixed here

Pressing **Escape while focus is inside any DataTables Buttons collection** throws in Bootstrap's dropdown data-API:

```
TypeError: Cannot read properties of undefined (reading 'parentNode')
    at qi.getOrCreateInstance (bootstrap5.bundle.min.js)
    at HTMLUListElement.dataApiKeydownHandler (bootstrap5.bundle.min.js)
```

Bootstrap delegates `keydown` on `.dropdown-menu` and then looks for a sibling `[data-bs-toggle="dropdown"]` to operate; DataTables renders the class without a toggle, so it constructs a `Dropdown` on `undefined`.

**It predates this change and is not caused by it** — reproduced on the current live server, which has no colvis button, by focusing the SearchBuilder panel's own "Clear All" and pressing Escape. Nothing observable breaks (the collection still closes, the column still toggles); it is a console error. Every fix I can see either restyles the collection or intercepts the keystroke ahead of DataTables' own dismissal, so it wants its own change rather than riding along with a one-line button.