### PR TITLE
Cache the DNS failures PingHosts pays for on every cycle

### DIFF
--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -5540,6 +5540,9 @@ msgstr "Name"
 msgid "Name. Must be unique."
 msgstr "Diff Parameter muss numerisch sein"
 
+msgid "Names looked up"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -10992,6 +10995,9 @@ msgstr "Sekunden"
 #, fuzzy
 msgid "sending on base port"
 msgstr "Senden auf Basis-Port"
+
+msgid "served from the unresolved cache"
+msgstr ""
 
 msgid "server does not appear to be online"
 msgstr ""

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -5538,6 +5538,9 @@ msgstr "Name"
 msgid "Name. Must be unique."
 msgstr "You must enter a name"
 
+msgid "Names looked up"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -10983,6 +10986,9 @@ msgstr "Icon"
 #, fuzzy
 msgid "sending on base port"
 msgstr "Pending MAC Export"
+
+msgid "served from the unresolved cache"
+msgstr ""
 
 msgid "server does not appear to be online"
 msgstr ""

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5657,6 +5657,9 @@ msgstr "Nombre"
 msgid "Name. Must be unique."
 msgstr "Evento debe ser una cadena"
 
+msgid "Names looked up"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -11164,6 +11167,9 @@ msgstr ""
 #, fuzzy
 msgid "sending on base port"
 msgstr "anfitriones pendientes"
+
+msgid "served from the unresolved cache"
+msgstr ""
 
 msgid "server does not appear to be online"
 msgstr ""

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5541,6 +5541,9 @@ msgstr "Name"
 msgid "Name. Must be unique."
 msgstr "Diff Parameter muss numerisch sein"
 
+msgid "Names looked up"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -10993,6 +10996,9 @@ msgstr "Sekunden"
 #, fuzzy
 msgid "sending on base port"
 msgstr "Senden auf Basis-Port"
+
+msgid "served from the unresolved cache"
+msgstr ""
 
 msgid "server does not appear to be online"
 msgstr ""

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -5540,6 +5540,9 @@ msgstr "prénom"
 msgid "Name. Must be unique."
 msgstr "Vous devez entrer un nom"
 
+msgid "Names looked up"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -10985,6 +10988,9 @@ msgstr "Icône"
 #, fuzzy
 msgid "sending on base port"
 msgstr "En attente MAC Export"
+
+msgid "served from the unresolved cache"
+msgstr ""
 
 msgid "server does not appear to be online"
 msgstr ""

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -5367,6 +5367,9 @@ msgstr "Nome"
 msgid "Name. Must be unique."
 msgstr "Il parametro Diff deve essere numerico"
 
+msgid "Names looked up"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -10631,6 +10634,9 @@ msgstr "secondi"
 
 msgid "sending on base port"
 msgstr "Inviando sulla porta di base"
+
+msgid "served from the unresolved cache"
+msgstr ""
 
 msgid "server does not appear to be online"
 msgstr ""

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -5328,6 +5328,9 @@ msgstr "名前"
 msgid "Name. Must be unique."
 msgstr "Diff パラメーターは数値で指定してください"
 
+msgid "Names looked up"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -10577,6 +10580,9 @@ msgstr "秒"
 #, fuzzy
 msgid "sending on base port"
 msgstr "ベースポートから送信中 "
+
+msgid "served from the unresolved cache"
+msgstr ""
 
 #, fuzzy
 msgid "server does not appear to be online"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -4696,6 +4696,9 @@ msgstr ""
 msgid "Name. Must be unique."
 msgstr ""
 
+msgid "Names looked up"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -9403,6 +9406,9 @@ msgid "seconds ago"
 msgstr ""
 
 msgid "sending on base port"
+msgstr ""
+
+msgid "served from the unresolved cache"
 msgstr ""
 
 msgid "server does not appear to be online"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -5539,6 +5539,9 @@ msgstr "Nome"
 msgid "Name. Must be unique."
 msgstr "Você deve digitar um nome"
 
