### PR TITLE
Ping hosts at a verified address instead of guessing at DNS

### DIFF
--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1010,6 +1010,9 @@ msgstr "Jährlich"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answered at a stored address this server cannot verify; rechecked by name"
+msgstr ""
+
 msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
 msgstr ""
 
@@ -5540,9 +5543,6 @@ msgstr "Name"
 msgid "Name. Must be unique."
 msgstr "Diff Parameter muss numerisch sein"
 
-msgid "Names looked up"
-msgstr ""
-
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -8383,6 +8383,10 @@ msgstr "Storage Node"
 msgid "Store one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Stored addresses used"
+msgstr "Speicherknoten hinzugefügt"
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -10356,6 +10360,9 @@ msgstr "und diesen als Master einstellen,"
 msgid "and the FOG client."
 msgstr "auf dem veralteten Client."
 
+msgid "another machine holds this address; clearing it"
+msgstr ""
+
 msgid "answering \"does not exist\" for a read that never ran"
 msgstr ""
 
@@ -10838,6 +10845,9 @@ msgstr "muss angegeben werden"
 
 msgid "n/a"
 msgstr "nicht verfügbar"
+
+msgid "names looked up"
+msgstr ""
 
 #, php-format
 msgid "needs FOG %s or newer; this server is %s"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1014,6 +1014,9 @@ msgstr "Annually"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answered at a stored address this server cannot verify; rechecked by name"
+msgstr ""
+
 msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
 msgstr ""
 
@@ -5538,9 +5541,6 @@ msgstr "Name"
 msgid "Name. Must be unique."
 msgstr "You must enter a name"
 
-msgid "Names looked up"
-msgstr ""
-
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -8380,6 +8380,10 @@ msgstr "Storage Node"
 msgid "Store one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Stored addresses used"
+msgstr "Storage Node Name"
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -10349,6 +10353,9 @@ msgstr ""
 msgid "and the FOG client."
 msgstr ""
 
+msgid "another machine holds this address; clearing it"
+msgstr ""
+
 msgid "answering \"does not exist\" for a read that never ran"
 msgstr ""
 
@@ -10830,6 +10837,9 @@ msgstr "No image specified"
 
 msgid "n/a"
 msgstr "n/a"
+
+msgid "names looked up"
+msgstr ""
 
 #, php-format
 msgid "needs FOG %s or newer; this server is %s"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1028,6 +1028,9 @@ msgstr "Anualmente"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answered at a stored address this server cannot verify; rechecked by name"
+msgstr ""
+
 msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
 msgstr ""
 
@@ -5657,9 +5660,6 @@ msgstr "Nombre"
 msgid "Name. Must be unique."
 msgstr "Evento debe ser una cadena"
 
-msgid "Names looked up"
-msgstr ""
-
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -8557,6 +8557,10 @@ msgstr "nodo de almacenamiento"
 msgid "Store one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Stored addresses used"
+msgstr "nodo de almacenamiento"
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -10530,6 +10534,9 @@ msgstr ""
 msgid "and the FOG client."
 msgstr ""
 
+msgid "another machine holds this address; clearing it"
+msgstr ""
+
 msgid "answering \"does not exist\" for a read that never ran"
 msgstr ""
 
@@ -11011,6 +11018,9 @@ msgid "must be specified"
 msgstr "No hay imagen especificada"
 
 msgid "n/a"
+msgstr ""
+
+msgid "names looked up"
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1010,6 +1010,9 @@ msgstr "Jährlich"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answered at a stored address this server cannot verify; rechecked by name"
+msgstr ""
+
 msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
 msgstr ""
 
@@ -5541,9 +5544,6 @@ msgstr "Name"
 msgid "Name. Must be unique."
 msgstr "Diff Parameter muss numerisch sein"
 
-msgid "Names looked up"
-msgstr ""
-
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -8384,6 +8384,10 @@ msgstr "Storage Node"
 msgid "Store one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Stored addresses used"
+msgstr "Speicherknoten hinzugefügt"
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -10357,6 +10361,9 @@ msgstr "und diesen als Master einstellen,"
 msgid "and the FOG client."
 msgstr "auf dem veralteten Client."
 
+msgid "another machine holds this address; clearing it"
+msgstr ""
+
 msgid "answering \"does not exist\" for a read that never ran"
 msgstr ""
 
@@ -10839,6 +10846,9 @@ msgstr "muss angegeben werden"
 
 msgid "n/a"
 msgstr "nicht verfügbar"
