### PR TITLE
Move the daemon service loop into core, leaving entry points as stubs

### DIFF
--- a/packages/service/FOGFileDeleter/FOGFileDeleter
+++ b/packages/service/FOGFileDeleter/FOGFileDeleter
@@ -12,8 +12,6 @@
  * @link     https://fogproject.org
  */
 
-use FOG\Base\FOGCore;
-
 /**
  * FOGFileDeleter service to delete files from FOG on schedule
  *
@@ -25,41 +23,5 @@ use FOG\Base\FOGCore;
  */
 require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
-$service_name = 'FOGFileDeleter';
-service_persist($service_name);
-$ServiceClass = FOGCore::getClass('FileDeleter');
-$ServiceClass->getBanner();
-$ServiceClass->waitInterfaceReady();
-$ServiceClass->waitDbReady();
-$ServiceClass->serviceStart();
-while (true) {
-    if (!$ServiceClass::$zzz) {
-        $ServiceClass::$zzz = 60;
-    }
-    if (!isset($nextrun)) {
-        $ServiceClass->serviceRun();
-        $nextrun = FOGCore::niceDate()
-            ->modify(
-                sprintf(
-                    '+%s second%s',
-                    $ServiceClass::$zzz,
-                    $ServiceClass::$zzz != 1 ? '' : 's'
-                )
-            );
-    }
-    if (FOGCore::niceDate() < $nextrun) {
-        usleep(100000);
-        continue;
-    }
-    $nextrun = FOGCore::niceDate()
-        ->modify(
-            sprintf(
-                '+%s second%s',
-                $ServiceClass::$zzz,
-                $ServiceClass::$zzz != 1 ? '' : 's'
-            )
-        );
-    $ServiceClass->serviceRun();
-}
-$ServiceClass::outall(sprintf(" * Service has ended."));
-exit(0);
+service_persist('FOGFileDeleter');
+\FOG\Base\FOGCore::getClass('FileDeleter')->run();

--- a/packages/service/FOGImageReplicator/FOGImageReplicator
+++ b/packages/service/FOGImageReplicator/FOGImageReplicator
@@ -12,8 +12,6 @@
  * @link     https://fogproject.org
  */
 
-use FOG\Base\FOGCore;
-
 /**
  * FOGImageReplicator service to replicate images in FOG
  *
@@ -25,42 +23,5 @@ use FOG\Base\FOGCore;
  */
 require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
-$service_name = 'FOGImageReplicator';
-service_persist($service_name);
-$ServiceClass = FOGCore::getClass('ImageReplicator');
-$ServiceClass->getBanner();
-$ServiceClass->waitInterfaceReady();
-$ServiceClass->waitDbReady();
-$ServiceClass->serviceStart();
-while (true) {
-    if (!$ServiceClass::$zzz) {
-        $ServiceClass::$zzz = 600;
-    }
-    if (!isset($nextrun)) {
-        $ServiceClass->serviceRun();
-        $nextrun = FOGCore::niceDate()
-            ->modify(
-                sprintf(
-                    '+%s second%s',
-                    $ServiceClass::$zzz,
-                    $ServiceClass::$zzz != 1 ? '' : 's'
-                )
-            );
-    }
-    if (FOGCore::niceDate() < $nextrun) {
-        usleep(100000);
-        $ServiceClass->doHousekeeping();
-        continue;
-    }
-    $nextrun = FOGCore::niceDate()
-        ->modify(
-            sprintf(
-                '+%s second%s',
-                $ServiceClass::$zzz,
-                $ServiceClass::$zzz != 1 ? '' : 's'
-            )
-        );
-    $ServiceClass->serviceRun();
-}
-$ServiceClass::outall(sprintf(" * Service has ended."));
-exit(0);
+service_persist('FOGImageReplicator');
+\FOG\Base\FOGCore::getClass('ImageReplicator')->run();

--- a/packages/service/FOGImageSize/FOGImageSize
+++ b/packages/service/FOGImageSize/FOGImageSize
@@ -12,8 +12,6 @@
  * @link     https://fogproject.org
  */
 
-use FOG\Base\FOGCore;
-
 /**
  * FOGImageSize service to get the size of images in FOG
  *
@@ -25,41 +23,5 @@ use FOG\Base\FOGCore;
  */
 require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
