### PR TITLE
Say on screen which dates predate the move to UTC

### DIFF
--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -3797,11 +3797,82 @@ if ($.fn.dataTable) {
     $.notify(tableId, detail || message, 'error');
   };
 }
+/**
+ * Suffix FOGManagerController::UNADJUSTED_SUFFIX appends to a date column's
+ * key when that row's value predates this server's move to UTC.
+ */
+var FOG_UNADJUSTED_SUFFIX = '__unadjusted';
+
+/**
+ * Puts the "not converted" marker on the cells the server flagged.
+ *
+ * The flag arrives as a SIBLING key on the row -- `hostLastDeploy` plus
+ * `hostLastDeploy__unadjusted` -- and the glyph is added to the cell's DOM
+ * here rather than to the value on the server. That split is the whole point.
+ * A DataTables cell's data is escaped into the cell, is what sorting and
+ * filtering compare, and is what the CSV/Excel buttons export; markup put
+ * there prints as tags and rides into the download (GH-1245, GH-1446). Adding
+ * it to the DOM after the fact leaves all three untouched -- and sorting on
+ * the raw value is the honest behavior anyway, because within the
+ * pre-boundary era the values are mutually consistent with each other.
+ *
+ * rowCallback rather than a columnDefs render for the same reason: a global
+ * render would also have to be the render for every column, and ten list
+ * pages define their own.
+ *
+ * @param {object} api  the DataTables API for the table
+ * @param {Node}   tr   the row's <tr>
+ * @param {object} data the row's data object
+ * @param {string} note the sentence to show on hover, from the payload
+ *
+ * @return {void}
+ */
+function fogMarkUnadjusted(api, tr, data, note) {
+  if (!note || !data || typeof data !== 'object') {
+    return;
+  }
+  var columns = api.settings()[0].aoColumns,
+    rowIndex = api.row(tr).index(),
+    suffixLen = FOG_UNADJUSTED_SUFFIX.length,
+    key,
+    base,
+    i,
+    cell;
+  for (key in data) {
+    if (!data[key] || key.slice(-suffixLen) !== FOG_UNADJUSTED_SUFFIX) {
+      continue;
+    }
+    base = key.slice(0, -suffixLen);
+    for (i = 0; i < columns.length; i++) {
+      if (columns[i].data !== base) {
+        continue;
+      }
+      cell = api.cell(rowIndex, i).node();
+      // A hidden column -- Responsive collapsed it, or column visibility
+      // turned it off -- has no node to decorate. Responsive redraws the
+      // child row from the cell data, which is exactly the value without
+      // the glyph, so the marker is a visible-column affordance and the
+      // tooltip is where the explanation lives.
+      if (!cell || $(cell).find('.fog-unadjusted').length) {
+        continue;
+      }
+      $(cell).append(
+        $('<span class="fog-unadjusted text-muted ms-1"'
+          + ' data-bs-toggle="tooltip" data-container="body">*</span>')
+          .attr('title', note)
+      );
+    }
+  }
+}
+
 $.fn.registerTable = function(onSelect, opts) {
   opts = opts || {};
 
   // Idempotent; every grid calls this and only the first does any work.
   fogMemoizeResponsiveMeasure();
+
+  // Resolved on the first rowCallback; see the note there.
+  var unadjustedTable = null;
 
   // Default row count comes from FOG_VIEW_DEFAULT_SCREEN (hidden #pageLength).
   var pageLength = parseInt($('#pageLength').val());
@@ -3847,6 +3918,25 @@ $.fn.registerTable = function(onSelect, opts) {
   var defaults = {
     paging: true,
     lengthChange: true,
+    // Marks any date the server flagged as predating this install's move to
+    // UTC. The note itself rides the payload (see the xhr handler below), so
+    // this is a no-op on an install that has not crossed the boundary and on
+    // every client-side table, neither of which sends one.
+    rowCallback: function(tr, data) {
+      // Reached through the row's own table rather than a closure: the first
+      // draw happens INSIDE the DataTable() call below, so the variable
+      // holding the API is not assigned yet when this first runs. Cached
+      // because it is otherwise a settings-array scan per row.
+      if (!unadjustedTable) {
+        unadjustedTable = $(tr).closest('table').DataTable();
+      }
+      fogMarkUnadjusted(
+        unadjustedTable,
+        tr,
+        data,
+        unadjustedTable.settings()[0].fogUnadjustedNote
+      );
+    },
     searching: true,
     ordering: true,
     info: true,
@@ -4050,6 +4140,15 @@ $.fn.registerTable = function(onSelect, opts) {
   // silently so. The extra name is what lets the off() below remove this one
   // handler when registerTable() is re-run over a retrieved table.
   $(this).off('xhr.dt.fogsb').on('xhr.dt.fogsb', function(e, settings, json) {
+    // Stashed on SETTINGS, which is the one object that is the table. A
+    // DataTables Api is constructed fresh per call, so a property set on one
+    // is gone by the next -- and rowCallback cannot close over the note
+    // anyway, because it is defined before the first response exists and runs
+    // after every one. Read before the _searchtypes guard below: a grid can
+    // carry unadjusted dates whether or not the server typed its columns.
+    if (json && typeof json._unadjustednote === 'string') {
+      settings.fogUnadjustedNote = json._unadjustednote;
+    }
     if (!json || !json._searchtypes) {
       return;
     }

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -10979,6 +10979,10 @@ msgstr ""
 msgid "recommended"
 msgstr "(empfohlen)"
 
+#, php-format
+msgid "recorded before this server moved to UTC; written in %s"
+msgstr ""
+
 msgid "register this at your provider"
 msgstr ""
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -10970,6 +10970,10 @@ msgstr ""
 msgid "recommended"
 msgstr ""
 
+#, php-format
+msgid "recorded before this server moved to UTC; written in %s"
+msgstr ""
+
 msgid "register this at your provider"
 msgstr ""
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -11153,6 +11153,10 @@ msgstr ""
 msgid "recommended"
 msgstr ""
 
+#, php-format
+msgid "recorded before this server moved to UTC; written in %s"
+msgstr ""
+
 msgid "register this at your provider"
 msgstr ""
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -10980,6 +10980,10 @@ msgstr ""
 msgid "recommended"
 msgstr "(empfohlen)"
 
+#, php-format
+msgid "recorded before this server moved to UTC; written in %s"
+msgstr ""
+
 msgid "register this at your provider"
 msgstr ""
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -10972,6 +10972,10 @@ msgstr ""
 msgid "recommended"
 msgstr ""
 
+#, php-format
+msgid "recorded before this server moved to UTC; written in %s"
+msgstr ""
+
 msgid "register this at your provider"
 msgstr ""
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -10620,6 +10620,10 @@ msgstr ""
 msgid "recommended"
 msgstr "Consigliato"
 
+#, php-format
+msgid "recorded before this server moved to UTC; written in %s"
+msgstr ""
+
 msgid "register this at your provider"
 msgstr ""
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -10565,6 +10565,10 @@ msgstr ""
 msgid "recommended"
 msgstr "推奨"
 
+#, php-format
+msgid "recorded before this server moved to UTC; written in %s"
+msgstr ""
+
 msgid "register this at your provider"
 msgstr ""
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -9393,6 +9393,10 @@ msgstr ""
 msgid "recommended"
 msgstr ""
 
+#, php-format
+msgid "recorded before this server moved to UTC; written in %s"
+msgstr ""
+
 msgid "register this at your provider"
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -10971,6 +10971,10 @@ msgstr ""
 msgid "recommended"
 msgstr ""
 
+#, php-format
+msgid "recorded before this server moved to UTC; written in %s"
+msgstr ""
+
 msgid "register this at your provider"
 msgstr ""
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -10971,6 +10971,10 @@ msgstr ""
 msgid "recommended"
 msgstr ""
 
+#, php-format
+msgid "recorded before this server moved to UTC; written in %s"
+msgstr ""
+
 msgid "register this at your provider"
 msgstr ""
 

--- a/packages/web/src/Base/FOGManagerController.php
+++ b/packages/web/src/Base/FOGManagerController.php
@@ -303,6 +303,17 @@ abstract class FOGManagerController extends FOGBase
      *
      * @return array
      */
+    /**
+     * Appended to a date column's output key to flag that row's value as
+     * predating the UTC boundary.
+     *
+     * Two underscores and a word no column is called, because this shares a
+     * namespace with every column's own output key -- fog.common.js reads it
+     * back by suffix, so a collision would put a marker on a real column.
+     *
+     * @var string
+     */
+    const UNADJUSTED_SUFFIX = '__unadjusted';
     public static function displayDates($rows, $table, $columns)
     {
         if (class_exists('\\FOG\\Router\\Route')
@@ -347,6 +358,27 @@ abstract class FOGManagerController extends FOGBase
                 if (!self::validDate($row[$key])) {
                     continue;
                 }
+                // The flag goes in BEFORE the value is rewritten, because
+                // isPreBoundary() classifies the STORED value and the next
+                // line replaces it with a display one.
+                //
+                // A sibling key rather than decoration on the value itself.
+                // A grid cell's data is not an HTML context: it is escaped
+                // into the cell, it is what sorting and filtering see, and it
+                // is what the CSV/Excel buttons export. Markup smuggled
+                // through it prints as tags and lands in the download
+                // (GH-1245, GH-1446). The browser reads this flag and adds
+                // the glyph to the cell's DOM instead, so the value stays a
+                // value everywhere it is used as one.
+                //
+                // Only written when true. An absent key is falsy in JS, so
+                // "false" costs a key on every date of every row for nothing.
+                if (\FOG\Base\StorageEpoch::isPreBoundary(
+                    (string)$row[$key],
+                    $isDatetime
+                )) {
+                    $row[$key . self::UNADJUSTED_SUFFIX] = true;
+                }
                 $row[$key] = self::toDisplayStored(
                     (string)$row[$key],
                     $isDatetime
@@ -356,6 +388,29 @@ abstract class FOGManagerController extends FOGBase
         unset($row);
 
         return $rows;
+    }
+    /**
+     * The sentence explaining an unadjusted marker, or '' when none applies.
+     *
+     * Carries displayDates()'s guard for the same reason displayDates() has
+     * it: a REST consumer gets raw stored values and no display conversion,
+     * so a note about a conversion that did not happen would be describing
+     * something it cannot see.
+     *
+     * @return string
+     */
+    public static function unadjustedNote()
+    {
+        if (class_exists('\\FOG\\Router\\Route')
+            && \FOG\Router\Route::$apiRequest
+        ) {
+            return '';
+        }
+        if (!\FOG\Base\StorageEpoch::active()) {
+            return '';
+        }
+
+        return \FOG\Base\StorageEpoch::note();
     }
     public static function dataOutput($columns, $data)
     {
@@ -1456,6 +1511,13 @@ abstract class FOGManagerController extends FOGBase
             // page, and page one is not enough to tell a date column from a
             // text one -- see searchTypes().
             '_searchtypes' => self::searchTypes($table, $columns),
+            // The tooltip text for any cell flagged UNADJUSTED_SUFFIX above.
+            // Once per response, not once per row: it is the same sentence
+            // every time, and it is a TRANSLATED one -- assembling it in JS
+            // would put a msgid somewhere xgettext never looks. Empty on an
+            // install that has not crossed the boundary, which is also every
+            // install where no row can carry the flag.
+            '_unadjustednote' => self::unadjustedNote(),
             //'sql_query' => $sql_query,
             //'filter_query' => $filter_query,
             //'total_query' => $total_query,

--- a/packages/web/src/Base/FOGPageRender.php
+++ b/packages/web/src/Base/FOGPageRender.php
@@ -417,6 +417,21 @@ trait FOGPageRender
      *
      * @return string
      */
+    /**
+     * Whether dateOrNever() has marked anything on this page as predating the
+     * UTC boundary.
+     *
+     * Per RENDER, not per value: the marker goes beside each affected date,
+     * the sentence explaining it appears once. A page that shows five dates
+     * of which one is old should not say the same thing five times.
+     *
+     * Never reset. dateOrNever() runs while a page builds its notes and
+     * renderInfoCard() runs afterward, both inside one request, so there is
+     * exactly one render to remember.
+     *
+     * @var bool
+     */
+    protected static $_unadjustedSeen = false;
     protected static function dateOrNever($value, $table = '', $column = '')
     {
         if (!$value || !self::validDate($value)) {
@@ -437,8 +452,21 @@ trait FOGPageRender
             ? 'datetime'
             : strtolower(trim((string)self::columnType($table, $column)));
 
-        return self::toDisplayStored($value, 0 !== strpos($type, 'timestamp'))
+        $isDatetime = 0 !== strpos($type, 'timestamp');
+        $out = self::toDisplayStored($value, $isDatetime)
             ->format('Y-m-d H:i:s');
+
+        // A pre-boundary value is real and usually means exactly what the
+        // reader thinks; what it is NOT is UTC, and nothing else on the page
+        // says so. Mark it and remember that we did, so renderInfoCard() can
+        // explain the marker once at the foot of the card rather than
+        // repeating a sentence beside every date.
+        if (\FOG\Base\StorageEpoch::isPreBoundary($value, $isDatetime)) {
+            self::$_unadjustedSeen = true;
+            $out .= \FOG\Base\StorageEpoch::MARKER;
+        }
+
+        return $out;
     }
 
     /**
@@ -554,6 +582,17 @@ trait FOGPageRender
             echo '</div>';
         }
         echo '</div>';
+        // Once, and only when something above actually carries the marker.
+        // A standing disclaimer on every edit page would be noise on the
+        // overwhelming majority of them, where every date is post-boundary.
+        if (self::$_unadjustedSeen) {
+            echo '<div class="small text-secondary mt-2" id="edit-info-unadjusted">';
+            echo \Initiator::e(
+                trim(\FOG\Base\StorageEpoch::MARKER)
+                . ' ' . \FOG\Base\StorageEpoch::note()
+            );
+            echo '</div>';
+        }
         echo '</div>';
         echo '</div>';
     }

--- a/packages/web/src/Base/StorageEpoch.php
+++ b/packages/web/src/Base/StorageEpoch.php
@@ -53,6 +53,23 @@ class StorageEpoch extends FOGBase
      */
     const BAND_HOURS = 26;
     /**
+     * What follows a value that predates the boundary.
+     *
+     * TEXT, not markup, and that is not a stylistic choice. Both display
+     * sites escape what they are given -- renderInfoCard()'s docblock says a
+     * page wanting markup there "has to grow an explicit opt-in rather than
+     * smuggling it through a value", and a grid cell that carries HTML in its
+     * DATA rather than in a renderer prints the tags literally and exports
+     * them to CSV (GH-1245, GH-1446). A marker that survives htmlspecialchars
+     * is the only kind that can ride a value at all.
+     *
+     * The grids do get a real muted glyph, but the browser adds it to the
+     * cell's DOM from a sibling flag; nothing decorated ever enters the value.
+     *
+     * @var string
+     */
+    const MARKER = ' *';
+    /**
      * The row, once read. False while it has not been looked for, null when
      * there is none.
      *
@@ -168,6 +185,30 @@ class StorageEpoch extends FOGBase
             // setting held something unusable even then.
             return new \DateTimeZone('UTC');
         }
+    }
+    /**
+     * The one-line explanation shown wherever a value is marked unadjusted.
+     *
+     * Built here rather than at each of the three display sites -- the info
+     * card, the grids, and the browser by way of the grid payload -- so all
+     * three say the same thing, and so the msgid is a literal that xgettext
+     * can see. A string assembled in JS never reaches the .pot at all, and a
+     * msgid built at runtime from a variable never translates (GH-1090).
+     *
+     * Names the zone rather than saying "some other zone", because the reader
+     * usually knows perfectly well what the value meant and the zone is what
+     * lets them confirm it. seZone is a record of what was true then, which is
+     * exactly what makes it safe to print next to an old value.
+     *
+     * @return string
+     */
+    public static function note()
+    {
+        return sprintf(
+            /* translators: %s is a time zone name, e.g. America/Chicago */
+            _('recorded before this server moved to UTC; written in %s'),
+            self::priorZone()->getName()
+        );
     }
     /**
      * Whether a stored value predates the boundary, and so does NOT mean UTC.

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -62,7 +62,7 @@ class System
     public function __construct()
     {
         self::_versionCompare();
-        define('FOG_VERSION', '1.6.0-beta.4616');
+        define('FOG_VERSION', '1.6.0-beta.4619');
         define('FOG_CHANNEL', 'Beta');
         // Bumped by one for every element added to $this->schema in
         // commons/schema.php, and it must never fall BELOW that element

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -95,7 +95,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 397);
-        define('FOG_BCACHE_VER', 345);
+        define('FOG_BCACHE_VER', 346);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/tests/unadjusted-dates-are-marked-not-converted.test.php
+++ b/tests/unadjusted-dates-are-marked-not-converted.test.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * A date that predates this install's move to UTC must be MARKED, and marking
+ * it must not change the value.
+ *
+ * The boundary (#1496) fixed what a date means from now on. It cannot fix what
+ * the old ones mean -- five different clocks wrote them and no sweep can tell
+ * which -- so the one thing left to do is say so on screen. That is only
+ * useful if the marker is additive: the value is real, the reader usually
+ * knows what it means, and sorting and filtering within the pre-boundary era
+ * are mutually consistent.
+ *
+ * The failure this exists to prevent is the marker riding the VALUE. FOG has
+ * shipped that bug twice -- GH-1245 and GH-1446 -- because a grid cell's data
+ * is escaped into the cell, is what sorting and filtering compare, and is what
+ * the CSV/Excel buttons export. Markup put there prints as tags and lands in
+ * the download. The info card is the same shape: renderInfoCard()'s own
+ * docblock says a page wanting markup there must "grow an explicit opt-in
+ * rather than smuggling it through a value".
+ *
+ * So the two display sites work differently on purpose, and both are pinned:
+ *
+ *  - grids get a SIBLING key and the browser decorates the cell's DOM;
+ *  - the info card gets a plain-text marker that survives htmlspecialchars,
+ *    plus one line of prose at the foot of the card explaining it.
+ *
+ * Usage: php tests/unadjusted-dates-are-marked-not-converted.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__) . '/packages/web';
+$fails = [];
+
+$mgr = file_get_contents($root . '/src/Base/FOGManagerController.php');
+$render = file_get_contents($root . '/src/Base/FOGPageRender.php');
+$epoch = file_get_contents($root . '/src/Base/StorageEpoch.php');
+$js = file_get_contents($root . '/management/js/fog/fog.common.js');
+
+// -- the grid half ---------------------------------------------------------
+
+// ORDER IS THE BUG. isPreBoundary() classifies the STORED value, and the next
+// statement replaces it with a display one. Flag second and every row is
+// classified on the wrong string -- silently, and in the direction that says
+// "already UTC" for values that are not. Anchored as one block so the two
+// cannot drift apart.
+if (!preg_match(
+    '#if \(\\\\FOG\\\\Base\\\\StorageEpoch::isPreBoundary\(\s*'
+    . '\(string\)\$row\[\$key\],\s*\$isDatetime\s*\)\) \{\s*'
+    . '\$row\[\$key \. self::UNADJUSTED_SUFFIX\] = true;\s*\}\s*'
+    . '\$row\[\$key\] = self::toDisplayStored\(#s',
+    $mgr
+)) {
+    $fails[] = 'displayDates() does not flag the row from the STORED value '
+        . 'immediately before rewriting it, so the classification is made '
+        . 'against the display value instead';
+}
+
+// A sibling, never the value. Any concatenation of the marker onto a row's
+// value is the bug this whole test is about.
+if (preg_match('#\$row\[\$key\][^\n]*\.=#', $mgr)
+    || preg_match('#\$row\[\$key\] = [^\n]*MARKER#', $mgr)
+) {
+    $fails[] = 'displayDates() decorates the grid value itself, which is '
+        . 'escaped into the cell, compared by sorting and filtering, and '
+        . 'exported to CSV';
+}
+
+// The note is display-only for the same reason the conversion is.
+if (!preg_match(
+    '#function unadjustedNote\(\)\s*\{\s*if \(class_exists\(.{0,60}Route.{0,30}'
+    . '\&\& \\\\FOG\\\\Router\\\\Route::\$apiRequest\s*\) \{\s*return \'\';#s',
+    $mgr
+)) {
+    $fails[] = 'unadjustedNote() is not gated on the request being a non-API '
+        . 'one, so a REST consumer is told about a display conversion that '
+        . 'never happened to the values it was sent';
+}
+
+// -- the browser half ------------------------------------------------------
+
+// The glyph goes into the DOM, and nowhere else. A render() would put it back
+// into the orthogonal data that sorting, filtering and export all read.
+if (!preg_match("#\\\$\(cell\)\.append\(#", $js)) {
+    $fails[] = 'the browser does not append the marker to the cell node, so '
+        . 'it is not being kept out of the cell data';
+}
+if (preg_match('#__unadjusted[^\n]*\n[^\n]*return data \+#', $js)) {
+    $fails[] = 'the marker is concatenated onto a cell value in JS, which '
+        . 'puts it into the CSV export and the sort comparator';
+}
+
+// A redraw must not stack a second glyph -- Scroller and Responsive redraw
+// rows constantly, so this runs many times over the same cell.
+if (!preg_match("#find\('\.fog-unadjusted'\)\.length#", $js)) {
+    $fails[] = 'fogMarkUnadjusted() has no guard against decorating a cell '
+        . 'twice, so a redrawn row accumulates markers';
+}
+
+// The note lives on settings, not on an Api object: a DataTables Api is
+// constructed per call, so a property set on one is gone by the next.
+if (!preg_match('#settings\.fogUnadjustedNote = json\._unadjustednote#', $js)) {
+    $fails[] = 'the payload note is not stashed on the DataTables settings '
+        . 'object, so rowCallback cannot read it back';
+}
+
+// -- the detail-page half --------------------------------------------------
+
+if (!preg_match(
+    '#StorageEpoch::isPreBoundary\(\$value, \$isDatetime\)\) \{\s*'
+    . 'self::\$_unadjustedSeen = true;\s*'
+    . '\$out \.= \\\\FOG\\\\Base\\\\StorageEpoch::MARKER;#s',
+    $render
+)) {
+    $fails[] = 'dateOrNever() does not mark a pre-boundary value and record '
+        . 'that it did, so either the date carries no marker or the card '
+        . 'never explains one';
+}
+
+// Once per page, and only when there is something to explain.
+if (!preg_match(
+    '#if \(self::\$_unadjustedSeen\) \{\s*echo \'<div class="small#s',
+    $render
+)) {
+    $fails[] = 'the info card prints its explanation unconditionally, which '
+        . 'is a standing disclaimer on every edit page in FOG';
+}
+
+// The marker has to survive htmlspecialchars, because both sites escape it.
+if (!preg_match("#const MARKER = '[^<>&\"']*';#", $epoch)) {
+    $fails[] = 'StorageEpoch::MARKER contains markup or a character that '
+        . 'htmlspecialchars would escape, so it cannot ride a value through '
+        . 'either display site';
+}
+
+// And the sentence must be a real msgid, not one assembled at runtime.
+if (!preg_match("#_\('recorded before this server moved to UTC; written in %s'\)#", $epoch)) {
+    $fails[] = 'the explanation is not a literal gettext msgid, so it never '
+        . 'reaches the .pot and can never be translated';
+}
+
+if ($fails) {
+    foreach ($fails as $f) {
+        echo "FAIL: $f\n";
+    }
+    exit(1);
+}
+echo "PASS: pre-boundary dates are marked additively -- value, sort and "
+    . "export untouched\n";
+exit(0);


### PR DESCRIPTION
Stage 2 of the UTC storage boundary. #1496 fixed what a stored date **means** from now on; it deliberately did not touch what the old ones mean, because five clocks wrote them and no sweep can tell which. The only thing left is to say so where somebody is reading one — this is that half, as specified in `docs/development/utc-storage-boundary.md` §2.7.

## Additive, everywhere

The value renders as it always did and the marker sits after it. Sorting and filtering keep working on the raw value, which is the honest behavior: within the pre-boundary era the values are mutually consistent with each other.

## Why the two display sites work differently

Because putting the marker in the value is a bug FOG has already shipped twice. A grid cell's data is escaped into the cell, is what sorting and filtering compare, and is what the CSV/Excel buttons export — markup put there prints as tags and rides into the download (#1245, #1446). `renderInfoCard()` is the same shape; its docblock already says a page wanting markup there must grow an explicit opt-in "rather than smuggling it through a value".

**Grids get a sibling key.** `displayDates()` writes `<column>__unadjusted => true` from the **stored** value, immediately before replacing it with the display one. Order is the whole thing: flag second and every row is classified against the wrong string, silently, in the direction that says "already UTC". `fog.common.js` reads the flag in `rowCallback` and appends the glyph to the cell's DOM. `rowCallback` rather than a `columnDefs` render because ten list pages define their own renders.

**The info card gets a plain-text marker** that survives `htmlspecialchars`, plus one line of prose at the foot of the card — printed once, and only when something above it actually carries a marker. A standing disclaimer on every edit page would be noise on the overwhelming majority of them, where every date is post-boundary.

The sentence naming the zone is built once in `StorageEpoch::note()`, so all three sites say the same thing and the msgid is a literal `xgettext` can see. One assembled in JS never reaches the `.pot`; one built at runtime from a variable never translates (#1090). The pre-commit hook picking it up into every `.po` in this diff is that working.

## Verified live

The shipped `fogMarkUnadjusted()` extracted from the committed file and run against the real host grid on a populated date column (`lastcheckin`):

| | before | after |
|---|---|---|
| cell text | `2026-08-30 14:46:12` | `2026-08-30 14:46:12*` |
| cell data | `2026-08-30 14:46:12` | **unchanged** |
| sort data | `2026-08-30 14:46:12` | **unchanged** |
| CSV export | `2026-08-30 14:46:12` | **unchanged** |

Plus: the tooltip carries the sentence, a second call adds no second glyph (Scroller and Responsive redraw rows constantly), and a row without the flag is untouched.

## Gate

`tests/unadjusted-dates-are-marked-not-converted.test.php`. All eight mutations go red:

- flagging *after* the value is rewritten instead of before
- dropping the non-API guard on the note
- dropping the redraw idempotence guard
- stashing the note on a DataTables `Api` instead of on `settings` (an `Api` is constructed per call, so the property is gone by the next one)
- the info card explaining unconditionally
- `dateOrNever()` no longer marking
- `MARKER` becoming markup
- the msgid assembled from a variable

## Not here

The REST sibling field (`createdTimeAdjusted: false`) the proposal also specifies. It changes the API contract and has to be described in `OpenAPI::_entitySchema()`, which is its own change with its own review surface. `displayDates()` and `unadjustedNote()` both stay gated on the request being a non-API one until then, so nothing about REST moves in this PR.

The admin-facing page still needs filing to `fog-docs`; that's next.

`FOG_BCACHE_VER` 345 → 346.