### PR TITLE
Stop persisting a grid's row selection to the user's preferences

### DIFF
--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -297,6 +297,26 @@ function fogStateKey(settings) {
  * entirely: a filter someone typed is not something to persist server-side
  * on their behalf.
  *
+ * A SELECTION is the same thing with teeth. DataTables Select registers its
+ * own stateSaveParams handler that writes `select.rows` -- the row ids -- into
+ * every save, and a matching stateLoadParams that re-selects them and calls
+ * state.save() again. Nothing here asked for that and nothing here reads it.
+ * Left in, three hosts ticked on Friday come back ticked on Monday, from
+ * whichever machine you next sign in on, because this store is server-side and
+ * lasts a year. Every bulk action on the page reads rows({selected: true}), so
+ * what is restored is not a view of the list -- it is a loaded gun pointed at
+ * rows the person in front of it did not choose, sitting somewhere down an
+ * 86-row virtual scroll where they cannot see it.
+ *
+ * Verified on the lab server before this was written: selecting three hosts
+ * POSTed `select: {rows: ["#211","#48","#49"], ...}` to
+ * system/userpref/dt.host.list.dataTable, and the next load came up with three
+ * rows selected and their checkboxes ticked.
+ *
+ * Select's restore is guarded on `void 0 !== l.select`, so dropping the key
+ * makes it a clean no-op rather than an error -- and skips the extra
+ * state.save() it fires on every page load.
+ *
  * @param {object} state the state DataTables wants saved
  *
  * @return {object} a copy safe to store
@@ -343,10 +363,11 @@ function fogApplyOrder(api) {
   }
   api.order(wanted).draw(false);
 }
-function fogStripStateSearch(state) {
+function fogStripVolatileState(state) {
   var copy = $.extend(true, {}, state), i;
   delete copy.search;
   delete copy.searchBuilder;
+  delete copy.select;
   for (i = 0; i < (copy.columns || []).length; i++) {
     delete copy.columns[i].search;
   }
@@ -623,7 +644,7 @@ var shouldReAuth,
       // affordance -- "I like filtering from the headers" -- and remembering
       // that is not the same as remembering a question somebody asked once.
       // The terms are still cleared when the row closes, and still stripped
-      // from the saved layout; see fogStripStateSearch().
+      // from the saved layout; see fogStripVolatileState().
       fogAffordanceStore(dt, 'searchrow', on);
     }
   },