+
+msgid "names looked up"
+msgstr ""
 
 #, php-format
 msgid "needs FOG %s or newer; this server is %s"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1015,6 +1015,9 @@ msgstr "Annuellement"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answered at a stored address this server cannot verify; rechecked by name"
+msgstr ""
+
 msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
 msgstr ""
 
@@ -5540,9 +5543,6 @@ msgstr "prénom"
 msgid "Name. Must be unique."
 msgstr "Vous devez entrer un nom"
 
-msgid "Names looked up"
-msgstr ""
-
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -8382,6 +8382,10 @@ msgstr "nœud de stockage"
 msgid "Store one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Stored addresses used"
+msgstr "Nom du nœud de stockage"
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -10351,6 +10355,9 @@ msgstr ""
 msgid "and the FOG client."
 msgstr ""
 
+msgid "another machine holds this address; clearing it"
+msgstr ""
+
 msgid "answering \"does not exist\" for a read that never ran"
 msgstr ""
 
@@ -10832,6 +10839,9 @@ msgstr "Aucune image spécifiée"
 
 msgid "n/a"
 msgstr "n / a"
+
+msgid "names looked up"
+msgstr ""
 
 #, php-format
 msgid "needs FOG %s or newer; this server is %s"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -986,6 +986,9 @@ msgstr "Annualmente"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answered at a stored address this server cannot verify; rechecked by name"
+msgstr ""
+
 msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
 msgstr ""
 
@@ -5367,9 +5370,6 @@ msgstr "Nome"
 msgid "Name. Must be unique."
 msgstr "Il parametro Diff deve essere numerico"
 
-msgid "Names looked up"
-msgstr ""
-
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -8116,6 +8116,10 @@ msgstr "Storage Node"
 msgid "Store one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Stored addresses used"
+msgstr "Nodo di archiviazione aggiunto!"
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -10027,6 +10031,9 @@ msgstr "ed imposta a master"
 msgid "and the FOG client."
 msgstr "sul vecchio client"
 
+msgid "another machine holds this address; clearing it"
+msgstr ""
+
 msgid "answering \"does not exist\" for a read that never ran"
 msgstr ""
 
@@ -10483,6 +10490,9 @@ msgstr "deve essere specificato"
 
 msgid "n/a"
 msgstr "n/d"
+
+msgid "names looked up"
+msgstr ""
 
 #, php-format
 msgid "needs FOG %s or newer; this server is %s"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -971,6 +971,9 @@ msgstr "毎年"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answered at a stored address this server cannot verify; rechecked by name"
+msgstr ""
+
 msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
 msgstr ""
 
@@ -5328,9 +5331,6 @@ msgstr "名前"
 msgid "Name. Must be unique."
 msgstr "Diff パラメーターは数値で指定してください"
 
-msgid "Names looked up"
-msgstr ""
-
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -8065,6 +8065,10 @@ msgstr "ストレージノード"
 msgid "Store one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Stored addresses used"
+msgstr "ストレージノードを追加しました！"
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -9972,6 +9976,9 @@ msgstr "そしてマスターに設定します"
 msgid "and the FOG client."
 msgstr "旧クライアント上"
 
+msgid "another machine holds this address; clearing it"
+msgstr ""
+
 msgid "answering \"does not exist\" for a read that never ran"
 msgstr ""
 
@@ -10428,6 +10435,9 @@ msgstr "指定する必要があります"
 
 msgid "n/a"
 msgstr "N/A"
+
+msgid "names looked up"
+msgstr ""
 
 #, php-format
 msgid "needs FOG %s or newer; this server is %s"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -867,6 +867,9 @@ msgstr ""
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answered at a stored address this server cannot verify; rechecked by name"
+msgstr ""
+
 msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
 msgstr ""
 
@@ -4696,9 +4699,6 @@ msgstr ""
 msgid "Name. Must be unique."
 msgstr ""
 
-msgid "Names looked up"
-msgstr ""
-
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -7125,6 +7125,9 @@ msgstr ""
 msgid "Store one of your preferences"
 msgstr ""
 
+msgid "Stored addresses used"
+msgstr ""
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -8848,6 +8851,9 @@ msgstr ""
 msgid "and the FOG client."
 msgstr ""
 
+msgid "another machine holds this address; clearing it"
+msgstr ""
+
 msgid "answering \"does not exist\" for a read that never ran"
 msgstr ""
 
@@ -9262,6 +9268,9 @@ msgid "must be specified"
 msgstr ""
 
 msgid "n/a"
+msgstr ""
+
+msgid "names looked up"
 msgstr ""
 
 #, php-format

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1014,6 +1014,9 @@ msgstr "Anualmente"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answered at a stored address this server cannot verify; rechecked by name"
+msgstr ""
+
 msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
 msgstr ""
 