-$service_name = 'FOGImageSize';
-service_persist($service_name);
-$ServiceClass = FOGCore::getClass('ImageSize');
-$ServiceClass->getBanner();
-$ServiceClass->waitInterfaceReady();
-$ServiceClass->waitDbReady();
-$ServiceClass->serviceStart();
-while (true) {
-    if (!$ServiceClass::$zzz) {
-        $ServiceClass::$zzz = 3600;
-    }
-    if (!isset($nextrun)) {
-        $ServiceClass->serviceRun();
-        $nextrun = FOGCore::niceDate()
-            ->modify(
-                sprintf(
-                    '+%s second%s',
-                    $ServiceClass::$zzz,
-                    $ServiceClass::$zzz != 1 ? '' : 's'
-                )
-            );
-    }
-    if (FOGCore::niceDate() < $nextrun) {
-        usleep(100000);
-        continue;
-    }
-    $nextrun = FOGCore::niceDate()
-        ->modify(
-            sprintf(
-                '+%s second%s',
-                $ServiceClass::$zzz,
-                $ServiceClass::$zzz != 1 ? '' : 's'
-            )
-        );
-    $ServiceClass->serviceRun();
-}
-$ServiceClass::outall(sprintf(" * Service has ended."));
-exit(0);
+service_persist('FOGImageSize');
+\FOG\Base\FOGCore::getClass('ImageSize')->run();

--- a/packages/service/FOGMulticastManager/FOGMulticastManager
+++ b/packages/service/FOGMulticastManager/FOGMulticastManager
@@ -12,8 +12,6 @@
  * @link     https://fogproject.org
  */
 
-use FOG\Base\FOGCore;
-
 /**
  * FOGMulticastManager service to enable MC tasks in FOG
  *
@@ -25,17 +23,5 @@ use FOG\Base\FOGCore;
  */
 require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
-$service_name = 'FOGMulticastManager';
-service_persist($service_name);
-$ServiceClass = FOGCore::getClass('MulticastManager');
-if (!file_exists(UDPSENDERPATH)) {
-    $ServiceClass::outall(' * Unable to locate udp-sender!.');
-    exit(1);
-}
-$ServiceClass->getBanner();
-$ServiceClass->waitInterfaceReady();
-$ServiceClass->waitDbReady();
-$ServiceClass->serviceStart();
-$ServiceClass->serviceRun();
-$ServiceClass::outall(' * Service has ended.');
-exit(0);
+service_persist('FOGMulticastManager');
+\FOG\Base\FOGCore::getClass('MulticastManager')->run();

--- a/packages/service/FOGPingHosts/FOGPingHosts
+++ b/packages/service/FOGPingHosts/FOGPingHosts
@@ -12,8 +12,6 @@
  * @link     https://fogproject.org
  */
 
-use FOG\Base\FOGCore;
-
 /**
  * FOGPingHosts service to ping hosts in FOG
  *
@@ -25,41 +23,5 @@ use FOG\Base\FOGCore;
  */
 require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
-$service_name = 'FOGPingHosts';
-service_persist($service_name);
-$ServiceClass = FOGCore::getClass('PingHosts');
-$ServiceClass->getBanner();
-$ServiceClass->waitInterfaceReady();
-$ServiceClass->waitDbReady();
-$ServiceClass->serviceStart();
-while (true) {
-    if (!$ServiceClass::$zzz) {
-        $ServiceClass::$zzz = 300;
-    }
-    if (!isset($nextrun)) {
-        $ServiceClass->serviceRun();
-        $nextrun = FOGCore::niceDate()
-            ->modify(
-                sprintf(
-                    '+%s second%s',
-                    $ServiceClass::$zzz,
-                    $ServiceClass::$zzz != 1 ? '' : 's'
-                )
-            );
-    }
-    if (FOGCore::niceDate() < $nextrun) {
-        usleep(100000);
-        continue;
-    }
-    $nextrun = FOGCore::niceDate()
-        ->modify(
-            sprintf(
-                '+%s second%s',
-                $ServiceClass::$zzz,
-                $ServiceClass::$zzz != 1 ? '' : 's'
-            )
-        );
-    $ServiceClass->serviceRun();
-}
-$ServiceClass::outall(sprintf(" * Service has ended."));
-exit(0);
+service_persist('FOGPingHosts');
+\FOG\Base\FOGCore::getClass('PingHosts')->run();

--- a/packages/service/FOGPluginRunner/FOGPluginRunner
+++ b/packages/service/FOGPluginRunner/FOGPluginRunner
@@ -12,8 +12,6 @@
  * @link     https://fogproject.org
  */
 
-use FOG\Base\FOGCore;
-
 /**
  * FOGPluginRunner service to run background work declared by plugins
  *
@@ -30,41 +28,5 @@ use FOG\Base\FOGCore;
  */
 require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