+msgid "Names looked up"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -10984,6 +10987,9 @@ msgstr "Ícone"
 #, fuzzy
 msgid "sending on base port"
 msgstr "Pendente MAC Exportação"
+
+msgid "served from the unresolved cache"
+msgstr ""
 
 msgid "server does not appear to be online"
 msgstr ""

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -5539,6 +5539,9 @@ msgstr "名称"
 msgid "Name. Must be unique."
 msgstr "您必须输入一个名称"
 
+msgid "Names looked up"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -10984,6 +10987,9 @@ msgstr "图标"
 #, fuzzy
 msgid "sending on base port"
 msgstr "待MAC出口"
+
+msgid "served from the unresolved cache"
+msgstr ""
 
 msgid "server does not appear to be online"
 msgstr ""

--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -335,6 +335,26 @@ abstract class FOGBase
      */
     protected static $interface = [];
     /**
+     * Names that did not resolve, and the time to stop believing that.
+     *
+     * name => unix timestamp the entry expires at. Only FAILURES are held --
+     * see resolveHostname() for why caching a success would be the wrong
+     * trade.
+     *
+     * @var array
+     */
+    protected static $unresolved = [];
+    /**
+     * How many times the system resolver has actually been called.
+     *
+     * Counts calls that reached gethostbyname(), so a caller can report how
+     * much of a cycle's resolving was served from $unresolved instead. Read
+     * it with resolverCalls().
+     *
+     * @var int
+     */
+    protected static $resolvercalls = 0;
+    /**
      * The current base pages requiring search functionality.
      *
      * @var array
@@ -4496,19 +4516,97 @@ abstract class FOGBase
     /**
      * Resolves a hostname to its IP address
      *
-     * @param string $host the item to test
+     * Optionally remembers FAILURES for $negativeTtl seconds, and only
+     * failures. The asymmetry is the whole design, and it is measured rather
+     * than assumed -- on the reference server:
+     *
+     *   a name that resolves     :    0.2 ms local, 23.8 ms remote
+     *   a name that does not     : 3776.3 ms, every single time
+     *
+     * A miss costs a full resolver timeout and nothing anywhere caches it:
+     * resolving the same dead name twice in a row costs 3.75 s twice. That is
+     * what makes a PingHosts cycle on a fleet that is not in DNS take 5m26s
+     * instead of 2s.
+     *
+     * So a success is re-resolved on every call -- it is cheap, and it is the
+     * answer that must not go stale, because a host whose address moved and
+     * is pinged at its old one reports the wrong thing. A failure is held,
+     * because it is expensive and because a stale failure is not a new wrong
+     * answer: the caller already treats an unresolvable name as unreachable,
+     * so a cached failure produces byte-identical behavior to a fresh one.
+     * The only thing it can miss is a name that STARTS resolving mid-run,
+     * which is why the entry expires rather than being permanent.
+     *
+     * $negativeTtl defaults to 0, which is no caching at all, so every
+     * existing caller behaves exactly as it did.
+     *
+     * @param string $host        the item to test
+     * @param int    $negativeTtl seconds to remember a failure, 0 to not
      *
      * @return string
      */
