### PR TITLE
Give the daemon entry points the core import the PSR-4 sweep skipped

### DIFF
--- a/bin/import-core-classes.php
+++ b/bin/import-core-classes.php
@@ -106,6 +106,40 @@ $handEdited = [
     'tests/oldcopy-retires-moved-classes.test.php',
 ];
 
+/**
+ * Is this file PHP source we should rewrite?
+ *
+ * Extension alone is not enough. The ten daemon entry points under
+ * packages/service/ are named for the systemd unit and carry NO extension at
+ * all -- packages/service/FOGImageSize/FOGImageSize -- because that name is
+ * what installInitScript() writes into the unit's ExecStart. An
+ * extension-only filter skipped every one of them, so the sweep that moved
+ * core to PSR-4 rewrote packages/service/lib/service_lib.php and nothing
+ * else, this tool reported "nothing to import", and all ten daemons shipped
+ * with a bare `FOGCore::` that no longer resolves.
+ *
+ * A shebang naming php is the only other marker they carry, so that is what
+ * is tested. Deliberately not "is it under packages/service": a rule tied to
+ * one directory would miss the next extension-less entry point somewhere
+ * else, which is the same shape of hole again.
+ *
+ * @param string $path the file to test
+ * @param string $ext  its extension, '' when it has none
+ *
+ * @return bool
+ */
+function isPhpSource($path, $ext)
+{
+    if ('php' === $ext) {
+        return true;
+    }
+    if ('' !== $ext) {
+        return false;
+    }
+    $head = (string)file_get_contents($path, false, null, 0, 64);
+    return (bool)preg_match('{^#![^\n]*\bphp\b}', $head);
+}
+
 $skip = [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT];
 $totalRefs = 0;
 $totalFiles = 0;
