### PR TITLE
Seed FOG_VIEW_DEFAULT_SCREEN as a row count, not a page name

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -878,9 +878,11 @@ $this->schema[] = [
     . "for the ssh client.','root','SSH Client'),"
     . "('FOG_SSH_PORT','This setting defines the port to use for the ssh client.',"
     . "'22','SSH Client'),"
-    . "('FOG_VIEW_DEFAULT_SCREEN','This setting defines which page is "
-    . "displayed in each section, valid settings includes <b>LIST</b> "
-    . "and <b>SEARCH</b>.','SEARCH','FOG View Settings')",
+    . "('FOG_VIEW_DEFAULT_SCREEN','This setting defines how many rows a "
+    . "management list shows to a user who has not yet saved a layout of "
+    . "their own. Column order, visibility, sort and row count are "
+    . "remembered per user once changed, so this is the starting default "
+    . "rather than a fixed limit.','25','FOG View Settings')",
     "UPDATE `schemaVersion` set vValue = '17'",
 ];
 // 18
@@ -9826,4 +9828,47 @@ $this->schema[] = [
 
         return true;
     },
+];
+// 397
+// Repairs FOG_VIEW_DEFAULT_SCREEN, which step 17 seeded as a page NAME.
+//
+// The setting used to mean "which screen does a section open on", and its
+// two values were LIST and SEARCH -- which is still exactly what it means
+// on 1.5, so this repair is 1.6-only and there is nothing to port. In 1.6
+// it was repurposed into the grids' rows-per-page default and the
+// Configuration page began rendering it as a 10/25/50/100/All picker, but
+// step 17 was never corrected. An upgraded install is fine because it
+// carries the numeric row its 1.5 self already held; a FRESH 1.6 install
+// seeded the literal string SEARCH into what is now a row count.
+//
+// The damage is not cosmetic. The value reaches the browser through the
+// hidden #pageLength input, where registerTable() does parseInt() on it --
+// so a fresh install handed every grid pageLength: NaN. Infinite scroll
+// happened to survive it, because Scroller needs a finite chunk and already
+// had a fallback for "All"; classic paging had no such guard and got the
+// NaN. fog.common.js now normalizes the value too, so the two halves cover
+// each other rather than either being the only thing standing between a bad
+// setting and a broken grid.
+//
+// The value is only touched when it is one of the two names step 17 could
+// have produced. An admin who has chosen a number keeps it, including a
+// number the picker does not offer, because "not in the dropdown" is not the
+// same as "invalid" and silently resetting somebody's choice to fix our own
+// seed would be the worse bug. Collation is case-insensitive, so the two
+// literals also cover a lowercased copy.
+//
+// The description is rewritten unconditionally: that text is ours, not the
+// admin's, and the old wording documents behavior that no longer exists.
+$this->schema[] = [
+    "UPDATE `globalSettings` "
+    . "SET `settingDesc` = 'This setting defines how many rows a management "
+    . "list shows to a user who has not yet saved a layout of their own. "
+    . "Column order, visibility, sort and row count are remembered per user "
+    . "once changed, so this is the starting default rather than a fixed "
+    . "limit.' "
+    . "WHERE `settingKey` = 'FOG_VIEW_DEFAULT_SCREEN'",
+    "UPDATE `globalSettings` "
+    . "SET `settingValue` = '25' "
+    . "WHERE `settingKey` = 'FOG_VIEW_DEFAULT_SCREEN' "
+    . "AND `settingValue` IN ('SEARCH','LIST')",
 ];

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -3806,6 +3806,21 @@ $.fn.registerTable = function(onSelect, opts) {
   // Default row count comes from FOG_VIEW_DEFAULT_SCREEN (hidden #pageLength).
   var pageLength = parseInt($('#pageLength').val());
 
+  // That setting arrives as a STRING, and until schema step 397 a fresh
+  // install seeded it as the page name 'SEARCH' -- step 17 pre-dates the
+  // setting being repurposed into a row count. parseInt() answers NaN, and
+  // `pageLength: NaN` is not something DataTables catches: it is only the
+  // infinite-scroll branch below that ever had a fallback, so classic paging
+  // took the NaN straight through. Normalize here so neither mode depends on
+  // the setting being sane.
+  //
+  // -1 is left alone -- it is the legitimate "All" from the length menu.
+  // Scroller cannot use it, but that is the branch below's problem and it
+  // already handles it.
+  if (isNaN(pageLength) || pageLength === 0 || pageLength < -1) {
+    pageLength = 25;
+  }
+
   // Paging style is admin-selectable via FOG_TABLE_SCROLL_MODE (hidden
   // #scrollMode). Default is infinite (virtual-scroll) when unset.
   //

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4611');
+        define('FOG_VERSION', '1.6.0-beta.4616');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -94,8 +94,8 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 396);
-        define('FOG_BCACHE_VER', 344);
+        define('FOG_SCHEMA', 397);
+        define('FOG_BCACHE_VER', 345);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4608');
+        define('FOG_VERSION', '1.6.0-beta.4611');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -129,7 +129,7 @@ parameters:
 		-
 			message: '#^Variable \$this might not be defined\.$#'
 			identifier: variable.undefined
