### PR TITLE
Arm auto-merge with the App token, not GITHUB_TOKEN

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -96,12 +96,51 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # THE APP TOKEN IS LOAD BEARING. This job does not work with
+      # secrets.GITHUB_TOKEN, and its failure mode is the worst kind: nothing
+      # errors, and the pull request never merges.
+      #
+      # GitHub will not start a workflow run from an event caused by
+      # GITHUB_TOKEN. That is the platform's anti-recursion rule and it is
+      # deliberate -- without it, a workflow that pushes a commit would
+      # trigger itself forever.
+      #
+      # Arming auto-merge makes GitHub enqueue the pull request later, and the
+      # enqueue is attributed to whoever armed it. Armed with GITHUB_TOKEN, the
+      # `merge_group` event that enqueue raises therefore starts NOTHING. The
+      # queue branch is created, tests.yml never runs against it, none of the
+      # required contexts is ever reported, and the entry sits in
+      # AWAITING_CHECKS until the ruleset's check_response_timeout_minutes (60)
+      # ejects it. Waiting cannot help: there is nothing left to arrive.
+      #
+      # OBSERVED, not deduced. On 2026-08-30, #1519, #1520 and #1521 were
+      # enqueued by hand and dispatched within seconds; #1522 and #1523 were
+      # enqueued by github-actions[bot] through this job and never dispatched
+      # at all -- zero workflow runs and zero check runs on the queue commit.
+      # Dequeuing #1522 and re-arming it as a human dispatched it in six
+      # seconds. The only variable was who did the enqueuing.
+      #
+      # An App token is not subject to the rule, which is why the regen job in
+      # tests.yml already mints one to push its commit. Same App, same org
+      # variable and secret; tests.yml passes `secrets: inherit`, which is what
+      # makes FOG_WORKFLOWS_PRIVATE_KEY resolvable here.
+      #
+      # A fork pull request has no secrets, so this step cannot mint anything
+      # there. That is already handled by the same-repo guard on the job.
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.FOG_WORKFLOWS_APPID }}
+          private-key: ${{ secrets.FOG_WORKFLOWS_PRIVATE_KEY }}
+          owner: FOGProject
+          repositories: "fogproject"
+
       # --merge, not the default, and not squash or rebase. The ruleset allows
       # merge commits ONLY, and asking for a method it forbids fails rather
       # than falling back.
       - name: Enable auto-merge
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ github.event.pull_request.number }}
         # DELIBERATELY NOT continue-on-error.
         #

--- a/tests/automerge-arms-safely.test.php
+++ b/tests/automerge-arms-safely.test.php
@@ -63,6 +63,37 @@ $results[] = [
     'and arms auto-merge rather than merging on the spot',
 ];
 
+// THE TOKEN. This is the one assertion here whose failure produces no error
+// anywhere -- the job goes green, auto-merge is armed, the pull request is
+// enqueued, and it then never merges.
+//
+// GitHub will not start a workflow run from an event caused by GITHUB_TOKEN.
+// The enqueue auto-merge performs is attributed to whoever armed it, so armed
+// with GITHUB_TOKEN the `merge_group` event starts nothing: the queue branch
+// is created, tests.yml never runs against it, no required context is ever
+// reported, and the entry sits in AWAITING_CHECKS until the ruleset's
+// 60-minute timeout ejects it.
+//
+// Observed on 2026-08-30: #1519/#1520/#1521 enqueued by hand dispatched in
+// seconds; #1522 and #1523 enqueued by this job never dispatched at all. The
+// only variable was who enqueued.
+//
+// An App token is exempt, which is why regen in tests.yml already mints one.
+$results[] = [
+    false === strpos($code, 'secrets.GITHUB_TOKEN'),
+    'it does not arm with GITHUB_TOKEN, whose enqueue can never trigger '
+        . 'the merge queue checks',
+];
+$results[] = [
+    false !== strpos($code, 'actions/create-github-app-token')
+        && (bool)preg_match(
+            '#GH_TOKEN:\s*\$\{\{\s*steps\.app-token\.outputs\.token#',
+            $code
+        ),
+    'it arms with the fog-workflows App token, which is exempt from the '
+        . 'anti-recursion rule',
+];
+
 // The draft opt-out, and the trigger that makes lifting it work.
 $results[] = [
     (bool)preg_match('#!\s*github\.event\.pull_request\.draft#', $code),


### PR DESCRIPTION
Arm auto-merge with the App token, not GITHUB_TOKEN

A pull request armed by this job is enqueued and then never merges. The
queue branch is created, no workflow runs against it, no required context
is ever reported, and the entry sits in AWAITING_CHECKS until the
ruleset's check_response_timeout_minutes (60) ejects it. Nothing errors.
Waiting cannot help, because there is nothing left to arrive.

CAUSE

GitHub will not start a workflow run from an event caused by
GITHUB_TOKEN. That is the platform's anti-recursion rule and it is
deliberate -- without it a workflow that pushes a commit would trigger
itself forever.

Auto-merge makes GitHub enqueue the pull request later, and the enqueue
is attributed to whoever armed it. Armed with GITHUB_TOKEN, the
merge_group event that enqueue raises therefore starts nothing at all --
including tests.yml, which is the only workflow supplying the eight
required contexts.

EVIDENCE

  PR    enqueued by             merge_group run
  1519  mastacontrola           dispatched
  1520  mastacontrola           dispatched
  1521  mastacontrola           dispatched
  1522  github-actions[bot]     NONE
  1522  mastacontrola (requeue) dispatched, 6 seconds later
  1523  github-actions[bot]     NONE

On both bot-enqueued entries the queue commit had zero workflow runs and
zero check runs:

    gh api repos/.../actions/runs?head_sha=<queue sha> --jq .total_count
    0

The only variable was who did the enqueuing. #1522 merged as soon as it
was dequeued and re-armed by a human.

FIX

Mint the fog-workflows App token and arm with that. App tokens are not
subject to the rule, which is why the regen job in tests.yml already
mints one to push its commit -- same App, same org variable and secret.
tests.yml passes `secrets: inherit`, which is what makes
FOG_WORKFLOWS_PRIVATE_KEY resolvable here.

A fork pull request has no secrets and so cannot mint anything, which the
job's existing same-repo guard already covers.

TEST

Two assertions added to tests/automerge-arms-safely.test.php: the
workflow must not reference secrets.GITHUB_TOKEN, and GH_TOKEN must come
from the app-token step.

  mutation                          result
  GH_TOKEN back to GITHUB_TOKEN     2 red
  app-token step deleted            1 red

Both were run. This is the assertion in that file whose failure is
completely silent -- the job goes green and the pull request simply never
merges -- so it is the one most worth pinning.

NOTE ON LANDING THIS ONE

This pull request is itself armed by the broken version of the file, so
it will need dequeuing and re-arming by hand once, like #1522. Every one
after it enqueues correctly.

Co-Authored-By: Claude <noreply@anthropic.com>
