### PR TITLE
Stop Bootstrap's dropdown keys crashing in DataTables collections

### DIFF
--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -4237,6 +4237,66 @@ function macVendorIcon(vendor) {
     + 'title="' + esc + '"></i>';
 }
 /**
+ * Keeps Bootstrap's dropdown keyboard handler out of DataTables collections.
+ *
+ * Bootstrap 5.3 registers one keydown handler on `document`, delegated to any
+ * `.dropdown-menu`. The DataTables Bootstrap 5 integration builds a button
+ * collection -- Column Visibility, Export -- as `<ul class="dropdown-menu">`
+ * inside `div.dt-button-collection`, with no `[data-bs-toggle="dropdown"]`
+ * anywhere near it, because DataTables opens and closes the collection itself.
+ *
+ * On Escape, ArrowUp or ArrowDown that handler calls preventDefault() and then
+ * goes looking for the toggle it assumes exists: the menu itself, a previous
+ * sibling, a next sibling, and finally
+ * findOne(toggle, event.delegateTarget.parentNode). The delegate target is
+ * `document`, whose parentNode is null, so that last lookup calls querySelector
+ * on null and throws "Illegal invocation" -- after the preventDefault has
+ * already landed. Inside an open collection that is a console error on each of
+ * those three keys, plus arrow keys that no longer scroll the list.
+ *
+ * On `window`, in the capture phase, and both halves matter. Bootstrap's
+ * EventHandler passes its `isDelegated` flag straight through as
+ * addEventListener's capture argument, so every delegated Bootstrap handler is
+ * a CAPTURE listener on `document` -- registered when the bundle loaded, which
+ * is before this file. Same node, same phase, so registration order wins and
+ * `document` capture is already too late: it runs second, stops the event, and
+ * Bootstrap has thrown regardless. `window` is the one position ahead of it,
+ * because the propagation path starts there.
+ *
+ * stopPropagation() at the top of the path halts the event outright, including
+ * at `body`, which is where DataTables binds the collection's own handlers.
+ * That is why the key list is exactly these three: DataTables traps Tab on
+ * keydown and dismisses on Escape KEYUP, so both still reach it untouched, and
+ * nothing else listens for arrows in here. The default action is untouched, so
+ * the arrows go back to scrolling the panel.
+ *
+ * A collection open inside a modal therefore takes Escape for itself: the
+ * collection closes on the keyup and the modal stays, which is what you want
+ * from one dismissable nested in another.
+ *
+ * Scoped to .dt-button-collection so a real Bootstrap dropdown -- which has a
+ * toggle and works correctly -- keeps its keyboard navigation.
+ */
+(function () {
+  var SUPPRESSED = ['Escape', 'ArrowUp', 'ArrowDown'];
+
+  window.addEventListener('keydown', function (e) {
+    if (SUPPRESSED.indexOf(e.key) === -1) {
+      return;
+    }
+    var target = e.target;
+    if (!target || !target.closest) {
+      return;
+    }
+    var menu = target.closest('.dropdown-menu');
+    if (!menu || !menu.closest('div.dt-button-collection')) {
+      return;
+    }
+    e.stopPropagation();
+  }, true);
+})();
+
+/**
  * Live vendor lookup for MAC inputs on the host create/edit forms.
  *
  * Delegated on document so it covers the create modal (rendered after page

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 396);
-        define('FOG_BCACHE_VER', 342);
+        define('FOG_BCACHE_VER', 343);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4589');
+        define('FOG_VERSION', '1.6.0-beta.4593');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/tests/dt-collections-suppress-bootstrap-dropdown-keys.test.php
+++ b/tests/dt-collections-suppress-bootstrap-dropdown-keys.test.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * DataTables button collections must not reach Bootstrap's dropdown keyboard
+ * handler.
+ *
+ * Bootstrap 5.3 delegates one keydown handler off `document` to any
+ * `.dropdown-menu`. A DataTables collection IS a `<ul class="dropdown-menu">`,
+ * but it has no `[data-bs-toggle="dropdown"]`, so on Escape/ArrowUp/ArrowDown
+ * the handler preventDefault()s and then throws looking for a toggle that was
+ * never there. Arrow keys stop scrolling the open panel and every one of those
+ * keys writes a console error.
+ *
+ * Four things are pinned, and each one alone leaves the bug reachable:
+ *
+ * - the listener exists at all;
+ * - it is on `window`, in the CAPTURE phase. Bootstrap's EventHandler passes
+ *   its delegation flag through as addEventListener's capture argument, so its
+ *   handler is itself a capture listener on `document`, registered before this
+ *   file loads. Both a bubble listener and a `document` capture listener
+ *   therefore run second and are silent no-ops -- they stop the event, look
+ *   correct, and Bootstrap has already thrown. This was measured, not
+ *   reasoned: the first cut of the fix used `document` and changed nothing;
+ * - it suppresses exactly Escape, ArrowUp and ArrowDown. Capture on `document`
+ *   halts the event before `body`, where DataTables binds the collection's own
+ *   Tab focus trap, so adding Tab here would break keyboard navigation
+ *   outright;
+ * - it is scoped to div.dt-button-collection, so a genuine Bootstrap dropdown
+ *   -- which has a toggle and works -- keeps its arrow-key navigation.
+ *
+ * Usage: php tests/dt-collections-suppress-bootstrap-dropdown-keys.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$js = file_get_contents(
+    $root . '/packages/web/management/js/fog/fog.common.js'
+);
+
+$fails = [];
+
+// The whole registration, not the function name: a listener that has quietly
+// become bubble-phase is the same bug with the right identifier on it.
+if (!preg_match(
+    '#window\.addEventListener\(\s*\'keydown\',\s*function\s*\(e\)\s*\{'
+    . '.*?\}\s*,\s*true\s*\)#s',
+    $js
+)) {
+    $fails[] = 'no capture-phase window keydown listener: on `document`, or '
+        . 'without the trailing `true`, this runs after Bootstrap has already '
+        . 'thrown -- it stops the event, reports nothing, and fixes nothing';
+}
+
+// The key list, in both directions.
+if (!preg_match(
+    "#SUPPRESSED = \\['Escape', 'ArrowUp', 'ArrowDown'\\]#",
+    $js
+)) {
+    $fails[] = 'the suppressed key list is not exactly Escape, ArrowUp and '
+        . 'ArrowDown -- the three Bootstrap acts on in a dropdown menu';
+}
+if (preg_match("#SUPPRESSED = \\[[^\\]]*'Tab'#", $js)) {
+    $fails[] = "'Tab' is in the suppressed list, which halts the event before "
+        . 'body and so kills the DataTables collection focus trap';
+}
+
+// And it may only fire inside a DataTables collection.
+if (!preg_match(
+    "#closest\\('div\\.dt-button-collection'\\)#",
+    $js
+)) {
+    $fails[] = 'the suppression is not scoped to div.dt-button-collection, so '
+        . 'it also disables arrow-key navigation in real Bootstrap dropdowns';
+}
+
+if ($fails) {
+    foreach ($fails as $f) {
+        echo "FAIL: $f\n";
+    }
+    exit(1);
+}
+echo "PASS: DataTables collections keep Bootstrap's dropdown keys away from "
+    . "document\n";
+exit(0);


### PR DESCRIPTION
## The bug

Bootstrap 5.3 delegates one keydown handler to any `.dropdown-menu`. The DataTables Bootstrap 5 integration builds a button collection — Column Visibility, Filter, Export — as `<ul class="dropdown-menu">` inside `div.dt-button-collection`, and there is no `[data-bs-toggle="dropdown"]` anywhere near it, because DataTables opens and closes the collection itself.

So with focus inside an open collection, Escape / ArrowUp / ArrowDown make that handler `preventDefault()` and then go hunting for a toggle that was never there:

```
TypeError: Cannot read properties of undefined (reading 'parentNode')
    at new Dropdown (bootstrap5.bundle.min.js)
    at Dropdown.getOrCreateInstance (bootstrap5.bundle.min.js)
    at HTMLUListElement.dataApiKeydownHandler (bootstrap5.bundle.min.js)
```

Measured on the live 1.6 server before the change: one uncaught TypeError per keypress on each of the three keys, and `defaultPrevented: true` on the arrows — so they no longer scroll the panel.

## The fix

Suppress exactly those three keys while focus is inside a `div.dt-button-collection`, before the event reaches Bootstrap.

**The binding position is the whole fix, and it is not obvious.** Bootstrap's `EventHandler` passes its `isDelegated` flag straight through as `addEventListener`'s capture argument, so its handler is itself a **capture** listener on `document`, registered when the bundle loaded. A `document` capture listener therefore runs *second* and is a silent no-op: it stops the event, looks correct, and Bootstrap has already thrown. That was the first cut of this change, and the live before/after run showed an identical error count — which is how it was caught. `window` is the one position ahead of it.

Stopping propagation at the top of the path halts the event outright, including at `body`, which is where DataTables binds the collection's own handlers. That is why the key list is exactly these three: DataTables traps **Tab on keydown** and dismisses on **Escape keyUP**, so both still reach it untouched. The default action is left alone, so the arrows go back to scrolling.

Scoped to `.dt-button-collection`, so a genuine Bootstrap dropdown — which has a toggle and works — keeps its keyboard navigation.

A collection open inside a modal now takes Escape for itself: the collection closes on the keyup and the modal stays, which is the right nesting behavior.

## Verified live

Against `https://10.255.20.1/fog`, host list, Column Visibility open with focus moved inside — the shipped IIFE extracted from the committed file and injected, so the "after" arm runs the code that will actually deploy.

| | before | after |
|---|---|---|
| ArrowDown | 1 error, `defaultPrevented` | 0 errors |
| ArrowUp | 1 error, `defaultPrevented` | 0 errors |
| Escape | 1 error | 0 errors |
| Tab | 0 errors, focus trapped | 0 errors, focus trapped |

And the two things it must not break: Escape still dismisses the collection, and the navbar's real Bootstrap dropdown (`#themeToggle`) still moves focus on ArrowDown.

## Gate

`tests/dt-collections-suppress-bootstrap-dropdown-keys.test.php` pins the `window` + capture pair, the key list in both directions (must hold the three, must not hold `Tab`), and the `.dt-button-collection` scope. All five mutations were run and go red — including `window` → `document`, the variant that shipped nothing.

`FOG_BCACHE_VER` 342 → 343, since this is a JS change.