-    public static function resolveHostname($host)
+    public static function resolveHostname($host, $negativeTtl = 0)
     {
         $host = trim($host);
         if (filter_var($host, FILTER_VALIDATE_IP)) {
             return $host;
         }
-        $host = gethostbyname($host);
-        $host = trim($host);
-        return $host;
+        $negativeTtl = (int)$negativeTtl;
+        $now = time();
+        if ($negativeTtl > 0
+            && isset(self::$unresolved[$host])
+            && self::$unresolved[$host] > $now
+        ) {
+            return $host;
+        }
+        self::$resolvercalls++;
+        $resolved = trim((string)gethostbyname($host));
+        // gethostbyname() hands back the name it was given when resolution
+        // fails, which is the only signal it gives -- there is no error to
+        // read. Ping::executeBatch() reads the same tell.
+        if ($negativeTtl > 0 && $resolved === $host) {
+            self::$unresolved[$host] = $now + self::negativeTtlJitter(
+                $negativeTtl
+            );
+            return $host;
+        }
+        unset(self::$unresolved[$host]);
+        return $resolved;
+    }
+    /**
+     * How long one failure is remembered for: somewhere in the upper half of
+     * $ttl, chosen per name.
+     *
+     * Without the spread every name cached in a single cycle expires in the
+     * same one, so the cost this removes comes back in a lump -- an 88-host
+     * fleet would run 2 s cycles for an hour and then one 5m26s cycle,
+     * forever. Jittered, the re-checks dribble across the window a few names
+     * at a time and no cycle is the expensive one.
+     *
+     * The lower bound is $ttl/2 rather than 0 so a short $ttl cannot collapse
+     * to "cache nothing"; the upper bound is $ttl so the documented ceiling
+     * on staleness is the ceiling.
+     *
+     * @param int $ttl the configured ceiling, in seconds
+     *
+     * @return int
+     */
+    public static function negativeTtlJitter($ttl)
+    {
+        $ttl = (int)$ttl;
+        if ($ttl < 2) {
+            return $ttl > 0 ? $ttl : 0;
+        }
+        return rand((int)ceil($ttl / 2), $ttl);
+    }
+    /**
+     * How many times the system resolver has been called this process.
+     *
+     * @return int
+     */
+    public static function resolverCalls()
+    {
+        return self::$resolvercalls;
     }
     /**
      * Gets the broadcast address of the server

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4593');
+        define('FOG_VERSION', '1.6.0-beta.4599');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Service/PingHosts.php
+++ b/packages/web/src/Service/PingHosts.php
@@ -54,6 +54,19 @@ class PingHosts extends FOGService
      */
     public static $sleepdefault = 300;
     /**
+     * Longest a name that failed to resolve is taken on trust, in seconds.
+     *
+     * The ceiling on how late this daemon can be to notice a host that has
+     * just been added to DNS; the actual per-name value is jittered below it
+     * so the re-checks spread out instead of all landing in one cycle. An
+     * hour is chosen against the 300 s cycle above -- long enough that the
+     * saving survives many cycles, short enough that an admin who fixes DNS
+     * does not have to restart the daemon to see it.
+     *
+     * @var int
+     */
+    const UNRESOLVED_TTL = 3600;
+    /**
      * Initializes the PingHost Class
      *
      * @return void
@@ -206,35 +219,60 @@ class PingHosts extends FOGService
                     $skip[(int)$row['id']] = true;
                 }
             }
-            // Resolution is still one blocking gethostbyname() per host, and
-            // with the connects batched it is now the DOMINANT cost of a
-            // cycle -- not a rounding error. A name that resolves is cheap; a
-            // name that does NOT costs a full resolver timeout, and a fleet
-            // whose hosts are not in DNS is the normal case rather than the
-            // pathological one.
+            // Resolution is one blocking gethostbyname() per host, and with
+            // the connects batched it WAS the dominant cost of a cycle --
+            // measured on an 88-host database where 86 names do not resolve,
+            // the whole cycle was 5m26s, of which the ping batch was 2s and
+            // the rest was here. Batching the connects had cut roughly three
+            // minutes off that (86 x 2s of connect timeout became one 2s
+            // window) but only moved the bottleneck rather than removing it.
             //
-            // Measured on an 88-host database where 86 names do not resolve:
-            // the whole cycle is 5m26s, of which the ping batch is 2s and the
-            // rest is here. Batching the connects still cut roughly 3 minutes
-            // off that (86 x 2s of connect timeout became one 2s window), but
-            // it did not make the cycle fast -- it moved the bottleneck.
+            // What removes it is caching the FAILURES, which is cheap because
+            // the cost is wildly asymmetric and nothing else caches it:
             //
-            // Left as it is deliberately, for now: core PHP has no
-            // asynchronous resolver, so removing this cost means either
-            // forking a resolver pool or giving the pinger an address that
-            // does not need looking up. The second is the real fix and it is
-            // a design decision, not a refactor -- hosts.hostIP exists and is
-            // written by nothing at all today.
+            //   a name that resolves  :    0.2 ms local, 23.8 ms remote
+            //   a name that does not  : 3776.3 ms, every single cycle
+            //
+            // Successes are still resolved every cycle, so a host that moves
+            // is pinged at its new address on the next one. Only the misses
+            // are held, and a held miss is not a new wrong answer -- an
+            // unresolvable name already records ENXIO without a connect
+            // being attempted (see Ping::executeBatch), so the cached path
+            // and the fresh path produce the same result. What it can miss
+            // is a host that STARTS resolving mid-run, which is what the TTL
+            // and its per-name jitter bound.
+            //
+            // This is not the end state. Giving the pinger an address it does
+            // not have to look up at all is still the real fix, and
+            // hosts.hostIP exists and is written by nothing today -- but that
+            // is a schema and client-protocol decision, and this is not.
             $targets = [];
             $names = [];
             $skipped = 0;
+            $before = self::resolverCalls();
             foreach ($hosts as $host) {
                 if (isset($skip[(int)$host->id])) {
                     $skipped++;
                     continue;
                 }
                 $names[$host->id] = $host->name;
-                $targets[$host->id] = self::resolveHostname($host->name);
+                $targets[$host->id] = self::resolveHostname(
+                    $host->name,
+                    self::UNRESOLVED_TTL
+                );
+            }
+            $looked = self::resolverCalls() - $before;
+            $cached = count($targets) - $looked;
+            if ($cached > 0) {
+                self::outall(
+                    sprintf(
+                        ' * %s: %d, %s: %d',
+                        _('Names looked up'),
+                        $looked,
+                        _('served from the unresolved cache'),
+                        $cached
+                    )
+                );
             }
             if ($skipped > 0) {
                 self::outall(

--- a/tests/resolve-hostname-negative-cache.test.php
+++ b/tests/resolve-hostname-negative-cache.test.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * FOGBase::resolveHostname() -- the negative cache PingHosts runs on.
+ *
+ * A PingHosts cycle on a fleet that is not in DNS took 5m26s on an 88-host
+ * database, of which the ping batch was 2s and the rest was resolution.
+ * Measured on the reference server, the cost is wildly asymmetric and nothing
+ * in the stack caches it:
+ *
+ *   a name that resolves  :    0.2 ms local, 23.8 ms remote
+ *   a name that does not  : 3776.3 ms, every single time
+ *
+ * So failures are cached and successes are not. This pins that split, which
+ * is the part with the correctness argument in it -- a stale failure is the
+ * same answer the caller would have reached anyway, a stale success is a host
+ * pinged at an address it has moved off.
+ *
+ * Asserted on the resolver CALL COUNT rather than on elapsed time. A timing
+ * assertion here would be measuring the local resolver's mood and would go
+ * flaky and then get deleted; the count is exactly what the cache is for.
+ *
+ * Names come from RFC 2606's reserved .invalid TLD, which is guaranteed never
+ * to resolve, so the miss path is real without depending on this machine's
+ * DNS being in any particular state.
+ *
+ * Usage: php tests/resolve-hostname-negative-cache.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$repo = dirname(__DIR__);
+require_once $repo . '/packages/web/vendor/autoload.php';
+
+use FOG\Base\FOGBase;
+
+// [passed, what it means], classified in one pass at the end. Collected as
+// plain data rather than through a helper that writes to globals: a static
+// analyzer cannot see a `global` write from inside a function, and then calls
+// the reporting below dead code.
+$results = [];
+
+/**
+ * Resolve, and report how many times the system resolver was actually hit.
+ *
+ * @param string $host the name to resolve
+ * @param int    $ttl  seconds to cache a failure for, 0 to not
+ *
+ * @return array [returned value, resolver calls spent]
+ */
+function resolveCounting($host, $ttl)
+{
+    $before = FOGBase::resolverCalls();
+    $got = FOGBase::resolveHostname($host, $ttl);
+    return [$got, FOGBase::resolverCalls() - $before];
+}
+
+// A literal IP never reaches the resolver at all, cache or no cache. This is
+// the reason checkIfNodeMaster() costs 0.003 ms a pass on a server whose
+// storage nodes are configured by address, and so needs none of this.
+[$got, $calls] = resolveCounting('10.255.20.1', 3600);
+$results[] = ['10.255.20.1' === $got, 'a literal IP is returned unchanged'];
+$results[] = [0 === $calls, 'a literal IP costs no resolver call'];
+
+// A failure, cached. gethostbyname() signals failure by handing the name
+// back, so that IS the expected return value -- both times.
+$dead = 'fog-negative-cache-' . getmypid() . '.invalid';
+[$got, $calls] = resolveCounting($dead, 3600);
+$results[] = [$dead === $got, 'an unresolvable name comes back unchanged'];
+$results[] = [1 === $calls, 'the first lookup of a dead name reaches the resolver'];
+
+[$got, $calls] = resolveCounting($dead, 3600);
+$results[] = [$dead === $got, 'a cached failure returns the same value as a fresh one'];
+$results[] = [0 === $calls, 'the second lookup of a dead name is served from cache'];
+
+// ... but only for callers that asked for it. The default is 0, which is what
+// keeps every pre-existing call site behaving exactly as it did.
+[, $calls] = resolveCounting($dead, 0);
+$results[] = [1 === $calls, 'ttl 0 ignores the cache and resolves anyway'];
+
+// The DEFAULT, called the way every pre-existing site calls it -- one
+// argument. Passing 0 explicitly above tests the path; it does not test that
+// the path is what an unchanged caller gets, and those are two different
+// claims. checkIfNodeMaster(), MulticastTask and the web all call it this way.
+$before = FOGBase::resolverCalls();
+FOGBase::resolveHostname($dead);
+FOGBase::resolveHostname($dead);
+$results[] = [
+    2 === FOGBase::resolverCalls() - $before,
+    'the default ttl is 0, so an unchanged caller never caches'
+];
+
+// A success is NOT cached: it must be re-read every time, because it is the
+// answer that goes stale in a way that matters.
+[$got, $calls] = resolveCounting('localhost', 3600);
+$results[] = [1 === $calls, 'the first lookup of a live name reaches the resolver'];
+$firstGot = $got;
+[$got, $calls] = resolveCounting('localhost', 3600);
+$results[] = [1 === $calls, 'a success is re-resolved rather than cached'];
+$results[] = [$firstGot === $got, 'and gives the same answer'];
+
+// An expired entry resolves again. ttl 1 with a second's wait is the one
+// place a real clock is unavoidable, and one second is not a flaky wait.
+$dead2 = 'fog-negative-expiry-' . getmypid() . '.invalid';
+resolveCounting($dead2, 1);
+sleep(2);
+[, $calls] = resolveCounting($dead2, 1);
+$results[] = [1 === $calls, 'an expired entry is looked up again'];
+
+// The jitter keeps every cached failure inside the documented ceiling while
+// spreading the re-checks, so no single cycle inherits all of them at once.
+$seen = [];
+for ($i = 0; $i < 200; $i++) {
+    $seen[] = FOGBase::negativeTtlJitter(3600);
+}
+$results[] = [min($seen) >= 1800, 'jitter never drops below half the ttl'];
+$results[] = [max($seen) <= 3600, 'jitter never exceeds the ttl'];
+$results[] = [count(array_unique($seen)) > 1, 'jitter actually spreads'];
+$results[] = [0 === FOGBase::negativeTtlJitter(0), 'a ttl of 0 jitters to 0'];
+$results[] = [1 === FOGBase::negativeTtlJitter(1), 'a ttl of 1 stays 1'];
+
+$failed = 0;
+foreach ($results as [$passed, $why]) {
+    echo $passed ? "  ok    $why\n" : "  FAIL  $why\n";
+    $failed += $passed ? 0 : 1;
+}
+echo "\n";
+if ($failed > 0) {
+    echo 'FAIL (' . $failed . ' of ' . count($results) . " assertions)\n";
+    exit(1);
+}
+echo 'PASS (' . count($results) . " assertions)\n";