-$service_name = 'FOGPluginRunner';
-service_persist($service_name);
-$ServiceClass = FOGCore::getClass('PluginRunner');
-$ServiceClass->getBanner();
-$ServiceClass->waitInterfaceReady();
-$ServiceClass->waitDbReady();
-$ServiceClass->serviceStart();
-while (true) {
-    if (!$ServiceClass::$zzz) {
-        $ServiceClass::$zzz = 60;
-    }
-    if (!isset($nextrun)) {
-        $ServiceClass->serviceRun();
-        $nextrun = FOGCore::niceDate()
-            ->modify(
-                sprintf(
-                    '+%s second%s',
-                    $ServiceClass::$zzz,
-                    $ServiceClass::$zzz != 1 ? '' : 's'
-                )
-            );
-    }
-    if (FOGCore::niceDate() < $nextrun) {
-        usleep(100000);
-        continue;
-    }
-    $nextrun = FOGCore::niceDate()
-        ->modify(
-            sprintf(
-                '+%s second%s',
-                $ServiceClass::$zzz,
-                $ServiceClass::$zzz != 1 ? '' : 's'
-            )
-        );
-    $ServiceClass->serviceRun();
-}
-$ServiceClass::outall(sprintf(" * Service has ended."));
-exit(0);
+service_persist('FOGPluginRunner');
+\FOG\Base\FOGCore::getClass('PluginRunner')->run();

--- a/packages/service/FOGRetentionRunner/FOGRetentionRunner
+++ b/packages/service/FOGRetentionRunner/FOGRetentionRunner
@@ -12,8 +12,6 @@
  * @link     https://fogproject.org
  */
 
-use FOG\Base\FOGCore;
-
 /**
  * FOGRetentionRunner service to age out the tables that record what happened
  *
@@ -37,41 +35,5 @@ use FOG\Base\FOGCore;
  */
 require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
-$service_name = 'FOGRetentionRunner';
-service_persist($service_name);
-$ServiceClass = FOGCore::getClass('RetentionRunner');
-$ServiceClass->getBanner();
-$ServiceClass->waitInterfaceReady();
-$ServiceClass->waitDbReady();
-$ServiceClass->serviceStart();
-while (true) {
-    if (!$ServiceClass::$zzz) {
-        $ServiceClass::$zzz = 3600;
-    }
-    if (!isset($nextrun)) {
-        $ServiceClass->serviceRun();
-        $nextrun = FOGCore::niceDate()
-            ->modify(
-                sprintf(
-                    '+%s second%s',
-                    $ServiceClass::$zzz,
-                    $ServiceClass::$zzz != 1 ? '' : 's'
-                )
-            );
-    }
-    if (FOGCore::niceDate() < $nextrun) {
-        usleep(100000);
-        continue;
-    }
-    $nextrun = FOGCore::niceDate()
-        ->modify(
-            sprintf(
-                '+%s second%s',
-                $ServiceClass::$zzz,
-                $ServiceClass::$zzz != 1 ? '' : 's'
-            )
-        );
-    $ServiceClass->serviceRun();
-}
-$ServiceClass::outall(sprintf(" * Service has ended."));
-exit(0);
+service_persist('FOGRetentionRunner');
+\FOG\Base\FOGCore::getClass('RetentionRunner')->run();

--- a/packages/service/FOGSnapinHash/FOGSnapinHash
+++ b/packages/service/FOGSnapinHash/FOGSnapinHash
@@ -12,8 +12,6 @@
  * @link     https://fogproject.org
  */
 
-use FOG\Base\FOGCore;
-
 /**
  * FOGSnapinHash service to get the hash of snapins in FOG
  *
@@ -25,41 +23,5 @@ use FOG\Base\FOGCore;
  */
 require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
-$service_name = 'FOGSnapinHash';
-service_persist($service_name);
-$ServiceClass = FOGCore::getClass('SnapinHash');
-$ServiceClass->getBanner();
-$ServiceClass->waitInterfaceReady();
-$ServiceClass->waitDbReady();
-$ServiceClass->serviceStart();
-while (true) {
-    if (!$ServiceClass::$zzz) {
-        $ServiceClass::$zzz = 600;
-    }
-    if (!isset($nextrun)) {
-        $ServiceClass->serviceRun();
-        $nextrun = FOGCore::niceDate()
-            ->modify(
-                sprintf(
-                    '+%s second%s',
-                    $ServiceClass::$zzz,
-                    $ServiceClass::$zzz != 1 ? '' : 's'
-                )
-            );
-    }
-    if (FOGCore::niceDate() < $nextrun) {
-        usleep(100000);
-        continue;
-    }
-    $nextrun = FOGCore::niceDate()
-        ->modify(
-            sprintf(
-                '+%s second%s',
-                $ServiceClass::$zzz,
-                $ServiceClass::$zzz != 1 ? '' : 's'
-            )
-        );
-    $ServiceClass->serviceRun();
-}
-$ServiceClass::outall(sprintf(" * Service has ended."));
-exit(0);
+service_persist('FOGSnapinHash');
+\FOG\Base\FOGCore::getClass('SnapinHash')->run();

--- a/packages/service/FOGSnapinReplicator/FOGSnapinReplicator
+++ b/packages/service/FOGSnapinReplicator/FOGSnapinReplicator
@@ -12,8 +12,6 @@
  * @link     https://fogproject.org
  */
 
-use FOG\Base\FOGCore;
-
 /**
  * FOGSnapinReplicator service to replicate snapins in FOG
  *
@@ -25,42 +23,5 @@ use FOG\Base\FOGCore;
  */
 require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