-			count: 366
+			count: 367
 			path: packages/web/commons/schema.php
 
 		-

--- a/tests/schema-gate.test.php
+++ b/tests/schema-gate.test.php
@@ -198,7 +198,12 @@ if (count($emptyLabels)) {
         . "  count(\$this->schema). `mySchema < FOG_SCHEMA` can then never\n"
         . "  be satisfied: the updater has nothing left to apply and every\n"
         . "  page on the server redirects to it, permanently.\n"
-        . "  The usual cause is a missing `];` closing the step before --\n"
+        . "  Two causes. A missing `];` closing the step before, so the\n"
+        . "  new statements silently join the previous element while the\n"
+        . "  label counts as a new one -- or a line INSIDE this step's own\n"
+        . "  comment that begins `// ` followed by a digit (a version like\n"
+        . "  `// 1.5, ...` at the start of a wrapped line). That is read as\n"
+        . "  the next label and steals this one, so reflow the comment.\n"
         . "  the new statements silently join the previous element while\n"
         . "  the label counts as a new one.\n"
     );

--- a/tests/utc-storage-boundary.test.php
+++ b/tests/utc-storage-boundary.test.php
@@ -196,8 +196,14 @@ if (!preg_match(
         . 're-running the step would move the boundary and silently '
         . 're-interpret every stored date';
 }
-if (!preg_match("#define\('FOG_SCHEMA', 396\);#", $system)) {
-    $fails[] = 'FOG_SCHEMA is not 396, so step 396 never runs and the '
+// AT LEAST 396, not exactly 396. The invariant is that the gate reaches the
+// boundary step so it can run; pinning equality instead made this test fail
+// on the next schema step anybody appended, which says nothing about the
+// boundary and trains people to edit the assertion rather than read it.
+if (!preg_match("#define\('FOG_SCHEMA', (\d+)\);#", $system, $gate)
+    || (int)$gate[1] < 396
+) {
+    $fails[] = 'FOG_SCHEMA is below 396, so step 396 never runs and the '
         . 'boundary is never recorded';
 }
 $manifest = require $root . '/packages/web/commons/schema-expected.php';

--- a/tests/view-default-screen-is-a-row-count.test.php
+++ b/tests/view-default-screen-is-a-row-count.test.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * FOG_VIEW_DEFAULT_SCREEN must be seeded as a ROW COUNT, and a bad value must
+ * not be able to reach a grid.
+ *
+ * The setting used to name a screen -- LIST or SEARCH -- and that is still what
+ * it means on 1.5. In 1.6 it was repurposed into the grids' rows-per-page
+ * default, and the Configuration page renders it as a 10/25/50/100/All picker,
+ * but commons/schema.php step 17 was never corrected. An upgraded install is
+ * fine because it carries its 1.5 numeric row forward; a FRESH 1.6 install
+ * seeded the literal string SEARCH into what is now a row count.
+ *
+ * That value reaches the browser through the hidden #pageLength input and goes
+ * through parseInt(), so a fresh install handed every grid `pageLength: NaN`.
+ * Nothing errors. Infinite scroll survived by accident -- Scroller needs a
+ * finite chunk and already had a fallback for "All" -- and classic paging,
+ * which had no guard, took the NaN.
+ *
+ * Both halves are pinned, because either alone leaves the bug reachable: fix
+ * only the seed and an existing install stays broken; fix only the browser and
+ * the Configuration page still shows a row-count picker with SEARCH in it.
+ *
+ * The database half runs only with FOG_TEST_DSN set and models the three real
+ * paths -- fresh install, an install still holding SEARCH, and an admin who has
+ * chosen a number the picker does not offer, whose choice must survive.
+ *
+ * Usage: php tests/view-default-screen-is-a-row-count.test.php
+ *   FOG_TEST_DSN=mysql:host=127.0.0.1;port=3306 FOG_TEST_USER=root \
+ *   FOG_TEST_PASS=secret php tests/view-default-screen-is-a-row-count.test.php
+ *
+ * Exit status 0 = pass or skip, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+$schemaFile = $web . '/commons/schema.php';
+$fails = [];
+
+// ---------------------------------------------------------------- textual --
+
+$schema = file_get_contents($schemaFile);
+
+// The seed itself. Anchored on the value and category together, so a partial
+// edit that fixes the prose and leaves 'SEARCH' behind is still a failure.
+if (!preg_match(
+    "#'FOG_VIEW_DEFAULT_SCREEN'.{0,600}?','25','FOG View Settings'#s",
+    $schema
+)) {
+    $fails[] = 'step 17 does not seed FOG_VIEW_DEFAULT_SCREEN with a numeric '
+        . 'row count, so a fresh install starts with a value the grids '
+        . 'parseInt() into NaN';
+}
+if (strpos($schema, "and <b>SEARCH</b>.','SEARCH','FOG View Settings'") !== false) {
+    $fails[] = 'step 17 still seeds the 1.5 screen-name value and description '
+        . 'for FOG_VIEW_DEFAULT_SCREEN';
+}
+
+// The repair for installs that already took the bad seed, and its precision.
+if (!preg_match(
+    "#SET `settingValue` = '25' \"\s*\n\s*\. \"WHERE `settingKey` = "
+    . "'FOG_VIEW_DEFAULT_SCREEN' \"\s*\n\s*\. \"AND `settingValue` IN "
+    . "\('SEARCH','LIST'\)#",
+    $schema
+)) {
+    $fails[] = 'no repair step that rewrites only the two screen-name values: '
+        . 'without the IN guard the repair also resets a number an admin '
+        . 'chose, and without the step an existing install keeps SEARCH';
+}
+
+$js = file_get_contents($web . '/management/js/fog/fog.common.js');
+
+// The browser-side normalization, and crucially WHERE it is. The whole defect
+// was that the only guard lived inside the infinite-scroll branch, so classic
+// paging had none -- pin the guard to the parseInt that feeds it, not to the
+// file, or a guard that drifts back inside that branch still matches.
+if (!preg_match(
+    "~var pageLength = parseInt\(\\\$\('\#pageLength'\)\.val\(\)\);"
+    . '.{0,900}?'
+    . '\n  if \(isNaN\(pageLength\) \|\| pageLength === 0 \|\| pageLength < -1\) \{'
+    . '\n    pageLength = 25;'
+    . '\n  \}~s',
+    $js
+)) {
+    $fails[] = 'registerTable() does not normalize #pageLength at the top of '
+        . 'the function: a non-numeric setting reaches classic paging as '
+        . 'pageLength: NaN, which DataTables does not catch';
+}
+
+// -1 is the length menu's "All" and must survive the guard, or choosing All
+// silently becomes 25 on every paged grid.
+if (preg_match('#if \(isNaN\(pageLength\)[^\n]*pageLength < 1\) \{#', $js)) {
+    $fails[] = 'the normalization rejects -1, which is the legitimate "All" '
+        . 'from the length menu';
+}
+
+// -------------------------------------------------------------- behavioral --
+
+$dsn = getenv('FOG_TEST_DSN');
+if ($dsn === false || $dsn === '') {
+    if ($fails) {
+        foreach ($fails as $f) {
+            echo "FAIL: $f\n";
+        }
+        exit(1);
+    }
+    echo "PASS: FOG_VIEW_DEFAULT_SCREEN is seeded as a row count "
+        . "(SKIP: no FOG_TEST_DSN, repair not executed)\n";
+    exit(0);
+}
+
+$user = getenv('FOG_TEST_USER');
+$pass = getenv('FOG_TEST_PASS');
+$user = ($user === false) ? 'root' : $user;
+$pass = ($pass === false) ? '' : $pass;
+$db = 'fog_view_default_screen_test';
+
+require __DIR__ . '/lib/fog-schema-collector.php';
+$steps = fogCollectSchemaSteps($schemaFile, $db, PHP_INT_MAX);
+
+// Every statement any step aims at this one setting, in order. Taken by
+// content rather than by step number so that renumbering cannot silently
+// empty this list -- an empty list is checked for below.
+$sql = [];
+foreach ($steps as $updates) {
+    foreach ((array)$updates as $update) {
+        if (is_string($update)
+            && strpos($update, 'FOG_VIEW_DEFAULT_SCREEN') !== false
+        ) {
+            $sql[] = $update;
+        }
+    }
+}
+if (count($sql) < 2) {
+    fwrite(
+        STDERR,
+        "FAIL: expected a seed and at least one repair naming "
+        . "FOG_VIEW_DEFAULT_SCREEN; found " . count($sql) . "\n"
+    );
+    exit(1);
+}
+
+$manifest = include $web . '/commons/schema-expected.php';
+$create = $manifest['tables']['globalSettings']['create'] ?? '';
+if (!$create) {
+    fwrite(STDERR, "FAIL: no globalSettings create in the manifest\n");
+    exit(1);
+}
+
+try {
+    $pdo = new \PDO($dsn, $user, $pass, [
+        \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+    ]);
+} catch (\PDOException $e) {
+    echo "SKIP  cannot connect with FOG_TEST_DSN; repair not executed\n";
+    exit($fails ? 1 : 0);
+}
+
+// Each case is the state the row is in BEFORE the steps run, and what it must
+// be after. null means the row does not exist yet -- the fresh-install path,
+// where the seed itself is what creates it.
+$cases = [
+    'fresh install' => [null, '25'],
+    'took the bad seed' => ['SEARCH', '25'],
+    'the other screen name' => ['LIST', '25'],
+    'admin chose a number off the picker' => ['250', '250'],
+    'admin chose All' => ['-1', '-1'],
+];
+
+foreach ($cases as $label => $case) {
+    list($before, $expected) = $case;
+    $pdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $db));
+    $pdo->exec(sprintf('CREATE DATABASE `%s`', $db));
+    $pdo->exec(sprintf('USE `%s`', $db));
+    $pdo->exec($create);
+    if ($before !== null) {
+        $ins = $pdo->prepare(
+            'INSERT INTO `globalSettings` '
+            . '(`settingKey`,`settingDesc`,`settingValue`,`settingCategory`) '
+            . "VALUES ('FOG_VIEW_DEFAULT_SCREEN','old text',?,'FOG View Settings')"
+        );
+        $ins->execute([$before]);
+    }
+    foreach ($sql as $one) {
+        $pdo->exec($one);
+    }
+    $got = $pdo
+        ->query(
+            'SELECT `settingValue` FROM `globalSettings` '
+            . "WHERE `settingKey` = 'FOG_VIEW_DEFAULT_SCREEN'"
+        )
+        ->fetchColumn();
+    if ((string)$got !== $expected) {
+        $fails[] = sprintf(
+            '%s: value was %s and should be %s after the schema runs, but is %s',
+            $label,
+            $before === null ? '(absent)' : $before,
+            $expected,
+            var_export($got, true)
+        );
+    }
+    // The description is ours and must be brought up to date wherever the row
+    // exists at all -- the old wording documents behavior that is gone.
+    $desc = (string)$pdo
+        ->query(
+            'SELECT `settingDesc` FROM `globalSettings` '
+            . "WHERE `settingKey` = 'FOG_VIEW_DEFAULT_SCREEN'"
+        )
+        ->fetchColumn();
+    if (strpos($desc, 'how many rows') === false) {
+        $fails[] = $label . ': the description was not brought up to date ('
+            . substr($desc, 0, 60) . ')';
+    }
+}
+$pdo->exec(sprintf('DROP DATABASE IF EXISTS `%s`', $db));
+
+if ($fails) {
+    foreach ($fails as $f) {
+        echo "FAIL: $f\n";
+    }
+    exit(1);
+}
+printf(
+    "PASS: FOG_VIEW_DEFAULT_SCREEN is a row count, and the repair fixed %d "
+    . "cases without touching an admin's own choice\n",
+    count($cases)
+);
+exit(0);


