### PR TITLE
Hold a grid's two tables together while the sidebar animates

### DIFF
--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -3495,6 +3495,60 @@ function fogReleaseColWidths(node) {
     .removeClass('fog-table-fixed')
     .find('colgroup > col').css('width', '');
 }
+/**
+ * Hold a scrolling table still while its container is resizing.
+ *
+ * DataTables pins the .dt-scroll-head table's width in a style attribute; the
+ * body table is width:100%. So the instant the container's width changes the
+ * body tracks it and the header does not, and makeColumnsResizable() has put
+ * table-layout:fixed over a shared colgroup, so the body shares its surplus out
+ * across its columns while the header does not. Nothing puts the two back in
+ * step until the debounced columns.adjust() in fogBindTableAutosize() runs.
+ *
+ * That is a long time to be wrong. Collapsing the sidebar animates .app-main
+ * over ~290ms, the 150ms debounce restarts on every frame of it, and the adjust
+ * is not free -- so the host list sat with a 1246px header against a 1496px
+ * body, columns up to 37px out of line, until t=735ms. It is the misalignment
+ * you can watch happen: the headers stay put and the rows walk right.
+ *
+ * Freezing the body at the header's width for the duration is what fixes it.
+ * The two candidates were measured against each other: releasing the header's
+ * pinned width so it grows with the body equalises the two TOTALS (250px of
+ * mismatch down to 1.5px) but leaves the columns 36.75px out, because the
+ * surplus is still shared out differently in a fixed-layout header than in the
+ * body -- and additionally releasing the colgroups is far worse (86px), since
+ * two tables left to size themselves from their own content never agree, which
+ * is the whole reason this sizing path exists. Freezing measured 0.1px.
+ *
+ * So nothing moves until the adjust lands, and then it moves once, correctly.
+ * Cheap on purpose: this runs per animation frame, so it must not call
+ * columns.adjust(), which fires column-sizing and makes Responsive re-measure
+ * every loaded row.
+ *
+ * @param {object} dt  the DataTables API for the table
+ *
+ * @return {void}
+ */
+function fogHoldBodyWidth(dt) {
+  var container = dt.table().container(),
+    head = $('div.dt-scroll-head table', container),
+    body = $('div.dt-scroll-body table', container);
+  if (!head.length || !body.length) {
+    return; // not a scrolling table: one table, no split to keep in step
+  }
+  body.css('width', head[0].getBoundingClientRect().width + 'px');
+}
+/**
+ * Undo fogHoldBodyWidth(), so the adjust that follows measures the real layout
+ * rather than the width we pinned to stop it flickering.
+ *
+ * @param {object} dt  the DataTables API for the table
+ *
+ * @return {void}
+ */
+function fogReleaseBodyWidth(dt) {
+  $('div.dt-scroll-body table', dt.table().container()).css('width', '');
+}
 function fogAdjustAllTables() {
   if (!$.fn.dataTable || !$.fn.dataTable.isDataTable) {
     return;
@@ -3507,6 +3561,10 @@ function fogAdjustAllTables() {
     if (!$.fn.dataTable.isDataTable(this)) {
       return;
     }
+    // Whatever fogHoldBodyWidth() pinned was there to stop the body drifting
+    // away from the header mid-resize. It must go before we measure, or the
+    // adjust below re-derives the layout from our own placeholder.
+    fogReleaseBodyWidth($(this).DataTable());
     var dt = $(this).DataTable(),
       init = (dt && typeof dt.init === 'function') ? dt.init() : null;
     // Null init: a node the table.dataTable selector matches but that isn't a
@@ -3537,8 +3595,29 @@ function fogBindTableAutosize() {
     return; // window/tab/observer handlers only need binding once per page
   }
   $.fn.dataTable.__fogScrollerBound = true;
-  var debounce;
+  var debounce,
+    lastWidth = null;
   function adjustSoon() {
+    // Hold the body to the header's width first, synchronously, so the pair
+    // cannot drift apart while the container moves. The debounce below is what
+    // keeps the expensive re-measure off the per-frame path, but it also means
+    // the mismatch would otherwise be on screen for the whole of the change
+    // plus 150ms plus the adjust.
+    //
+    // Only on a WIDTH change. This observer also fires for height changes --
+    // notably when the rows first render, which is not a resize at all -- and
+    // pinning there would fight the initial layout. Width is the only input to
+    // the header/body mismatch.
+    var main = document.querySelector('.app-main'),
+      width = main ? Math.round(main.getBoundingClientRect().width) : null;
+    if (width !== null && width !== lastWidth) {
+      lastWidth = width;
+      $('table.dataTable').each(function() {
+        if ($.fn.dataTable.isDataTable(this)) {
+          fogHoldBodyWidth($(this).DataTable());
+        }
+      });
+    }
     clearTimeout(debounce);
     debounce = setTimeout(fogAdjustAllTables, 150);
   }

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4570');
+        define('FOG_VERSION', '1.6.0-beta.4572');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4577');
+        define('FOG_VERSION', '1.6.0-beta.4580');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4580');
+        define('FOG_VERSION', '1.6.0-beta.4582');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4572');
+        define('FOG_VERSION', '1.6.0-beta.4574');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4573');
+        define('FOG_VERSION', '1.6.0-beta.4577');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 396);
-        define('FOG_BCACHE_VER', 341);
+        define('FOG_BCACHE_VER', 342);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a


### PR DESCRIPTION
## Problem

Collapsing the sidebar leaves every scrolling grid visibly misaligned for the best part of a second — the column headers stay where they are and the data rows walk right — and putting the sidebar back leaves a different offset again.

**This is not #1418's stale scrollbar reservation.** The settled state is correct: sampled on a browser with real 15px scrollbars, four toggles gave zero drift and `staleReservation: false` every time. It is a *transient*, and sampling once after the transition misses it entirely — it only appears frame by frame.

DataTables pins the `.dt-scroll-head` table's width in a style attribute while the body table is `width:100%`, so the moment the container's width changes the body tracks it and the header does not. `makeColumnsResizable()` has also put `table-layout:fixed` over a shared colgroup, so the body shares its surplus out across its columns while the header does not. (The comment on `fogAdjustAllTables()` already describes this mismatch — the bug is that nothing corrects it until far too late.)

Per-frame trace, host list, one collapse:

| t (ms) | `.app-main` | head table | body table | delta | head inline width |
|---|---|---|---|---|---|
| 4 | 1335 | 1246 | 1246 | 0 | `1246px` |
| 136 | 1436 | 1246 | 1347 | 101 | `1246px` |
| 291 | 1585 | 1246 | 1496 | **250** | `1246px` |
| 735 | 1585 | 1513 | 1513 | 0 | `1512.94px` |

250px is exactly the sidebar's width; worst per-column drift 37px. It is corrected only when the debounced `columns.adjust()` runs — the 150ms debounce restarts on every frame of the ~290ms transition, and the adjust itself is not free.

It is **asymmetric**, because only widening separates them: collapse is broken, expand measures 0.05px. Expanding narrows the container and the body cannot shrink below its content.

Related: this was measurably worse before #1497 — the correction landed at t=914ms then and t=735ms after, because the Responsive re-measure storm was running inside the adjust.

## Fix

Three candidates, built and measured rather than argued about:

| approach | worst column drift | table delta |
|---|---|---|
| as shipped | 37.36px | 250px |
| release the header's pinned width so it grows with the body | 36.75px | 1.5px |
| …and also release the colgroups | **86px** (and breaks the clean expand direction) | 586px |
| **hold the body at the header's width for the duration** | **0.22px** | **1.47px** |

Releasing the header equalises the two *totals* but leaves the columns out, because a fixed-layout header still shares its surplus differently. Releasing the colgroups on top is much worse — two tables left to size themselves from their own content never agree, which is the whole reason this sizing path exists.

So hold the body. Nothing moves until the adjust lands, and then it moves once, correctly. The hold is taken synchronously on the ResizeObserver's own frames (no `columns.adjust()`, so no Responsive re-measure) and dropped at the top of `fogAdjustAllTables()` so the adjust measures the real layout rather than the placeholder.

**Gated on a width change.** That observer also fires for height changes — notably when the rows first render, which is not a resize at all — and pinning there fights the initial layout. Ungated, it measurably moved the four-row snapin list's settled columns.

## Verification

Host list, collapse: **worst column drift 37.36px over 442ms → 0.22px over 0ms.** Expand stays clean.

Settled column widths unchanged on host, image, user, snapin and group, header equal to body in every case.

One methodology note worth recording: DataTables persists column layout to `userpref`, so single alternating A/B runs contaminate each other — an early comparison showed two small grids "differing" when the arms had simply inherited each other's saved state. Each arm was re-run **three times consecutively** to let it reach its own steady state; both then produce byte-identical widths.

Both `phpstan` passes clean. `FOG_BCACHE_VER` bumped 341 → 342.

## Downstream

None — no route or class-list change.