### PR TITLE
Account menu, and ask the real administrator whether a span may start

### DIFF
--- a/packages/web/lib/pages/impersonatemanagement.page.php
+++ b/packages/web/lib/pages/impersonatemanagement.page.php
@@ -13,7 +13,6 @@
 
 namespace FOG;
 
-use FOG\Auth\Authorization;
 use FOG\Auth\Identity;
 use FOG\Base\FOGPage;
 use FOG\Items\User;
@@ -68,7 +67,7 @@ class ImpersonateManagement extends FOGPage
     public function index(...$args)
     {
         $this->title = _('Impersonate a user');
-        if (!Authorization::can(Identity::PERMISSION)) {
+        if (!Identity::canStart()) {
             self::setMessage(
                 _('You do not have permission to impersonate users.'),
                 _('Permission denied'),
@@ -103,7 +102,7 @@ class ImpersonateManagement extends FOGPage
      */
     public function startModalAjax(...$args)
     {
-        if (!Authorization::can(Identity::PERMISSION)) {
+        if (!Identity::canStart()) {
             echo '<p class="text-body-secondary">'
                 . \Initiator::e(
                     _('You do not have permission to impersonate users.')

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -501,7 +501,11 @@ function fogAffordanceRestore(dt, name, apply) {
  * next navigation would read as broken.
  */
 function fogBindTimezonePicker() {
-  var modal = document.getElementById('tzModal');
+  // #prefsModal, not #tzModal: the timezone picker now shares the preferences
+  // dialog with the theme choices. Missing this rename is a silent failure --
+  // the dialog still opens and the select still renders, it just never loads
+  // the stored value and Save does nothing.
+  var modal = document.getElementById('prefsModal');
   if (!modal) {
     return;
   }

--- a/packages/web/management/js/fog/theme.js
+++ b/packages/web/management/js/fog/theme.js
@@ -50,35 +50,22 @@
             detail: { dark: theme === 'dark' }
         }));
 
-        var toggle = document.getElementById('themeToggle');
-        if (!toggle) {
+        // The picker used to be a navbar dropdown whose ICON carried the
+        // state, so this also rewrote that icon and its title. The three
+        // choices now live in the preferences dialog, where the tick below is
+        // the state display and there is no icon to keep in step.
+        //
+        // What survives is the carrier: a hidden element holding the STORED
+        // preference, which is not always the value on <html> -- '' means the
+        // browser resolved it, and the tick has to distinguish "system, which
+        // happens to be dark" from "dark". Its absence is also how this file
+        // recognizes the login page, which has no session and so no stored
+        // preference to read or write.
+        var carrier = document.getElementById('themePref');
+        if (!carrier) {
             return;
         }
-        toggle.setAttribute('data-theme-pref', pref);
-
-        // The icon shows the state the user is IN, not the action a click
-        // performs -- with three states there is no single next action, and a
-        // half-filled circle is the only honest icon for "whatever the system
-        // says".
-        var icon = toggle.querySelector('i');
-        if (icon) {
-            if (pref === 'dark') {
-                icon.className = 'far fa-moon';
-            } else if (pref === 'light') {
-                icon.className = 'far fa-sun';
-            } else {
-                icon.className = 'fas fa-circle-half-stroke';
-            }
-        }
-        var label = toggle.getAttribute(
-            pref === 'dark'
-                ? 'data-label-dark'
-                : (pref === 'light' ? 'data-label-light' : 'data-label-system')
-        ) || '';
-        if (label) {
-            toggle.setAttribute('title', label);
-            toggle.setAttribute('aria-label', label);
-        }
+        carrier.setAttribute('data-theme-pref', pref);
 
         // Tick the chosen row. invisible rather than d-none so the three rows
         // keep the same width and the menu does not jump as the tick moves.
@@ -101,14 +88,14 @@
     }
 
     document.addEventListener('DOMContentLoaded', function () {
-        var toggle = document.getElementById('themeToggle');
-        if (!toggle) {
+        var carrier = document.getElementById('themePref');
+        if (!carrier) {
             // The login page: no session, so no preference to read or write.
             // The pre-paint script has already resolved the system value.
             return;
         }
 
-        var pref = toggle.getAttribute('data-theme-pref') || '';
+        var pref = carrier.getAttribute('data-theme-pref') || '';
 
         // One-time adoption of the choice made when the theme lived in a
         // cookie. Only when the user has no stored preference yet, so it can

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -591,6 +591,10 @@ msgid "Accessed By"
 msgstr "Zugriff von"
 
 #, fuzzy
+msgid "Account"
+msgstr "Zugriffskontrollen"
+
+#, fuzzy
 msgid "Account Name"
 msgstr "Zugriffskontrollen"
 
@@ -3896,6 +3900,9 @@ msgstr "Stündlich"
 msgid "Hours field is invalid"
 msgstr "Stundenwert ist nicht gültig"
 
+msgid "How FOG looks to you. \"System\" follows whatever your device is set to."
+msgstr ""
+
 msgid "How each column may be filtered, keyed by the column name: \"date\", \"num\", \"string\", or false where the column may not be searched at all. Derived from the column type on the server, so it is answerable without reading any rows."
 msgstr ""
 
@@ -4236,8 +4243,13 @@ msgstr ""
 msgid "Impersonate a user"
 msgstr ""
 
-msgid "Impersonate another"
-msgstr ""
+#, fuzzy
+msgid "Impersonate another user"
+msgstr "Sitzungsname"
+
+#, fuzzy
+msgid "Impersonate user"
+msgstr "Imagezuordnung"
 
 #, fuzzy
 msgid "Impersonating"
@@ -5163,6 +5175,10 @@ msgstr "Log-Viewer"
 #, fuzzy
 msgid "Log entry type filter"
 msgstr "Drucker-Update fehlgeschlagen!"
+
+#, fuzzy
+msgid "Log out"
+msgstr "Log-Viewer"
 
 msgid "Log out and sign in as an administrator"
 msgstr ""
@@ -6705,6 +6721,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preferences"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -7694,9 +7713,6 @@ msgstr "Name der Speichergruppe"
 #, fuzzy
 msgid "Set failed"
 msgstr "Service-Update fehlgeschlagen"
-
-msgid "Set your display timezone"
-msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -9157,15 +9173,6 @@ msgid "The web application can read the following private keys. It should not be
 msgstr ""
 
 msgid "Theme"
-msgstr ""
-
-msgid "Theme: dark"
-msgstr ""
-
-msgid "Theme: follow system"
-msgstr ""
-
-msgid "Theme: light"
 msgstr ""
 
 msgid "There are"
@@ -10763,6 +10770,10 @@ msgstr ""
 #, fuzzy
 msgid "images to a storage group"
 msgstr "bildet ab zu einer Speichergruppe"
+
+#, php-format
+msgid "impersonated by %s"
+msgstr ""
 
 #, fuzzy
 msgid "in"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -595,6 +595,10 @@ msgid "Accessed By"
 msgstr "Accessed By"
 
 #, fuzzy
+msgid "Account"
+msgstr "All Access Controls"
+
+#, fuzzy
 msgid "Account Name"
 msgstr "All Access Controls"
 
@@ -3897,6 +3901,9 @@ msgstr "Hourly"
 msgid "Hours field is invalid"
 msgstr "Hour value is not valid"
 
+msgid "How FOG looks to you. \"System\" follows whatever your device is set to."
+msgstr ""
+
 msgid "How each column may be filtered, keyed by the column name: \"date\", \"num\", \"string\", or false where the column may not be searched at all. Derived from the column type on the server, so it is answerable without reading any rows."
 msgstr ""
 
@@ -4237,8 +4244,13 @@ msgstr ""
 msgid "Impersonate a user"
 msgstr ""
 
-msgid "Impersonate another"
-msgstr ""
+#, fuzzy
+msgid "Impersonate another user"
+msgstr "Session Name"
+
+#, fuzzy
+msgid "Impersonate user"
+msgstr "Image Association"
 
 #, fuzzy
 msgid "Impersonating"
@@ -5161,6 +5173,10 @@ msgstr "Log Viewer"
 #, fuzzy
 msgid "Log entry type filter"
 msgstr "Printer update failed!"
+
+#, fuzzy
+msgid "Log out"
+msgstr "Log Viewer"
 
 msgid "Log out and sign in as an administrator"
 msgstr ""
@@ -6702,6 +6718,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preferences"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -7691,9 +7710,6 @@ msgstr "Storage Group Name"
 #, fuzzy
 msgid "Set failed"
 msgstr "Service update failed"
-
-msgid "Set your display timezone"
-msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -9152,15 +9168,6 @@ msgid "The web application can read the following private keys. It should not be
 msgstr ""
 
 msgid "Theme"
-msgstr ""
-
-msgid "Theme: dark"
-msgstr ""
-
-msgid "Theme: follow system"
-msgstr ""
-
-msgid "Theme: light"
 msgstr ""
 
 msgid "There are"
@@ -10756,6 +10763,10 @@ msgstr ""
 #, fuzzy
 msgid "images to a storage group"
 msgstr "Primary Storage Group"
+
+#, php-format
+msgid "impersonated by %s"
+msgstr ""
 
 #, fuzzy
 msgid "in"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -597,6 +597,10 @@ msgid "Accessed By"
 msgstr "Exitoso"
 
 #, fuzzy
+msgid "Account"
+msgstr "impresora iPrint"
+
+#, fuzzy
 msgid "Account Name"
 msgstr "impresora iPrint"
 
@@ -3965,6 +3969,9 @@ msgstr "Cada hora"
 msgid "Hours field is invalid"
 msgstr "tipo de tarea no es válida"
 
+msgid "How FOG looks to you. \"System\" follows whatever your device is set to."
+msgstr ""
+
 msgid "How each column may be filtered, keyed by the column name: \"date\", \"num\", \"string\", or false where the column may not be searched at all. Derived from the column type on the server, so it is answerable without reading any rows."
 msgstr ""
 
@@ -4314,8 +4321,13 @@ msgstr ""
 msgid "Impersonate a user"
 msgstr ""
 
-msgid "Impersonate another"
-msgstr ""
+#, fuzzy
+msgid "Impersonate another user"
+msgstr "Nombre de sesión"
+
+#, fuzzy
+msgid "Impersonate user"
+msgstr "Asociación para la imagen"
 
 #, fuzzy
 msgid "Impersonating"
@@ -5266,6 +5278,10 @@ msgstr "FOG Visor de registro"
 #, fuzzy
 msgid "Log entry type filter"
 msgstr "actualización de la impresora ha fallado!"
+
+#, fuzzy
+msgid "Log out"
+msgstr "FOG Visor de registro"
 
 msgid "Log out and sign in as an administrator"
 msgstr ""
@@ -6836,6 +6852,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preferences"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -7840,9 +7859,6 @@ msgstr "Nombre del grupo de almacenamiento"
 #, fuzzy
 msgid "Set failed"
 msgstr "actualización de servicio no pudo"
-
-msgid "Set your display timezone"
-msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -9334,15 +9350,6 @@ msgid "The web application can read the following private keys. It should not be
 msgstr ""
 
 msgid "Theme"
-msgstr ""
-
-msgid "Theme: dark"
-msgstr ""
-
-msgid "Theme: follow system"
-msgstr ""
-
-msgid "Theme: light"
 msgstr ""
 
 #, fuzzy
@@ -10940,6 +10947,10 @@ msgstr ""
 #, fuzzy
 msgid "images to a storage group"
 msgstr "Grupo de almacenamiento primaria"
+
+#, php-format
+msgid "impersonated by %s"
+msgstr ""
 
 #, fuzzy
 msgid "in"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -591,6 +591,10 @@ msgid "Accessed By"
 msgstr "Zugriff von"
 
 #, fuzzy
+msgid "Account"
+msgstr "Zugriffskontrollen"
+
+#, fuzzy
 msgid "Account Name"
 msgstr "Zugriffskontrollen"
 
@@ -3896,6 +3900,9 @@ msgstr "Stündlich"
 msgid "Hours field is invalid"
 msgstr "Stundenwert ist nicht gültig"
 
+msgid "How FOG looks to you. \"System\" follows whatever your device is set to."
+msgstr ""
+
 msgid "How each column may be filtered, keyed by the column name: \"date\", \"num\", \"string\", or false where the column may not be searched at all. Derived from the column type on the server, so it is answerable without reading any rows."
 msgstr ""
 
@@ -4236,8 +4243,13 @@ msgstr ""
 msgid "Impersonate a user"
 msgstr ""
 
-msgid "Impersonate another"
-msgstr ""
+#, fuzzy
+msgid "Impersonate another user"
+msgstr "Sitzungsname"
+
+#, fuzzy
+msgid "Impersonate user"
+msgstr "Imagezuordnung"
 
 #, fuzzy
 msgid "Impersonating"
@@ -5164,6 +5176,10 @@ msgstr "Log-Viewer"
 #, fuzzy
 msgid "Log entry type filter"
 msgstr "Drucker-Update fehlgeschlagen!"
+
+#, fuzzy
+msgid "Log out"
+msgstr "Log-Viewer"
 
 msgid "Log out and sign in as an administrator"
 msgstr ""
@@ -6706,6 +6722,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preferences"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -7695,9 +7714,6 @@ msgstr "Name der Speichergruppe"
 #, fuzzy
 msgid "Set failed"
 msgstr "Service-Update fehlgeschlagen"
-
-msgid "Set your display timezone"
-msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -9158,15 +9174,6 @@ msgid "The web application can read the following private keys. It should not be
 msgstr ""
 
 msgid "Theme"
-msgstr ""
-
-msgid "Theme: dark"
-msgstr ""
-
-msgid "Theme: follow system"
-msgstr ""
-
-msgid "Theme: light"
 msgstr ""
 
 msgid "There are"
@@ -10764,6 +10771,10 @@ msgstr ""
 #, fuzzy
 msgid "images to a storage group"
 msgstr "bildet ab zu einer Speichergruppe"
+
+#, php-format
+msgid "impersonated by %s"
+msgstr ""
 
 #, fuzzy
 msgid "in"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -596,6 +596,10 @@ msgid "Accessed By"
 msgstr "Consulté par"
 
 #, fuzzy
+msgid "Account"
+msgstr "Tous les contrôles d'accès"
+
+#, fuzzy
 msgid "Account Name"
 msgstr "Tous les contrôles d'accès"
 
@@ -3899,6 +3903,9 @@ msgstr "horaire"
 msgid "Hours field is invalid"
 msgstr "valeur Heure est pas valide"
 
+msgid "How FOG looks to you. \"System\" follows whatever your device is set to."
+msgstr ""
+
 msgid "How each column may be filtered, keyed by the column name: \"date\", \"num\", \"string\", or false where the column may not be searched at all. Derived from the column type on the server, so it is answerable without reading any rows."
 msgstr ""
 
@@ -4239,8 +4246,13 @@ msgstr ""
 msgid "Impersonate a user"
 msgstr ""
 
-msgid "Impersonate another"
-msgstr ""
+#, fuzzy
+msgid "Impersonate another user"
+msgstr "Nom de session"
+
+#, fuzzy
+msgid "Impersonate user"
+msgstr "Association Image"
 
 #, fuzzy
 msgid "Impersonating"
@@ -5163,6 +5175,10 @@ msgstr "Log Viewer"
 #, fuzzy
 msgid "Log entry type filter"
 msgstr "mise à jour de l'imprimante a échoué!"
+
+#, fuzzy
+msgid "Log out"
+msgstr "Log Viewer"
 
 msgid "Log out and sign in as an administrator"
 msgstr ""
@@ -6704,6 +6720,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preferences"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -7693,9 +7712,6 @@ msgstr "Nom du groupe de stockage"
 #, fuzzy
 msgid "Set failed"
 msgstr "mise à jour du service n'a pas"
-
-msgid "Set your display timezone"
-msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -9154,15 +9170,6 @@ msgid "The web application can read the following private keys. It should not be
 msgstr ""
 
 msgid "Theme"
-msgstr ""
-
-msgid "Theme: dark"
-msgstr ""
-
-msgid "Theme: follow system"
-msgstr ""
-
-msgid "Theme: light"
 msgstr ""
 
 msgid "There are"
@@ -10758,6 +10765,10 @@ msgstr ""
 #, fuzzy
 msgid "images to a storage group"
 msgstr "Groupe de stockage primaire"
+
+#, php-format
+msgid "impersonated by %s"
+msgstr ""
 
 #, fuzzy
 msgid "in"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -582,6 +582,10 @@ msgid "Accessed By"
 msgstr "Si accede da"
 
 #, fuzzy
+msgid "Account"
+msgstr "Controllo accessi"
+
+#, fuzzy
 msgid "Account Name"
 msgstr "Controllo accessi"
 
@@ -3793,6 +3797,9 @@ msgstr "ogni ora"
 msgid "Hours field is invalid"
 msgstr "il valore ora non è valido"
 
+msgid "How FOG looks to you. \"System\" follows whatever your device is set to."
+msgstr ""
+
 msgid "How each column may be filtered, keyed by the column name: \"date\", \"num\", \"string\", or false where the column may not be searched at all. Derived from the column type on the server, so it is answerable without reading any rows."
 msgstr ""
 
@@ -4121,8 +4128,13 @@ msgstr ""
 msgid "Impersonate a user"
 msgstr ""
 
-msgid "Impersonate another"
-msgstr ""
+#, fuzzy
+msgid "Impersonate another user"
+msgstr "Nome sessione"
+
+#, fuzzy
+msgid "Impersonate user"
+msgstr "Associazione immagine"
 
 #, fuzzy
 msgid "Impersonating"
@@ -4996,6 +5008,10 @@ msgstr "Log Viewer"
 #, fuzzy
 msgid "Log entry type filter"
 msgstr "Aggiornamento della stampante non è riuscito!"
+
+#, fuzzy
+msgid "Log out"
+msgstr "Log Viewer"
 
 msgid "Log out and sign in as an administrator"
 msgstr ""
@@ -6501,6 +6517,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preferences"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -7465,9 +7484,6 @@ msgstr "Nome gruppo di archiviazione"
 
 msgid "Set failed"
 msgstr "Fallita impostazione"
-
-msgid "Set your display timezone"
-msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -8868,15 +8884,6 @@ msgid "The web application can read the following private keys. It should not be
 msgstr ""
 
 msgid "Theme"
-msgstr ""
-
-msgid "Theme: dark"
-msgstr ""
-
-msgid "Theme: follow system"
-msgstr ""
-
-msgid "Theme: light"
 msgstr ""
 
 msgid "There are"
@@ -10416,6 +10423,10 @@ msgstr ""
 
 msgid "images to a storage group"
 msgstr "Immagini in un gruppo di archiviazione"
+
+#, php-format
+msgid "impersonated by %s"
+msgstr ""
 
 #, fuzzy
 msgid "in"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -567,6 +567,10 @@ msgid "Accessed By"
 msgstr "アクセス元"
 
 #, fuzzy
+msgid "Account"
+msgstr "リセット対象のアカウント名"
+
+#, fuzzy
 msgid "Account Name"
 msgstr "リセット対象のアカウント名"
 
@@ -3763,6 +3767,9 @@ msgstr "時間単位"
 msgid "Hours field is invalid"
 msgstr "時間の値が無効です"
 
+msgid "How FOG looks to you. \"System\" follows whatever your device is set to."
+msgstr ""
+
 msgid "How each column may be filtered, keyed by the column name: \"date\", \"num\", \"string\", or false where the column may not be searched at all. Derived from the column type on the server, so it is answerable without reading any rows."
 msgstr ""
 
@@ -4087,8 +4094,13 @@ msgstr ""
 msgid "Impersonate a user"
 msgstr ""
 
-msgid "Impersonate another"
-msgstr ""
+#, fuzzy
+msgid "Impersonate another user"
+msgstr "アクセス拒否"
+
+#, fuzzy
+msgid "Impersonate user"
+msgstr "イメージの関連付け"
 
 #, fuzzy
 msgid "Impersonating"
@@ -4958,6 +4970,10 @@ msgstr "ログビューアー"
 #, fuzzy
 msgid "Log entry type filter"
 msgstr "サイトの更新に失敗しました！"
+
+#, fuzzy
+msgid "Log out"
+msgstr "ログビューアー"
 
 msgid "Log out and sign in as an administrator"
 msgstr ""
@@ -6470,6 +6486,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preferences"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -7422,9 +7441,6 @@ msgstr "ストレージグループの説明"
 
 msgid "Set failed"
 msgstr "設定に失敗しました"
-
-msgid "Set your display timezone"
-msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -8812,15 +8828,6 @@ msgid "The web application can read the following private keys. It should not be
 msgstr ""
 
 msgid "Theme"
-msgstr ""
-
-msgid "Theme: dark"
-msgstr ""
-
-msgid "Theme: follow system"
-msgstr ""
-
-msgid "Theme: light"
 msgstr ""
 
 msgid "There are"
@@ -10361,6 +10368,10 @@ msgstr ""
 
 msgid "images to a storage group"
 msgstr "イメージをストレージグループへ"
+
+#, php-format
+msgid "impersonated by %s"
+msgstr ""
 
 #, fuzzy
 msgid "in"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -514,6 +514,9 @@ msgstr ""
 msgid "Accessed By"
 msgstr ""
 
+msgid "Account"
+msgstr ""
+
 msgid "Account Name"
 msgstr ""
 
@@ -3319,6 +3322,9 @@ msgstr ""
 msgid "Hours field is invalid"
 msgstr ""
 
+msgid "How FOG looks to you. \"System\" follows whatever your device is set to."
+msgstr ""
+
 msgid "How each column may be filtered, keyed by the column name: \"date\", \"num\", \"string\", or false where the column may not be searched at all. Derived from the column type on the server, so it is answerable without reading any rows."
 msgstr ""
 
@@ -3609,7 +3615,10 @@ msgstr ""
 msgid "Impersonate a user"
 msgstr ""
 
-msgid "Impersonate another"
+msgid "Impersonate another user"
+msgstr ""
+
+msgid "Impersonate user"
 msgstr ""
 
 msgid "Impersonating"
@@ -4379,6 +4388,9 @@ msgid "Log entry"
 msgstr ""
 
 msgid "Log entry type filter"
+msgstr ""
+
+msgid "Log out"
 msgstr ""
 
 msgid "Log out and sign in as an administrator"
@@ -5701,6 +5713,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preferences"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -6553,9 +6568,6 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr ""
 
 msgid "Set failed"
-msgstr ""
-
-msgid "Set your display timezone"
 msgstr ""
 
 msgid "Setting"
@@ -7796,15 +7808,6 @@ msgid "The web application can read the following private keys. It should not be
 msgstr ""
 
 msgid "Theme"
-msgstr ""
-
-msgid "Theme: dark"
-msgstr ""
-
-msgid "Theme: follow system"
-msgstr ""
-
-msgid "Theme: light"
 msgstr ""
 
 msgid "There are"
@@ -9198,6 +9201,10 @@ msgid "images and snapinfiles are opt-in: each is an outbound request to the nod
 msgstr ""
 
 msgid "images to a storage group"
+msgstr ""
+
+#, php-format
+msgid "impersonated by %s"
 msgstr ""
 
 msgid "in"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -595,6 +595,10 @@ msgid "Accessed By"
 msgstr "acessada por"
 
 #, fuzzy
+msgid "Account"
+msgstr "Todos os controles de acesso"
+
+#, fuzzy
 msgid "Account Name"
 msgstr "Todos os controles de acesso"
 
@@ -3898,6 +3902,9 @@ msgstr "de hora em hora"
 msgid "Hours field is invalid"
 msgstr "valor da hora não é válido"
 
+msgid "How FOG looks to you. \"System\" follows whatever your device is set to."
+msgstr ""
+
 msgid "How each column may be filtered, keyed by the column name: \"date\", \"num\", \"string\", or false where the column may not be searched at all. Derived from the column type on the server, so it is answerable without reading any rows."
 msgstr ""
 
@@ -4238,8 +4245,13 @@ msgstr ""
 msgid "Impersonate a user"
 msgstr ""
 
-msgid "Impersonate another"
-msgstr ""
+#, fuzzy
+msgid "Impersonate another user"
+msgstr "Nome da sessão"
+
+#, fuzzy
+msgid "Impersonate user"
+msgstr "Associação imagem"
 
 #, fuzzy
 msgid "Impersonating"
@@ -5162,6 +5174,10 @@ msgstr "Visualizador de log"
 #, fuzzy
 msgid "Log entry type filter"
 msgstr "atualização da impressora falhou!"
+
+#, fuzzy
+msgid "Log out"
+msgstr "Visualizador de log"
 
 msgid "Log out and sign in as an administrator"
 msgstr ""
@@ -6703,6 +6719,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preferences"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -7692,9 +7711,6 @@ msgstr "Nome do grupo de armazenamento"
 #, fuzzy
 msgid "Set failed"
 msgstr "atualização do Service falhou"
-
-msgid "Set your display timezone"
-msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -9153,15 +9169,6 @@ msgid "The web application can read the following private keys. It should not be
 msgstr ""
 
 msgid "Theme"
-msgstr ""
-
-msgid "Theme: dark"
-msgstr ""
-
-msgid "Theme: follow system"
-msgstr ""
-
-msgid "Theme: light"
 msgstr ""
 
 msgid "There are"
@@ -10757,6 +10764,10 @@ msgstr ""
 #, fuzzy
 msgid "images to a storage group"
 msgstr "Grupo de armazenamento primário"
+
+#, php-format
+msgid "impersonated by %s"
+msgstr ""
 
 #, fuzzy
 msgid "in"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -595,6 +595,10 @@ msgid "Accessed By"
 msgstr "通过访问"
 
 #, fuzzy
+msgid "Account"
+msgstr "所有访问控制"
+
+#, fuzzy
 msgid "Account Name"
 msgstr "所有访问控制"
 
@@ -3898,6 +3902,9 @@ msgstr "每小时"
 msgid "Hours field is invalid"
 msgstr "小时值无效"
 
+msgid "How FOG looks to you. \"System\" follows whatever your device is set to."
+msgstr ""
+
 msgid "How each column may be filtered, keyed by the column name: \"date\", \"num\", \"string\", or false where the column may not be searched at all. Derived from the column type on the server, so it is answerable without reading any rows."
 msgstr ""
 
@@ -4238,8 +4245,13 @@ msgstr ""
 msgid "Impersonate a user"
 msgstr ""
 
-msgid "Impersonate another"
-msgstr ""
+#, fuzzy
+msgid "Impersonate another user"
+msgstr "会话名称"
+
+#, fuzzy
+msgid "Impersonate user"
+msgstr "图像协会"
 
 #, fuzzy
 msgid "Impersonating"
@@ -5162,6 +5174,10 @@ msgstr "日志查看器"
 #, fuzzy
 msgid "Log entry type filter"
 msgstr "打印机更新失败！"
+
+#, fuzzy
+msgid "Log out"
+msgstr "日志查看器"
 
 msgid "Log out and sign in as an administrator"
 msgstr ""
@@ -6703,6 +6719,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preferences"
+msgstr ""
+
 msgid "Preferred over mapping straight to a role: the user group holds the roles, so policy stays in one place and the directory only decides who is in which bucket."
 msgstr ""
 
@@ -7692,9 +7711,6 @@ msgstr "存储组名称"
 #, fuzzy
 msgid "Set failed"
 msgstr "服务更新失败"
-
-msgid "Set your display timezone"
-msgstr ""
 
 #, fuzzy
 msgid "Setting"
@@ -9153,15 +9169,6 @@ msgid "The web application can read the following private keys. It should not be
 msgstr ""
 
 msgid "Theme"
-msgstr ""
-
-msgid "Theme: dark"
-msgstr ""
-
-msgid "Theme: follow system"
-msgstr ""
-
-msgid "Theme: light"
 msgstr ""
 
 msgid "There are"
@@ -10757,6 +10764,10 @@ msgstr ""
 #, fuzzy
 msgid "images to a storage group"
 msgstr "主存储组"
+
+#, php-format
+msgid "impersonated by %s"
+msgstr ""
 
 #, fuzzy
 msgid "in"

--- a/packages/web/management/other/index.php
+++ b/packages/web/management/other/index.php
@@ -226,90 +226,56 @@ if ($isLoggedIn && \FOG\Auth\Identity::canStart()) : ?>
                     </li>
                 </ul>
                 <ul class="navbar-nav ms-auto">
-                    <li class="nav-item dropdown">
-                        <?php
-                        // A three-state picker, not a toggle: "follow the
-                        // system" is a state a user can choose and return to,
-                        // and a two-way toggle has nowhere to put it. Sat in
-                        // the navbar beside the clock rather than in settings
-                        // because people currently assume FOG is light-only.
-                        //
-                        // data-theme-pref carries the STORED value, which is
-                        // not always the value on <html>: '' means the browser
-                        // resolved it. theme.js needs both to tick the right
-                        // row.
-        ?>
-                        <a href="#" id="themeToggle" class="nav-link" role="button"
-                           data-bs-toggle="dropdown" aria-expanded="false"
-                           data-theme-pref="<?= Initiator::e($themePref); ?>"
-                           data-label-system="<?= _('Theme: follow system'); ?>"
-                           data-label-light="<?= _('Theme: light'); ?>"
-                           data-label-dark="<?= _('Theme: dark'); ?>"
-                           title="<?= _('Theme'); ?>"
-                           aria-label="<?= _('Theme'); ?>">
-                            <i class="far fa-moon"></i>
-                        </a>
-                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="themeToggle">
-                            <li>
-                                <button class="dropdown-item" type="button" data-theme-choice="">
-                                    <i class="fas fa-circle-half-stroke fa-fw me-2"></i><?= _('System'); ?>
-                                    <i class="fas fa-check fa-fw ms-2 theme-choice-tick invisible"></i>
-                                </button>
-                            </li>
-                            <li>
-                                <button class="dropdown-item" type="button" data-theme-choice="light">
-                                    <i class="far fa-sun fa-fw me-2"></i><?= _('Light'); ?>
-                                    <i class="fas fa-check fa-fw ms-2 theme-choice-tick invisible"></i>
-                                </button>
-                            </li>
-                            <li>
-                                <button class="dropdown-item" type="button" data-theme-choice="dark">
-                                    <i class="far fa-moon fa-fw me-2"></i><?= _('Dark'); ?>
-                                    <i class="fas fa-check fa-fw ms-2 theme-choice-tick invisible"></i>
-                                </button>
-                            </li>
-                        </ul>
-                    </li>
-                    <li class="nav-item">
-                        <a href="#" id="tzToggle" class="nav-link" role="button"
-                           data-bs-toggle="modal" data-bs-target="#tzModal"
-                           title="<?= _('Set your display timezone'); ?>"
-                           aria-label="<?= _('Set your display timezone'); ?>">
-                            <i class="far fa-clock"></i>
-                        </a>
-                    </li>
                     <?php
-                    // THE ACCOUNT MENU. One dropdown, everything about who
-                    // you are and how you stop being them.
+                    // The stored theme preference, carried for theme.js.
                     //
-                    // These were four bare navbar links -- theme, clock,
-                    // impersonation, logout -- and the impersonation ones
-                    // pushed Logout along the bar every time a span opened.
-                    // A control that moves when the mode changes is a control
-                    // people misclick, and Logout is the worst one to misclick
-                    // while wearing somebody else's account.
+                    // Hidden, and an element of its own rather than an
+                    // attribute on a control, because the three choices now
+                    // live in the preferences dialog and no navbar control
+                    // displays the theme any more. What theme.js still needs
+                    // is the STORED value, which is not the value on <html>:
+                    // '' means the browser resolved it, and the tick in the
+                    // dialog has to tell "system, which happens to be dark"
+                    // from "dark".
                     //
-                    // So the identity controls live behind one stable target,
-                    // and the menu states the identity ITSELF rather than
-                    // leaving it to be inferred from the sidebar. That is not
-                    // decoration: #impersonation-bar is four pixels of colour
-                    // and carries its text only in aria-label, so before this
-                    // there was nothing on screen that NAMED the account being
-                    // worn or the administrator wearing it.
-                    //
-                    // THE CLOCK IS THE POINT, not a garnish. The motivating
-                    // ticket for impersonation is "this user says their times
-                    // are wrong", so the menu prints the current time as that
-                    // user sees it, zone abbreviation included. Answering the
-                    // question the feature exists for should not require
-                    // navigating anywhere.
-                    //
-                    // Rendered server-side, so it is the time at page render
-                    // rather than a live clock. Deliberate: a ticking clock
-                    // needs a timer, and a self-rescheduling timer is the bug
-                    // class ADR 0012 is about. What is being checked is the
-                    // ZONE, which does not tick.
-                    $acctName = (string)self::$FOGUser->get('name');
+                    // Its ABSENCE is also how theme.js recognizes the login
+                    // page -- no session, so no preference to read or write.
+                    // Anything that moves this must keep that true.
+        ?>
+                    <span id="themePref" class="d-none"
+                          data-theme-pref="<?= Initiator::e($themePref); ?>"></span>
+                    <?php
+        // THE ACCOUNT MENU. One dropdown, everything about who
+        // you are and how you stop being them.
+        //
+        // These were four bare navbar links -- theme, clock,
+        // impersonation, logout -- and the impersonation ones
+        // pushed Logout along the bar every time a span opened.
+        // A control that moves when the mode changes is a control
+        // people misclick, and Logout is the worst one to misclick
+        // while wearing somebody else's account.
+        //
+        // So the identity controls live behind one stable target,
+        // and the menu states the identity ITSELF rather than
+        // leaving it to be inferred from the sidebar. That is not
+        // decoration: #impersonation-bar is four pixels of color
+        // and carries its text only in aria-label, so before this
+        // there was nothing on screen that NAMED the account being
+        // worn or the administrator wearing it.
+        //
+        // THE CLOCK IS THE POINT, not a garnish. The motivating
+        // ticket for impersonation is "this user says their times
+        // are wrong", so the menu prints the current time as that
+        // user sees it, zone abbreviation included. Answering the
+        // question the feature exists for should not require
+        // navigating anywhere.
+        //
+        // Rendered server-side, so it is the time at page render
+        // rather than a live clock. Deliberate: a ticking clock
+        // needs a timer, and a self-rescheduling timer is the bug
+        // class ADR 0012 is about. What is being checked is the
+        // ZONE, which does not tick.
+        $acctName = (string)self::$FOGUser->get('name');
         $acctReal = $impersonating
             ? \FOG\Auth\Identity::realUserName()
             : '';
@@ -381,6 +347,34 @@ if ($isLoggedIn && \FOG\Auth\Identity::canStart()) : ?>
                                 <a class="dropdown-item" href="../management/index.php?node=impersonate&amp;sub=end"><i class="fas fa-user-slash fa-fw me-2"></i><?= _('End impersonation'); ?></a>
                             </li>
                             <?php endif; ?>
+                            <li><hr class="dropdown-divider"></li>
+                            <?php
+                            // Theme and display timezone, which are the same
+                            // KIND of thing -- per-user preferences, stored in
+                            // userPrefs, changing what this one person sees and
+                            // nothing about what is stored or what anyone else
+                            // sees. They were two separate navbar icons, which
+                            // put a three-state picker and a modal trigger in
+                            // the chrome and said nothing about them belonging
+                            // together.
+                            //
+                            // A dialog rather than more rows in this menu:
+                            // theme is a three-way choice with a tick and
+                            // timezone is a several-hundred-option select, and
+                            // both are form controls wearing a menu's clothes.
+                            // It is also where the next per-user preference
+                            // goes without this menu growing again.
+                            //
+                            // Reached from HERE because that is what makes the
+                            // impersonation workflow one path: become the user,
+                            // open this menu, see their clock is wrong, fix it,
+                            // drop back. Preferences follow the impersonated
+                            // identity like every other read, which is the
+                            // whole point of the feature.
+        ?>
+                            <li>
+                                <a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#prefsModal"><i class="fas fa-sliders fa-fw me-2"></i><?= _('Preferences'); ?></a>
+                            </li>
                             <li><hr class="dropdown-divider"></li>
                             <li>
                                 <a class="dropdown-item" href="../management/index.php?node=logout"><i class="fas fa-right-from-bracket fa-fw me-2"></i><?= _('Log out'); ?></a>
@@ -493,14 +487,69 @@ if ('' === trim($tzDefault)) {
 }
 $tzList = \DateTimeZone::listIdentifiers();
 ?>
-                <div class="modal fade" id="tzModal" tabindex="-1" aria-labelledby="tzModalLabel" aria-hidden="true">
+                <?php
+                // PREFERENCES: everything about how THIS person sees FOG.
+                //
+                // Was #tzModal, holding the timezone alone while the theme sat
+                // in a navbar dropdown of its own. They are the same kind of
+                // thing -- per-user, stored in userPrefs, changing only what
+                // the one viewer sees -- and splitting them across two bits of
+                // chrome said otherwise.
+                //
+                // STATIC, not fetched. The impersonation picker is fetched on
+                // open because building it costs a users query and two subset
+                // tests per user; this costs a listIdentifiers() call and no
+                // database at all. Shipping it also means theme.js and
+                // fog.common.js still find their controls at DOMContentLoaded,
+                // where they bind directly -- fetching the body would break
+                // both silently, with the dialog rendering perfectly and
+                // nothing in it working.
+                //
+                // THE TWO HALVES SAVE DIFFERENTLY, deliberately. Theme applies
+                // on click and writes in the background: it is a client-side
+                // attribute flip, so waiting on the network would add lag to
+                // something that cannot fail visibly. Timezone needs Save and
+                // then reloads, because every date already on the page was
+                // rendered server-side in the old zone and cannot be relabeled
+                // in place.
+?>
+                <div class="modal fade" id="prefsModal" tabindex="-1" aria-labelledby="prefsModalLabel" aria-hidden="true">
                     <div class="modal-dialog">
                         <div class="modal-content">
                             <div class="modal-header">
-                                <h5 class="modal-title" id="tzModalLabel"><?= _('Display timezone'); ?></h5>
+                                <h5 class="modal-title" id="prefsModalLabel"><?= _('Preferences'); ?></h5>
                                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?= _('Close'); ?>"></button>
                             </div>
                             <div class="modal-body">
+                                <?php
+                // A three-state picker, not a toggle: "follow
+                // the system" is a state a user can choose and
+                // return to, and a two-way toggle has nowhere
+                // to put it.
+                //
+                // The tick is `invisible` rather than `d-none`
+                // so the three rows keep the same width and
+                // nothing shifts as it moves.
+?>
+                                <h6 class="mb-1"><?= _('Theme'); ?></h6>
+                                <p class="text-body-secondary small">
+                                    <?= _('How FOG looks to you. "System" follows whatever your device is set to.'); ?>
+                                </p>
+                                <div class="list-group mb-4">
+                                    <button class="list-group-item list-group-item-action d-flex align-items-center" type="button" data-theme-choice="">
+                                        <i class="fas fa-circle-half-stroke fa-fw me-2"></i><?= _('System'); ?>
+                                        <i class="fas fa-check fa-fw ms-auto theme-choice-tick invisible"></i>
+                                    </button>
+                                    <button class="list-group-item list-group-item-action d-flex align-items-center" type="button" data-theme-choice="light">
+                                        <i class="far fa-sun fa-fw me-2"></i><?= _('Light'); ?>
+                                        <i class="fas fa-check fa-fw ms-auto theme-choice-tick invisible"></i>
+                                    </button>
+                                    <button class="list-group-item list-group-item-action d-flex align-items-center" type="button" data-theme-choice="dark">
+                                        <i class="far fa-moon fa-fw me-2"></i><?= _('Dark'); ?>
+                                        <i class="fas fa-check fa-fw ms-auto theme-choice-tick invisible"></i>
+                                    </button>
+                                </div>
+                                <h6 class="mb-1"><?= _('Display timezone'); ?></h6>
                                 <p class="text-body-secondary small">
                                     <?= _('Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else.'); ?>
                                 </p>

--- a/packages/web/management/other/index.php
+++ b/packages/web/management/other/index.php
@@ -184,14 +184,15 @@ if ($isLoggedIn && $impersonating):
 // nobody opens.
 //
 // Rendered only for somebody who can actually use it, so the markup is not
-// carried on every page for every user. `$impersonating` is enough on its own
-// for the second arm: a span is open, so the permission was checked when it
-// started, and "impersonate another" must stay reachable even if the grant
-// has since been withdrawn -- otherwise the way out of a span becomes the
-// only remaining control, which is the trap the ungated exit exists to avoid.
-if ($isLoggedIn
-    && ($impersonating || Authorization::can(\FOG\Auth\Identity::PERMISSION))
-) : ?>
+// carried on every page for every user.
+//
+// Identity::canStart(), NOT Authorization::can() -- the same predicate the
+// trigger below uses, and it asks the REAL administrator. A bare can() answers
+// for the effective identity, which while a span is open is the impersonated
+// user, so wearing a roleless account withdrew the administrator's own ability
+// to swap masks. This gate and the trigger must move together: a trigger with
+// no modal opens nothing, and a modal with no trigger is dead markup.
+if ($isLoggedIn && \FOG\Auth\Identity::canStart()) : ?>
     <div class="modal fade" id="impersonate-modal" tabindex="-1"
          aria-labelledby="impersonate-modal-label" aria-hidden="true">
         <div class="modal-dialog modal-lg">
@@ -278,39 +279,113 @@ if ($isLoggedIn
                         </a>
                     </li>
                     <?php
-                    // Under the logout control, deliberately: the two things
-                    // an impersonating administrator most needs are next to
-                    // the thing they would otherwise reach for. Both are
-                    // plain links and neither is an AJAX page link -- ending
-                    // a span changes who the whole shell belongs to, so it
-                    // has to be a full render rather than a content swap.
+                    // THE ACCOUNT MENU. One dropdown, everything about who
+                    // you are and how you stop being them.
                     //
-                    // "Impersonate another" points at the picker, which is
-                    // end-then-start on submit. Never a swap: impersonation
-                    // is always exactly one level deep, so the audit never
-                    // has to answer "acting as B, who was being acted as by
-                    // A".
+                    // These were four bare navbar links -- theme, clock,
+                    // impersonation, logout -- and the impersonation ones
+                    // pushed Logout along the bar every time a span opened.
+                    // A control that moves when the mode changes is a control
+                    // people misclick, and Logout is the worst one to misclick
+                    // while wearing somebody else's account.
                     //
-                    // ENDING is a plain GET link and STARTING is a modal, and
-                    // the asymmetry is deliberate. The exit has to work for a
-                    // mask holding no roles, with no JavaScript, from any
-                    // page -- a link is the only thing that cannot be broken
-                    // by a script error. Starting is one select and one
-                    // button, which is a dialog, not a page.
-                    if ($impersonating): ?>
-                    <li class="nav-item">
-                        <a class="nav-link" href="../management/index.php?node=impersonate&amp;sub=end"><i class="fas fa-user-slash"></i> <?= _('End impersonation'); ?></a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="#" data-bs-toggle="modal" data-bs-target="#impersonate-modal"><i class="fas fa-user-group"></i> <?= _('Impersonate another'); ?></a>
-                    </li>
-                    <?php elseif (Authorization::can(\FOG\Auth\Identity::PERMISSION)): ?>
-                    <li class="nav-item">
-                        <a class="nav-link" href="#" data-bs-toggle="modal" data-bs-target="#impersonate-modal"><i class="fas fa-user-group"></i> <?= _('Impersonate a user'); ?></a>
-                    </li>
-                    <?php endif; ?>
-                    <li class="nav-item">
-                        <a class="nav-link" href="../management/index.php?node=logout"><i class="fas fa-right-from-bracket"></i> <?= _('Logout'); ?></a>
+                    // So the identity controls live behind one stable target,
+                    // and the menu states the identity ITSELF rather than
+                    // leaving it to be inferred from the sidebar. That is not
+                    // decoration: #impersonation-bar is four pixels of colour
+                    // and carries its text only in aria-label, so before this
+                    // there was nothing on screen that NAMED the account being
+                    // worn or the administrator wearing it.
+                    //
+                    // THE CLOCK IS THE POINT, not a garnish. The motivating
+                    // ticket for impersonation is "this user says their times
+                    // are wrong", so the menu prints the current time as that
+                    // user sees it, zone abbreviation included. Answering the
+                    // question the feature exists for should not require
+                    // navigating anywhere.
+                    //
+                    // Rendered server-side, so it is the time at page render
+                    // rather than a live clock. Deliberate: a ticking clock
+                    // needs a timer, and a self-rescheduling timer is the bug
+                    // class ADR 0012 is about. What is being checked is the
+                    // ZONE, which does not tick.
+                    $acctName = (string)self::$FOGUser->get('name');
+        $acctReal = $impersonating
+            ? \FOG\Auth\Identity::realUserName()
+            : '';
+        ?>
+                    <li class="nav-item dropdown">
+                        <a href="#" id="accountMenu" class="nav-link" role="button"
+                           data-bs-toggle="dropdown" aria-expanded="false"
+                           title="<?= _('Account'); ?>"
+                           aria-label="<?= _('Account'); ?>">
+                            <i class="fas fa-circle-user"></i>
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="accountMenu">
+                            <li>
+                                <h6 class="dropdown-header mb-0"><?= Initiator::e($acctName); ?></h6>
+                                <?php if ('' !== $acctReal): ?>
+                                <span class="dropdown-item-text pt-0 small text-body-secondary"><?= sprintf(_('impersonated by %s'), Initiator::e($acctReal)); ?></span>
+                                <?php endif; ?>
+                            </li>
+                            <li><hr class="dropdown-divider"></li>
+                            <li>
+                                <span class="dropdown-item-text small text-body-secondary">
+                                    <i class="far fa-clock fa-fw me-1"></i><?= Initiator::e(FOGPage::formatTime('now', 'M j, Y g:i A T')); ?>
+                                </span>
+                            </li>
+                            <?php
+                // Ordered as the two questions are actually asked:
+                // become somebody (or somebody else), then stop.
+                //
+                // TWO INDEPENDENT GATES, not one if/else. They
+                // used to be an if/elseif on $impersonating, which
+                // tied "can I start one" to "am I in one" -- and
+                // the elseif arm's bare Authorization::can() then
+                // asked the MASK, so it was only ever correct
+                // because that arm could not be reached during a
+                // span. Wearing a roleless account therefore
+                // refused the administrator their own swap, with
+                // "you do not have permission to impersonate
+                // users" -- a sentence that was true of the mask
+                // and false of the person reading it.
+                //
+                // canStart() asks the real administrator, so it
+                // answers the same whether or not a mask is in
+                // place. Ending is gated on there being a span and
+                // on NOTHING else, ever: revoke the grant mid-span
+                // and the swap disappears while the exit stays.
+                // The way out is never the control that goes
+                // missing.
+                //
+                // "Impersonate another" is end-then-start on
+                // submit, never a swap -- impersonation is always
+                // exactly one level deep, so the audit never has
+                // to answer "acting as B, who was being acted as
+                // by A".
+                if (\FOG\Auth\Identity::canStart()): ?>
+                            <li>
+                                <a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#impersonate-modal"><i class="fas fa-user-group fa-fw me-2"></i><?= $impersonating ? _('Impersonate another user') : _('Impersonate user'); ?></a>
+                            </li>
+                            <?php endif; ?>
+                            <?php
+                // A plain GET link, and it stays one. The exit has
+                // to work for a mask holding no roles, from any
+                // page, with no JavaScript -- a link is the only
+                // thing a script error cannot break. Not an AJAX
+                // page link either: ending a span changes who the
+                // whole shell belongs to, so it needs a full
+                // render rather than a content swap.
+                if ($impersonating): ?>
+                            <li>
+                                <a class="dropdown-item" href="../management/index.php?node=impersonate&amp;sub=end"><i class="fas fa-user-slash fa-fw me-2"></i><?= _('End impersonation'); ?></a>
+                            </li>
+                            <?php endif; ?>
+                            <li><hr class="dropdown-divider"></li>
+                            <li>
+                                <a class="dropdown-item" href="../management/index.php?node=logout"><i class="fas fa-right-from-bracket fa-fw me-2"></i><?= _('Log out'); ?></a>
+                            </li>
+                        </ul>
                     </li>
                 </ul>
             </div>

--- a/packages/web/src/Auth/Identity.php
+++ b/packages/web/src/Auth/Identity.php
@@ -451,6 +451,41 @@ class Identity extends FOGBase
         return '';
     }
     /**
+     * May the person actually driving this session start an impersonation?
+     *
+     * ASKS THE REAL ADMINISTRATOR, NEVER THE MASK. Authorization::can() with
+     * no user id answers for the EFFECTIVE identity, which while a span is
+     * open is the impersonated user -- and that is right for every other
+     * permission in FOG, because seeing what they see is the whole point.
+     * Starting an impersonation is the one capability that is not theirs to
+     * have: it belongs to the administrator underneath.
+     *
+     * Getting this wrong is not a lockout that announces itself. It refuses
+     * "impersonate another" with "you do not have permission to impersonate
+     * users", addressed to an administrator who plainly does, because the
+     * sentence is true of the mask it accidentally asked about. The first
+     * report of it was exactly that: alice holds no roles, so the dialog
+     * said no to the administrator wearing her.
+     *
+     * It also decides the withdrawn-grant case correctly and quietly. If the
+     * grant is revoked mid-span this goes false, so "impersonate another"
+     * disappears while "end impersonation" -- which is never permission
+     * checked, by design -- stays. The way out can never be the control that
+     * is missing.
+     *
+     * The engine already had this right: refusalReason() and begin() both
+     * take the real id explicitly. This exists so the DISPLAY gates cannot
+     * reach a different answer than the engine will, and
+     * tests/impersonation-start-gate-asks-the-real-user.test.php holds them
+     * to using it.
+     *
+     * @return bool
+     */
+    public static function canStart()
+    {
+        return Authorization::can(self::PERMISSION, self::realUserID());
+    }
+    /**
      * May this administrator impersonate this user?
      *
      * Both subset tests must pass, and two edges are decided here rather

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -131,7 +131,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 398);
-        define('FOG_BCACHE_VER', 350);
+        define('FOG_BCACHE_VER', 351);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1365,7 +1365,7 @@ parameters:
 		-
 			message: '#^Accessing self\:\:\$FOGUser outside of class scope\.$#'
 			identifier: outOfClass.self
-			count: 7
+			count: 8
 			path: packages/web/management/other/index.php
 
 		-

--- a/tests/impersonation-start-gate-asks-the-real-user.test.php
+++ b/tests/impersonation-start-gate-asks-the-real-user.test.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * Starting an impersonation is the REAL administrator's capability.
+ *
+ * Every other permission in FOG is answered for the EFFECTIVE identity,
+ * because seeing what the impersonated user sees is the entire point of the
+ * feature. Authorization::can() with no user id does exactly that, and it is
+ * right everywhere except here. Starting a span is the one capability that
+ * does not belong to the person being worn.
+ *
+ * THE BUG THIS EXISTS FOR did not look like a permission bug. Impersonating
+ * `alice`, an account holding no roles, turned "Impersonate another" into
+ * "You do not have permission to impersonate users." -- a sentence that was
+ * perfectly true of alice and false of the administrator reading it. The
+ * engine was never wrong: refusalReason() and begin() both take the real id
+ * explicitly and would have allowed it. Only the DISPLAY gates asked, and
+ * they asked the mask. So the control that refused was the control for
+ * getting out of the mask.
+ *
+ * The shell's two gates were an if/elseif on $impersonating, which hid it:
+ * the arm carrying the bare can() could not be reached during a span, so the
+ * wrong identity was only consulted once "impersonate another" existed. That
+ * is why this pins BOTH halves -- the predicate, and the fact that nothing
+ * outside Identity itself is allowed to ask the question any other way.
+ *
+ * Third half, and the one that matters most if the grant is ever revoked
+ * mid-span: ENDING must not be gated on canStart(). A withdrawn grant should
+ * remove the swap and leave the exit, never the other way round, or the mask
+ * becomes a trap.
+ *
+ * MUTATION-VERIFIED -- see the table in the pull request. Each edit was made
+ * against a scratch copy of the file and restored from that copy.
+ *
+ * Usage: php tests/impersonation-start-gate-asks-the-real-user.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+use FOG\Auth\Authorization;
+use FOG\Auth\Identity;
+use FOG\Items\User;
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('impersonation-start-gate');
+/*
+ * Nothing here queries, but User::set() logs and the logger reads a setting,
+ * so constructing even a fake user needs SOMETHING behind $DB.
+ */
+FogTestHarness::fakeDb();
+
+$fails = [];
+$checks = 0;
+
+/**
+ * Record one assertion.
+ *
+ * @param string   $label  what was being asserted
+ * @param bool     $cond   whether it held
+ * @param string[] $fails  collected failures
+ * @param int      $checks assertions run
+ *
+ * @return void
+ */
+function check($label, $cond, array &$fails, &$checks)
+{
+    $checks++;
+    if (!$cond) {
+        $fails[] = $label;
+    }
+}
+
+/**
+ * PHP source with its comments removed.
+ *
+ * Every scan below is a claim about CODE, and the comments in both files
+ * discuss Authorization::can() and Identity::PERMISSION at length precisely
+ * because getting them wrong is the bug. A raw grep would fail on its own
+ * documentation.
+ *
+ * @param string $src PHP source
+ *
+ * @return string
+ */
+function stripPhpComments($src)
+{
+    $out = '';
+    foreach (token_get_all($src) as $token) {
+        if (is_array($token)
+            && in_array($token[0], [T_COMMENT, T_DOC_COMMENT], true)
+        ) {
+            continue;
+        }
+        $out .= is_array($token) ? $token[1] : $token;
+    }
+
+    return $out;
+}
+
+/**
+ * A User object that reports the given id and name without a database.
+ *
+ * @param int    $id   the user id
+ * @param string $name the user name
+ *
+ * @return User
+ */
+function fakeUser($id, $name)
+{
+    $u = new User(0);
+    $u->set('id', $id)->set('name', $name);
+
+    return $u;
+}
+
+/*
+ * BEHAVIOR.
+ *
+ * User 1 is the administrator and holds '*'. User 7 is alice, who holds
+ * nothing. Seeding Authorization's permission cache directly keeps the whole
+ * roles/groups join out of a test that is about WHICH ID gets asked, not
+ * about how permissions are computed.
+ */
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+$_SESSION = [];
+$_SESSION[Identity::SESSION_REAL] = 1;
+$_SESSION[Identity::SESSION_MASK] = 7;
+$_SESSION[Identity::SESSION_SPAN] = str_repeat('b', 32);
+
+FogTestHarness::setStatic('Authorization', '_permCache', [1 => ['*'], 7 => []]);
+FogTestHarness::setStatic('FOGBase', 'FOGUser', fakeUser(7, 'alice'));
+
+check(
+    'canStart() answered NO to an administrator wearing a roleless account'
+    . ' -- it asked the mask instead of the real user',
+    true === Identity::canStart(),
+    $fails,
+    $checks
+);
+/*
+ * The other side of the same coin, and the reason the check above is not
+ * vacuous: a bare can() genuinely answers differently here. If this ever goes
+ * true the fixture has stopped reproducing the condition and the check above
+ * proves nothing.
+ */
+check(
+    'the fixture is not reproducing the bug: a bare Authorization::can()'
+    . ' agrees with canStart(), so nothing distinguishes them',
+    false === Authorization::can(Identity::PERMISSION),
+    $fails,
+    $checks
+);
+
+/*
+ * WITHDRAWN GRANT. Revoke the administrator's own permission mid-span and
+ * starting must stop being offered -- canStart() is not a rubber stamp for
+ * "a span is already open".
+ */
+FogTestHarness::setStatic('Authorization', '_permCache', [1 => [], 7 => []]);
+check(
+    'canStart() stayed true after the real administrator lost the grant',
+    false === Identity::canStart(),
+    $fails,
+    $checks
+);
+
+/*
+ * NO SESSION. realUserID() answers 0 and getPermissions() grants nothing to
+ * id 0, so this is belt and braces -- but it is the state every logged-out
+ * request is in, and the shell calls canStart() on all of them.
+ */
+$_SESSION = [];
+FogTestHarness::setStatic('Authorization', '_permCache', [0 => ['*']]);
+check(
+    'canStart() answered yes with no user in the session',
+    false === Identity::canStart(),
+    $fails,
+    $checks
+);
+
+/*
+ * SOURCE. Nothing outside Identity may ask this question for itself.
+ */
+$web = dirname(__DIR__) . '/packages/web';
+$files = [
+    'the page shell' => $web . '/management/other/index.php',
+    'the impersonate page' => $web . '/lib/pages/impersonatemanagement.page.php',
+];
+foreach ($files as $label => $path) {
+    $src = stripPhpComments((string)file_get_contents($path));
+    check(
+        "$label was not found, so nothing about it was checked",
+        '' !== $src,
+        $fails,
+        $checks
+    );
+    /*
+     * Matching can(...PERMISSION) in either spelling -- imported as
+     * Identity::PERMISSION, or fully qualified as the shell writes it.
+     */
+    check(
+        "$label asks Authorization::can() for Identity::PERMISSION directly."
+        . ' That answers for the EFFECTIVE user, which during a span is the'
+        . ' impersonated one. Use Identity::canStart().',
+        0 === preg_match(
+            '#Authorization::can\(\s*\\\\?(?:FOG\\\\Auth\\\\)?Identity::PERMISSION#',
+            $src
+        ),
+        $fails,
+        $checks
+    );
+    check(
+        "$label does not use Identity::canStart() at all, so its gate is"
+        . ' asking something else entirely',
+        false !== strpos($src, 'Identity::canStart()'),
+        $fails,
+        $checks
+    );
+}
+
+/*
+ * And the exit is gated on the SPAN, never on the permission. Found
+ * structurally rather than by eye: take the conditional immediately enclosing
+ * the end link and read what it tests.
+ */
+$shell = stripPhpComments((string)file_get_contents($files['the page shell']));
+$endAt = strpos($shell, 'sub=end');
+check(
+    'the page shell no longer emits an end-impersonation link at all',
+    false !== $endAt,
+    $fails,
+    $checks
+);
+if (false !== $endAt) {
+    $before = substr($shell, 0, $endAt);
+    $ifAt = strrpos($before, 'if (');
+    $guard = false === $ifAt
+        ? ''
+        : substr($before, $ifAt, (int)strpos($before, ')', $ifAt) - $ifAt + 1);
+    check(
+        'the end-impersonation link is guarded by ' . var_export($guard, true)
+        . ' -- it must be guarded by $impersonating and by nothing else.'
+        . ' Gate the exit on the permission and a revoked grant traps the'
+        . ' administrator inside the mask.',
+        false !== strpos($guard, '$impersonating')
+        && false === strpos($guard, 'canStart'),
+        $fails,
+        $checks
+    );
+}
+
+if (count($fails)) {
+    fwrite(STDERR, 'FAIL (' . count($fails) . " of $checks checks)\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+fwrite(STDOUT, "PASS ($checks checks)\n");
+exit(0);

--- a/tests/theme-user-preference.test.php
+++ b/tests/theme-user-preference.test.php
@@ -105,12 +105,35 @@ if (['', 'dark', 'light'] !== $offered) {
         . implode(',', $offered) . ')';
 }
 
-// Visible, in the navbar, beside the timezone clock -- not buried in a
-// settings page, because people assume FOG is light-only until they see it.
-if (!preg_match('/navbar-nav ms-auto.*?tzToggle/s', $shell)
-    || !preg_match('/navbar-nav ms-auto.*?themeToggle/s', $shell)
+// REACHABLE, and reachable from the chrome rather than from a settings page
+// somewhere in the tree.
+//
+// This used to assert the stronger thing -- that the picker was IN the navbar
+// beside the clock -- on the reasoning that people assume FOG is light-only
+// until they see the control. That reasoning is sound and the cost is real:
+// the choices now sit one click deeper, behind Preferences in the account
+// menu. It was moved anyway because theme and display timezone are the same
+// kind of thing (per-user, stored in userPrefs, changing only what the one
+// viewer sees) and two separate navbar icons said otherwise, while a
+// three-state picker and a several-hundred-option select are both form
+// controls rather than chrome.
+//
+// So what is pinned is what still has to be TRUE: the choices live in the
+// preferences dialog, and something in the page shell opens that dialog. A
+// dialog nothing targets is a preference nobody can change, and it fails
+// silently -- everything renders, the control is simply unreachable.
+if (!preg_match('/id="prefsModal".*?data-theme-choice/s', $shell)) {
+    $fails[] = 'the theme choices are not inside the preferences dialog';
+}
+if (false === strpos($shell, 'data-bs-target="#prefsModal"')) {
+    $fails[] = 'nothing in the page shell opens the preferences dialog';
+}
+// And theme.js reads the stored preference from the carrier the shell emits.
+// A rename on either side leaves the picker rendering and doing nothing.
+if (false === strpos($shell, 'id="themePref"')
+    || false === strpos($js, "getElementById('themePref')")
 ) {
-    $fails[] = 'the theme picker is not in the navbar beside the clock';
+    $fails[] = 'the shell and theme.js disagree about the preference carrier';
 }
 
 // --- the client side -----------------------------------------------------


### PR DESCRIPTION
Two commits. The first is a permission bug with a screenshot; the second is the UI it was found in.

## 1. The start gate asked the mask, not the administrator

Impersonating `alice`, an account holding no roles, turned **Impersonate another** into *"You do not have permission to impersonate users."* The sentence was true of alice and false of the administrator reading it — and the control that refused was the control for getting **out** of alice.

`Authorization::can()` with no user id answers for the **effective** identity, which during a span is the impersonated user. That is correct for every other permission in FOG — seeing what they see is the entire point — and wrong for exactly one. Starting a span is not a capability the person being worn has to hold.

The engine was never wrong: `refusalReason()` and `begin()` both take the real id explicitly and would have allowed it. Only the four **display** gates asked, and they asked the mask. `Identity::canStart()` now asks the real administrator, and all four use it.

**Why it hid.** The shell's gates were an `if/elseif` on `$impersonating`. The arm carrying the bare `can()` was the *not*-impersonating arm, where the mask and the real user are the same person — so it could not give a wrong answer until "impersonate another" existed to reach the other arm. The modal's own gate had a `$impersonating ||` short circuit in front of it, written for the withdrawn-grant case, which rendered the dialog and then let its body refuse. That is the screenshot.

They are now two **independent** gates:

| | gated on |
|---|---|
| ending | there being a span, and nothing else, ever |
| starting | `canStart()`, which asks the real administrator |

That also settles the withdrawn-grant case properly instead of working around it: revoke the grant mid-span and the swap disappears while the exit stays. The way out is never the control that goes missing.

## 2. One account menu, one preferences dialog

The identity controls were bare navbar links, and the impersonation ones pushed **Logout** along the bar every time a span opened. A control that moves when the mode changes is a control people misclick, and Logout is the worst one to misclick while wearing somebody else's account.

So: one dropdown under a person icon, which **states** the identity rather than leaving it to be inferred. That is not decoration — `#impersonation-bar` is four pixels of color carrying its text only in `aria-label`, so nothing on screen named the account being worn or the administrator wearing it. It also prints the current time in the viewer's own display timezone, abbreviation included: the motivating ticket for the whole feature is *"this user says their times are wrong"*, and answering that should not require navigating anywhere. Server-rendered rather than ticking — a self-rescheduling timer is the bug class ADR 0012 is about, and what is being checked is the **zone**, which does not tick.

Theme and display timezone move into one `#prefsModal` behind **Preferences**. They are the same kind of thing — per-user, stored in `userPrefs`, changing only what one viewer sees — and two separate navbar icons said otherwise, while a three-state picker and a several-hundred-option select are both form controls rather than chrome. Reaching it from the account menu is what makes the impersonation workflow one path: become the user, see their clock is wrong, fix it, drop back.

**What this costs, stated plainly.** `theme-user-preference.test.php` asserted the picker was *in the navbar beside the clock*, on the reasoning that people assume FOG is light-only until they see the control. That reasoning is sound and the cost is real — the choices now sit one click deeper. The assertion is repointed rather than deleted, and now pins what still has to be true.

**Static, not fetched.** The impersonation picker is fetched on open because building it costs a users query and two subset tests per user; this costs one `listIdentifiers()` and no database. Shipping it in the shell is also what keeps `theme.js` and `fog.common.js` working — both bind **directly** at `DOMContentLoaded`, so a fetched body would break both silently, with the dialog rendering perfectly and nothing in it working.

The two halves still save differently, deliberately: theme applies on click and writes in the background (a client-side attribute flip cannot fail visibly, so waiting on the network only adds lag); timezone needs Save and reloads, because every date on the page was rendered server-side in the old zone.

## Tests

`tests/impersonation-start-gate-asks-the-real-user.test.php`, 12 checks. The behavioral half asserts **both** that `canStart()` is true for an administrator wearing a roleless account **and** that a bare `can()` is false in the same fixture — without the second, the first would still pass if the fixture stopped reproducing the condition, and would be proving nothing.

| mutation | result |
|---|---|
| `canStart()` drops the real id | 1 red |
| shell gate reverts to a bare `can()` | 1 red |
| page class gate reverts to a bare `can()` | 1 red |
| the exit gets gated on `canStart()` too | 1 red |
| carrier renamed in the shell only | 1 red |
| nothing targets `#prefsModal` | 1 red |
| `theme.js` looks up the old id | 1 red |

The exit check is found structurally rather than by eye: it reads the conditional immediately enclosing the end link and asserts what it tests. The source scans tokenize first — both files discuss `Authorization::can()` and `Identity::PERMISSION` at length in their comments, precisely because getting them wrong is the bug, so a raw grep fails on its own documentation.

`bash tests/run-all.sh` → 237 passed, 0 failed. Both phpstan passes clean. `phpstan-baseline.neon`: the `self::$FOGUser` count for the page shell goes 7 → 8 for the account name read.

`FOG_BCACHE_VER` 350 → 351 for `theme.js` and `fog.common.js`.

## Downstream

No route class added or removed, so FogApi's hardcoded class list is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135Lu8hmugc8hDwKZig7Q2z