### PR DESCRIPTION
PingHosts resolves every host name it is about to ping, one blocking
gethostbyname() each. With the connects already batched, that resolution is
the dominant cost of a cycle: measured on the reference database, 25 names
took 94.8 seconds. At the 300 s default cycle that is 7.6 HOURS a day of a
daemon sitting in the resolver.

THE COST IS ASYMMETRIC, WHICH IS THE WHOLE FIX

  a name that resolves  :    0.2 ms local, 23.8 ms remote
  a name that does not  : 3776.3 ms, every single time

A miss is a full resolver timeout, and nothing anywhere caches it -- resolving
the same dead name twice in a row costs 3.75 s twice, confirmed. A fleet whose
hosts are not in DNS is the normal case, not the pathological one.

So failures are cached and successes are not:

- A success is cheap, and it is the answer that must not go stale. A host
  whose address moved and is pinged at the old one reports the wrong thing,
  so every live host is still resolved fresh on every cycle.
- A failure is expensive, and a stale one is not a new wrong answer. An
  unresolvable name already records ENXIO without a connect being attempted
  (Ping::executeBatch reads the same gethostbyname() tell), so the cached path
  and the fresh path produce byte-identical results. The only thing it can
  miss is a name that STARTS resolving mid-run, which is what the TTL bounds.

