### PR TITLE
Stop Responsive re-measuring every loaded row on every column adjust

### DIFF
--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -3222,6 +3222,100 @@ function fogFetchIfShort(dt, waited) {
   }
   dt.draw(false);
 }
+/**
+ * Stop DataTables Responsive re-measuring every loaded row on every adjust.
+ *
+ * Responsive answers `column-sizing` -- which every columns.adjust() fires --
+ * by running _resizeAuto(), and _resizeAuto() deep-clones the header, the
+ * footer and EVERY row of the current page into a hidden table so the browser
+ * will compute each column's natural width. With Scroller the "current page"
+ * is every row fetched so far, so the cost is linear in the size of the list.
+ * Measured on a 86-host list: 8 calls per load at ~140ms each, of which only
+ * 15ms is building the clone -- the other ~125ms is the layout the browser is
+ * forced into to answer offsetWidth.
+ *
+ * Most of those calls cannot produce a new answer. The widths _resizeAuto()
+ * reads come only from the markup it clones; it measures with the table at
+ * width:auto inside a 1px hidden box, so the viewport is not an input. Five of
+ * the eight calls returned a vector byte-identical to the call before them.
+ *
+ * So sign exactly what gets cloned -- the table node's class list, the visible
+ * column set, and the header/body/footer HTML -- and when the signature is
+ * unchanged, restore the previous answer instead of re-measuring. Signing the
+ * markup rather than a draw counter is what keeps this correct: Responsive
+ * converges over two passes, adding `dtr-control` to the first column between
+ * them, and that genuinely does change the answer. A coarser key would cache
+ * the pre-convergence widths and leave the column permanently 17px narrow.
+ *
+ * The class list is sorted before signing because addClass()/removeClass()
+ * reorder the tokens without changing what renders, and that alone defeated
+ * the cache twice per load.
+ *
+ * The signature costs ~1.5ms against the ~140ms it skips. Nothing else caches
+ * it, so a stale entry cannot outlive the table.
+ *
+ * Dropped on window resize: the markup does not change when the browser zooms
+ * or the font size does, but the metrics do.
+ *
+ * @return {void}
+ */
+function fogMemoizeResponsiveMeasure() {
+  var Responsive = $.fn.dataTable ? $.fn.dataTable.Responsive : null;
+  if (!Responsive || !Responsive.prototype ||
+    typeof Responsive.prototype._resizeAuto !== 'function' ||
+    Responsive.prototype._fogMemoized
+  ) {
+    return;
+  }
+  Responsive.prototype._fogMemoized = true;
+  var original = Responsive.prototype._resizeAuto;
+  Responsive.prototype._resizeAuto = function() {
+    var dt = this.s ? this.s.dt : null,
+      node = dt ? dt.table().node() : null,
+      footer,
+      signature,
+      i;
+    // No table to sign: fall through untouched rather than guess.
+    if (!node) {
+      return original.apply(this, arguments);
+    }
+    footer = dt.table().footer();
+    signature = String(node.className).split(/\s+/).sort().join(' ') + '\u0000' +
+      dt.columns().indexes().filter(function(index) {
+        return dt.column(index).visible();
+      }).toArray().join(',') + '\u0000' +
+      dt.table().header().innerHTML + '\u0000' +
+      dt.table().body().innerHTML + '\u0000' +
+      (footer ? footer.innerHTML : '');
+    if (this._fogSignature === signature && this._fogMinWidths) {
+      for (i = 0; i < this._fogMinWidths.length; i++) {
+        // s.columns is the array _resizeAuto() writes minWidth into, and is
+        // what _resize() reads a moment later to pick the columns to drop.
+        if (this.s.columns[i]) {
+          this.s.columns[i].minWidth = this._fogMinWidths[i];
+        }
+      }
+      return;
+    }
+    var result = original.apply(this, arguments);
+    this._fogSignature = signature;
+    this._fogMinWidths = $.map(this.s.columns, function(column) {
+      return column.minWidth;
+    });
+    return result;
+  };
+  $(window).on('resize.fogresponsivememo', function() {
+    $('table.dataTable').each(function() {
+      if (!$.fn.dataTable.isDataTable(this)) {
+        return;
+      }
+      var settings = $(this).DataTable().settings()[0];
+      if (settings && settings._responsive) {
+        settings._responsive._fogSignature = null;
+      }
+    });
+  });
+}
 function fogSizeScroller(dt, release) {
   // dt.init() can be null for nodes the table.dataTable selector also matches
   // but that aren't fully-initialized Scroller tables (e.g. the scrollY split
@@ -3518,6 +3612,9 @@ if ($.fn.dataTable) {
 }
 $.fn.registerTable = function(onSelect, opts) {
   opts = opts || {};
+
+  // Idempotent; every grid calls this and only the first does any work.
+  fogMemoizeResponsiveMeasure();
 
   // Default row count comes from FOG_VIEW_DEFAULT_SCREEN (hidden #pageLength).
   var pageLength = parseInt($('#pageLength').val());

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4562');
+        define('FOG_VERSION', '1.6.0-beta.4568');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4568');
+        define('FOG_VERSION', '1.6.0-beta.4570');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4555');
+        define('FOG_VERSION', '1.6.0-beta.4559');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 395);
-        define('FOG_BCACHE_VER', 339);
+        define('FOG_BCACHE_VER', 340);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a


### PR DESCRIPTION
## Problem

The host list still took ~1.5s to settle for 86 rows after #1486, and got worse with list size. The server was never involved — the grid POST answers in **30ms** by curl.

The cost is `DataTables.Responsive._resizeAuto()`. It answers **every** `column-sizing` event — which is every `columns.adjust()` — by deep-cloning the header, the footer and **every row of the current page** into a hidden table so the browser will compute each column's natural width. With Scroller the "current page" is every row fetched so far, so the cost is linear in the size of the list.

Measured on 10.255.20.1, host list, 86 rows:

| | |
|---|---|
| `_resizeAuto` calls per load | **8** |
| total | **~870ms** |
| per call | ~140ms |
| of which building the clone | **15ms** — the other ~125ms is forced layout |

It scales at roughly **10ms per row per page load**: 2 rows 23ms, 4 rows 39ms, 29 rows 194ms, 86 rows 870ms. A 1000-host list implies ~10s.

A note for anyone re-measuring this: the same grid POST that curl answers in 30ms *appears* as 1062ms to a hooked `XMLHttpRequest`, purely because `loadend` cannot fire while the main thread is blocked. Prove server time with curl, not from the page.

## Fix

**Five of the eight calls returned a `minWidth` vector byte-identical to the call before them** — 551ms provably recomputing an unchanged answer.

The widths come only from the markup Responsive clones, and it measures with the table at `width:auto` inside a 1px hidden box, so the viewport is not an input. So sign exactly what gets cloned — the table node's class list, the visible column set, and the header/body/footer HTML — and restore the previous answer when the signature is unchanged. The signature costs **~1.5ms** against the ~140ms it skips.

`fogMemoizeResponsiveMeasure()` in `fog.common.js`, installed once from `$.fn.registerTable()`.

### Why the cache key is what it is

- **Not the draw counter or row count.** Responsive converges over *two* passes within a single draw: the first measures, `_resize()` then adds `dtr-control` to the first column, and the second legitimately measures it 17px wider (166 → 183). A key coarse enough to treat those as one call would cache the pre-convergence width and leave that column permanently narrow.
- **The class list is sorted before signing.** `addClass`/`removeClass` reorder the tokens without changing what renders, and that alone defeated the cache twice per load.
- **Dropped on `window.resize`.** The markup does not change when the browser zooms or the font size does, but the metrics do.
- `fog-table-fixed` stays in the signature — it is `table-layout: fixed`, which genuinely changes how the clone lays out.

## Verification

The real patched file was served over CDP against the live server (`Fetch.fulfillRequest`, so nothing on the webroot moved), and A/B'd against the deployed file — which was confirmed byte-identical to `origin/working-1.6` first, so no branch drift could be mistaken for an effect.

| grid | rows | before | after | rendered widths |
|---|---|---|---|---|
| host | 86 | 870ms | **571ms** | identical |
| image | 29 | 194ms | **108ms** | identical |
| snapin | 4 | 39ms | 25ms | identical |
| group | 2 | 23ms | 14ms | identical |

Header and body column widths and the Responsive collapse set are byte-identical in every arm. Both `phpstan` passes clean.

`FOG_BCACHE_VER` bumped 339 → 340, since `fog.common.js` changed.

## What this does not fix

With `responsive: false` the cost is **0ms**, but two columns stop collapsing and the table overflows horizontally — so Responsive is genuinely earning its keep here, not dead weight. This change recovers the redundant third of its cost; the rest is the feature itself, and whether wide desktop grids should opt out of it is a UX decision, not a perf cleanup.

## Downstream

None — no route or class-list change.