### PR TITLE
Stop the daemons waking ten times a second to do nothing

### DIFF
--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4586');
+        define('FOG_VERSION', '1.6.0-beta.4589');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Service/FOGService.php
+++ b/packages/web/src/Service/FOGService.php
@@ -29,6 +29,22 @@ use FOG\Router\Route;
 abstract class FOGService extends FOGBase
 {
     /**
+     * Longest a daemon sleeps in one go while waiting for its next pass.
+     *
+     * Bounds how stale a changed $sleeptime can be -- see waitUntilDue(). Five
+     * seconds is well inside the 300 s settings cache the daemons already read
+     * through, so it costs nothing in freshness and takes the idle wake rate
+     * from 10Hz to 0.2Hz.
+     *
+     * Keep it between 1 and roughly 60 if you change it. Below 1 the wait loop
+     * is back to spinning; far above the settings cache the bound stops
+     * meaning anything, because the value it is protecting the freshness of is
+     * itself stale by then.
+     *
+     * @var int
+     */
+    const IDLE_TICK_CAP = 5;
+    /**
      * The path for the log
      *
      * @var string
@@ -414,18 +430,80 @@ abstract class FOGService extends FOGBase
                 $nextrun = $this->scheduleNextRun();
             }
             if (self::niceDate() < $nextrun) {
-                usleep(100000);
-                // Called on every daemon now, where before only the two
-                // replicators did. It is inert for the other seven: the base
-                // implementation only walks $this->procRef, which nothing
-                // outside FOGReplicator and MulticastManager ever populates,
-                // so an empty list skips the whole body.
-                $this->doHousekeeping();
+                $this->waitUntilDue($nextrun);
                 continue;
             }
             $nextrun = $this->scheduleNextRun();
             $this->serviceRun();
         }
+    }
+    /**
+     * Idle until the next pass is due, reaping transfers while any are live.
+     *
+     * The loop used to wake ten times a second unconditionally -- usleep(100000)
+     * plus a doHousekeeping() -- whatever the service was waiting for. Measured
+     * on an idle server that is 43 s of CPU per day per daemon, 432 s across the
+     * ten, none of it doing anything: ImageSize spends an hour between passes and
+     * woke 36,000 times to get there.
+     *
+     * The 100ms tick is not arbitrary, though, and this is why the rate is
+     * conditional rather than simply longer. cleanupProcList() is what notices a
+     * finished replication transfer, closes its pipes and proc_close()s it; at a
+     * slower rate a completed transfer sits unreaped, and its "Sync finished"
+     * line arrives late. So: tick at the old rate exactly while there is
+     * something in $procRef to reap, and idle properly when there is not.
+     *
+     * $procRef is populated only by startTasking(), i.e. only by the two
+     * replicators and MulticastManager, and only while a transfer is actually
+     * running. Every other daemon, and those three between transfers, take the
+     * cheap path -- which is the case that was costing everything.
+     *
+     * The cap keeps a long interval from becoming a long blind spot:
+     * serviceRun() re-reads $sleeptime each pass, so an admin shortening a
+     * 3600 s interval would otherwise not be noticed until the pass after next.
+     * Shutdown does not depend on it -- the child clears its signal handlers in
+     * Service_persist(), so SIGTERM ends it mid-sleep.
+     *
+     * @param \DateTime $nextrun when the next pass is due
+     *
+     * @return void
+     */
+    protected function waitUntilDue($nextrun)
+    {
+        if (!empty($this->procRef)) {
+            usleep(100000);
+            $this->doHousekeeping();
+            return;
+        }
+        $nap = self::idleNap($nextrun->getTimestamp() - time());
+        if ($nap < 1) {
+            usleep(100000);
+            return;
+        }
+        sleep($nap);
+    }
+    /**
+     * Whole seconds to sleep, given the seconds left before the next pass.
+     *
+     * Split out from waitUntilDue() so the arithmetic can be tested without a
+     * database, a service instance or a five-second wait -- the surrounding
+     * method is all side effects, and a test of it could only ever assert on
+     * elapsed wall-clock, which is exactly the kind of assertion that goes
+     * flaky and then gets deleted.
+     *
+     * 0 means "do not sleep": the pass is due now, or its deadline has
+     * already gone by, and the caller should tick straight through.
+     *
+     * @param int $remaining seconds until the next pass is due
+     *
+     * @return int
+     */
+    public static function idleNap($remaining)
+    {
+        if ($remaining < 1) {
+            return 0;
+        }
+        return (int)min($remaining, self::IDLE_TICK_CAP);
     }
     /**
      * When the next pass is due: now, plus this service's sleep time.

--- a/tests/daemon-idle-nap.test.php
+++ b/tests/daemon-idle-nap.test.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * FOGService::idleNap() -- how long a daemon sleeps between passes.
+ *
+ * The wait loop used to wake ten times a second whatever it was waiting for:
+ * usleep(100000) plus a doHousekeeping(), unconditionally. Measured on an idle
+ * server that is 43 s of CPU per day per daemon and 432 s across the ten, none
+ * of it doing anything -- ImageSize waits an hour between passes and woke
+ * 36,000 times to get there.
+ *
+ * waitUntilDue() now ticks at the old rate only while $procRef holds a live
+ * transfer to reap, and otherwise sleeps. This pins the arithmetic of the
+ * "otherwise", which is the part with edges:
+ *
+ *   - the cap, so a long interval never becomes a long blind spot on a changed
+ *     $sleeptime;
+ *   - the remainder under the cap, which is slept whole so the pass lands on
+ *     time rather than early;
+ *   - a deadline already past, which must not sleep at all.
+ *
+ * Static and instant on purpose. The method is split out of waitUntilDue()
+ * precisely so this file needs no database, no service instance and no
+ * five-second wait -- a test that asserted on elapsed wall-clock would go
+ * flaky and then get deleted.
+ *
+ * The cap's own bounds are not asserted here. Its value is a compile-time
+ * constant, so any check of it is dead code by construction and static
+ * analysis says so; the range that keeps it sane is documented on the constant
+ * instead, where whoever changes it is already reading.
+ *
+ * Usage: php tests/daemon-idle-nap.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$repo = dirname(__DIR__);
+require_once $repo . '/packages/web/vendor/autoload.php';
+
+$cap = \FOG\Service\FOGService::IDLE_TICK_CAP;
+
+$cases = [
+    // [seconds remaining, expected nap, why]
+    [3600, $cap, 'a long interval is capped, not slept through'],
+    [$cap, $cap, 'exactly the cap sleeps the cap'],
+    [$cap + 1, $cap, 'one over the cap is still capped'],
+    [3, 3, 'under the cap sleeps the remainder, so the pass is on time'],
+    [1, 1, 'one second left sleeps one second'],
+    [0, 0, 'due now does not sleep'],
+    [-5, 0, 'a deadline already past does not sleep'],
+];
+
+$fails = [];
+$oks = [];
+
+foreach ($cases as [$remaining, $expected, $why]) {
+    $got = \FOG\Service\FOGService::idleNap($remaining);
+    if ($got !== $expected) {
+        $fails[] = "idleNap($remaining) = $got, expected $expected -- $why";
+        continue;
+    }
+    $oks[] = "idleNap($remaining) = $got -- $why";
+}
+
+foreach ($oks as $m) {
+    echo "  ok    $m\n";
+}
+foreach ($fails as $m) {
+    echo "  FAIL  $m\n";
+}
+echo "\n";
+if ([] !== $fails) {
+    echo 'FAIL (' . count($fails) . ' of '
+        . (count($oks) + count($fails)) . " assertions)\n";
+    exit(1);
+}
+echo 'PASS (' . count($oks) . " assertions)\n";


### PR DESCRIPTION
Follow-on to #1500, which moved the daemon loop into `FOGService::run()`. Now
that the loop is in one place, its wait can be fixed in one place.

## The problem

`run()`'s wait ticked at 10Hz whatever it was waiting for — `usleep(100000)`
plus a `doHousekeeping()`, unconditionally. Measured on an idle server that is
**43 s of CPU per day per daemon, 432 s across the ten**, none of it doing
anything: `ImageSize` waits an hour between passes and woke 36,000 times to get
there.

## Why the rate is conditional rather than just longer

The 100ms tick is load bearing for exactly one thing. `cleanupProcList()` is
what notices a finished replication transfer, closes its pipes and
`proc_close()`s it; slowing that path leaves handles open longer and delays
every "Sync finished" line. So `waitUntilDue()` keeps the original rate while
`$procRef` holds something to reap, and sleeps otherwise.

`$procRef` is populated only by `startTasking()` — the two replicators and
`MulticastManager`, and only while a transfer is actually running. Every other
daemon, and those three between transfers, take the cheap path, which is the
case that was costing everything.

## Measured, not assumed

The first hypothesis was that `niceDate()` was the cost: it builds a
`DateTimeZone` (through `storageTimeZone()`, which also tests `StorageEpoch`)
and a `DateTime` on every tick. It is 23× an integer compare — 0.641 µs against
0.027 µs — but that is only 5.5 s/day across all ten daemons, so it is **not**
the problem and is left alone.

| | idle CPU |
|---|---|
| before | 0.020 s per 40 s → 43.2 s/day/daemon, 432 s/day for ten |
| after | below the measurement floor (<10 ms over the same window) |

And the busy path is unchanged, which is the half that matters for correctness.
Driving `waitUntilDue()` directly with a populated `$procRef` against a shadow
webroot:

| | elapsed |
|---|---|
| idle (`$procRef` empty) | 5000.3 ms |
| busy (`$procRef` occupied) | 100.2 ms |

## The cap

`IDLE_TICK_CAP` bounds how stale a changed `$sleeptime` can be: `serviceRun()`
re-reads it each pass, so a daemon sleeping a whole 3600 s interval would not
notice an admin shortening it until the pass after next. Five seconds is well
inside the 300 s settings cache the daemons already read through, so it costs
nothing in freshness while taking the idle wake rate from 10Hz to 0.2Hz.

Shutdown does not depend on the cap — the child clears its signal handlers in
`Service_persist()`, so SIGTERM ends it mid-sleep.

## Testing

The arithmetic is split into a pure static `idleNap()` so it can be tested
without a database, a service instance, or a five-second wait; a test asserting
on elapsed wall-clock would go flaky and then get deleted.

Verified by mutation, both red:

- removing the past-deadline guard → `idleNap(-5)` returns `-5`
- removing the cap → `idleNap(6)` returns `6`

219/219 suite, both phpstan passes clean.

No behavior change to what any daemon does, only to how often it wakes up to
find there is nothing to do.