-$service_name = 'FOGSnapinReplicator';
-service_persist($service_name);
-$ServiceClass = FOGCore::getClass('SnapinReplicator');
-$ServiceClass->getBanner();
-$ServiceClass->waitInterfaceReady();
-$ServiceClass->waitDbReady();
-$ServiceClass->serviceStart();
-while (true) {
-    if (!$ServiceClass::$zzz) {
-        $ServiceClass::$zzz = 600;
-    }
-    if (!isset($nextrun)) {
-        $ServiceClass->serviceRun();
-        $nextrun = FOGCore::niceDate()
-            ->modify(
-                sprintf(
-                    '+%s second%s',
-                    $ServiceClass::$zzz,
-                    $ServiceClass::$zzz != 1 ? '' : 's'
-                )
-            );
-    }
-    if (FOGCore::niceDate() < $nextrun) {
-        usleep(100000);
-        $ServiceClass->doHousekeeping();
-        continue;
-    }
-    $nextrun = FOGCore::niceDate()
-        ->modify(
-            sprintf(
-                '+%s second%s',
-                $ServiceClass::$zzz,
-                $ServiceClass::$zzz != 1 ? '' : 's'
-            )
-        );
-    $ServiceClass->serviceRun();
-}
-$ServiceClass::outall(sprintf(" * Service has ended."));
-exit(0);
+service_persist('FOGSnapinReplicator');
+\FOG\Base\FOGCore::getClass('SnapinReplicator')->run();

--- a/packages/service/FOGTaskScheduler/FOGTaskScheduler
+++ b/packages/service/FOGTaskScheduler/FOGTaskScheduler
@@ -12,8 +12,6 @@
  * @link     https://fogproject.org
  */
 
-use FOG\Base\FOGCore;
-
 /**
  * FOGScheduler service to start scheduled tasks in FOG
  *
@@ -25,41 +23,5 @@ use FOG\Base\FOGCore;
  */
 require dirname(realpath(__FILE__)).'/../etc/config.php';
 require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
