### PR TITLE
Store dates in UTC from a recorded boundary, and never convert what is there

### DIFF
--- a/bin/psr4-scan.php
+++ b/bin/psr4-scan.php
@@ -123,6 +123,12 @@ const TABLE = [
     'PluginTask' => 'Base',
     'LoadGlobals' => 'Base',
     'System' => 'Base',
+    // Base, not Db or Util: it answers a question FOGBase itself has to ask
+    // before it can read or write any date at all -- which zone stored values
+    // mean -- and it is consulted from storageTimeZone(), which is on the
+    // boot path. It reads one table, but so does every model; what makes it
+    // Base is who depends on it.
+    'StorageEpoch' => 'Base',
     // Bases of their own derived buckets.
     'FOGClient' => 'Client',
     'FOGService' => 'Service',

--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -822,6 +822,16 @@ return [
                 'stReturnDetails' => 'varchar(250) NOT NULL DEFAULT \'\'',
             ],
         ],
+        'storageEpoch' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `storageEpoch` ( `seID` int(11) NOT NULL AUTO_INCREMENT, `seBoundary` datetime DEFAULT NULL, `seZone` varchar(64) NOT NULL DEFAULT \'\', `seDbZone` varchar(64) NOT NULL DEFAULT \'\', `seSchema` int(11) NOT NULL DEFAULT 0, PRIMARY KEY (`seID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'seID' => 'int(11) NOT NULL',
+                'seBoundary' => 'datetime DEFAULT NULL',
+                'seZone' => 'varchar(64) NOT NULL DEFAULT \'\'',
+                'seDbZone' => 'varchar(64) NOT NULL DEFAULT \'\'',
+                'seSchema' => 'int(11) NOT NULL DEFAULT 0',
+            ],
+        ],
         'supportedOS' => [
             'create' => 'CREATE TABLE IF NOT EXISTS `supportedOS` ( `osID` int(10) unsigned NOT NULL AUTO_INCREMENT, `osName` varchar(150) NOT NULL DEFAULT \'\', `osValue` int(10) unsigned NOT NULL DEFAULT 0, PRIMARY KEY (`osID`), UNIQUE KEY `osName` (`osName`), KEY `new_index` (`osValue`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -9754,3 +9754,76 @@ $this->schema[] =
 
         return true;
     };
+// 396
+$this->schema[] = [
+    // The UTC storage boundary.
+    //
+    // From this step on, every value FOG writes into a date column is UTC:
+    // storageTimeZone() answers UTC once this row exists, and the database
+    // session runs at +00:00 so NOW() and DEFAULT current_timestamp() agree
+    // with it. FOG_TZ_INFO stops being a storage zone and becomes what its
+    // name always suggested -- the install's default DISPLAY zone.
+    //
+    // Nothing already stored is converted. It cannot be: up to five clocks
+    // have written these columns (PHP through FOG_TZ_INFO, MySQL NOW(),
+    // MySQL DEFAULT current_timestamp(), the display-zone regression fixed
+    // in #1491, and the fog-client's own clock), and no sweep can know which
+    // wrote any given row. So instead of guessing, this records the instant
+    // the convention changed and every reader compares against it. See
+    // docs/development/utc-storage-boundary.md.
+    //
+    // Its own table rather than a globalSettings row: the configuration page
+    // renders every row of that table with no WHERE, and `setting` is a
+    // routed class, so the value would be one careless edit away from
+    // changing the meaning of every timestamp in the install. Rather than a
+    // column on schemaVersion, whose seed INSERT is positional -- a third
+    // column makes a fresh install die on 1136 -- and whose entire contract
+    // with the installer and the updater is "one integer".
+    "CREATE TABLE IF NOT EXISTS `storageEpoch` ( "
+    . "`seID` int(11) NOT NULL AUTO_INCREMENT, "
+    . "`seBoundary` datetime DEFAULT NULL, "
+    . "`seZone` varchar(64) NOT NULL DEFAULT '', "
+    . "`seDbZone` varchar(64) NOT NULL DEFAULT '', "
+    . "`seSchema` int(11) NOT NULL DEFAULT 0, "
+    . "PRIMARY KEY (`seID`) "
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC",
+    // Written once and never again. The guard is a row count rather than an
+    // INSERT IGNORE on a fixed id: re-running the step on an install that
+    // already has a boundary must not move it, and moving it is the one
+    // change that would silently re-interpret every date in the database.
+    //
+    // seZone and seDbZone are recorded because they are what lets a reader
+    // say what a pre-boundary value MEANT, and what would let a future
+    // maintainer narrow the 26-hour band deliberately rather than
+    // rediscover why it is wide. UTC_TIMESTAMP() rather than NOW(): the
+    // session zone is not yet pinned at this point in the upgrade.
+    function () {
+        $existing = self::$DB
+            ->query('SELECT COUNT(`seID`) AS `c` FROM `storageEpoch`')
+            ->fetch()
+            ->get('c');
+        if ((int)$existing > 0) {
+            return true;
+        }
+        // Read straight out of globalSettings rather than through
+        // getSetting(): a schema step runs with the settings cache in
+        // whatever state the rest of the upgrade left it, and this value
+        // has to be the one that was in force, not a default.
+        $zone = (string)self::$DB
+            ->query(
+                'SELECT `settingValue` FROM `globalSettings` '
+                . "WHERE `settingKey` = 'FOG_TZ_INFO'"
+            )
+            ->fetch()
+            ->get('settingValue');
+        self::$DB->query(
+            'INSERT INTO `storageEpoch` '
+            . '(`seBoundary`, `seZone`, `seDbZone`, `seSchema`) '
+            . 'SELECT UTC_TIMESTAMP(), '
+            . self::$DB->sanitize($zone) . ', '
+            . '@@global.system_time_zone, 396'
+        );
+
+        return true;
+    },
+];

--- a/packages/web/lib/pages/hostmanagement.page.php
+++ b/packages/web/lib/pages/hostmanagement.page.php
@@ -1181,7 +1181,11 @@ class HostManagement extends FOGPage
         // Deliberately NOT read from INPUT_POST like every other value here:
         // these two are written by the ping service and by the client
         // check-in, so the object is the only source that can be right.