@@ -118,7 +152,7 @@ foreach ($targets as $target) {
     $walk = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($target));
     foreach ($walk as $file) {
         $path = $file->getPathname();
-        if (!$file->isFile() || 'php' !== $file->getExtension()
+        if (!$file->isFile() || !isPhpSource($path, $file->getExtension())
             || false !== strpos($path, '/plugins/')
             || false !== strpos($path, '/vendor/')
             || in_array(
@@ -228,8 +262,13 @@ foreach ($targets as $target) {
             // declare(strict_types=1) has to be the very first statement in
             // the file -- putting the imports above it is a parse error, not
             // a style problem. api/index.php found this immediately.
+            //
+            // The optional leading shebang is the daemon entry points: they
+            // open `#!/usr/bin/php -q` and only then `<?php`, so without it
+            // this anchor -- `^` under /s, i.e. start of file -- matches
+            // nothing and the imports are silently never written.
             $src = preg_replace(
-                '/^(<\?php\n(?:\s*declare\s*\([^)]*\)\s*;\n)?(?:\s*\/\*\*.*?\*\/\n)?(?:\s*declare\s*\([^)]*\)\s*;\n)?)/s',
+                '/^((?:#![^\n]*\n)?<\?php\n(?:\s*declare\s*\([^)]*\)\s*;\n)?(?:\s*\/\*\*.*?\*\/\n)?(?:\s*declare\s*\([^)]*\)\s*;\n)?)/s',
                 "$1\n" . $block . "\n",
                 $src,
                 1

--- a/packages/service/FOGFileDeleter/FOGFileDeleter
+++ b/packages/service/FOGFileDeleter/FOGFileDeleter
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * FOGFileDeleter service to delete files from FOG on schedule
  *
@@ -24,7 +27,7 @@ require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
 $service_name = 'FOGFileDeleter';
 service_persist($service_name);
-$ServiceClass = $FOGCore::getClass('FileDeleter');
+$ServiceClass = FOGCore::getClass('FileDeleter');
 $ServiceClass->getBanner();
 $ServiceClass->waitInterfaceReady();
 $ServiceClass->waitDbReady();

--- a/packages/service/FOGImageReplicator/FOGImageReplicator
+++ b/packages/service/FOGImageReplicator/FOGImageReplicator
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * FOGImageReplicator service to replicate images in FOG
  *
@@ -24,7 +27,7 @@ require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
 $service_name = 'FOGImageReplicator';
 service_persist($service_name);
-$ServiceClass = $FOGCore::getClass('ImageReplicator');
+$ServiceClass = FOGCore::getClass('ImageReplicator');
 $ServiceClass->getBanner();
 $ServiceClass->waitInterfaceReady();
 $ServiceClass->waitDbReady();

--- a/packages/service/FOGImageSize/FOGImageSize
+++ b/packages/service/FOGImageSize/FOGImageSize
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * FOGImageSize service to get the size of images in FOG
  *
@@ -24,7 +27,7 @@ require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
 $service_name = 'FOGImageSize';
 service_persist($service_name);
-$ServiceClass = $FOGCore::getClass('ImageSize');
+$ServiceClass = FOGCore::getClass('ImageSize');
 $ServiceClass->getBanner();
 $ServiceClass->waitInterfaceReady();
 $ServiceClass->waitDbReady();

--- a/packages/service/FOGMulticastManager/FOGMulticastManager
+++ b/packages/service/FOGMulticastManager/FOGMulticastManager
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * FOGMulticastManager service to enable MC tasks in FOG
  *

--- a/packages/service/FOGPingHosts/FOGPingHosts
+++ b/packages/service/FOGPingHosts/FOGPingHosts
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * FOGPingHosts service to ping hosts in FOG
  *
@@ -24,7 +27,7 @@ require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
 $service_name = 'FOGPingHosts';
 service_persist($service_name);
-$ServiceClass = $FOGCore::getClass('PingHosts');
+$ServiceClass = FOGCore::getClass('PingHosts');
 $ServiceClass->getBanner();
 $ServiceClass->waitInterfaceReady();
 $ServiceClass->waitDbReady();

--- a/packages/service/FOGPluginRunner/FOGPluginRunner
+++ b/packages/service/FOGPluginRunner/FOGPluginRunner
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * FOGPluginRunner service to run background work declared by plugins
  *
@@ -29,7 +32,7 @@ require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
 $service_name = 'FOGPluginRunner';
 service_persist($service_name);
-$ServiceClass = $FOGCore::getClass('PluginRunner');
+$ServiceClass = FOGCore::getClass('PluginRunner');
 $ServiceClass->getBanner();
 $ServiceClass->waitInterfaceReady();
 $ServiceClass->waitDbReady();

--- a/packages/service/FOGRetentionRunner/FOGRetentionRunner
+++ b/packages/service/FOGRetentionRunner/FOGRetentionRunner
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * FOGRetentionRunner service to age out the tables that record what happened
  *
@@ -36,7 +39,7 @@ require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
 $service_name = 'FOGRetentionRunner';
 service_persist($service_name);
-$ServiceClass = $FOGCore::getClass('RetentionRunner');
+$ServiceClass = FOGCore::getClass('RetentionRunner');
 $ServiceClass->getBanner();
 $ServiceClass->waitInterfaceReady();
 $ServiceClass->waitDbReady();

--- a/packages/service/FOGSnapinHash/FOGSnapinHash
+++ b/packages/service/FOGSnapinHash/FOGSnapinHash
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * FOGSnapinHash service to get the hash of snapins in FOG
  *
@@ -24,7 +27,7 @@ require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
 $service_name = 'FOGSnapinHash';
 service_persist($service_name);
-$ServiceClass = $FOGCore::getClass('SnapinHash');
+$ServiceClass = FOGCore::getClass('SnapinHash');
 $ServiceClass->getBanner();
 $ServiceClass->waitInterfaceReady();
 $ServiceClass->waitDbReady();

--- a/packages/service/FOGSnapinReplicator/FOGSnapinReplicator
+++ b/packages/service/FOGSnapinReplicator/FOGSnapinReplicator
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * FOGSnapinReplicator service to replicate snapins in FOG
  *
@@ -24,7 +27,7 @@ require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
 $service_name = 'FOGSnapinReplicator';
 service_persist($service_name);
-$ServiceClass = $FOGCore::getClass('SnapinReplicator');
+$ServiceClass = FOGCore::getClass('SnapinReplicator');
 $ServiceClass->getBanner();
 $ServiceClass->waitInterfaceReady();
 $ServiceClass->waitDbReady();

--- a/packages/service/FOGTaskScheduler/FOGTaskScheduler
+++ b/packages/service/FOGTaskScheduler/FOGTaskScheduler
@@ -11,6 +11,9 @@
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
+
+use FOG\Base\FOGCore;
+
 /**
  * FOGScheduler service to start scheduled tasks in FOG
  *
@@ -24,7 +27,7 @@ require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
 $service_name = 'FOGTaskScheduler';
 service_persist($service_name);
-$ServiceClass = $FOGCore::getClass('TaskScheduler');
+$ServiceClass = FOGCore::getClass('TaskScheduler');
 $ServiceClass->getBanner();
 $ServiceClass->waitInterfaceReady();
 $ServiceClass->waitDbReady();

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4570');
+        define('FOG_VERSION', '1.6.0-beta.4573');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/tests/no-bare-core-references.test.php
+++ b/tests/no-bare-core-references.test.php
@@ -62,16 +62,53 @@ if (count($core) < 150) {
     exit(1);
 }
 
+// `git ls-files` unfiltered, then PHP source picked out by extension OR by a
+// php shebang. NOT `git ls-files "*.php"`, which is what this test shipped
+// with and what let the whole of packages/service through: the ten daemon
+// entry points are named for their systemd unit and carry no extension at
+// all (packages/service/FOGImageSize/FOGImageSize), because that name is what
+// installInitScript() writes into ExecStart. The glob excluded every one of
+// them, so all ten kept a bare `FOGCore::` -- a class-not-found the moment
+// the forked child reached its first loop iteration -- while this test, and
+// bin/import-core-classes.php, both reported the tree clean.
+$tracked = [];
+exec('cd ' . escapeshellarg($repo) . ' && git ls-files 2>/dev/null', $tracked);
 $files = [];
-exec(
-    'cd ' . escapeshellarg($repo) . ' && git ls-files "*.php" 2>/dev/null',
-    $files
-);
+foreach ($tracked as $rel) {
+    $path = $repo . '/' . $rel;
+    if (!is_file($path)) {
+        continue;
+    }
+    if ('php' === strtolower(pathinfo($rel, PATHINFO_EXTENSION))) {
+        $files[] = $rel;
+        continue;
+    }
+    if ('' !== pathinfo($rel, PATHINFO_EXTENSION)) {
+        continue;
+    }
+    $head = (string)file_get_contents($path, false, null, 0, 64);
+    if (preg_match('{^#![^\n]*\bphp\b}', $head)) {
+        $files[] = $rel;
+    }
+}
 if (count($files) < 200) {
     fwrite(
         STDERR,
         'FAIL: git ls-files returned ' . count($files) . " PHP files; expected"
         . " the whole tree. Not run from a checkout?\n"
+    );
+    exit(1);
+}
+// The ten daemon entry points are the reason the selection above is not a
+// glob. Assert they are actually in the scan set, so a future change back to
+// `git ls-files "*.php"` fails here instead of silently measuring nothing.
+$daemons = preg_grep('{^packages/service/FOG[A-Za-z]+/FOG[A-Za-z]+$}', $files);
+if (count($daemons) < 10) {
+    fwrite(
+        STDERR,
+        'FAIL: only ' . count($daemons) . " daemon entry points in the scan"
+        . " set; expected 10. The extension-less files are being skipped"
+        . " again -- that is the bug this test exists to catch.\n"
     );
     exit(1);
 }


### PR DESCRIPTION
## The symptom

Every FOG daemon has been dying one loop iteration into its work since 1ecf0255d ("Retire the reverse-alias plugin ABI"), and `systemctl status` has reported all ten units **active** the whole time.

On this box the tell was the process tree: nine of the ten daemons had a supervisor and **no child**.

```
3909022  1        root  Ss  php /opt/fog/service/FOGFileDeleter/FOGFileDeleter    <- supervisor
                                                                                  <- no child
```

`fogscheduler.log` had not grown in an hour. `multicast.log` stops dead at `08-27-26 15:29` — seven minutes before 1ecf0255d was authored — and has not had a line since.

## The cause

1ecf0255d deleted the 202 `class_alias()` calls that re-exported core into the global namespace, and added `use` imports everywhere that needed them. The ten daemon entry points under `packages/service/` did not get one.

They are plain, non-namespaced files that call `FOGCore::niceDate()` unqualified. PHP resolves an unqualified class name from the global namespace and *only* from there, so the first pass round the service loop is:

```
FOG autoloader: "FOGCore" is a core class and core is no longer aliased into
the global namespace. Use FOG\Base\FOGCore -- either as a `use` import or
fully qualified. See ADR 0013.
PHP Fatal error:  Uncaught Error: Class "FOGCore" not found
  in .../FOGImageReplicator on line 38
```

The child dies, the supervisor stays up, systemd sees a live main process. Nine of the ten got one useful pass in before dying, which is why the logs read as an idle service rather than a dead one. `FOGMulticastManager` fataled earlier still, at its `FOGCore::getClass('MulticastManager')` on line 27, so it never did any work at all.

## Why three separate gates all reported clean

The same assumption, three times: **that a PHP file is a file named `*.php`.**

The daemon entry points are named for their systemd unit — `packages/service/FOGImageSize/FOGImageSize` — because that name is what `installInitScript()` writes into `ExecStart`. They carry no extension at all.

| Gate | Why it missed all ten |
|---|---|
| `bin/import-core-classes.php` | filtered on `getExtension()`, so the sweep rewrote `packages/service/lib/service_lib.php` and nothing else — then reported *"nothing to import"* |
| `tests/no-bare-core-references.test.php` | reads `git ls-files "*.php"`. Its own docblock says it scans the whole tree precisely so a forgotten directory is impossible; the glob quietly excluded these ten files |
| `phpstan.neon` | already lists `packages/service` in `paths`, and PHPStan *does* report `Call to static method niceDate() on an unknown class FOGCore` when handed one of these files by name — but `fileExtensions` defaults to `['php']` |

## The fix

- `use FOG\Base\FOGCore;` in all ten entry points, written by `bin/import-core-classes.php` rather than by hand.
- `$FOGCore::getClass(...)` → `FOGCore::getClass(...)`. The variable form worked by accident — `LoadGlobals` happens to set `$GLOBALS['FOGCore']` — but it is invisible to any token scan, so it would have gone on hiding this class of break from the gates even once they could see the file.
- `import-core-classes.php` recognises a php shebang as well as a `.php` extension, and its global-namespace insertion anchor now steps over that shebang line. Without that second half the anchor is start-of-file and matches nothing, so `--fix` would have written no import while still reporting success.
- `no-bare-core-references.test.php` selects from unfiltered `git ls-files` by the same rule, and **asserts the ten daemons are actually in the scan set** — so a future change back to a glob fails loudly instead of measuring nothing.

## Deliberately not done

Wiring the daemons into `phpstan.neon`. It is the strongest of the three gates — it would catch any undefined symbol in a daemon, not just core ones — but `paths` does not accept globs (`packages/service/*/FOG*` → *"Path ... does not exist"*), so it means a hand-listed set of ten: the exact shape of hand-maintained list that failed here in the first place, plus ~20 baseline entries for the intentional `while (true)` and its trailing unreachable line. Recorded here so the gap is a decision rather than another oversight.

`dev-branch` does not have this bug and needs no port: it has no `packages/web/src/`, core is not namespaced there, and `FOGCore` is a real global class.

## Verification

**Both gates were made to fail before being trusted.**

| Mutation | Result |
|---|---|
| delete one daemon's `use FOG\Base\FOGCore;` | test exit 1 (4 hits reported), tool exit 1 |
| restore `git ls-files "*.php"` | `FAIL: only 0 daemon entry points in the scan set; expected 10` |

**The daemons were run for real**, out of the checkout against the live webroot, no deploy:

- *unfixed* — `Uncaught Error: Class "FOGCore" not found ... on line 38`, child gone, only the supervisor left at +8s and +28s.
- *fixed* — `FOGImageReplicator`, `FOGMulticastManager` and `FOGSnapinReplicator` each hold a live child across the whole window, no fatal, no re-fork.

**Suite and analysis:** 217 passed / 0 failed; `phpstan analyse` and `phpstan analyse -c phpstan-tests.neon` both `[OK] No errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ayQTtRnNrTt4TfVavgPMy