@@ -5539,9 +5542,6 @@ msgstr "Nome"
 msgid "Name. Must be unique."
 msgstr "Você deve digitar um nome"
 
-msgid "Names looked up"
-msgstr ""
-
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -8381,6 +8381,10 @@ msgstr "Nó de armazenamento"
 msgid "Store one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Stored addresses used"
+msgstr "Nome Storage Node"
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -10350,6 +10354,9 @@ msgstr ""
 msgid "and the FOG client."
 msgstr ""
 
+msgid "another machine holds this address; clearing it"
+msgstr ""
+
 msgid "answering \"does not exist\" for a read that never ran"
 msgstr ""
 
@@ -10831,6 +10838,9 @@ msgstr "Nenhuma imagem especificada"
 
 msgid "n/a"
 msgstr "n / D"
+
+msgid "names looked up"
+msgstr ""
 
 #, php-format
 msgid "needs FOG %s or newer; this server is %s"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1014,6 +1014,9 @@ msgstr "每年"
 msgid "Another record still refers to this one and the database refused the delete. The message names what is holding it; retry once that is reassigned or removed."
 msgstr ""
 
+msgid "Answered at a stored address this server cannot verify; rechecked by name"
+msgstr ""
+
 msgid "Answers an empty value when the key has never been set, rather than 404 -- \"no opinion\" is a normal answer here, not a missing resource."
 msgstr ""
 
@@ -5539,9 +5542,6 @@ msgstr "名称"
 msgid "Name. Must be unique."
 msgstr "您必须输入一个名称"
 
-msgid "Names looked up"
-msgstr ""
-
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -8381,6 +8381,10 @@ msgstr "存储节点"
 msgid "Store one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Stored addresses used"
+msgstr "存储节点名称"
+
 msgid "Streams a full SQL dump as an attachment."
 msgstr ""
 
@@ -10350,6 +10354,9 @@ msgstr ""
 msgid "and the FOG client."
 msgstr ""
 
+msgid "another machine holds this address; clearing it"
+msgstr ""
+
 msgid "answering \"does not exist\" for a read that never ran"
 msgstr ""
 
@@ -10831,6 +10838,9 @@ msgstr "没有指定的图像"
 
 msgid "n/a"
 msgstr "N / A"
+
+msgid "names looked up"
+msgstr ""
 
 #, php-format
 msgid "needs FOG %s or newer; this server is %s"

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4608');
+        define('FOG_VERSION', '1.6.0-beta.4611');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Client/FOGClient.php
+++ b/packages/web/src/Client/FOGClient.php
@@ -89,13 +89,38 @@ abstract class FOGClient extends FOGBase
                 // different fact from "FOGPingHosts could open a socket to
                 // it", and keeping the two apart is the entire point of
                 // having two columns (schema step 353).
+                //
+                // hostIP rides along too. It is the address this request
+                // arrived FROM, which is the only address anything here
+                // knows to be real -- the client never tells us its IP and
+                // does not need to, so this costs no protocol change and no
+                // client release.
+                //
+                // It is written on every check-in rather than once, because
+                // its whole value is being recent: a DHCP lease moves, and a
+                // stored address that is not refreshed is how a ping ends up
+                // answered by whatever holds the lease now. PingHosts does
+                // not trust it on age alone either -- it confirms the MAC
+                // answering there is one this host registers before believing
+                // the reply. See Ping::identityMatches().
+                $update = [
+                    'pingstatus' => 0,
+                    'lastcheckin' => self::niceDate()->format('Y-m-d H:i:s')
+                ];
+                // REMOTE_ADDR only. X-Forwarded-For is caller-supplied and
+                // would let anything that can reach this endpoint write any
+                // address it liked into a field the pinger acts on.
+                $peer = filter_var(
+                    trim((string)($_SERVER['REMOTE_ADDR'] ?? '')),
+                    FILTER_VALIDATE_IP
+                );
+                if (false !== $peer) {
+                    $update['ip'] = $peer;
+                }
                 self::getClass('HostManager')->update(
                     ['id' => self::$Host->get('id')],
                     '',
-                    [
-                        'pingstatus' => 0,
-                        'lastcheckin' => self::niceDate()->format('Y-m-d H:i:s')
-                    ]
+                    $update
                 );
             }
             $moduleid = filter_input(INPUT_POST, 'moduleid');

--- a/packages/web/src/Net/Ping.php
+++ b/packages/web/src/Net/Ping.php
@@ -664,4 +664,126 @@ class Ping
 
         return $results;
     }
