### PR TITLE
Pin plugins v1.6.21, which follows ReportManagement into FOG\Pages

### DIFF
--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -144,7 +144,7 @@ class System
         // installer reads this to pick which release to download, so a given
         // FOG release ships a known set of plugins rather than whatever the
         // default branch held on the day someone installed.
-        define('FOG_PLUGINS_VERSION', 'v1.6.20');
+        define('FOG_PLUGINS_VERSION', 'v1.6.21');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already


### PR DESCRIPTION
One constant. `bin/fetch-plugins.sh` reads the pinned tag straight out of
`FOG_PLUGINS_VERSION`, so this is what decides which plugin release an install
actually fetches.

#1528 moved the last 52 flat-namespace core classes into
`src/{Pages,Hooks,Reports,Events}`, which made `\FOG\ReportManagement` into
`\FOG\Pages\ReportManagement`. Eight bundled plugin reports extend it — ldap,
location, ou, subnetgroup, taskstateedit, tasktypeedit, windowskey and
wolbroadcast —
and on today's pin they fatal with `Class "FOG\ReportManagement" not found` the
moment someone opens one. The autoloader refuses the flat spelling and logs the
correct FQCN rather than resolving it, so the failure names its own fix, but the
report page is gone.

[fog-plugins v1.6.21](https://github.com/FOGProject/fog-plugins/releases/tag/v1.6.21)
(FOGProject/fog-plugins#32) carries the eight edits. Without this bump the fix
exists and reaches nobody.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTEiBnDpNrgzu1tSqt1318
