### PR TITLE
Fix the log viewer's local-node check and a silently-empty CSRF token

### DIFF
--- a/packages/web/src/Auth/Authorization.php
+++ b/packages/web/src/Auth/Authorization.php
@@ -573,6 +573,15 @@ class Authorization extends FOGBase
             // narrowly: an audit row necessarily discloses attempted
             // usernames.
             'audit' => ['view', 'manage'],
+            // The log viewer. Third sibling under Logging, and the one that
+            // shipped without an entry here when it moved to its own node
+            // (#1507) -- so it fell into "a node absent from the registry is
+            // left alone" above, and a '*' holder saw "Create New Logviewer"
+            // and "List All Logviewers" in the sidebar for a page that only
+            // ever implements index(). No `manage`: unlike audit, there is no
+            // retention window or other setting to gate separately from
+            // reading it.
+            'logviewer' => ['view'],
             // `install` is uploading an archive -- new executable code on
             // the server, deliberately its own permission (ADR 0009).
             // create/delete are the plugin ROW, which is how one is switched

--- a/packages/web/src/Net/FOGURLRequests.php
+++ b/packages/web/src/Net/FOGURLRequests.php
@@ -768,7 +768,13 @@ class FOGURLRequests extends FOGBase
             $this->options[CURLOPT_USERPWD] = $auth;
         }
         // ---- BEGIN CSRF + session forwarding ----
-        $csrfToken = class_exists('CSRF') ? CSRF::token() : '';
+        // CSRF is namespaced (FOG\Auth\CSRF, imported above) and core classes
+        // are no longer bare-aliased into the global namespace (ADR 0013 SS2).
+        // class_exists() takes a string, which `use` does not rewrite, so
+        // class_exists('CSRF') always checked the global namespace, always
+        // got refused, and always fell back to '' -- silently sending every
+        // node-to-node request with no CSRF token at all.
+        $csrfToken = CSRF::token();
 
         // Important: release the session lock so the called script can read it
         if (session_status() === PHP_SESSION_ACTIVE) {

--- a/packages/web/status/logtoview.php
+++ b/packages/web/status/logtoview.php
@@ -171,7 +171,16 @@ $ip = trim($ip);
 if (filter_var($ip, FILTER_VALIDATE_IP) === false) {
     return print json_encode(_('IP Passed is incorrect'));
 }
-if (false !== strpos(filter_input(INPUT_SERVER, 'HTTP_HOST'), $ip)) {
+// Which storage node am I? Compare against SERVER_ADDR (the socket this
+// request actually landed on), not the client's Host header -- Host is
+// whatever name/alias the browser typed (a hostname behind OIDC, a load
+// balancer, an /etc/hosts alias), and almost never equals this node's own
+// IP as a substring. That mismatch always fell through to the "remote
+// node" branch below, which self-proxies over HTTP with no session --
+// so even the master's own logs went through an unauthenticated request
+// to itself and got rejected. SERVER_ADDR is set by the web server from
+// the actual connection, independent of how the client addressed us.
+if ($ip === filter_input(INPUT_SERVER, 'SERVER_ADDR')) {
     $str = vals(
         $reverse,
         $HookManager,


### PR DESCRIPTION
## Summary
- The log viewer decided "is this storage node me?" by checking whether the browser's `Host` header contained the node's IP as a substring. That only holds when the page is loaded via the raw IP; any hostname/alias pointing at the same box (reverse proxy, OIDC redirect target, `/etc/hosts` alias) always took the "remote node" branch and self-proxied over HTTP with no session -- so the request got rejected and the log panel stayed empty with no visible error. Fixed by comparing against `SERVER_ADDR` (the address the connection actually landed on) instead.
- That proxy path goes through `FOGURLRequests::process()`, which attached the CSRF token via `class_exists('CSRF') ? CSRF::token() : ''`. `CSRF` is namespaced (`FOG\Auth\CSRF`, already imported) and `class_exists()` takes a string that a `use` import doesn't rewrite, so this always checked the global namespace, always failed, and always sent an empty token -- every node-to-node request through this method was silently missing its CSRF token, not just this one.
- Also adds `logviewer` to `Authorization::coreRegistry()` (view-only). It shipped without an entry when it became its own node, so a `*` holder saw "Create New Logviewer" / "List All Logviewers" in the sidebar for a page that only implements `index()`.

Follow-on from #1530 -- that PR fixed the dead script path; this fixes why the log panel was still empty for anyone reaching the server by hostname instead of raw IP.

## Test plan
- [x] Reproduced live: `?node=logviewer` via a hostname (not the server's raw IP) returned "Forbidden (invalid CSRF token)" on every poll; via the raw IP it worked.
- [x] Confirmed via a diagnostic probe that `CSRF::validate()` succeeded with matching session/header tokens -- the failure was the self-proxy branch being taken at all, not a real CSRF mismatch.
- [x] Applied both fixes to the live lab and re-ran the exact failing request: log content now returns under the hostname path.
- [x] Re-verified the raw-IP path still works (no regression).
- [x] Verified the sidebar no longer shows Create/List entries for Log Viewer.

Co-Authored-By: Claude <noreply@anthropic.com>