+    /**
+     * The kernel's IP -> MAC table, as [ip => mac].
+     *
+     * WHY A PING NEEDS THIS AT ALL
+     *
+     * An echo reply says an address answered. It does not say WHICH machine
+     * answered, and on a DHCP network those are different questions: a lease
+     * handed to MachineA on Monday can belong to PrinterX by Friday, so
+     * pinging a host's last known address and calling it up reports a machine
+     * that has been switched off all week as online. That is a worse answer
+     * than the "not reachable" it replaces, because it is confidently wrong
+     * rather than merely unhelpful.
+     *
+     * FOG's identity for a host is its MAC -- that is what it registers, what
+     * it PXE-boots, what it images against -- so the MAC is what turns "this
+     * address answered" into "this HOST answered".
+     *
+     * WHAT IT CANNOT DO
+     *
+     * ARP is link-local. An entry exists only for an address on a segment
+     * this server can talk to directly, so a routed or off-site client has no
+     * entry and its identity is simply not knowable from here. That case must
+     * read as "cannot verify" and never as "verified", which is why this
+     * returns a map to be looked up in rather than a boolean to be trusted.
+     *
+     * Parsed from `ip neigh`, matching getIPAddress() and getBroadcast()
+     * above, which already shell out to /sbin/ip. Entries in the FAILED state
+     * are dropped: they carry no lladdr and mean the kernel asked and got
+     * nothing back.
+     *
+     * @return array ip => lowercase colon-separated MAC
+     */
+    public static function arpTable()
+    {
+        $lines = [];
+        exec('/sbin/ip neigh show 2>/dev/null', $lines, $retVal);
+        $table = [];
+        foreach ((array)$lines as $line) {
+            // "10.255.25.1 dev eno2 lladdr 08:00:27:e9:ff:13 REACHABLE"
+            if (!preg_match(
+                '#^(\S+)\s+dev\s+\S+\s+lladdr\s+(\S+)#',
+                (string)$line,
+                $m
+            )) {
+                continue;
+            }
+            if (!filter_var($m[1], FILTER_VALIDATE_IP)) {
+                continue;
+            }
+            // An address can appear once per interface -- a MAC reachable on
+            // two segments is one machine, so first entry wins rather than
+            // last, and either way the MAC is the same.
+            if (!isset($table[$m[1]])) {
+                $table[$m[1]] = strtolower(trim($m[2]));
+            }
+        }
+
+        return $table;
+    }
+    /**
+     * Is the machine answering at $ip the one owning $macs?
+     *
+     * Three-valued ON PURPOSE, and the third value is the point:
+     *
+     *   true  - the address answered and its MAC is one this host registers
+     *   false - it answered and the MAC belongs to something else, so the
+     *           address has been recycled and the stored one is now a lie
+     *   null  - no ARP entry, so this server cannot tell, and the caller must
+     *           not treat that as either answer
+     *
+     * A boolean would have to fold `null` into one of the other two, and both
+     * foldings are wrong: into true it invents the false-up this exists to
+     * prevent, into false it reports every routed host down.
+     *
+     * @param string $ip    the address that answered
+     * @param array  $macs  MACs registered to the host, any case or separator
+     * @param array  $table an arpTable() result, read once per cycle
+     *
+     * @return bool|null
+     */
+    public static function identityMatches($ip, array $macs, array $table)
+    {
+        $ip = trim((string)$ip);
+        if (!isset($table[$ip])) {
+            return null;
+        }
+        $seen = self::_normalizeMac($table[$ip]);
+        if ('' === $seen) {
+            return null;
+        }
+        foreach ($macs as $mac) {
+            if (self::_normalizeMac($mac) === $seen) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+    /**
+     * Reduce a MAC to bare lowercase hex so representations compare equal.
+     *
+     * hostMAC rows, `ip neigh` output and anything an admin typed disagree on
+     * separators and case; comparing the raw strings would report a mismatch
+     * for aa:bb:.. against AA-BB-.. and clear a perfectly good address.
+     *
+     * @param string $mac any representation
+     *
+     * @return string
+     */
+    private static function _normalizeMac($mac)
+    {
+        $mac = strtolower((string)$mac);
+
+        // No length check. The only way a malformed value could verify is by
+        // normalizing to the same string as the observed one, and
+        // identityMatches() has already refused an empty $seen before this is
+        // reached -- so a short or junk MAC can only ever compare unequal to
+        // a real 12-character one. A length test here would be a branch no
+        // input can take, which is worse than absent: it reads as a guard and
+        // has no evidence behind it.
+        return (string)preg_replace('#[^0-9a-f]#', '', $mac);
+    }
 }

--- a/packages/web/src/Service/PingHosts.php
+++ b/packages/web/src/Service/PingHosts.php
@@ -242,12 +242,29 @@ class PingHosts extends FOGService
             // is a host that STARTS resolving mid-run, which is what the TTL
             // and its per-name jitter bound.
             //
-            // This is not the end state. Giving the pinger an address it does
-            // not have to look up at all is still the real fix, and
-            // hosts.hostIP exists and is written by nothing today -- but that
-            // is a schema and client-protocol decision, and this is not.
+            // hosts.hostIP is now written on every client check-in (see
+            // FOGClient), so a host with a working agent needs no lookup at
+            // all -- the block below prefers that address and only resolves
+            // the name when there is none. The cache still matters: the
+            // hosts that most need pinging are exactly the ones whose agent
+            // is NOT checking in, so they are the ones with no stored
+            // address to prefer.
+            // hostIP per host, for the preference below. Read as a bulk
+            // column rather than through the host objects: getNames() answers
+            // with id and name only, and hydrating 86 Host objects to read
+            // one varchar would be the query storm this daemon was already
+            // fixed for once.
+            $storedIps = [];
+            foreach ((array)Route::getIds('host', [], ['id', 'ip']) as $row) {
+                $ip = trim((string)($row['ip'] ?? ''));
+                if ('' !== $ip && filter_var($ip, FILTER_VALIDATE_IP)) {
+                    $storedIps[(int)($row['id'] ?? 0)] = $ip;
+                }
+            }
+
             $targets = [];
             $names = [];
+            $fromStored = [];
             $skipped = 0;
             $before = self::resolverCalls();
             foreach ($hosts as $host) {
@@ -256,21 +273,32 @@ class PingHosts extends FOGService
                     continue;
                 }
                 $names[$host->id] = $host->name;
+                // The stored address wins when there is one, and costs no
+                // resolver call. It is NOT yet trusted -- everything it
+                // produces goes through the identity check below before it
+                // is allowed to mean "up".
+                if (isset($storedIps[(int)$host->id])) {
+                    $targets[$host->id] = $storedIps[(int)$host->id];
+                    $fromStored[$host->id] = true;
+                    continue;
+                }
                 $targets[$host->id] = self::resolveHostname(
                     $host->name,
                     self::UNRESOLVED_TTL
                 );
             }
             $looked = self::resolverCalls() - $before;
