### PR TITLE
Measure Responsive column widths with cloneNode, not the DataTables API

### DIFF
--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -3223,6 +3223,111 @@ function fogFetchIfShort(dt, waited) {
   dt.draw(false);
 }
 /**
+ * Measure a table's natural column widths the cheap way.
+ *
+ * This is a like-for-like replacement for DataTables Responsive's own
+ * _resizeAuto(). The measurement is identical -- build a throwaway copy of the
+ * table at width:auto inside a 1px hidden box and read offsetWidth off a row of
+ * empty cells -- but it assembles that copy with native cloneNode instead of
+ * walking the DataTables API cell by cell.
+ *
+ * That walk is the cost. On the 86-row host list the shipped version spends
+ * ~105ms a call, of which only ~25ms is the layout the browser is asked for and
+ * ~15ms the cloning; the remaining ~65ms is rows().every() and cells().every()
+ * doing 946 individual jQuery clones. Cloning each row once, natively, gets the
+ * same answer in ~30ms. Measured 4.4x on hosts, 2.8x on images and users, with
+ * byte-identical minWidth vectors at 1600/1280/1024/860/700px.
+ *
+ * (The vector does not change with viewport width, which is not a bug in the
+ * test: the copy is measured at width:auto in a 1px box, so only content and
+ * CSS are inputs. That is also what makes fogMemoizeResponsiveMeasure() safe.)
+ *
+ * Two cases hand back to the original rather than guess:
+ *
+ *  - childNodeStore holding anything. When a row's details are expanded
+ *    Responsive MOVES the hidden columns' nodes into the child row, so a plain
+ *    cloneNode of the parent would measure cells whose content has gone
+ *    elsewhere and report those columns too narrow.
+ *  - auto measurement switched off, per-table or per-column, where the original
+ *    deliberately leaves minWidth alone.
+ *
+ * @param {function} original  Responsive's own _resizeAuto, for those cases
+ *
+ * @return {function} a replacement to install on the prototype
+ */
+function fogFastResizeAuto(original) {
+  return function() {
+    var dt = this.s.dt,
+      columns = this.s.columns,
+      i;
+    // Same guard as the original: with auto off it writes no minWidth at all,
+    // and anything else here would invent numbers it never had.
+    if (!this.c.auto || $.inArray(true, $.map(columns, function(c) {
+      return c.auto;
+    })) === -1) {
+      return;
+    }
+    if (!$.isEmptyObject(this.s.childNodeStore)) {
+      return original.apply(this, arguments);
+    }
+    var visible = dt.columns().indexes().filter(function(index) {
+        return dt.column(index).visible();
+      }),
+      node = dt.table().node(),
+      clone = node.cloneNode(false),
+      probe = document.createElement('tr'),
+      body = document.createElement('tbody'),
+      source = node.querySelectorAll('tbody > tr'),
+      cells,
+      row;
+    clone.style.width = 'auto';
+    clone.style.position = 'relative';
+    clone.appendChild(dt.table().header().cloneNode(true));
+    if (dt.table().footer()) {
+      clone.appendChild(dt.table().footer().cloneNode(true));
+    }
+    clone.appendChild(body);
+    // The empty row whose cells are what actually gets measured. One per
+    // visible column, and it goes in FIRST so its cells are the ones the table
+    // layout reports against.
+    for (i = 0; i < visible.count(); i++) {
+      probe.appendChild(document.createElement('td'));
+    }
+    body.appendChild(probe);
+    for (i = 0; i < source.length; i++) {
+      // Responsive's own child rows are not data and would skew the widths.
+      if (source[i].className.indexOf('child') === -1) {
+        body.appendChild(source[i].cloneNode(true));
+      }
+    }
+    // Undo every display/width the live table is carrying so the copy is sized
+    // by its content alone -- which is the whole point of the measurement.
+    cells = clone.querySelectorAll('th, td');
+    for (i = 0; i < cells.length; i++) {
+      cells[i].style.display = '';
+      cells[i].style.width = 'auto';
+      cells[i].style.minWidth = '0';
+      cells[i].removeAttribute('name');
+    }
+    if (this.c.details && this.c.details.type === 'inline') {
+      // The control column is wider with the expand affordance on it, and the
+      // original adds these to its copy unconditionally too.
+      clone.className += ' dtr-inline collapsed';
+    }
+    row = document.createElement('div');
+    row.style.cssText = 'width:1px;height:1px;overflow:hidden;clear:both';
+    row.appendChild(clone);
+    node.parentNode.insertBefore(row, node);
+    for (i = 0; i < probe.children.length; i++) {
+      // s.columns is indexed by COLUMN, the probe by visible position, and the
+      // two only coincide while nothing is hidden.
+      columns[dt.column.index('fromVisible', i)].minWidth =
+        probe.children[i].offsetWidth || 0;
+    }
+    row.parentNode.removeChild(row);
+  };
+}
+/**
  * Stop DataTables Responsive re-measuring every loaded row on every adjust.
  *
  * Responsive answers `column-sizing` -- which every columns.adjust() fires --
@@ -3268,7 +3373,10 @@ function fogMemoizeResponsiveMeasure() {
     return;
   }
   Responsive.prototype._fogMemoized = true;
-  var original = Responsive.prototype._resizeAuto;
+  // Swap in the cheap measurement first, so what the memo wraps -- and what
+  // runs on a cache MISS -- is the fast one. Order matters: the memo must stay
+  // the outer layer or a hit would still pay for a measurement.
+  var original = fogFastResizeAuto(Responsive.prototype._resizeAuto);
   Responsive.prototype._resizeAuto = function() {
     var dt = this.s ? this.s.dt : null,
       node = dt ? dt.table().node() : null,

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 396);
-        define('FOG_BCACHE_VER', 342);
+        define('FOG_BCACHE_VER', 343);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 396);
-        define('FOG_BCACHE_VER', 343);
+        define('FOG_BCACHE_VER', 344);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4600');
+        define('FOG_VERSION', '1.6.0-beta.4608');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4598');
+        define('FOG_VERSION', '1.6.0-beta.4600');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4593');
+        define('FOG_VERSION', '1.6.0-beta.4598');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/tests/dt-responsive-fast-measure.test.php
+++ b/tests/dt-responsive-fast-measure.test.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * The fast Responsive measurement must stay under the memo, and must keep the
+ * three things that make it equivalent to what it replaces.
+ *
+ * `fogFastResizeAuto()` rebuilds Responsive's `_resizeAuto()` measurement with
+ * native cloneNode instead of the DataTables API walk. Every failure mode here
+ * is silent -- the grid still renders and the columns are merely wrong or the
+ * page is merely slow again -- so each of these is pinned as its own check:
+ *
+ * - it is installed as what the memo WRAPS, not beside it. Reverting that line
+ *   to `Responsive.prototype._resizeAuto` leaves both functions present and the
+ *   fast one simply never runs;
+ * - it hands back to the original while `childNodeStore` holds anything. An
+ *   expanded row has had its hidden columns' nodes MOVED into the child row, so
+ *   a plain clone of the parent measures those columns empty and reports them
+ *   too narrow;
+ * - it hands back when auto measurement is off, per-table or per-column, where
+ *   the original deliberately writes no minWidth at all;
+ * - it maps the probe cell back to a column with `column.index('fromVisible')`.
+ *   `s.columns` is indexed by column and the probe by visible position, so
+ *   using the loop counter directly is correct until a column is hidden and
+ *   then assigns every width one column to the left.
+ *
+ * Usage: php tests/dt-responsive-fast-measure.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$js = file_get_contents(
+    $root . '/packages/web/management/js/fog/fog.common.js'
+);
+
+$fails = [];
+
+// Isolate the function body so a guard cannot be satisfied by an identically
+// worded one somewhere else in the file.
+if (!preg_match(
+    '#function fogFastResizeAuto\(original\)\s*\{(.*?)\n\}\n#s',
+    $js,
+    $m
+)) {
+    $fails[] = 'fogFastResizeAuto() is gone: nothing below can be checked';
+    $body = '';
+} else {
+    $body = $m[1];
+}
+
+// The install, whole. The function name alone would still match after the
+// wrapping was undone.
+if (!preg_match(
+    '#var original = fogFastResizeAuto\(\s*Responsive\.prototype\._resizeAuto\s*\);#',
+    $js
+)) {
+    $fails[] = 'the memo does not wrap the fast measurement: with `var '
+        . 'original = Responsive.prototype._resizeAuto` both functions are '
+        . 'still here and the fast one never runs on a cache miss';
+}
+
+if ($body !== '' && !preg_match(
+    '#if \(!\$\.isEmptyObject\(this\.s\.childNodeStore\)\) \{\s*'
+    . 'return original\.apply\(this, arguments\);#s',
+    $body
+)) {
+    $fails[] = 'no childNodeStore deferral: with a row expanded, the hidden '
+        . 'columns\' nodes have been moved into the child row and cloning the '
+        . 'parent measures them empty';
+}
+
+if ($body !== '' && !preg_match(
+    '#if \(!this\.c\.auto \|\| \$\.inArray\(true, \$\.map\(columns, function\(c\) \{'
+    . '\s*return c\.auto;\s*\}\)\) === -1\) \{\s*return;#s',
+    $body
+)) {
+    $fails[] = 'no auto-off guard: the original writes no minWidth at all in '
+        . 'that case, so anything written here is invented';
+}
+
+if ($body !== '' && !preg_match(
+    '#columns\[dt\.column\.index\(\'fromVisible\', i\)\]\.minWidth#',
+    $body
+)) {
+    $fails[] = 'the probe cell is not mapped back through fromVisible: '
+        . 'indexing s.columns by visible position silently shifts every width '
+        . 'one column left as soon as a column is hidden';
+}
+
+if ($fails) {
+    fwrite(STDERR, "FAIL\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, '  - ' . $f . "\n");
+    }
+    exit(1);
+}
+
+echo "PASS: fast Responsive measurement is installed under the memo and keeps "
+    . "its three equivalence guards\n";
+exit(0);


### PR DESCRIPTION
Third and last of the grid-load series, after #1497 (memoize the measurement) and #1499 (hold the body width while the sidebar animates). Those two removed the *repeated* cost; this one makes the measurement itself cheap, so the calls a memo cannot skip stop dominating the load.

## What is slow

DataTables Responsive answers every `column-sizing` event by running `_resizeAuto()`. That builds a throwaway copy of the table at `width:auto` inside a 1px hidden box and reads `offsetWidth` off a row of empty cells — a reasonable way to ask the browser for each column's natural width.

The measurement is cheap. Assembling the copy is not. It walks `rows().every()` and `cells().every()` and clones each cell individually through jQuery — **946 clones on the 86-row host list**. Of the ~105ms a call costs there, only ~25ms is the layout the browser is actually asked for and ~15ms the cloning; the rest is the API walk.

## What this does

A like-for-like replacement that clones each row once with native `cloneNode`. Same inputs, same probe row, same hidden box, same answer.

It sits **under** the #1497 memo rather than beside it — the memo stays the outer layer, so a cache hit still costs nothing and this is what a miss pays instead.

Two cases hand back to the shipped implementation rather than guess:

- **`childNodeStore` holding anything.** When a row's details are expanded Responsive *moves* the hidden columns' nodes into the child row, so a plain clone of the parent would measure those columns empty and report them too narrow.
- **auto measurement switched off**, per-table or per-column, where the original deliberately writes no `minWidth` at all.

## Evidence

Byte-identical `minWidth` vectors versus the original on host, image and user grids, at 1600/1280/1024/860/700px. (The vector does not vary with viewport width — the copy is measured at `width:auto` in a 1px box, so only content and CSS are inputs. That is the same property #1497's cache relies on.)

Three consecutive runs an arm against the lab server, header and body widths agreeing in every one:

| grid | `_resizeAuto` total, before | after |
|---|---|---|
| host (86 rows) | 496 / 492 / 578 ms | 191 / 157 ms |
| image (30 rows) | 95 / 92 / 90 ms | 34 / 38 ms |
| user | 57 ms | 25 ms |
| snapin | 30 ms | 18 ms |
| group | 12 ms | 9 ms |

CPU profile of a host-list load, inclusive time in the `column-sizing` handler: **380 / 382 / 392 ms → 170 / 175 / 176 ms**. Main-thread busy time over the same 4.2s window: ~1100ms → ~620ms.

## Notes

- `FOG_BCACHE_VER` 343 → 344. working-1.6 took 343 for #1502 while this branch was open, so the merge left one number covering two different `fog.common.js`.
- Both phpstan passes clean.