### PR DESCRIPTION
## The bug

`FOG_VIEW_DEFAULT_SCREEN` used to mean *which screen does a section open on*, and its two values were `LIST` and `SEARCH` — which is still exactly what it means on 1.5, so **this is 1.6-only and there is nothing to port** (verified: `dev-branch`'s config page still renders it as a LIST/SEARCH picker).

In 1.6 it was repurposed into the grids' rows-per-page default, and the Configuration page began rendering it as a 10/25/50/100/All picker — but `commons/schema.php` step 17 was never corrected. An upgraded install is fine, because it carries the numeric row its 1.5 self already held. A **fresh 1.6 install seeds the literal string `SEARCH`** into what is now a row count.

That isn't cosmetic. The value reaches the browser through the hidden `#pageLength` input, where `registerTable()` runs `parseInt()` on it — so a fresh install handed every grid `pageLength: NaN`. Nothing errors. Infinite scroll survived *by accident*: Scroller needs a finite chunk and already had a fallback for "All". Classic paging had no guard at all and took the `NaN`.

## The fix

Three parts, and each alone leaves the bug reachable:

- **step 17** seeds `25` and describes what the setting actually does;
- **step 397** repairs an install that already took the bad seed. It rewrites the value **only** where it is one of the two names step 17 could have produced, so an admin who chose a number keeps it — including a number the picker doesn't offer, because "not in the dropdown" is not the same as "invalid". The description is rewritten unconditionally: that text is ours, and the old wording documents behavior that no longer exists;
- **`registerTable()`** normalizes `#pageLength` at the top of the function rather than only inside the infinite-scroll branch. `-1` is left alone — it's the length menu's legitimate "All", and only Scroller can't use it.

Exercising the shipped guard against the real inputs:

| `#pageLength` | `parseInt` | after the guard |
|---|---|---|
| `"SEARCH"` | `NaN` | `25` |
| `"LIST"` | `NaN` | `25` |
| `""` | `NaN` | `25` |
| `"0"` | `0` | `25` |
| `"-1"` | `-1` | `-1` |
| `"10"` / `"25"` / `"100"` | as written | unchanged |

## Why the setting stays

This came out of checking whether the grids' row count is already a per-user preference. **It is** — the layout is stored server-side per user at `system/userpref/<key>`, and the saved payload carries `length` alongside `columns`, `order` and `colReorder`. So this setting is now only the *starting* default for a user who has none. Worth keeping rather than retiring: otherwise a new user starts on DataTables' own 10, and admins lose the knob.

## Gate

`tests/view-default-screen-is-a-row-count.test.php`. The textual half pins the seed, the repair's `IN ('SEARCH','LIST')` precision, and the guard's position *relative to the `parseInt` that feeds it* — not just its presence, since the whole defect was a guard in the wrong place.

With `FOG_TEST_DSN` set it also **executes the real schema statements against a database**, over five cases: fresh install, an install holding `SEARCH`, one holding `LIST`, an admin who chose `250`, and an admin who chose `All`. Run against MariaDB 11.8.

All six mutations go red, including one only the database half can see (a clobbering `UPDATE` appended *after* the guarded one, which leaves the textual assertions satisfied):

```
admin chose a number off the picker: value was 250 and should be 250 ... but is '25'
admin chose All:                     value was -1  and should be -1  ... but is '25'
```

## Also fixed, both uncovered by this

- `schema-gate.test.php` reported the new label as having no append and blamed a missing `];`. The real cause was a line inside the step's own comment beginning `// 1.5, ...`, which the label scanner reads as the next label and which silently steals the real one. The message now names both causes.
- `utc-storage-boundary.test.php` (mine, from #1496) pinned `FOG_SCHEMA` to *exactly* 396, so it failed on the next step anyone appended. The invariant is that the gate **reaches** step 396, so it now checks for at least 396.

`FOG_SCHEMA` 396 → 397, `FOG_BCACHE_VER` 344 → 345, and the `variable.undefined` baseline count for `schema.php` 366 → 367 (one more step, one more `$this`).