-            $cached = count($targets) - $looked;
-            if ($cached > 0) {
+            $cached = count($targets) - count($fromStored) - $looked;
+            if (count($fromStored) > 0 || $cached > 0) {
                 self::outall(
                     sprintf(
-                        ' * %s: %d, %s: %d',
-                        _('Names looked up'),
+                        ' * %s: %d, %s: %d, %s: %d',
+                        _('Stored addresses used'),
+                        count($fromStored),
+                        _('names looked up'),
                         $looked,
                         _('served from the unresolved cache'),
-                        $cached
+                        max(0, $cached)
                     )
                 );
             }
@@ -344,6 +372,23 @@ class PingHosts extends FOGService
                     $method[$id] = Ping::METHOD_TCP;
                 }
             }
+            // IDENTITY, not reachability. Everything above establishes that
+            // an address answered; for a stored address that is not the same
+            // claim as "this host is up", because a DHCP lease moves and the
+            // machine now holding it may be a printer.
+            //
+            // Only answers matter here -- a stored address that did not
+            // respond is already recorded as down, and no identity check
+            // makes a silent address more or less down.
+            $results = $this->_verifyStored(
+                $results,
+                $method,
+                $targets,
+                $names,
+                $fromStored,
+                $timeout,
+                $port
+            );
             $elapsed = microtime(true) - $started;
             // Group by result so the whole cycle costs a handful of UPDATEs
             // instead of one per host. update() turns an array of ids into
@@ -472,6 +517,151 @@ class PingHosts extends FOGService
      *
      * @return void
      */