-$service_name = 'FOGTaskScheduler';
-service_persist($service_name);
-$ServiceClass = FOGCore::getClass('TaskScheduler');
-$ServiceClass->getBanner();
-$ServiceClass->waitInterfaceReady();
-$ServiceClass->waitDbReady();
-$ServiceClass->serviceStart();
-while (true) {
-    if (!$ServiceClass::$zzz) {
-        $ServiceClass::$zzz = 60;
-    }
-    if (!isset($nextrun)) {
-        $ServiceClass->serviceRun();
-        $nextrun = FOGCore::niceDate()
-            ->modify(
-                sprintf(
-                    '+%s second%s',
-                    $ServiceClass::$zzz,
-                    $ServiceClass::$zzz != 1 ? '' : 's'
-                )
-            );
-    }
-    if (FOGCore::niceDate() < $nextrun) {
-        usleep(100000);
-        continue;
-    }
-    $nextrun = FOGCore::niceDate()
-        ->modify(
-            sprintf(
-                '+%s second%s',
-                $ServiceClass::$zzz,
-                $ServiceClass::$zzz != 1 ? '' : 's'
-            )
-        );
-    $ServiceClass->serviceRun();
-}
-$ServiceClass::outall(sprintf(" * Service has ended."));
-exit(0);
+service_persist('FOGTaskScheduler');
+\FOG\Base\FOGCore::getClass('TaskScheduler')->run();

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4582');
+        define('FOG_VERSION', '1.6.0-beta.4586');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Service/FOGService.php
+++ b/packages/web/src/Service/FOGService.php
@@ -53,6 +53,18 @@ abstract class FOGService extends FOGBase
      */
     public static $zzz = '';
     /**
+     * Fallback sleep, in seconds, when $sleeptime's globalSetting is unset.
+     *
+     * Each daemon entry point used to carry its own literal here -- 60 for
+     * FileDeleter, 3600 for ImageSize, and so on -- inside a copy of the
+     * service loop that lived outside the analyzed tree. The value is a
+     * property of the service, not of the script that starts it, so it sits
+     * beside $sleeptime, which already names that service's globalSetting.
+     *
+     * @var int
+     */
+    public static $sleepdefault = 600;
+    /**
      * Process references
      *
      * @var array
@@ -219,8 +231,9 @@ abstract class FOGService extends FOGBase
         // keeps what the banner was actually useful for -- a visible marker of
         // where a restart begins, and which build is running.
         //
-        // Still emitted from the eight daemon entry points under
-        // packages/service/, so the signature stays as it is.
+        // Called from run() now rather than from each entry point, so it is
+        // emitted once per daemon start exactly as before. The signature is
+        // unchanged: MulticastManager overrides run() and still calls it.
         self::outall(
             sprintf(
                 '===== FOG %s -- %s starting =====',
@@ -361,6 +374,75 @@ abstract class FOGService extends FOGBase
                 )
             );
         }
+    }
+    /**
+     * The whole life of a daemon: bring it up, then run it until killed.
+     *
+     * This is the loop that used to be copy-pasted into each of the ten
+     * entry points under packages/service/. Those files are named for their
+     * systemd unit and so carry no extension, which put them outside every
+     * *.php filter in the tree -- PHPStan's paths, bin/import-core-classes.php
+     * and tests/no-bare-core-references.test.php alike. The PSR-4 sweep
+     * therefore skipped all ten, each kept a bare `FOGCore::niceDate()` that
+     * no longer resolved, and every daemon died one iteration in while systemd
+     * reported the unit active (GH-1498).
+     *
+     * Living here instead of there is the actual fix for that class of bug:
+     * this file is analyzed, swept and deployed by the same paths as the rest
+     * of core, and what remains in packages/service/ is a five-line stub with
+     * no logic left to drift. ExecStart deliberately still points at that
+     * stub rather than into the webroot -- eight of the ten units run as root
+     * with Restart=always, and the webroot is writable by the web user.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $this->getBanner();
+        $this->waitInterfaceReady();
+        $this->waitDbReady();
+        $this->serviceStart();
+        $nextrun = null;
+        // for(;;) rather than while(true), matching Service_persist()'s own
+        // supervisor loop in packages/service/lib/service_lib.php.
+        for (;;) {
+            if (!static::$zzz) {
+                static::$zzz = static::$sleepdefault;
+            }
+            if (null === $nextrun) {
+                $this->serviceRun();
+                $nextrun = $this->scheduleNextRun();
+            }
+            if (self::niceDate() < $nextrun) {
+                usleep(100000);
+                // Called on every daemon now, where before only the two
+                // replicators did. It is inert for the other seven: the base
+                // implementation only walks $this->procRef, which nothing
+                // outside FOGReplicator and MulticastManager ever populates,
+                // so an empty list skips the whole body.
+                $this->doHousekeeping();
+                continue;
+            }
+            $nextrun = $this->scheduleNextRun();
+            $this->serviceRun();
+        }
+    }
+    /**
+     * When the next pass is due: now, plus this service's sleep time.
+     *
+     * The pluralization this replaces was inverted -- `$zzz != 1 ? '' : 's'`
+     * appended the "s" only when the interval was exactly one second, giving
+     * "+1 seconds" and "+600 second". DateTime::modify() accepts either form,
+     * so nothing misbehaved; dropping the ternary removes the trap rather
+     * than inverting it.
+     *
+     * @return \DateTime
+     */
+    protected function scheduleNextRun()
+    {
+        return self::niceDate()->modify(
+            sprintf('+%d seconds', (int)static::$zzz)
+        );
     }
     /**
      * Replicates data without having to keep repeating

--- a/packages/web/src/Service/FileDeleter.php
+++ b/packages/web/src/Service/FileDeleter.php
@@ -39,6 +39,12 @@ class FileDeleter extends FOGService
      */
     public static $sleeptime = 'FILEDELETEQUEUESLEEPTIME';
     /**
+     * Fallback sleep when the globalSetting above is unset.
+     *
+     * @var int
+     */
+    public static $sleepdefault = 60;
+    /**
      * Initializes The services environment
      *
      * @return void

--- a/packages/web/src/Service/ImageSize.php
+++ b/packages/web/src/Service/ImageSize.php
@@ -38,6 +38,12 @@ class ImageSize extends FOGItemScanner
      */
     public static $sleeptime = 'IMAGESIZESLEEPTIME';
     /**
+     * Fallback sleep when the globalSetting above is unset.
+     *
+     * @var int
+     */
+    public static $sleepdefault = 3600;
+    /**
      * Everything that differs from the other scanner.
      *
      * @return array

--- a/packages/web/src/Service/MulticastManager.php
+++ b/packages/web/src/Service/MulticastManager.php
@@ -45,6 +45,31 @@ class MulticastManager extends FOGService
      */
     protected $altLog;
     /**
+     * One pass, not the scheduled loop the other nine daemons run.
+     *
+     * serviceRun() here does not return between passes -- it holds the
+     * running udpcast sessions and polls them itself -- so FOGService::run()'s
+     * nextrun scheduling has nothing to schedule. The preflight is the other
+     * difference: without udp-sender there is no point starting at all, and
+     * exiting non-zero is what makes systemd report the unit failed rather
+     * than let it sit "active" doing nothing.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        if (!file_exists(UDPSENDERPATH)) {
+            self::outall(' * Unable to locate udp-sender!.');
+            exit(1);
+        }
+        $this->getBanner();
+        $this->waitInterfaceReady();
+        $this->waitDbReady();
+        $this->serviceStart();
+        $this->serviceRun();
+        self::outall(' * Service has ended.');
+    }
+    /**
      * Initializes the MulticastManager class
      *
      * @return void

--- a/packages/web/src/Service/PingHosts.php
+++ b/packages/web/src/Service/PingHosts.php
@@ -48,6 +48,12 @@ class PingHosts extends FOGService
      */
     public static $sleeptime = 'PINGHOSTSLEEPTIME';
     /**
+     * Fallback sleep when the globalSetting above is unset.
+     *
+     * @var int
+     */
+    public static $sleepdefault = 300;
+    /**
      * Initializes the PingHost Class
      *
      * @return void

--- a/packages/web/src/Service/PluginRunner.php
+++ b/packages/web/src/Service/PluginRunner.php
@@ -88,6 +88,12 @@ class PluginRunner extends FOGService
      */
     public static $sleeptime = 'PLUGINRUNNERSLEEPTIME';
     /**
+     * Fallback sleep when the globalSetting above is unset.
+     *
+     * @var int
+     */
+    public static $sleepdefault = 60;
+    /**
      * When each discovered task is next due, keyed "<plugin>/<task>".
      *
      * Held in memory, not a table (ADR 0010 decision 5). A restart therefore

--- a/packages/web/src/Service/RetentionRunner.php
+++ b/packages/web/src/Service/RetentionRunner.php
@@ -98,6 +98,12 @@ class RetentionRunner extends FOGService
      */
     public static $sleeptime = 'RETENTIONRUNNERSLEEPTIME';
     /**
+     * Fallback sleep when the globalSetting above is unset.
+     *
+     * @var int
+     */
+    public static $sleepdefault = 3600;
+    /**
      * The last idle reason logged, and when.
      *
      * @var string|null

--- a/packages/web/src/Service/TaskScheduler.php
+++ b/packages/web/src/Service/TaskScheduler.php
@@ -39,6 +39,12 @@ class TaskScheduler extends FOGService
      */
     public static $sleeptime = 'SCHEDULERSLEEPTIME';
     /**
+     * Fallback sleep when the globalSetting above is unset.
+     *
+     * @var int
+     */
+    public static $sleepdefault = 60;
+    /**
      * Initializes The services environment
      *
      * @return void

--- a/tests/daemon-entry-points-are-stubs.test.php
+++ b/tests/daemon-entry-points-are-stubs.test.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Every daemon entry point is a stub, and the class it names can actually run.
+ *
+ * The ten files under packages/service/<Name>/<Name> are named for their
+ * systemd unit, so they carry no extension -- which puts them outside every
+ * `*.php` filter in this tree. PHPStan's `paths` skips them, and until GH-1498
+ * so did bin/import-core-classes.php and
+ * tests/no-bare-core-references.test.php. That is how the PSR-4 sweep left all
+ * ten with a bare `FOGCore::niceDate()` and every daemon died one loop
+ * iteration in while systemd reported the unit active.
+ *
+ * The fix was to stop keeping logic there at all: the service loop moved to
+ * FOGService::run(), which lives under packages/web/src/ where the analyzer,
+ * the sweeper and copybacktrunk.sh all reach it. What is left in each entry
+ * point is the part that genuinely must be an executable file outside the
+ * webroot, because ExecStart points at it and eight of the ten units run as
+ * root while the webroot is writable by the web user.
+ *
+ * So this file pins the ARRANGEMENT, which is the thing that stops the bug
+ * coming back:
+ *
+ *   1. each entry point hands off to \FOG\Base\FOGCore::getClass('X')->run()
+ *      -- fully qualified, because an import is a thing to forget and the
+ *      sweeper cannot see this file to add one;
+ *   2. class X exists under src/Service/ and has a run(), its own or
+ *      inherited;
+ *   3. the entry point holds no loop and no second statement of substance.
+ *      This is the anti-regrowth assertion: logic that reappears here is
+ *      logic nothing analyzes.
+ *
+ * Usage: php tests/daemon-entry-points-are-stubs.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$repo = dirname(__DIR__);
+$serviceDir = $repo . '/packages/service';
+$classDir = $repo . '/packages/web/src/Service';
+
+/**
+ * Results are accumulated rather than counted through `global $pass/$fail`,
+ * which the other suites use. Two reasons: a global mutated inside a helper
+ * is invisible to static analysis, so PHPStan reads the final `$fail > 0` as
+ * a comparison between 0 and 0 that is always false -- i.e. it can prove the
+ * failure branch is dead, which for a test file is precisely the wrong thing
+ * to be true. Keeping the tallies local means the analyzer can see them, and
+ * the check at the foot is a real one.
+ */
+$oks = [];
+$fails = [];
+
+/**
+ * Does $class, or anything it extends inside src/Service/, declare run()?
+ *
+ * Walks the chain rather than assuming a depth: ImageReplicator extends
+ * FOGReplicator extends FOGService, and ImageSize goes through
+ * FOGItemScanner. Hard-coding "own file or FOGService.php" would pass today
+ * and quietly stop meaning anything the moment somebody puts run() on an
+ * intermediate.
+ */
+function declaresRun(string $classDir, string $class, array $seen = []): bool
+{
+    if (isset($seen[$class]) || !is_file($classDir . '/' . $class . '.php')) {
+        return false;
+    }
+    $seen[$class] = true;
+    $src = (string)file_get_contents($classDir . '/' . $class . '.php');
+    if (preg_match('/\bfunction\s+run\s*\(/', $src)) {
+        return true;
+    }
+    if (preg_match('/\bclass\s+\w+\s+extends\s+(\w+)/', $src, $m)) {
+        return declaresRun($classDir, $m[1], $seen);
+    }
+    return false;
+}
+
+$entries = glob($serviceDir . '/FOG*/FOG*');
+sort($entries);
+
+if (count($entries) < 10) {
+    fwrite(
+        STDERR,
+        'FAIL: found ' . count($entries) . " daemon entry points, expected at"
+        . " least 10. The scan is looking in the wrong place, so this test"
+        . " would pass by measuring nothing.\n"
+    );
+    exit(1);
+}
+
+echo "1. each entry point hands off to a runnable service class\n";
+foreach ($entries as $path) {
+    $rel = str_replace($repo . '/', '', $path);
+    $src = (string)file_get_contents($path);
+
+    if (!preg_match(
+        '/\\\\FOG\\\\Base\\\\FOGCore::getClass\(\s*\'(\w+)\'\s*\)->run\(\)/',
+        $src,
+        $m
+    )) {
+        $fails[] = ("$rel does not hand off via \\FOG\\Base\\FOGCore::getClass('X')->run()");
+        continue;
+    }
+    $class = $m[1];
+
+    if (!is_file($classDir . '/' . $class . '.php')) {
+        $fails[] = "$rel names $class, which src/Service/ does not declare";
+        continue;
+    }
+    if (!declaresRun($classDir, $class)) {
+        $fails[] = "$rel names $class, which has no run() in its class chain";
+        continue;
+    }
+    $oks[] = "$rel -> $class::run()";
+}
+
+echo "\n2. no entry point has grown logic back\n";
+foreach ($entries as $path) {
+    $rel = str_replace($repo . '/', '', $path);
+    $src = (string)file_get_contents($path);
+
+    // Tokenized: `while` inside the file docblock prose is not a loop, and
+    // these files carry a lot of prose.
+    $loops = 0;
+    foreach (token_get_all($src) as $t) {
+        if (is_array($t)
+            && in_array($t[0], [T_WHILE, T_FOR, T_FOREACH, T_DO], true)
+        ) {
+            $loops++;
+        }
+    }
+    if ($loops > 0) {
+        $fails[] = "$rel contains $loops loop(s) -- the service loop belongs in src/Service/";
+        continue;
+    }
+
+    // Exactly one ->run(). More than one means something is being sequenced
+    // here rather than inside the class.
+    $runs = preg_match_all('/->run\(\)/', $src);
+    if (1 !== $runs) {
+        $fails[] = "$rel calls ->run() $runs times, expected exactly 1";
+        continue;
+    }
+    $oks[] = "$rel is still a stub (no loops, one hand-off)";
+}
+
+foreach ($oks as $m) {
+    echo "  ok    $m\n";
+}
+foreach ($fails as $m) {
+    echo "  FAIL  $m\n";
+}
+echo "\n";
+if ([] !== $fails) {
+    echo 'FAIL (' . count($fails) . ' of '
+        . (count($oks) + count($fails)) . " assertions)\n";
+    exit(1);
+}
+echo 'PASS (' . count($oks) . " assertions)\n";