-        $lastPing = self::dateOrNever($this->obj->get('lastping'));
+        $lastPing = self::dateOrNever(
+            $this->obj->get('lastping'),
+            'hosts',
+            'hostLastPing'
+        );
         // Say WHICH probe reached it, when the row knows. A timestamp with
         // no method answers "was it up" and leaves "is the service on
         // PINGHOSTPORT running" unanswered, which is the next question
@@ -1196,7 +1200,11 @@ class HostManagement extends FOGPage
                 strtoupper($pingMethod)
             );
         }
-        $lastCheckin = self::dateOrNever($this->obj->get('lastcheckin'));
+        $lastCheckin = self::dateOrNever(
+            $this->obj->get('lastcheckin'),
+            'hosts',
+            'hostLastCheckin'
+        );
         // The Secure Boot ledger's two halves, prepared very differently on
         // purpose (schema steps 376 and 377).
         //
@@ -1207,7 +1215,11 @@ class HostManagement extends FOGPage
         // "Secure Boot ON" invites the reader to treat a report from eight
         // months ago as current.
         $sbState = SecureBootState::label($this->obj->get('sbstate'));
-        $sbStateTime = self::dateOrNever($this->obj->get('sbstatetime'));
+        $sbStateTime = self::dateOrNever(
+            $this->obj->get('sbstatetime'),
+            'hosts',
+            'hostSbStateTime'
+        );
         if (_('Never') !== $sbStateTime) {
             $sbState = sprintf(
                 /* translators: 1: a Secure Boot state, 2: a date and time */
@@ -3820,7 +3832,11 @@ class HostManagement extends FOGPage
             _('Host') => $this->obj->get('name'),
             _('Primary MAC') => (string)$this->obj->get('mac'),
             _('Assigned Image') => $this->obj->getImageName(),
-            _('Last Deployed') => self::dateOrNever($this->obj->get('deployed')),
+            _('Last Deployed') => self::dateOrNever(
+                $this->obj->get('deployed'),
+                'hosts',
+                'hostLastDeploy'
+            ),
             _('Primary Group') => (
                 $primaryGroup->isValid() ?
                 $primaryGroup->get('name') :

--- a/packages/web/lib/pages/imagemanagement.page.php
+++ b/packages/web/lib/pages/imagemanagement.page.php
@@ -1043,7 +1043,11 @@ class ImageManagement extends FOGPage
             _('Image') => $this->obj->get('name'),
             _('OS') => $this->obj->getOS()->get('name'),
             _('Image Type') => $this->obj->getImageType()->get('name'),
-            _('Last Captured') => self::dateOrNever($this->obj->get('deployed')),
+            _('Last Captured') => self::dateOrNever(
+                $this->obj->get('deployed'),
+                'images',
+                'imageLastDeploy'
+            ),
             _('Size on Server') => self::formatByteSize($this->obj->get('srvsize')),
             _('Primary Storage Group') => $this->obj->getStorageGroup()->get('name')
         ];

--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -1831,10 +1831,28 @@ abstract class FOGBase
     /**
      * The zone stored datetimes are written in and interpreted as.
      *
+     * UTC on any install that has crossed the boundary; FOG_TZ_INFO on one
+     * that has not yet.
+     *
      * @return \DateTimeZone
      */
     public static function storageTimeZone()
     {
+        // Once the boundary is recorded, storage IS UTC and FOG_TZ_INFO has
+        // stopped meaning anything about what is written -- see
+        // StorageEpoch and docs/development/utc-storage-boundary.md. Gating
+        // on the row rather than on a schema number is deliberate: a
+        // half-upgraded install then behaves exactly as it did before,
+        // rather than in some third way nobody has thought about.
+        // class_exists() rather than a bare call: this is reached from
+        // LoadGlobals and from the installer, and a test harness that pulls
+        // FOGBase in on its own has no autoloader for anything else. A
+        // missing StorageEpoch has to mean "no boundary" -- the behavior
+        // before any of this -- rather than a fatal on every date in the
+        // install.
+        if (class_exists(StorageEpoch::class) && StorageEpoch::active()) {
+            return new \DateTimeZone('UTC');
+        }
         if (empty(self::$TimeZone)) {
             return new \DateTimeZone('UTC');
         }
@@ -1843,6 +1861,34 @@ abstract class FOGBase
         } catch (\Exception $e) {
             // An unusable name must not take out every page that shows a date.
             return new \DateTimeZone('UTC');
+        }
+    }
+    /**
+     * The zone an install shows dates in when the reader has no preference.
+     *
+     * Split out from displayTimeZone() when storage moved to UTC. Before the
+     * boundary the two answers were the same value read twice, so nothing
+     * had to distinguish them; after it, defaulting the DISPLAY zone to the
+     * STORAGE zone would show UTC to every user who has not chosen
+     * otherwise -- which is every user, on an install that has just
+     * upgraded.
+     *
+     * @return \DateTimeZone
+     */
+    public static function defaultDisplayTimeZone()
+    {
+        // FOG_TZ_INFO. Before the boundary this is also the storage zone, so
+        // nothing moves; after it, this is all it ever means -- the zone an
+        // install shows dates in for anyone who has not chosen their own.
+        if (empty(self::$TimeZone)) {
+            return self::storageTimeZone();
+        }
+        try {
+            return new \DateTimeZone(self::$TimeZone);
+        } catch (\Exception $e) {
+            // An unusable name must not take out every page that shows a
+            // date; the storage zone is at least a real one.
+            return self::storageTimeZone();
         }
     }
     /**
@@ -1863,7 +1909,7 @@ abstract class FOGBase
         if (null !== self::$_displayTimeZone) {
             return self::$_displayTimeZone;
         }
-        $storage = self::storageTimeZone();
+        $storage = self::defaultDisplayTimeZone();
         $user = self::$FOGUser;
         // NOTHING is cached until the answer is one worth keeping.
         //
@@ -1989,6 +2035,48 @@ abstract class FOGBase
      *
      * @return \DateTime
      */
+    /**
+     * Renders a value that came OUT OF A COLUMN, in the viewer's zone.
+     *
+     * toDisplay() assumes the value means what storageTimeZone() says values
+     * mean. That is true of everything written after the boundary and false
+     * of everything written before it: those were written when FOG_TZ_INFO
+     * was the storage zone, so reading one as UTC and converting moves it by
+     * the offset between the two, silently, on data nobody can check.
+     *
+     * A pre-boundary value is therefore read in the zone that WAS the
+     * storage zone, which is what StorageEpoch::priorZone() recorded. That
+     * is not a guess about what the value means -- it is exactly the
+     * interpretation FOG applied to it before this change, so an old row
+     * renders the same as it always did.
+     *
+     * The column type is not a detail. A TIMESTAMP column has always held a
+     * UTC instant and hands one back whatever the row's age, so it is never
+     * pre-boundary; passing false here for a DATETIME column, or true for a
+     * TIMESTAMP one, is the one mistake that turns a correct timestamp into
+     * a wrong one.
+     *
+     * @param mixed $value      The stored value.
+     * @param bool  $isDatetime Whether it came from a DATETIME column.
+     *
+     * @return \DateTime
+     */
+    public static function toDisplayStored($value, $isDatetime = true)
+    {
+        if (!StorageEpoch::isPreBoundary($value, $isDatetime)) {
+            return self::toDisplay($value);
+        }
+        try {
+            $out = new \DateTime(
+                trim((string)$value),
+                StorageEpoch::priorZone()
+            );
+        } catch (\Exception $e) {
+            return self::toDisplay($value);
+        }
+
+        return $out->setTimezone(self::displayTimeZone());
+    }
     public static function toDisplay($date = 'now')
     {
         $out = $date instanceof \DateTime ? clone $date : self::niceDate($date);

--- a/packages/web/src/Base/FOGManagerController.php
+++ b/packages/web/src/Base/FOGManagerController.php
@@ -297,34 +297,47 @@ abstract class FOGManagerController extends FOGBase
      * A no-op whenever the display and storage zones agree, which is every
      * account that has not chosen a preference.
      *
-     * @param array $rows  Rows as dataOutput() built them.
-     * @param array $types The per-column search types, keyed as the rows are.
+     * @param array  $rows    Rows as dataOutput() built them.
+     * @param string $table   The table being queried.
+     * @param array  $columns Column information array.
      *
      * @return array
      */
-    public static function displayDates($rows, $types)
+    public static function displayDates($rows, $table, $columns)
     {
-        if (self::displayTimeZone()->getName()
-            === self::storageTimeZone()->getName()
-        ) {
-            return $rows;
-        }
         if (class_exists('\\FOG\\Router\\Route')
             && \FOG\Router\Route::$apiRequest
         ) {
             return $rows;
         }
+        // Which output keys are dates, and -- separately -- which of those
+        // came from a DATETIME column rather than a TIMESTAMP one. The
+        // second question is the one that decides whether a value can be
+        // pre-boundary at all: a TIMESTAMP has always held a UTC instant and
+        // hands one back however old the row is. Taken from columnType(),
+        // which answers from the manifest for core and from the server's own
+        // catalog for a plugin's table, so a plugin grid is typed correctly
+        // without the plugin doing anything.
         $dateKeys = [];
-        foreach ((array)$types as $key => $type) {
-            if ($type === 'date') {
-                $dateKeys[] = $key;
+        foreach ((array)$columns as $column) {
+            if (!isset($column['dt'], $column['db'])) {
+                continue;
             }
+            if (self::searchBuilderType($table, $column['db']) !== 'date') {
+                continue;
+            }
+            $type = strtolower(trim((string)self::columnType($table, $column['db'])));
+            $dateKeys[$column['dt']] = 0 !== strpos($type, 'timestamp');
         }
         if (!$dateKeys) {
             return $rows;
         }
+        // No early return on the two zones matching any more. They match for
+        // a viewer with no preference on an install that has crossed the
+        // boundary -- and that is exactly the reader a pre-boundary value
+        // has to be un-converted for.
         foreach ($rows as &$row) {
-            foreach ($dateKeys as $key) {
+            foreach ($dateKeys as $key => $isDatetime) {
                 if (!isset($row[$key]) || '' === trim((string)$row[$key])) {
                     continue;
                 }
@@ -334,8 +347,10 @@ abstract class FOGManagerController extends FOGBase
                 if (!self::validDate($row[$key])) {
                     continue;
                 }
-                $row[$key] = self::toDisplay((string)$row[$key])
-                    ->format('Y-m-d H:i:s');
+                $row[$key] = self::toDisplayStored(
+                    (string)$row[$key],
+                    $isDatetime
+                )->format('Y-m-d H:i:s');
             }
         }
         unset($row);
@@ -1433,7 +1448,8 @@ abstract class FOGManagerController extends FOGBase
                 ? []
                 : self::displayDates(
                     self::dataOutput($columns, $data),
-                    self::searchTypes($table, $columns)
+                    $table,
+                    $columns
                 ),
             // How each column may be filtered, for the client's search UI.
             // Server-derived because a server-side grid hands the browser one

--- a/packages/web/src/Base/FOGPageRender.php
+++ b/packages/web/src/Base/FOGPageRender.php
@@ -411,21 +411,34 @@ trait FOGPageRender
      * column in the schema reaches a page this way, so the guard belongs
      * next to the other shared renderers rather than on one page.
      *
-     * @param string|null $value The stored datetime, or null.
+     * @param string|null $value  The stored datetime, or null.
+     * @param string      $table  The table it came out of.
+     * @param string      $column The column it came out of.
      *
      * @return string
      */
-    protected static function dateOrNever($value)
+    protected static function dateOrNever($value, $table = '', $column = '')
     {
         if (!$value || !self::validDate($value)) {
             return _('Never');
         }
 
-        // toDisplay(), not niceDate(): niceDate reads the value in the zone it
-        // was STORED in and formatting it straight back hands you the same
-        // string you started with, so the viewer's zone would never be applied
-        // anywhere a date is shown on a form.
-        return self::toDisplay($value)->format('Y-m-d H:i:s');
+        // toDisplayStored(), not niceDate(): niceDate reads the value in the
+        // zone it was STORED in and formatting it straight back hands you the
+        // same string you started with, so the viewer's zone would never be
+        // applied anywhere a date is shown on a form.
+        //
+        // The table and column decide whether the value can predate the UTC
+        // boundary: a TIMESTAMP column has always held a UTC instant, a
+        // DATETIME one holds whatever clock wrote it. Unhinted callers are
+        // treated as DATETIME, which is what all five in core are and what a
+        // page adding a sixth is overwhelmingly likely to be.
+        $type = '' === $table
+            ? 'datetime'
+            : strtolower(trim((string)self::columnType($table, $column)));
+
+        return self::toDisplayStored($value, 0 !== strpos($type, 'timestamp'))
+            ->format('Y-m-d H:i:s');
     }
 
     /**

--- a/packages/web/src/Base/StorageEpoch.php
+++ b/packages/web/src/Base/StorageEpoch.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * The instant this install started storing dates in UTC, and what was true
+ * before it.
+ *
+ * Nothing that was already stored is ever converted. Up to five different
+ * clocks have written FOG's date columns -- PHP through FOG_TZ_INFO, MySQL
+ * NOW() in hand-written statements, MySQL DEFAULT current_timestamp(), the
+ * display-zone regression fixed in #1491, and the fog-client's own clock on
+ * check-in -- and no sweep can know which one wrote any given row. A
+ * conversion is also one-way: once 10:13:47 has become 15:13:47 there is
+ * nothing left saying which it was. So the convention change is RECORDED
+ * and every reader compares against it.
+ *
+ * Full reasoning, including the alternatives rejected and why:
+ * docs/development/utc-storage-boundary.md.
+ *
+ * @category Base
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Base;
+
+/**
+ * Reads the one row schema step 396 wrote, and answers the two questions
+ * every date on the way to a screen has to ask of it.
+ *
+ * @category Base
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class StorageEpoch extends FOGBase
+{
+    /**
+     * Hours either side of the boundary in which a value cannot be
+     * classified, and is treated as pre-boundary.
+     *
+     * UTC-12 to UTC+14 is the full span of real offsets, so 26 hours is safe
+     * on any install without having to trust a recorded zone. A narrower
+     * band computed from seZone and seDbZone would be more precise and is
+     * not worth it: the cost of being too wide is that a handful of values
+     * written in the day around a one-time upgrade are labeled unadjusted
+     * when they could have been labeled exactly, and the cost of being too
+     * narrow is a timestamp silently an hour wrong and presented as right.
+     * That asymmetry is the whole argument.
+     *
+     * @var int
+     */
+    const BAND_HOURS = 26;
+    /**
+     * The row, once read. False while it has not been looked for, null when
+     * there is none.
+     *
+     * @var array|null|false
+     */
+    private static $_row = false;
+    /**
+     * The parsed boundary, memoized.
+     *
+     * @var \DateTime|null
+     */
+    private static $_boundary = null;
+    /**
+     * Reads the row, at most once per process.
+     *
+     * Every failure answers "no boundary": a database that is not up yet
+     * (the installer runs this code path before the schema exists), a table
+     * an older install does not have, a permissions problem. Answering "no
+     * boundary" means behaving exactly as FOG did before this existed,
+     * which is the only safe default -- the alternative is claiming values
+     * are UTC on an install that never made them so.
+     *
+     * @return array|null
+     */
+    private static function _row()
+    {
+        if (false !== self::$_row) {
+            return self::$_row;
+        }
+        self::$_row = null;
+        if (!self::$DB) {
+            return self::$_row;
+        }
+        try {
+            $row = self::$DB
+                ->query(
+                    'SELECT `seBoundary`, `seZone`, `seDbZone`, `seSchema` '
+                    . 'FROM `storageEpoch` ORDER BY `seID` LIMIT 1'
+                )
+                ->fetch()
+                ->get();
+        } catch (\Throwable $e) {
+            return self::$_row;
+        }
+        if (!is_array($row) || empty($row['seBoundary'])) {
+            return self::$_row;
+        }
+        self::$_row = $row;
+
+        return self::$_row;
+    }
+    /**
+     * Whether this install has crossed the boundary.
+     *
+     * This is the switch for the whole feature. Until the row exists,
+     * storageTimeZone() keeps answering FOG_TZ_INFO and the database session
+     * keeps its own zone, so a half-upgraded install behaves exactly as it
+     * did before rather than in some third way.
+     *
+     * @return bool
+     */
+    public static function active()
+    {
+        return null !== self::_row();
+    }
+    /**
+     * The boundary instant, in UTC.
+     *
+     * @return \DateTime|null
+     */
+    public static function boundary()
+    {
+        if (null !== self::$_boundary) {
+            return self::$_boundary;
+        }
+        $row = self::_row();
+        if (null === $row) {
+            return null;
+        }
+        try {
+            self::$_boundary = new \DateTime(
+                (string)$row['seBoundary'],
+                new \DateTimeZone('UTC')
+            );
+        } catch (\Exception $e) {
+            return null;
+        }
+
+        return self::$_boundary;
+    }
+    /**
+     * The zone pre-boundary values were written in, as far as anything can
+     * say.
+     *
+     * seZone is a RECORD of what FOG_TZ_INFO was when the boundary was
+     * stamped, not a live read of it. That is the point: after the boundary
+     * FOG_TZ_INFO becomes a display setting an admin may change freely, and
+     * changing it must not silently re-interpret every old row.
+     *
+     * @return \DateTimeZone
+     */
+    public static function priorZone()
+    {
+        $row = self::_row();
+        $name = null === $row ? '' : trim((string)$row['seZone']);
+        if ('' === $name) {
+            return new \DateTimeZone('UTC');
+        }
+        try {
+            return new \DateTimeZone($name);
+        } catch (\Exception $e) {
+            // A zone name this PHP no longer knows -- tzdata moved, or the
+            // setting held something unusable even then.
+            return new \DateTimeZone('UTC');
+        }
+    }
+    /**
+     * Whether a stored value predates the boundary, and so does NOT mean UTC.
+     *
+     * The column type decides more than the value does, and getting that
+     * backwards is the one way this can make a correct timestamp wrong:
+     *
+     *  - A TIMESTAMP column has ALWAYS held a UTC instant. MySQL converts it
+     *    on the way in and out using the session zone, so once the session
+     *    runs at +00:00 the string handed back is UTC for every row in the
+     *    table, however old. Those are never pre-boundary.
+     *  - A DATETIME column is stored verbatim and means whatever the clock
+     *    that wrote it meant. Only those can be pre-boundary.
+     *
+     * @param string $value      The stored value.
+     * @param bool   $isDatetime Whether the column is DATETIME rather than
+     *                           TIMESTAMP.
+     *
+     * @return bool
+     */
+    public static function isPreBoundary($value, $isDatetime = true)
+    {
+        if (!$isDatetime || !self::active()) {
+            return false;
+        }
+        $boundary = self::boundary();
+        if (null === $boundary) {
+            return false;
+        }
+        $value = trim((string)$value);
+        if ('' === $value || !self::validDate($value)) {
+            return false;
+        }
+        try {
+            // Read in UTC, which is what the value claims to be if it is
+            // post-boundary. The band is what covers it being wrong by an
+            // offset if it is not.
+            $when = new \DateTime($value, new \DateTimeZone('UTC'));
+        } catch (\Exception $e) {
+            return false;
+        }
+        $cutoff = clone $boundary;
+        $cutoff->modify('+' . self::BAND_HOURS . ' hours');
+
+        return $when < $cutoff;
+    }
+}

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4552');
+        define('FOG_VERSION', '1.6.0-beta.4555');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4555');
+        define('FOG_VERSION', '1.6.0-beta.4562');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -94,7 +94,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 395);
+        define('FOG_SCHEMA', 396);
         define('FOG_BCACHE_VER', 339);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/src/Db/PDODB.php
+++ b/packages/web/src/Db/PDODB.php
@@ -320,6 +320,7 @@ class PDODB extends DatabaseManager
              * being off. Schema steps 344 and 345 repair the rows that were
              * written while they were.
              */
+            self::_pinSessionZone();
         } catch (\PDOException $e) {
             if ($dbexists) {
                 self::$_link = false;
@@ -809,6 +810,65 @@ class PDODB extends DatabaseManager
      *
      * @return string
      */
+    /**
+     * Runs the session at UTC once this install has crossed the boundary.
+     *
+     * Three clocks reach a date column and only one of them is PHP. NOW() in
+     * a hand-written statement and DEFAULT current_timestamp() are both
+     * evaluated by the server in the session zone, which FOG has never set
+     * -- so it is SYSTEM, the database host's own zone. On a single-box
+     * install that happens to agree with FOG_TZ_INFO and the disagreement is
+     * invisible; on a remote-database or containerised one it is a silent
+     * whole-hours error.
+     *
+     * Pinning the session to +00:00 makes all three agree by construction
+     * rather than by call site, and it is what makes TIMESTAMP columns hand
+     * their value back as UTC -- which is what they have always held
+     * underneath.
+     *
+     * Read straight off the link rather than through StorageEpoch: this runs
+     * inside _connect(), before FOGBase::$DB has been assigned, so the
+     * helper would have nothing to query through and would answer "no
+     * boundary" every time. A numeric offset rather than a name, so it works
+     * on a server whose time zone tables were never loaded.
+     *
+     * Every failure is silent and leaves the session alone, which is the
+     * pre-boundary behavior: the table does not exist on an install that has
+     * not upgraded, and the query runs before the schema updater on one that
+     * is upgrading right now.
+     *
+     * @return void
+     */
+    private static function _pinSessionZone()
+    {
+        if (!self::$_link) {
+            return;
+        }
+        try {
+            $st = self::$_link->query(
+                'SELECT `seID` FROM `storageEpoch` LIMIT 1'
+            );
+            if (!$st) {
+                return;
+            }
+            // DRAINED AND CLOSED BEFORE THE SET, and that is not tidiness.
+            // This link runs UNBUFFERED, so a statement left open makes the
+            // very next call fail with "Cannot execute queries while other
+            // unbuffered queries are active" -- which this method's own
+            // catch would then swallow, leaving the session on SYSTEM with
+            // nothing logged and every clock still disagreeing. Found in the
+            // lab by asserting @@session.time_zone rather than by trusting
+            // that the SET had run.
+            $rows = $st->fetchAll(\PDO::FETCH_NUM);
+            $st->closeCursor();
+            if (!$rows) {
+                return;
+            }
+            self::$_link->exec("SET SESSION time_zone = '+00:00'");
+        } catch (\Throwable $e) {
+            return;
+        }
+    }
     public function connectError()
     {
         if (!self::$_connectError) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -81,7 +81,7 @@ parameters:
 		-
 			message: '#^Accessing self\:\:\$DB outside of class scope\.$#'
 			identifier: outOfClass.self
-			count: 101
+			count: 105
 			path: packages/web/commons/schema.php
 
 		-
@@ -129,7 +129,7 @@ parameters:
 		-
 			message: '#^Variable \$this might not be defined\.$#'
 			identifier: variable.undefined
-			count: 365
+			count: 366
 			path: packages/web/commons/schema.php
 
 		-
@@ -1929,7 +1929,7 @@ parameters:
 		-
 			message: '#^Static property FOG\\Base\\FOGBase\:\:\$TimeZone \(object\) in empty\(\) is not falsy\.$#'
 			identifier: empty.property
-			count: 2
+			count: 3
 			path: packages/web/src/Base/FOGBase.php
 
 		-
@@ -2929,6 +2929,24 @@ parameters:
 			path: packages/web/src/Db/PDODB.php
 
 		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 1
+			path: packages/web/src/Base/StorageEpoch.php
+
+		-
+			message: '#^Cannot call method exec\(\) on resource\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: packages/web/src/Db/PDODB.php
+
+		-
+			message: '#^Static method FOG\\Db\\PDODB\:\:_pinSessionZone\(\) is unused\.$#'
+			identifier: method.unused
+			count: 1
+			path: packages/web/src/Db/PDODB.php
+
+		-
 			message: '#^Cannot call method prepare\(\) on resource\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -2937,7 +2955,7 @@ parameters:
 		-
 			message: '#^Cannot call method query\(\) on resource\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 3
 			path: packages/web/src/Db/PDODB.php
 
 		-
@@ -2979,7 +2997,7 @@ parameters:
 		-
 			message: '#^Negated boolean expression is always false\.$#'
 			identifier: booleanNot.alwaysFalse
-			count: 6
+			count: 7
 			path: packages/web/src/Db/PDODB.php
 
 		-

--- a/tests/display-timezone-split.test.php
+++ b/tests/display-timezone-split.test.php
@@ -94,7 +94,12 @@ $display = tzMethod(
     'FOGBase::displayTimeZone()'
 );
 if ('' !== $display) {
-    if (!preg_match('#self::storageTimeZone\(\)#', $display)) {
+    // The install default is defaultDisplayTimeZone() -- FOG_TZ_INFO -- and
+    // deliberately NOT storageTimeZone() any more. Before the UTC boundary
+    // the two were the same value read twice; after it, falling back to
+    // storage would show UTC to every account that has never opened its
+    // preferences, which is every account on a freshly upgraded install.
+    if (!preg_match('#self::defaultDisplayTimeZone\(\)#', $display)) {
         $fails[] = 'displayTimeZone() does not fall back to the install '
             . 'default; an account with no preference must be unaffected';
     }
@@ -146,19 +151,25 @@ if ('' !== $format) {
 
 $dateOrNever = tzMethod(
     $render,
-    'protected static function dateOrNever($value)',
+    "protected static function dateOrNever(\$value, \$table = '', \$column = '')",
     'FOGPageRender::dateOrNever()'
 );
-if ('' !== $dateOrNever && !preg_match('#self::toDisplay\(\$value\)#', $dateOrNever)) {
-    $fails[] = 'dateOrNever() does not convert; niceDate() formatted straight '
-        . 'back hands you the stored string, so no form date would ever move';
+// toDisplayStored(), not toDisplay(), since the UTC boundary: a value from
+// before it does not mean what storageTimeZone() now says values mean, and
+// reading one as UTC moves it by the offset. Still a conversion either way --
+// niceDate() formatted straight back hands you the stored string, so no form
+// date would ever move.
+if ('' !== $dateOrNever
+    && !preg_match('#self::toDisplayStored\(\$value, #', $dateOrNever)
+) {
+    $fails[] = 'dateOrNever() does not convert through toDisplayStored()';
 }
 
 // ------------------------------------------------------------ grid cells
 
 $displayDates = tzMethod(
     $manager,
-    'public static function displayDates($rows, $types)',
+    'public static function displayDates($rows, $table, $columns)',
     'FOGManagerController::displayDates()'
 );
 if ('' !== $displayDates) {
@@ -166,15 +177,21 @@ if ('' !== $displayDates) {
         $fails[] = 'displayDates() does not exempt REST responses; a script '
             . 'would get a different answer depending on whose token it used';
     }
-    if (!preg_match('#displayTimeZone\(\)->getName\(\)\s*===\s*self::storageTimeZone\(\)->getName\(\)#s', $displayDates)) {
-        $fails[] = 'displayDates() does not short-circuit when the zones agree, '
-            . 'which is every account that has not set a preference';
+    // The zones-match short circuit that used to live here is GONE, and its
+    // absence is now the thing worth pinning. It skipped the whole method
+    // whenever display and storage agreed -- which after the UTC boundary is
+    // exactly the reader (no preference, freshly upgraded install) whose
+    // pre-boundary values must NOT be read as UTC.
+    if (preg_match('#displayTimeZone\(\)->getName\(\)\s*===\s*self::storageTimeZone\(\)->getName\(\)#s', $displayDates)) {
+        $fails[] = 'displayDates() short-circuits when the zones agree again; '
+            . 'that skips pre-boundary handling for every reader without a '
+            . 'preference';
     }
     if (!preg_match('#validDate#', $displayDates)) {
         $fails[] = 'displayDates() does not exempt the zero date';
     }
 }
-if (!preg_match('#self::displayDates\(\s*self::dataOutput\(\$columns, \$data\),#s', $manager)) {
+if (!preg_match('#self::displayDates\(\s*self::dataOutput\(\$columns, \$data\),\s*\$table,\s*\$columns\s*\)#s', $manager)) {
     $fails[] = 'the grid payload is not passed through displayDates(), so a '
         . 'chosen timezone would apply everywhere except the lists, which is '
         . 'where the timestamps people read actually live';

--- a/tests/utc-storage-boundary.test.php
+++ b/tests/utc-storage-boundary.test.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * The UTC storage boundary must stay a boundary.
+ *
+ * From schema step 396 an install stores dates in UTC and shows them in the
+ * reader's zone. Nothing already stored is converted, because up to five
+ * clocks have written FOG's date columns and no sweep can know which wrote
+ * any given row. So the instant the convention changed is RECORDED, and
+ * every value on its way to a screen is compared against it.
+ *
+ * Every failure in this area is silent and looks like data. A value wrong by
+ * a whole number of hours is indistinguishable from a correct one in
+ * isolation, there is no error, nothing is logged, and the reader has no way
+ * to tell. That is why the invariants are pinned here rather than left to
+ * review.
+ *
+ * Usage: php tests/utc-storage-boundary.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$base = file_get_contents($root . '/packages/web/src/Base/FOGBase.php');
+$epoch = file_get_contents($root . '/packages/web/src/Base/StorageEpoch.php');
+$pdodb = file_get_contents($root . '/packages/web/src/Db/PDODB.php');
+$mgr = file_get_contents(
+    $root . '/packages/web/src/Base/FOGManagerController.php'
+);
+$render = file_get_contents(
+    $root . '/packages/web/src/Base/FOGPageRender.php'
+);
+$schema = file_get_contents($root . '/packages/web/commons/schema.php');
+$system = file_get_contents($root . '/packages/web/src/Base/System.php');
+
+$fails = [];
+
+// ---------------------------------------------------- the flip itself
+
+// Anchored on the whole guard. A check for the string 'UTC' anywhere in
+// storageTimeZone() passes on the pre-existing fallback two lines below it,
+// which is the one thing this must not be confused with: that fallback fires
+// when FOG_TZ_INFO is UNSET, and it always has.
+if (!preg_match(
+    '#function storageTimeZone\(\)\s*\{.*?'
+    . 'if \(class_exists\(StorageEpoch::class\) && StorageEpoch::active\(\)\) \{\s*'
+    . "return new \\\\DateTimeZone\('UTC'\);#s",
+    $base
+)) {
+    $fails[] = 'storageTimeZone() no longer answers UTC once the boundary '
+        . 'row exists, so new writes would go back to FOG_TZ_INFO while '
+        . 'everything reading them assumes UTC';
+}
+
+// The display default must NOT be the storage zone. This is the one line
+// that decides what every user who has never opened their preferences sees:
+// pointed at storageTimeZone() it shows them UTC.
+if (!preg_match(
+    '#function displayTimeZone\(\).*?\$storage = self::defaultDisplayTimeZone\(\);#s',
+    $base
+)) {
+    $fails[] = 'displayTimeZone() no longer defaults to '
+        . 'defaultDisplayTimeZone(); every reader without a preference '
+        . 'would be shown UTC instead of the install\'s own zone';
+}
+if (!preg_match(
+    '#function defaultDisplayTimeZone\(\)\s*\{.*?'
+    . 'return new \\\\DateTimeZone\(self::\$TimeZone\);#s',
+    $base
+)) {
+    $fails[] = 'defaultDisplayTimeZone() no longer reads FOG_TZ_INFO';
+}
+
+// ------------------------------------------------- the database session
+
+if (!preg_match('#self::_pinSessionZone\(\);#', $pdodb)) {
+    $fails[] = 'PDODB no longer pins the session zone on connect, so NOW() '
+        . 'and DEFAULT current_timestamp() go back to the database host\'s '
+        . 'own zone while PHP writes UTC';
+}
+// The drain is load bearing, not tidiness: this link is unbuffered, so a
+// statement left open makes the SET throw, and the method's own catch then
+// swallows it. The failure is invisible -- the session simply stays on
+// SYSTEM.
+if (!preg_match(
+    '#function _pinSessionZone\(\).*?'
+    . '\$rows = \$st->fetchAll\(\\\\PDO::FETCH_NUM\);\s*'
+    . '\$st->closeCursor\(\);.*?'
+    . 'SET SESSION time_zone = \'\+00:00\'#s',
+    $pdodb
+)) {
+    $fails[] = '_pinSessionZone() no longer drains and closes its gate '
+        . 'query before the SET; on an unbuffered link that throws, the '
+        . 'catch swallows it, and the session silently stays on SYSTEM';
+}
+
+// -------------------------------------------------- the classification
+
+// A TIMESTAMP column has always held a UTC instant and can never be
+// pre-boundary. Getting this backwards moves every old timestamp by the
+// offset -- the single most damaging thing in this change.
+if (!preg_match(
+    '#function isPreBoundary\(\$value, \$isDatetime = true\)\s*\{\s*'
+    . 'if \(!\$isDatetime \|\| !self::active\(\)\) \{\s*return false;#s',
+    $epoch
+)) {
+    $fails[] = 'isPreBoundary() no longer exempts non-DATETIME columns; a '
+        . 'TIMESTAMP column always held a UTC instant, so treating one as '
+        . 'pre-boundary shifts every old row by the offset';
+}
+if (!preg_match('#const BAND_HOURS = 26;#', $epoch)) {
+    $fails[] = 'the 26-hour band is gone; UTC-12 to UTC+14 is the full span '
+        . 'of real offsets, and a narrower band lets a value written just '
+        . 'before the boundary be read as though it were after it';
+}
+// Never invents a boundary. Every failure path has to answer "no boundary",
+// which is the pre-change behavior; answering "yes" on an install that never
+// migrated would claim its values are UTC when they are not.
+if (!preg_match(
+    '#function active\(\)\s*\{\s*return null !== self::_row\(\);#s',
+    $epoch
+)) {
+    $fails[] = 'StorageEpoch::active() is no longer decided by the row '
+        . 'alone';
+}
+
+// ------------------------------------------------------ the read paths
+
+// Both display chokepoints, and both must pass the column type through.
+if (!preg_match(
+    '#\$row\[\$key\] = self::toDisplayStored\(\s*'
+    . '\(string\)\$row\[\$key\],\s*\$isDatetime\s*\)#s',
+    $mgr
+)) {
+    $fails[] = 'the grid no longer renders dates through toDisplayStored() '
+        . 'with the column type, so a pre-boundary value would be read as '
+        . 'UTC and shown at the wrong hour';
+}
+// The early return this replaced compared the two zones and skipped the
+// whole thing when they matched -- which is exactly the reader (no
+// preference, post-upgrade install) a pre-boundary value must NOT be
+// converted for.
+if (preg_match(
+    '#function displayDates\(.*?if \(self::displayTimeZone\(\)->getName\(\)#s',
+    $mgr
+)) {
+    $fails[] = 'displayDates() has its zones-match early return back; that '
+        . 'skips pre-boundary handling for every reader without a '
+        . 'preference';
+}
+if (!preg_match(
+    '#function dateOrNever\(\$value, \$table = \'\', \$column = \'\'\)#',
+    $render
+)) {
+    $fails[] = 'dateOrNever() no longer takes the table and column it needs '
+        . 'to tell a DATETIME from a TIMESTAMP';
+}
+// Every core caller has to hand them over, or the default silently decides.
+foreach ([
+    'hostmanagement' => 4,
+    'imagemanagement' => 1,
+] as $page => $expected) {
+    $src = file_get_contents(
+        $root . '/packages/web/lib/pages/' . $page . '.page.php'
+    );
+    $hinted = preg_match_all(
+        "#dateOrNever\(\s*\\\$this->obj->get\('[a-z]+'\),\s*'[a-z]+',\s*'[A-Za-z]+'\s*\)#s",
+        $src
+    );
+    $all = preg_match_all('#self::dateOrNever\(#', $src);
+    if ($hinted < $expected || $hinted !== $all) {
+        $fails[] = sprintf(
+            '%s.page.php has %d dateOrNever() calls and %d of them name '
+            . 'their table and column; an unhinted one is assumed DATETIME',
+            $page,
+            $all,
+            $hinted
+        );
+    }
+}
+
+// ------------------------------------------------------- the migration
+
+if (!preg_match(
+    '#CREATE TABLE IF NOT EXISTS `storageEpoch`#',
+    $schema
+)) {
+    $fails[] = 'schema.php no longer creates the storageEpoch table';
+}
+// Written once and never again. Moving the boundary re-interprets every
+// date in the database, so the guard is the whole safety of the step.
+if (!preg_match(
+    '#SELECT COUNT\(`seID`\) AS `c` FROM `storageEpoch`.*?'
+    . 'if \(\(int\)\$existing > 0\) \{\s*return true;#s',
+    $schema
+)) {
+    $fails[] = 'the boundary insert is no longer guarded by a row count; '
+        . 're-running the step would move the boundary and silently '
+        . 're-interpret every stored date';
+}
+if (!preg_match("#define\('FOG_SCHEMA', 396\);#", $system)) {
+    $fails[] = 'FOG_SCHEMA is not 396, so step 396 never runs and the '
+        . 'boundary is never recorded';
+}
+$manifest = require $root . '/packages/web/commons/schema-expected.php';
+if (!isset($manifest['tables']['storageEpoch']['columns']['seBoundary'])) {
+    $fails[] = 'storageEpoch is missing from the schema manifest, so the '
+        . 'reconciler would not create it on an install that skipped the '
+        . 'step';
+}
+
+if ($fails) {
+    foreach ($fails as $f) {
+        echo "FAIL: $f\n";
+    }
+    exit(1);
+}
+echo "PASS: the UTC storage boundary holds -- the flip, the session, the "
+    . "classification, both read paths and the migration\n";
+exit(0);


### PR DESCRIPTION
Builds the design from #1494. Docs: `docs/development/utc-storage-boundary.md`.

## Why not a conversion

FOG has never had one clock. Up to five have written its date columns — PHP through `FOG_TZ_INFO`, MySQL `NOW()` in hand-written statements, MySQL `DEFAULT current_timestamp()`, the display-zone regression fixed in #1491, and the fog-client's own clock on check-in — and nothing records which wrote any given row. A `CONVERT_TZ` sweep must assume one source zone, is one-way, would move the TIMESTAMP columns twice, and cannot be tested: a value wrong by whole hours is indistinguishable from a right one in isolation.

So the convention change is **recorded** and every reader compares against it.

## What lands

**Schema step 396** creates `storageEpoch` and writes one row — the instant (UTC), the `FOG_TZ_INFO` in force, the database host's zone, and the step that did it. The insert is guarded by a row count: moving the boundary would silently re-interpret every date in the install.

Its own table, not `globalSettings` (the configuration page renders every row of that table with no `WHERE`, and `setting` is in `Route::$validClasses`) and not a column on `schemaVersion` — whose seed INSERT is positional, so a third column makes a fresh install die on `1136 Column count doesn't match value count`. Verified by running that exact statement against a three-column copy.

From that row on:

| | |
|---|---|
| `storageTimeZone()` | answers UTC, **gated on the row** rather than a schema number, so a half-upgraded install behaves exactly as it did before |
| the database session | runs at `+00:00`, so `NOW()` and `DEFAULT current_timestamp()` agree with PHP by construction rather than by call site — no chasing the six `NOW()` sites — and TIMESTAMP columns hand back the UTC instant they always held |
| `FOG_TZ_INFO` | becomes the install's **default display zone**. `displayTimeZone()` used to default to the storage zone, which after the flip would show UTC to everyone who has never opened their preferences |

**Nothing already stored moves.** A pre-boundary value is read in the zone that *was* the storage zone — not a guess, but exactly the interpretation FOG applied to it yesterday — so an old row renders as it always did.

**The column type decides more than the value does.** A TIMESTAMP column has always held a UTC instant and can never be pre-boundary; treating one as such would shift every old row by the offset. Both display paths (`displayDates()` for grids, `dateOrNever()` for forms) now carry the type, from `columnType()`, which answers from the manifest for core and the server's catalog for plugin tables.

The **26-hour band** is wide on purpose. UTC−12 to UTC+14 is the full span of real offsets, so it is safe without trusting a recorded zone. Too wide costs a handful of values around a one-time upgrade being read in the old zone; too narrow costs a timestamp silently an hour wrong and presented as right.

## Verification

Against a database whose MySQL runs **UTC** while `FOG_TZ_INFO` says **America/Chicago** — the disagreeing-clocks case this exists for. One host row with a pre-boundary imaged date and a post-boundary check-in, read through the **real grid** at three display zones:

| viewer | Imaged (pre-boundary, stored `2026-08-26 07:36:50` Chicago) | Last Check-In (post-boundary, stored `2026-09-02 11:33` UTC) |
|---|---|---|
| install default (America/Chicago) | `07:36:50` — unmoved, as it always rendered | `06:45` — UTC→Chicago |
| UTC | `12:36:50` — Chicago→UTC | `11:45` — unmoved |
| Asia/Tokyo | `21:36:50` — Chicago→Tokyo | `20:45` — UTC→Tokyo |

Correct in both directions at every zone.

`tests/utc-storage-boundary.test.php` pins the flip, the session pin, the classification, both read paths and the migration. Thirteen mutations, thirteen caught:

```
caught:  the boundary stops flipping storage to UTC
caught:  the display default points back at the storage zone
caught:  the install default stops being FOG_TZ_INFO
caught:  the session zone is never pinned
caught:  the cursor drain is dropped (the silent 2014)
caught:  TIMESTAMP columns lose their exemption
caught:  the band is narrowed to an hour
caught:  the grid goes back to plain toDisplay()
caught:  the zones-match early return comes back
caught:  dateOrNever loses its column hint
caught:  one page stops naming its column
caught:  the boundary insert loses its once-only guard
caught:  FOG_SCHEMA is not bumped
```

`tests/display-timezone-split.test.php` (from #1484) pinned `displayTimeZone()` falling back to `storageTimeZone()` and the old zones-match short circuit. Both are now the *opposite* of what is wanted, so it pins the refined rule — including that the short circuit stays gone, since it skipped the whole method for exactly the reader whose pre-boundary values must not be read as UTC.

Both PHPStan passes clean, `tests/run-all.sh` 216 passed 0 failed.

## Found in the lab

`_pinSessionZone()` originally read its gate row and ran the `SET` with the statement still open. FOG's PDO link is **unbuffered**, so the `SET` threw `2014 Cannot execute queries while other unbuffered queries are active` — and the method's own `catch` swallowed it, leaving the session on `SYSTEM` with nothing logged and every clock still disagreeing. Caught only by asserting `@@session.time_zone` directly rather than trusting that the `SET` had run. The drain is now pinned by the gate.

Separately: PHPStan does not analyse the region of `PDODB::_connect()` that this call sits in — a deliberately-invalid method name there produces no error at all — which is why `_pinSessionZone()` is reported unused and had to be baselined. Its behavior is proved by the lab run, not by the static analysis.

## Known cost, and what comes next

For the **26 hours after an upgrade**, genuinely post-boundary values are classified as pre-boundary — that is what the band is for, since a value written just before the flip in local time can carry a wall-clock string that looks like it came after. For a reader with **no display preference** this is invisible: the prior zone and the display zone are the same. It shows only for someone who has chosen a different zone, in that one window.

The visible "unadjusted" marker — the muted flag in a grid, the line of prose on a detail page, the `…Adjusted: false` sibling field over REST, and the admin page explaining why old timestamps cannot be corrected — is the next change, not this one. This one is the correctness half.