+    /**
+     * Turn "an address answered" into "this host answered".
+     *
+     * Only hosts probed at a STORED address are examined, and only those that
+     * answered. A name resolved through DNS is already the host's own name so
+     * it identifies itself; a stored address does not, because a DHCP lease
+     * outlives the machine that held it. Pinging MachineA's old address and
+     * reporting MachineA up when PrinterX now holds it is a confidently wrong
+     * answer, and worse than the "not reachable" it would replace.
+     *
+     * Three outcomes, matching Ping::identityMatches():
+     *
+     *   verified   - the MAC at that address is one this host registers.
+     *                Kept as up.
+     *   mismatched - some other machine holds the address. Recorded down and
+     *                the stored address CLEARED, so the next cycle resolves
+     *                by name instead of asking the same wrong question again.
+     *   unverified - no ARP entry, so the host is off this server's segments
+     *                and its identity is not knowable from here. Falls back
+     *                to the DNS name, which is what this daemon did before
+     *                hostIP existed. Never treated as verified: doing so
+     *                would reintroduce the false-up for exactly the routed
+     *                hosts that cannot be checked.
+     *
+     * @param array $results    id => errno from the probes
+     * @param array $method     id => METHOD_*, updated in step for fallbacks
+     * @param array $targets    id => address probed
+     * @param array $names      id => host name
+     * @param array $fromStored id => true when the target came from hostIP
+     * @param int   $timeout    probe timeout, for the fallback batch
+     * @param int   $port       probe port, for the fallback batch
+     *
+     * @return array the corrected $results
+     */
+    private function _verifyStored(
+        array $results,
+        array &$method,
+        array $targets,
+        array $names,
+        array $fromStored,
+        $timeout,
+        $port
+    ) {
+        $answered = [];
+        foreach ($fromStored as $id => $unused) {
+            if (0 === (int)($results[$id] ?? -1)) {
+                $answered[$id] = $targets[$id];
+            }
+        }
+        if (count($answered) < 1) {
+            return $results;
+        }
+
+        // One read for the whole cycle, not one per host: the table is the
+        // same for every lookup and shelling out per host would put an exec
+        // in a loop, which is the shape this daemon has been fixed for twice.
+        $arp = Ping::arpTable();
+
+        // Same reasoning for the MACs -- one bulk read keyed by host.
+        $macs = [];
+        $rows = Route::getIds(
+            'macaddressassociation',
+            ['hostID' => array_keys($answered)],
+            ['hostID', 'mac']
+        );
+        foreach ((array)$rows as $row) {
+            $macs[(int)($row['hostID'] ?? 0)][] = (string)($row['mac'] ?? '');
+        }
+
+        $recycled = [];
+        $unverified = [];
+        foreach ($answered as $id => $ip) {
+            $verdict = Ping::identityMatches(
+                $ip,
+                $macs[(int)$id] ?? [],
+                $arp
+            );
+            if (true === $verdict) {
+                continue;
+            }
+            if (false === $verdict) {
+                $recycled[$id] = $ip;
+                continue;
+            }
+            $unverified[$id] = $ip;
+        }
+
+        if (count($recycled) > 0) {
+            foreach ($recycled as $id => $ip) {
+                self::outall(
+                    sprintf(
+                        ' ! %s (%s): %s',
+                        $names[$id] ?? $id,
+                        $ip,
+                        _('another machine holds this address; clearing it')
+                    )
+                );
+                // ENXIO is what an unusable target already records elsewhere
+                // in this cycle, so the stored result stays one value rather
+                // than gaining a second spelling of "we could not ask".
+                $results[$id] = SOCKET_ENXIO;
+            }
+            // Cleared in one statement. The address is not merely stale, it
+            // is known to belong to something else, so leaving it would have
+            // every future cycle re-derive the same wrong answer.
+            self::getClass('HostManager')->update(
+                ['id' => array_keys($recycled)],
+                '',
+                ['ip' => '']
+            );
+        }
+
+        if (count($unverified) < 1) {
+            return $results;
+        }
+
+        // Off-segment: ask the question the old way. Mostly this resolves to
+        // nothing and lands on ENXIO, which is the honest answer -- but a
+        // host that IS in DNS gets a real probe rather than being written off.
+        $fallback = [];
+        foreach ($unverified as $id => $ip) {
+            $target = self::resolveHostname(
+                $names[$id] ?? '',
+                self::UNRESOLVED_TTL
+            );
+            $fallback[$id] = $target;
+            $results[$id] = SOCKET_ENXIO;
+        }
+        self::outall(
+            sprintf(
+                ' * %s: %d',
+                _(
+                    'Answered at a stored address this server cannot verify;'
+                    . ' rechecked by name'
+                ),
+                count($fallback)
+            )
+        );
+        foreach (Ping::executeBatch($fallback, $timeout, $port) as $id => $code) {
+            $results[$id] = $code;
+            $method[$id] = Ping::METHOD_TCP;
+        }
+
+        return $results;
+    }
     public function serviceRun()
     {
         $this->_commonOutput();

--- a/tests/ping-identity-verification.test.php
+++ b/tests/ping-identity-verification.test.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Ping::identityMatches() -- does the machine at this address belong to us?
+ *
+ * PingHosts now prefers hosts.hostIP, written on every client check-in, over
+ * a DNS lookup. That is only safe because of this function.
+ *
+ * An echo reply says an ADDRESS answered. On a DHCP network that is not the
+ * same claim as "this host is up": a lease handed to MachineA on Monday can
+ * belong to PrinterX by Friday, so pinging a host's last known address and
+ * calling it up reports a machine that has been off all week as online. That
+ * is worse than the "not reachable" it replaces, because it is confidently
+ * wrong rather than merely unhelpful -- and it is the failure the maintainer
+ * raised before this was built.
+ *
+ * FOG's identity for a host is its MAC, so the MAC at that address is what
+ * turns "an address answered" into "this host answered".
+ *
+ * THE THIRD VALUE IS THE POINT. ARP is link-local, so an off-segment host has
+ * no entry and its identity is not knowable from this server at all. That
+ * must read as null -- "cannot tell" -- and never as either answer: folded
+ * into true it invents the false-up this exists to prevent, folded into false
+ * it reports every routed host down. Both foldings are pinned below.
+ *
+ * Pure and instant: no network, no database, no daemon. The ARP table is
+ * passed in, so this reads a fixture rather than whatever this machine's
+ * kernel happens to hold.
+ *
+ * Usage: php tests/ping-identity-verification.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$repo = dirname(__DIR__);
+require_once $repo . '/packages/web/vendor/autoload.php';
+
+use FOG\Net\Ping;
+
+// [passed, what it means], classified at the end. Plain data rather than a
+// helper writing to globals: a static analyzer cannot see a `global` write
+// from inside a function and calls the reporting below dead code.
+$results = [];
+
+$arp = [
+    '10.255.20.50' => '08:00:27:e5:df:5e',
+    '10.255.20.51' => 'AA-BB-CC-DD-EE-FF',
+    '10.255.20.52' => '',
+];
+
+$mine = ['08:00:27:e5:df:5e'];
+
+// The address answered and the MAC is ours. The only case that may be up.
+$results[] = [
+    true === Ping::identityMatches('10.255.20.50', $mine, $arp),
+    'a matching MAC verifies the host',
+];
+
+// The address answered and something else holds it -- the PrinterX case.
+$results[] = [
+    false === Ping::identityMatches('10.255.20.51', $mine, $arp),
+    'a different MAC at the address is a mismatch, not a match',
+];
+
+// Off-segment: no entry at all. Must be "cannot tell", not either answer.
+$results[] = [
+    null === Ping::identityMatches('10.255.20.99', $mine, $arp),
+    'an address with no ARP entry is unverifiable, not down',
+];
+$results[] = [
+    false !== Ping::identityMatches('10.255.20.99', $mine, $arp),
+    'and unverifiable is NOT reported as a mismatch',
+];
+$results[] = [
+    true !== Ping::identityMatches('10.255.20.99', $mine, $arp),
+    'and unverifiable is NOT reported as verified',
+];
+
+// An entry with no usable lladdr is the same "cannot tell" -- the kernel
+// asked and got nothing back, which is not evidence about identity.
+$results[] = [
+    null === Ping::identityMatches('10.255.20.52', $mine, $arp),
+    'an empty lladdr is unverifiable rather than a mismatch',
+];
+
+// A host with no MACs registered cannot be verified against anything. It must
+// not pass: "we know nothing about this host" is not "this is our host".
+$results[] = [
+    false === Ping::identityMatches('10.255.20.50', [], $arp),
+    'a host with no registered MACs never verifies',
+];
+
+// Separator and case must not decide identity. hostMAC rows, `ip neigh` and
+// anything an admin typed disagree on both, and a false mismatch here CLEARS
+// a perfectly good stored address.
+foreach (['08-00-27-E5-DF-5E', '08:00:27:E5:DF:5E', '080027e5df5e'] as $form) {
+    $results[] = [
+        true === Ping::identityMatches('10.255.20.50', [$form], $arp),
+        "MAC form '$form' compares equal",
+    ];
+}
+
+// Any one of a host's MACs is enough -- a machine with wired and wireless
+// answers on whichever it is using.
+$results[] = [
+    true === Ping::identityMatches(
+        '10.255.20.50',
+        ['de:ad:be:ef:00:01', '08:00:27:e5:df:5e'],
+        $arp
+    ),
+    'any one of the host MACs is enough to verify',
+];
+
+// Junk must not verify by accident -- normalization strips separators, so a
+// short or malformed value must be rejected rather than compared loosely.
+foreach (['', 'not-a-mac', '08:00:27'] as $junk) {
+    $results[] = [
+        true !== Ping::identityMatches('10.255.20.50', [$junk], $arp),
+        "malformed MAC '$junk' does not verify",
+    ];
+}
+
+$failed = 0;
+foreach ($results as [$passed, $why]) {
+    echo $passed ? "  ok    $why\n" : "  FAIL  $why\n";
+    $failed += $passed ? 0 : 1;
+}
+echo "\n";
+if ($failed > 0) {
+    echo 'FAIL (' . $failed . ' of ' . count($results) . " assertions)\n";
+    exit(1);
+}
+echo 'PASS (' . count($results) . " assertions)\n";


### PR DESCRIPTION
PingHosts resolves hostName through the system resolver and pings whatever
comes back. On a fleet that is not in DNS -- the normal case, not the
pathological one -- that resolves to nothing and the daemon does no work at
all. Measured on the reference server: 86 hosts, 0 probed, every cycle for
hours, with the ping batch itself taking 0.01s and the other 5m41s spent
failing to resolve.

hosts.hostIP has been in the schema for years, indexed, mapped in Host.php,
and written by nothing.

WRITING IT COSTS NO PROTOCOL CHANGE

The client never has to tell us its address: the check-in arrived FROM it, so
REMOTE_ADDR is already in hand and is the only address here known to be real.
It rides the update FOGClient already issues for pingstatus and lastcheckin,
so there is no new statement, no new field, and no client release.

REMOTE_ADDR only, never X-Forwarded-For -- that header is caller-supplied and
would let anything able to reach the endpoint write any address it liked into
a field the pinger then acts on.

WHY A STORED ADDRESS IS NOT ENOUGH ON ITS OWN

Raised by the maintainer before this was built, and it is the crux: a DHCP
lease outlives the machine that held it. Ping MachineA's last known address
after PrinterX has been given it and the reply says the address is alive, not
that MachineA is. FOG would then report a machine that has been switched off
for a week as online.

That is a REGRESSION dressed as a fix. Today's failure is a false down, which
is unhelpful; a stale hostIP is a false up, which is confidently wrong, and
for an imaging tool that is the worse direction to be wrong in.

A freshness bound does not rescue it either. Trusting hostIP only for a window
after the last check-in makes it reliable exactly when it is unnecessary --
PingHosts SKIPS hosts that are checking in -- and stale exactly when it is
needed, because the hosts that need pinging are the ones whose agent has gone
quiet.

SO VERIFY IDENTITY, NOT REACHABILITY

FOG's identity for a host is its MAC. The kernel's ARP table maps address to
MAC, so the MAC answering at that address is what turns "an address answered"
into "this host answered". Ping::identityMatches() is three-valued, and the
third value is the design:

  true   the MAC there is one this host registers -- up
  false  another machine holds the address -- down, and hostIP is CLEARED so
         the next cycle stops asking the same wrong question
  null   no ARP entry, so identity is not knowable from this server

null is not folded into either answer. Into true it invents the false-up this
exists to prevent; into false it reports every routed host down. ARP is
link-local, so an off-segment host genuinely cannot be checked from here and
falls back to the DNS name -- what the daemon did before hostIP existed.
Chosen deliberately over trusting the address anyway (maintainer decision):
routed sites get no benefit from this, which is a real cost, and it is
preferable to the daemon saying "up" when it does not know.

MEASURED LIVE

  arpTable() parsed 9 entries; ip neigh reports 11 lines, 9 distinct
    addresses -- the two repeats are one address on both eno2 and wlo1,
    collapsed deliberately, and no address carries two different MACs
  host 105 verifiable at 10.255.25.1 -- a real host, matched against its own
    registered MAC, on a server where DNS resolves none of the 86

TESTING

tests/ping-identity-verification.test.php is pure: the ARP table is passed in,
so it reads a fixture rather than whatever this kernel holds. It pins the
three outcomes, both wrong foldings of null explicitly, MAC separator and case
equivalence -- a false mismatch there CLEARS a good address -- and that a host
with no registered MACs never verifies.

Verified by mutation (mutate_ping_identity.sh), all four red: null folded into
verified, null folded into mismatch, the empty-lladdr guard removed, and MAC
normalization removed.

A fifth mutation exposed dead code rather than a gap: a length check in
_normalizeMac() could be deleted with the suite still green. It was
unreachable -- identityMatches() already refuses an empty observed MAC, so a
malformed value can only ever compare unequal to a real one. Removed rather
than propped up with a contrived assertion; a branch no input can take reads
as a guard and has no evidence behind it.

No schema change. hostIP already exists.

223/223 suite, both phpstan passes clean.

Co-Authored-By: Claude <noreply@anthropic.com>