--- a/tests/retention-runner-daemon.test.php
+++ b/tests/retention-runner-daemon.test.php
@@ -272,9 +272,15 @@ check(
     $failures,
     $checks
 );
+// The CALL, not the `$service_name = '...'` assignment this used to look
+// for. That variable was an intermediate the entry points no longer carry --
+// they pass the name straight to service_persist() -- and pinning it meant
+// the assertion could have gone on passing with the assignment present and
+// the call gone. What matters is that the supervisor is told which daemon
+// it is: that name is what tags every line in servicemaster.log.
 check(
     'and registers itself with service_persist under its own name',
-    false !== strpos($wrapper, "\$service_name = '" . $name . "'"),
+    false !== strpos($wrapper, "service_persist('" . $name . "')"),
     $failures,
     $checks
 );


### PR DESCRIPTION
Follow-up to #1498. That PR fixed the ten broken daemons and taught two gates to see extension-less files. This removes the reason those files need special-casing at all.

## Why the entry points kept breaking

`packages/service/<Name>/<Name>` carries no extension, because that name is what `installInitScript()` writes into `ExecStart`. Every `*.php` filter in the tree therefore skipped all ten — PHPStan's `paths` (which already lists `packages/service`, and *does* report the missing class when handed one of these files by name), `bin/import-core-classes.php`, and `tests/no-bare-core-references.test.php`.

