### PR TITLE
Skip the suite when regen pushes, as the comment already said to

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -196,7 +196,15 @@ jobs:
     #     queued. Testing this SHA would be testing a tree that no longer
     #     exists. An empty value (regen skipped) reads as not-'true' and lets
     #     the suite run, which is what fork and dev-branch pull requests need.
-    if: ${{ !cancelled() }}
+    #
+    # The second half was described here for weeks and never written into the
+    # expression, so every push that earned a regen commit paid for a full
+    # suite twice: the suite started on the pre-correction tree, regen's push
+    # raised `synchronize` mid-run, and that superseded run was cancelled and
+    # repeated against the bot's commit. The comment measures the suite at 418
+    # of a run's 447 runner-seconds, so this was very nearly the whole cost of
+    # a run, discarded, on essentially every push.
+    if: ${{ !cancelled() && needs.regen.outputs.pushed != 'true' }}
 
     uses: FOGProject/fog-workflows/.github/workflows/fogproject-tests.yml@main
 
@@ -243,7 +251,11 @@ jobs:
   phpstan:
     name: phpstan
     needs: regen
-    if: ${{ !cancelled() }}
+    # Same pair as `suite:` above, including the pushed guard, and for the same
+    # reason -- see the note there. This job runs php-cs-fixer's output through
+    # static analysis, so testing a tree regen is about to replace is the same
+    # waste here as it is there.
+    if: ${{ !cancelled() && needs.regen.outputs.pushed != 'true' }}
     runs-on: ubuntu-latest
 
     # Read-only. This job never writes to the repository -- unlike regen, which

--- a/tests/regen-push-skips-the-suite.test.php
+++ b/tests/regen-push-skips-the-suite.test.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * A regen push must SKIP the suite on that run, not race it.
+ *
+ * .github/workflows/tests.yml runs `regen` first. When it pushes a commit to
+ * the pull request's head branch, that push raises `synchronize` and starts a
+ * fresh run against the corrected tree -- so the current run's suite is
+ * testing a tree that is already gone.
+ *
+ * The guard that stops it is `needs.regen.outputs.pushed != 'true'` on both
+ * dependent jobs. It was described in the comment above `suite:` for weeks
+ * and never written into the expression, which cost a full suite on
+ * essentially every push: the suite started, regen's push superseded the run
+ * mid-flight, and everything ran again on the bot's commit. The comment puts
+ * the suite at 418 of a run's 447 runner-seconds.
+ *
+ * Both ends of the contract already existed -- fog-workflows'
+ * fogproject-pr-regen.yml declares the `pushed` output and its description
+ * says "The caller uses it to SKIP the test suite on this run". Only the
+ * caller was missing.
+ *
+ * WHY THIS READS `if:` LINES RATHER THAN GREPPING THE FILE
+ *
+ * The comment above the guard QUOTES the guard, so a file-wide search for
+ * `pushed != 'true'` passes on the documentation with the expression deleted
+ * -- a gate that reads its own docs. Only lines that are actually an `if:`
+ * key are considered here.
+ *
+ * WHAT MUST NOT BREAK
+ *
+ * `!cancelled()` has to stay. A `needs:` imposes an implicit success(), so
+ * without it a regen that FAILED or was SKIPPED -- fork pull request, wrong
+ * base, denylisted head, or ANY merge_group event, where regen's condition
+ * reads a null github.event.pull_request -- would take the suite with it.
+ * None of the required contexts would ever report and the pull request would
+ * be unmergeable. On a merge_group that is precisely the hang that stranded
+ * GH-1514 in the queue at AWAITING_CHECKS.
+ *
+ * The empty case is the one that carries that: regen skipped leaves `pushed`
+ * unset, and '' != 'true' is TRUE, so the suite runs. The guard may only ever
+ * suppress the suite when a push actually happened.
+ *
+ * Usage: php tests/regen-push-skips-the-suite.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$repo = dirname(__DIR__);
+$file = $repo . '/.github/workflows/tests.yml';
+$src = is_file($file) ? (string)file_get_contents($file) : '';
+
+// Only real `if:` keys -- never a comment that happens to quote one.
+$conditions = [];
+foreach (preg_split('#\r?\n#', $src) as $line) {
+    if (preg_match('#^\s+if:\s*(.+?)\s*$#', $line, $m)) {
+        $conditions[] = $m[1];
+    }
+}
+
+// The two guarded jobs, by the condition they must carry. regen's own `if:`
+// is a multi-line block scalar (`if: >-`) and so is not one of these.
+$guarded = array_values(
+    array_filter(
+        $conditions,
+        function ($c) {
+            return false !== strpos($c, 'cancelled()');
+        }
+    )
+);
+
+$results = [];
+
+$results[] = [
+    '' !== $src,
+    'the workflow is readable',
+];
+
+$results[] = [
+    2 === count($guarded),
+    'exactly two jobs hang off regen (suite and phpstan), found '
+        . count($guarded),
+];
+
+// THE FIX. Both must actually carry the guard, in the expression rather than
+// in the prose above it.
+$withGuard = array_values(
+    array_filter(
+        $guarded,
+        function ($c) {
+            return (bool)preg_match(
+                "#needs\.regen\.outputs\.pushed\s*!=\s*'true'#",
+                $c
+            );
+        }
+    )
+);
+$results[] = [
+    count($guarded) > 0 && count($withGuard) === count($guarded),
+    "both carry needs.regen.outputs.pushed != 'true', so a regen push "
+        . 'skips this run instead of racing it',
+];
+
+// And must keep !cancelled(), or a skipped regen -- every merge_group event
+// included -- takes the suite with it and nothing ever reports.
+$withCancelGuard = array_values(
+    array_filter(
+        $guarded,
+        function ($c) {
+            return false !== strpos($c, '!cancelled()');
+        }
+    )
+);
+$results[] = [
+    count($guarded) > 0 && count($withCancelGuard) === count($guarded),
+    'both keep !cancelled(), so a skipped or failed regen cannot strand '
+        . 'the required contexts',
+];
+
+// The guard must be a NEGATIVE test against 'true'. Written as
+// `== 'false'` it would suppress the suite whenever regen is skipped --
+// exactly backwards, and unmergeable on forks and in the merge queue.
+$results[] = [
+    0 === count(
+        array_filter(
+            $guarded,
+            function ($c) {
+                return (bool)preg_match(
+                    "#needs\.regen\.outputs\.pushed\s*==#",
+                    $c
+                );
+            }
+        )
+    ),
+    "the guard tests != 'true' rather than == anything, so an unset output "
+        . '(regen skipped) still runs the suite',
+];
+
+// Both jobs must still depend on regen at all; the guard reads its output.
+$results[] = [
+    2 === preg_match_all('#^\s+needs:\s*regen\s*$#m', $src),
+    'both jobs still declare needs: regen, which is what makes the output '
+        . 'readable',
+];
+
+$failed = 0;
+foreach ($results as [$passed, $why]) {
+    echo $passed ? "  ok    $why\n" : "  FAIL  $why\n";
+    $failed += $passed ? 0 : 1;
+}
+echo "\n";
+if ($failed > 0) {
+    echo 'FAIL (' . $failed . ' of ' . count($results) . " assertions)\n";
+    exit(1);
+}
+echo 'PASS (' . count($results) . " assertions)\n";

