### PR TITLE
Reach every node that has a page class, not just the ones in the sidebar

### DIFF
--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -694,17 +694,7 @@ abstract class FOGPage extends FOGBase
         // enforcement point either way.
         self::$pluginIsAvailable = $pluginSysOn && count($hookMenu ?: []) > 0;
 
-        $knownNodes = self::fastmerge(
-            $knownNodes,
-            [
-                'home',
-                'logout',
-                'hwinfo',
-                'client',
-                'schema',
-                'ipxe'
-            ]
-        );
+        $knownNodes = self::knownNodes($knownNodes);
 
         if ($node
             && !in_array($node, $knownNodes)
@@ -715,6 +705,52 @@ abstract class FOGPage extends FOGBase
         $main = self::_buildMenuStructure($menu);
         $hookMain = self::_buildMenuStructure($hookMenu);
         return $main;
+    }
+    /**
+     * Nodes that have a page class but no sidebar entry.
+     *
+     * `ipxe` earns its place for a different reason from the rest: it IS a
+     * sidebar node, so it arrives through $menuNodes anyway, and naming it
+     * here only keeps it reachable if that entry is ever removed.
+     *
+     * @var string[]
+     */
+    const NODES_WITHOUT_MENU_ENTRY = ['ipxe'];
+    /**
+     * Every node the known-node guard will let through.
+     *
+     * The guard in buildMainMenuItems() redirects an unrecognized $node to
+     * the dashboard, and it runs from Page::render() -- i.e. AFTER
+     * FOGPageManager has already dispatched and the page has echoed itself
+     * into the output buffer. So a node missing from this list does not 404
+     * and does not deny: it renders, is discarded, and the browser lands back
+     * on the dashboard. On screen that is indistinguishable from clicking a
+     * link that does nothing, which is how `impersonate` shipped broken.
+     *
+     * Authorization::exemptNodes() is merged in rather than the guard keeping
+     * its own copy of the same names. That list is already the answer to "is
+     * this a real node that carries its own gate instead of a permission",
+     * and every entry it holds -- home, logout, hwinfo, client, schema --
+     * was independently written out here too, which is exactly the
+     * duplication that let a seventh entry be added to one and not the other.
+     * It is the runtime-merged accessor, not the constant, so a plugin's own
+     * exempt node (ADR 0009) is reachable for the same reason.
+     *
+     * This is presentation only. FOGPageManager::render() remains the
+     * enforcement point, and a node reaching dispatch still has to pass
+     * Authorization::requirePagePermission().
+     *
+     * @param string[] $menuNodes nodes that do have a sidebar entry
+     *
+     * @return string[]
+     */
+    public static function knownNodes(array $menuNodes = [])
+    {
+        return self::fastmerge(
+            $menuNodes,
+            self::NODES_WITHOUT_MENU_ENTRY,
+            Authorization::exemptNodes()
+        );
     }
     /**
      * Builds the menu structure.

--- a/tests/menu-guard-reaches-every-page-node.test.php
+++ b/tests/menu-guard-reaches-every-page-node.test.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * A node with a page class must survive the known-node guard.
+ *
+ * FOGPage::buildMainMenuItems() redirects any $node absent from its known
+ * list back to the dashboard. It runs from Page::render() -- AFTER
+ * FOGPageManager::render() has dispatched and the page has echoed itself
+ * into the output buffer -- so a missing node does not 404 and does not
+ * deny. It renders, is discarded, and the browser lands on the dashboard.
+ *
+ * On screen that is indistinguishable from a link that does nothing, and
+ * there is no log line, no status code and no message. That is how
+ * `impersonate` shipped: the page class registered, the permission check
+ * passed, index() built its card, and the guard threw the whole thing away
+ * because the node has no sidebar entry.
+ *
+ * Two properties, and the split matters:
+ *
+ *   (a) EVERY node declared by a *.page.php is reachable. This is the
+ *       general invariant and it fails for whichever node is next.
+ *   (b) The guard's list is DERIVED from Authorization::exemptNodes()
+ *       rather than keeping its own copy of the same names. Asserted by
+ *       calling FOGPage::knownNodes() -- the function the guard itself
+ *       calls -- so removing the merge makes this red. A test that merely
+ *       re-computed the union would pass on the broken code, because it
+ *       would be checking its own arithmetic rather than the guard's.
+ *
+ * MUTATION-VERIFIED:
+ *
+ *   drop Authorization::exemptNodes() from knownNodes() -> (b) and the
+ *       impersonate/logout/hwinfo arms of (a) red
+ *   remove 'impersonate' from Authorization::EXEMPT_NODES -> (a) red for
+ *       impersonate
+ *   restore the old hardcoded literal list in place of knownNodes() -> (b)
+ *       red
+ *
+ * Usage: php tests/menu-guard-reaches-every-page-node.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+use FOG\Auth\Authorization;
+use FOG\Base\FOGPage;
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('menu-guard');
+FogTestHarness::fakeDb();
+
+$fails = [];
+$checks = 0;
+
+/**
+ * Record one assertion.
+ *
+ * By reference rather than through `global`, matching the sibling test
+ * files: a global write is invisible to static analysis, so the final
+ * `count($fails)` reads as always-zero and the whole failure path is
+ * reported as dead code.
+ *
+ * @param string   $label  what was being asserted
+ * @param bool     $cond   whether it held
+ * @param string[] $fails  collected failures
+ * @param int      $checks assertions run
+ *
+ * @return void
+ */
+function check($label, $cond, array &$fails, &$checks)
+{
+    $checks++;
+    if (!$cond) {
+        $fails[] = $label;
+    }
+}
+
+$web = dirname(__DIR__) . '/packages/web';
+
+/*
+ * The sidebar's own nodes, read out of the $menu literal in
+ * buildMainMenuItems(). Parsed rather than called: building the real menu
+ * needs a signed-in user, the hook manager and a database, and none of that
+ * changes which keys the literal declares.
+ *
+ * Bounded to the function body so the parse cannot drift into an unrelated
+ * array further down the file.
+ */
+$src = (string)file_get_contents($web . '/src/Base/FOGPage.php');
+$start = strpos($src, 'public static function buildMainMenuItems');
+$end = strpos($src, 'public static function knownNodes');
+check(
+    'buildMainMenuItems and knownNodes are both present in FOGPage',
+    false !== $start && false !== $end && $end > $start,
+    $fails,
+    $checks
+);
+$body = (false !== $start && false !== $end)
+    ? substr($src, $start, $end - $start)
+    : '';
+preg_match_all("#^\s{12}'([a-z0-9_]+)' => \[#m", $body, $m);
+$menuNodes = $m[1];
+/*
+ * Plus the ones inserted conditionally rather than declared in the literal
+ * -- `plugin` is added by arrayInsertAfter() only when FOG_PLUGINSYS_ENABLED
+ * is on. It is a sidebar node whenever the feature exists, so the guard is
+ * doing the right thing by redirecting it when the feature is off; what it
+ * must not do is redirect it when the feature is on.
+ */
+preg_match_all(
+    "#arrayInsertAfter\(\s*'[a-z0-9_]+',\s*\\\$menu,\s*'([a-z0-9_]+)'#",
+    $body,
+    $ins
+);
+$menuNodes = array_merge($menuNodes, $ins[1]);
+check(
+    'the sidebar menu literal parsed to a plausible node list',
+    count($menuNodes) > 10,
+    $fails,
+    $checks
+);
+
+/*
+ * (a) EVERY page class's node reaches dispatch.
+ *
+ * A page class is the definition of "this node exists": FOGPageManager
+ * registers one only when its declared $node equals the requested one, so a
+ * node no page class declares is genuinely unreachable and SHOULD redirect.
+ */
+$known = FOGPage::knownNodes($menuNodes);
+$pageNodes = [];
+foreach ((array)glob($web . '/lib/pages/*.page.php') as $file) {
+    $text = (string)file_get_contents($file);
+    if (!preg_match("#public\s+\\\$node\s*=\s*'([a-z0-9_]+)'#", $text, $n)) {
+        continue;
+    }
+    $pageNodes[$n[1]] = basename($file);
+}
+check(
+    'the page classes parsed to a plausible node list',
+    count($pageNodes) > 10,
+    $fails,
+    $checks
+);
+foreach ($pageNodes as $node => $file) {
+    check(
+        "$file declares node '$node', which the menu guard redirects away",
+        in_array($node, $known, true),
+        $fails,
+        $checks
+    );
+}
+
+/*
+ * (b) The guard DERIVES its escapes from the exempt-node list.
+ *
+ * Every exempt node is by definition a real node that carries its own gate
+ * instead of a permission, which is precisely the set most likely to have no
+ * sidebar entry. Before this was derived, five of them were written out by
+ * hand in the guard as well -- and the sixth and seventh, `login` and
+ * `impersonate`, were not.
+ *
+ * Asserted through knownNodes() with an EMPTY menu, so a name that only
+ * survives because it also has a sidebar entry cannot mask a missing merge.
+ */
+$escapes = FOGPage::knownNodes();
+foreach (Authorization::exemptNodes() as $exempt) {
+    check(
+        "exempt node '$exempt' is not reachable when it has no menu entry",
+        in_array($exempt, $escapes, true),
+        $fails,
+        $checks
+    );
+}
+
+/*
+ * And the guard still redirects something that is genuinely not a node --
+ * otherwise the fix would be "let everything through", which loses the
+ * stale-bookmark behavior the guard exists for.
+ */
+check(
+    'an unknown node is treated as known',
+    !in_array('nosuchnode', FOGPage::knownNodes($menuNodes), true),
+    $fails,
+    $checks
+);
+
+if (count($fails)) {
+    fwrite(STDERR, 'FAIL (' . count($fails) . " of $checks checks)\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+fwrite(STDOUT, "PASS ($checks checks)\n");
+exit(0);


### PR DESCRIPTION
## The bug

Clicking **Impersonate a user** landed straight back on the dashboard. The page class registered, `Authorization::can('impersonate.start')` returned true, `index()` built its card — and then `FOGPage::buildMainMenuItems()` threw all of it away.

```php
if ($node && !in_array($node, $knownNodes)) {
    self::redirect('../management/index.php');
}
```

That guard runs from `Page::render()` — **after** `FOGPageManager::render()` has dispatched and the page has echoed itself into the output buffer. So a node missing from the list does not 404 and does not deny. It renders, is discarded, and the browser lands on the dashboard. No status code, no message, nothing in any log. On screen it is indistinguishable from a link that does nothing.

Reproduced by driving the real function per node:

```
home        : renders
host        : renders
logout      : renders
ipxe        : renders
impersonate : REDIRECTED to dashboard
nosuchnode  : REDIRECTED to dashboard
```

`impersonate` behaved exactly like a node that does not exist.

## Why it was there to be hit

`$knownNodes` was the sidebar's own keys plus a hardcoded literal:

```php
['home', 'logout', 'hwinfo', 'client', 'schema', 'ipxe']
```

Five of those six are `Authorization::EXEMPT_NODES` entries, written out a second time by hand. **That duplication is the bug.** A node reachable only from the user dropdown — `logout` is the existing example — has to be named in both places, and nothing anywhere said so. `impersonate` was the seventh exempt node and the first to be added after the two lists had drifted; `login` is the sixth and was already missing.

## The fix

The escapes are now derived. `FOGPage::knownNodes()` merges the sidebar's nodes with `Authorization::exemptNodes()`, leaving only `ipxe` as a literal — and that one only as insurance, since it is a sidebar node anyway.

`exemptNodes()` rather than the constant, so a plugin's own exempt node is reachable for the same reason (ADR 0009).

**Presentation only.** `FOGPageManager::render()` remains the enforcement point, a node reaching dispatch still passes `requirePagePermission()`, and an unknown node still redirects — which is what the guard is for, and is asserted.

## Test

`tests/menu-guard-reaches-every-page-node.test.php`, 38 checks, pinning two things:

- **(a)** every node declared by a `*.page.php` survives the guard — the general invariant, which fails for whichever node is next rather than for this one;
- **(b)** the escapes come from `exemptNodes()` rather than a copy, asserted by calling `knownNodes()` itself. A test that re-computed the union would pass on the broken code, because it would be checking its own arithmetic instead of the guard's.

Writing (a) immediately surfaced `plugin`, which is inserted by `arrayInsertAfter()` when `FOG_PLUGINSYS_ENABLED` is on rather than declared in the literal — a real sidebar node the first parse could not see, not a second bug.

Mutation-verified:

| mutation | result |
|---|---|
| drop the `exemptNodes()` merge from `knownNodes()` | 10 checks red |
| remove `impersonate` from `EXEMPT_NODES` | 2 checks red |

End to end, the same repro script against a shadow tree carrying only this one changed file, same database:

```
impersonate : renders
nosuchnode  : REDIRECTED to dashboard
```

`bash tests/run-all.sh` → 234 passed, 0 failed. Both phpstan passes clean.

## Downstream

No route class added or removed, so FogApi's hardcoded class list is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135Lu8hmugc8hDwKZig7Q2z