They are also the one tree `copybacktrunk.sh` does not deploy. So for three days every deploy carried the fix for everything **except** the files that were actually broken.

Teaching three gates about a special case does not fix that. Moving the code does.

## What moved

`FOGService::run()` now holds the loop — banner, `waitInterfaceReady`, `waitDbReady`, `serviceStart`, then the nextrun scheduling. It was copy-pasted into nine of the ten entry points, differing in exactly two things, both properties of the *service* rather than of the script that starts it:

| Was in the entry point | Now |
|---|---|
| `if (!$zzz) { $zzz = N; }` | `FOGService::$sleepdefault`, overridden per class beside the `$sleeptime` that already names its globalSetting |
| `doHousekeeping()` — only the two replicators | called by `run()` for all ten |

Defaults are the literals the entry points carried, unchanged: 60 for FileDeleter/TaskScheduler/PluginRunner, 300 PingHosts, 600 the base (ImageReplicator, SnapinHash, SnapinReplicator), 3600 ImageSize/RetentionRunner.

`MulticastManager` overrides `run()`: its `serviceRun()` holds the udpcast sessions and never returns between passes, so there is nothing to schedule, and the udp-sender preflight belongs with it.

Each entry point is now four lines with no logic:

```php
require dirname(realpath(__FILE__)).'/../etc/config.php';
require dirname(realpath(__FILE__)).'/../lib/service_lib.php';
service_persist('FOGImageReplicator');
\FOG\Base\FOGCore::getClass('ImageReplicator')->run();
```