@@ -3992,8 +4013,10 @@ $.fn.registerTable = function(onSelect, opts) {
     colReorder: true,
     // Column order, which columns are showing, page length and sort now
     // persist per user, through the preference store rather than
-    // localStorage -- see stateSaveCallback below. Searches are deliberately
-    // NOT part of it; fogStripStateSearch() says why.
+    // localStorage -- see stateSaveCallback below. Searches and the row
+    // SELECTION are deliberately NOT part of it; fogStripVolatileState() says
+    // why. The selection in particular is put there by the Select extension
+    // itself, not by anything here, so it has to be taken back out.
     stateSave: true,
     // Long enough that a layout survives a holiday. DataTables discards a
     // state older than this, which is the escape hatch if a saved layout ever
@@ -4010,7 +4033,7 @@ $.fn.registerTable = function(onSelect, opts) {
       // ours to fix here. The key survives any reordering, and fogApplyOrder()
       // puts the sort back where it belongs once the table is up.
       data.fogOrder = fogOrderKeys(settings, data.order);
-      value = JSON.stringify(fogStripStateSearch(data));
+      value = JSON.stringify(fogStripVolatileState(data));
       if (!key) {
         return;
       }
@@ -4050,7 +4073,7 @@ $.fn.registerTable = function(onSelect, opts) {
           // -- or by localStorage before this shipped -- can carry a saved
           // search, and restoring one invisibly is the failure this whole
           // arrangement is written to avoid.
-          callback(fogStripStateSearch(JSON.parse(raw)));
+          callback(fogStripVolatileState(JSON.parse(raw)));
         } catch (e) {
           // A corrupt or truncated value means "no saved layout", not a
           // broken table. JSON.parse throwing here would otherwise take out

--- a/packages/web/management/js/fog/fog.filters.js
+++ b/packages/web/management/js/fog/fog.filters.js
@@ -3,7 +3,7 @@
  *
  * A filter someone SAVED and then PICKED is a different thing from a filter
  * silently restored on their behalf. The layout state deliberately drops
- * searches on the way out (fogStripStateSearch in fog.common.js) because a
+ * searches on the way out (fogStripVolatileState in fog.common.js) because a
  * restored filter looks exactly like missing data -- you open Hosts, see 4 of
  * 4000, and nothing on screen says why. Everything here is built around
  * keeping that distinction true:

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -131,7 +131,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 397);
-        define('FOG_BCACHE_VER', 348);
+        define('FOG_BCACHE_VER', 349);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/tests/datatable-state-persistence.test.php
+++ b/tests/datatable-state-persistence.test.php
@@ -24,6 +24,14 @@
  *    stock DataTables 2.0.8 and ColReorder 2.0.3 using the library's own
  *    localStorage callbacks, so the compensation has to live here.
  *
+ * ...and one that fails LOUDLY, in the wrong hands. DataTables Select writes
+ * the selected row ids into every state save of its own accord and re-selects
+ * them on load. Nothing here asked for it and nothing here reads it, but every
+ * bulk action on a list page reads rows({selected: true}) -- so a selection
+ * made on one machine on Friday comes back armed on another on Monday, out of
+ * sight down a virtual scroll. It has to be stripped, and stripped by name,
+ * because it is not this code that puts it there.
+ *
  * Usage: php tests/datatable-state-persistence.test.php
  * Exit status 0 = pass, 1 = fail.
  */
@@ -63,25 +71,26 @@ if (!preg_match('#fogPrefFetch\(key, function\(err, value\)#', $load)) {
 // ------------------------------------------------------- the timestamp
 
 if (!preg_match(
-    '#function fogStripStateSearch\(state\) \{(.*?)\n\}#s',
+    '#function fogStripVolatileState\(state\) \{(.*?)\n\}#s',
     $js,
     $m
 )) {
-    $fails[] = 'fogStripStateSearch() not found';
+    $fails[] = 'fogStripVolatileState() not found';
 } else {
     if (preg_match('#delete\s+copy\.time#', $m[1])) {
-        $fails[] = 'fogStripStateSearch() deletes the state timestamp; '
+        $fails[] = 'fogStripVolatileState() deletes the state timestamp; '
             . 'DataTables drops a state that has no time and the saved '
             . 'layout can never be restored';
     }
-    // What it MUST still strip: a stored search would be reapplied invisibly.
-    foreach (['search', 'searchBuilder'] as $stripped) {
+    // What it MUST still strip: a stored search would be reapplied invisibly,
+    // and a stored selection would be reapplied invisibly AND acted on.
+    foreach (['search', 'searchBuilder', 'select'] as $stripped) {
         if (!preg_match('#delete\s+copy\.' . $stripped . '\b#', $m[1])) {
-            $fails[] = "fogStripStateSearch() no longer strips $stripped";
+            $fails[] = "fogStripVolatileState() no longer strips $stripped";
         }
     }
     if (!preg_match('#delete\s+copy\.columns\[i\]\.search#', $m[1])) {
-        $fails[] = 'fogStripStateSearch() no longer strips per-column search';
+        $fails[] = 'fogStripVolatileState() no longer strips per-column search';
     }
 }
 


### PR DESCRIPTION
Select three hosts on Friday and they come back selected on Monday — from whichever machine you next sign in on, checkboxes ticked.

## Where it comes from

Not from FOG. DataTables Select registers its own handlers:

```js
c.on("stateSaveParams", function (e, t, l) {
    l.select = {};
    l.select.rows = c.rows({selected: true}).ids(true).toArray();
    ...
}).on("stateLoadParams", t)   // t re-selects them, then calls c.state.save()
```

FOG's `stateSaveCallback` then POSTs the whole state to `system/userpref`, where `stateDuration` keeps it for a year and — because the store is server-side — it follows the user between machines.

## Verified on the lab server, before and after

Selecting three rows on the host list:

| | before | after |
|---|---|---|
| stored on the server | `select: {"rows":["#211","#48","#49"],"columns":[],"cells":[]}` | key absent |
| stored in localStorage | same | key absent |
| rows selected after a reload | **3** | 0 |
| checkboxes ticked after a reload | **3** | 0 |
| sort + column visibility after a reload | restored | restored |

## Why it matters more than the search case

A restored search was already ruled out for being invisible — you open Hosts, see 3 of 86, and nothing on screen says why. A restored selection is that with teeth: every bulk action on a list page reads `rows({selected: true})`, so what comes back is not a view of the list but a set of rows armed for Delete or Deploy that the person in front of the screen never chose, sitting somewhere down an 86-row virtual scroll where they cannot see it.

## The change

`select` is dropped alongside the searches, **on the way out and on the way in**. The second half is what clears a value an older release already stored, so there is no migration and no stale rows to clean up.

Select's restore is guarded on `void 0 !== l.select`, so the key going missing is a clean no-op rather than an error — and it skips the extra `state.save()` that restore fires on every page load.

`fogStripStateSearch()` is renamed `fogStripVolatileState()`. Its docblock always said "the parts of a DataTables state that must not be restored"; searches just stopped being all of them.

## Test

`tests/datatable-state-persistence.test.php` gains `select` to the list of keys the strip must remove, and a docblock paragraph on why. Mutation-tested to red against the strip being deleted, against stripping the wrong key, and against the function being renamed away.

`FOG_BCACHE_VER` bumped 348 → 349. Both phpstan passes clean, unscoped.

## Not changed, deliberately

Selection still survives within a visit — paging, scrolling and redraws are in-memory DataTables state and are untouched. Only the persisted copy goes. If you *do* want a selection to survive an accidental F5 on the same machine, that is a different feature (localStorage-only, short-lived, and visible on screen) and worth its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pw3TYxZtANXmPFvVk8VxbP