Per-name jitter in the upper half of the TTL keeps that saving smooth. Without
it every name cached in one cycle expires in one cycle, so an 88-host fleet
would run 2 s cycles for an hour and then one 5m26s cycle, forever. Spread,
the re-checks dribble across the window a few names at a time.

resolveHostname()'s new argument defaults to 0, which is no caching, so every
existing call site behaves exactly as it did. PingHosts is the only opt-in.

MEASURED

  first cycle  : 94788.9 ms, 25 resolver calls,  0 from cache
  second cycle :     0.0 ms,  0 resolver calls, 25 from cache
  third cycle  :     0.0 ms,  0 resolver calls, 25 from cache

  projected at a 300 s cycle: 27299 s/day -> 0 s/day of resolving

WHAT WAS CHECKED AND LEFT ALONE

checkIfNodeMaster() also calls resolveHostname() per storage node per pass,
and MulticastManager calls checkIfNodeMaster() on every tick of its inner loop
rather than once per interval. It looked like the same bug and it is not: the
node `ip` field holds a literal address, so resolveHostname() short-circuits
at filter_var() and never reaches the resolver. Measured at 0.003 ms for a
whole pass across three nodes. Nothing to fix, so nothing changed.

This is also not the end state for PingHosts. Giving the pinger an address it
never has to look up is still the real fix, and hosts.hostIP exists and is
written by nothing today -- but that is a schema and client-protocol decision,
and this is not.

TESTING

tests/resolve-hostname-negative-cache.test.php asserts on the resolver CALL
COUNT, not on elapsed time; a timing assertion here would be measuring the
local resolver's mood and would go flaky and then get deleted. Names come from
RFC 2606's reserved .invalid TLD so the miss path is real without depending on
this machine's DNS.

Verified by mutation, all five red -- mutate_resolve_negative_cache.sh:
never reading the cache, caching successes too, entries that never expire,
jitter collapsing to zero, and caching on by default. The last one was a real
catch: the first cut of the test passed 0 explicitly and so proved the ttl-0
PATH worked without proving it was what an unchanged caller gets.

220/220 suite, both phpstan passes clean.

Co-Authored-By: Claude <noreply@anthropic.com>