Fully qualified rather than imported — there is no second reference to justify a `use`, and a fully qualified name cannot be broken by a future namespace move.

## ExecStart still points at the stub, not the webroot

| Path | Owner / mode |
|---|---|
| `/opt/fog/service/FOGImageReplicator/FOGImageReplicator` | `root:root 0755` |
| `/var/www/html/fog/src/Service/ImageReplicator.php` | `nginx:nginx 0664` + ACLs |

Eight of the ten units run as **root** with `Restart=always`. Aiming systemd at the webroot would turn any web-tier file write into root on the next restart. The stub is the part that genuinely has to live outside the webroot — and it is now a file that should never need to change again.

## Behavior changes, both deliberate

- **`doHousekeeping()` now runs on all ten** rather than the two replicators. Inert for the other eight: the base implementation walks `$this->procRef` only, which nothing outside `FOGReplicator` and `MulticastManager` populates, so an empty list skips the whole body.
- **The `"+%s second%s"` pluralization is gone.** It was inverted — the `s` was appended only when the interval was *exactly one second*, so it emitted `+1 seconds` and `+600 second`. `DateTime::modify()` accepts both, so nothing misbehaved; `sprintf('+%d seconds')` removes the trap rather than inverting it.

The unreachable `outall(' * Service has ended.'); exit(0);` after each infinite loop is not carried over.

## Gates

`tests/daemon-entry-points-are-stubs.test.php` pins the arrangement: each entry point hands off via a fully qualified `getClass()->run()`, that class resolves and has a `run()` somewhere in its chain, and the file contains **no loop and exactly one hand-off**. The last is the anti-regrowth assertion — logic that reappears there is logic nothing analyzes.

`tests/retention-runner-daemon.test.php` asserted `$service_name = 'FOG…'`, an intermediate the stubs no longer carry. It now pins the `service_persist()` **call**, which is what the assertion was always about and which the old form could not actually prove.

## Verification

**Every assertion was made to fail before being trusted.**

| Mutation | Result |
|---|---|
| loop added back to a stub | `contains 1 loop(s)` → exit 1 |
| `run()` renamed on `FOGService` | 9 of 10 red; MulticastManager correctly still green on its own override |
| stub pointed at a class that does not exist | `names PingHostsTypo, which src/Service/ does not declare` |
| `service_persist()` name changed | retention assertion → exit 1 |

**Run for real**, against a shadow webroot on the live database (the checkout's `src/` overlaid on a copy of the deployment, so unmerged code is genuinely exercised):

- `ImageSize` — full 30-image pass, real sizes computed, then holds its cadence rather than spinning.
- `MulticastManager` — its own 10s task loop again, having been dead since `08-27 15:29`.
- `ImageReplicator`, `SnapinReplicator` — supervisor plus a live child across the whole window.

218/218 suite, both phpstan passes `[OK] No errors`.

## Follow-ups

`copybacktrunk.sh` will need to restart the daemon units, since their code now moves with a webroot deploy. That is a `fog-community-scripts` change and will be its own PR. Further DRY/efficiency work inside `src/Service/` is queued separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ayQTtRnNrTt4TfVavgPMy