--- a/tests/us-spelling.test.php
+++ b/tests/us-spelling.test.php
@@ -79,6 +79,13 @@ $allowed = [
     // spelling would silently lose every locale's string. Converging them
     // needs a schema step, which is a migration and not a spelling fix.
     "(5,'Cancelled'",
+    // GitHub Actions' OWN function name, quoted by the workflow gate in
+    // tests/regen-push-skips-the-suite.test.php. There is no `canceled()`
+    // alternative -- the expression language spells it this way -- and that
+    // test exists to match the expression the workflow actually carries, so
+    // the string cannot be rewritten without the assertion ceasing to mean
+    // anything.
+    'cancelled()',
     // Sender and receiver for the task list's Recent pane, in one file.
     // Rewriting either alone empties the pane.
     'value="cancelled"',


### PR DESCRIPTION
`tests.yml` runs `regen` first so a correction is made *before* the suite runs rather than after it. When regen pushes, that push raises `synchronize` and starts a fresh run against the corrected tree — so the current run's suite is testing a tree that no longer exists. The comment above `suite:` describes the guard that stops it:

> `pushed != 'true'` — **the saving.** regen sets this output only when a commit actually landed on the head branch, and that push has by then raised `synchronize`, so a run against the corrected tree is already queued. Testing this SHA would be testing a tree that no longer exists.

The expression underneath it was:

```yaml
    if: ${{ !cancelled() }}
```

Only the first half was ever written into code.

So the intended saving was never taken, and what happened on every push that earned a regen commit was the **opposite** of the design: the suite started on the pre-correction tree, regen's push superseded the run mid-flight, that run was cancelled, and the whole suite ran again against the bot's commit. The same comment measures the suite at **418 of a run's 447 runner-seconds** — very nearly a whole run's cost, discarded, routinely.

Both ends of the contract already existed. `fog-workflows`' `fogproject-pr-regen.yml` declares the output, and its own description says *"The caller uses it to SKIP the test suite on this run"*. Only the caller was missing.

`phpstan` carries the same pair, for the reason its comment already gives: it has to see the tree regen will actually leave behind.

## What must not break, and why the guard is a negative test

An unset output has to mean **run**. regen is skipped on a fork PR, on the wrong base, on a denylisted head — and on every `merge_group` event, where its condition reads a null `github.event.pull_request`. In all of those `pushed` is `''`, and `'' != 'true'` is TRUE, so the suite runs.

Written the other way round — `== 'false'` — the suite would be suppressed exactly when regen is skipped, no required context would ever report, and nothing could merge. On a `merge_group` that is precisely the hang that stranded #1514 in the queue at `AWAITING_CHECKS`.

`!cancelled()` stays for the same family of reasons: a `needs:` imposes an implicit `success()`, so without it a failed or skipped regen takes the suite with it.

## Testing

`tests/regen-push-skips-the-suite.test.php` reads `if:` **keys** rather than grepping the file, and that is load-bearing here: the comment above the guard *quotes* the guard, so a file-wide search for `pushed != 'true'` passes on the documentation with the expression deleted. Not hypothetical — that is mutation M1, and it is the same trap that caught a different test in this tree earlier today.

Verified by mutation, all five red:

| Mutation | Restores |
|---|---|
| guard deleted from both, comment left intact | the bug exactly as it shipped |
| guard removed from one job only | phpstan still races the push |
| sense inverted to `== 'false'` | unmergeable on forks and in the queue |
| `!cancelled()` dropped | #1514's queue hang |
| `needs: regen` removed | output unreadable, guard silently always-true |

`us-spelling` gets one allowlist entry. `cancelled()` is the Actions function's own name and there is no `canceled()` alternative, so a test whose whole job is matching the real expression cannot spell it the US way. The one place the word appeared as an ordinary variable name was renamed instead — an allowlist should cover a string that *cannot* change.

230/230 suite, both phpstan passes clean.

## This PR is its own demonstration

Workflows for a `pull_request` are read from the merge of head into base, so this change applies to this pull request. If regen pushes here, `suite` and `phpstan` should report **skipped** on that first run and run once on the second — rather than starting, being cancelled, and repeating.
