### PR TITLE
Convert FOG service-log timestamps to the viewer's display zone

### DIFF
--- a/packages/web/status/logtoview.php
+++ b/packages/web/status/logtoview.php
@@ -44,6 +44,41 @@ if (!(isset($_POST['file'])
 $file = '';
 $lines = '';
 /**
+ * Re-labels FOG's own service-log timestamps into the viewer's display zone.
+ *
+ * FOG's service logs (Scheduler, Multicast, Image Replicator, ...) stamp
+ * every line via Service_Log_message(), which has no signed-in viewer to
+ * convert for and so always writes in the storage zone -- UTC once the
+ * storage boundary is crossed. This re-parses that exact stamp in the same
+ * zone it was written, then shows it in the requesting viewer's own display
+ * zone, same as every other date in the UI. A line that doesn't match
+ * (Apache, nginx, syslog, ...) is left untouched -- their own software chose
+ * whatever zone they carry, and this cannot know it.
+ *
+ * @param string $output raw log text, possibly spanning many lines.
+ *
+ * @return string
+ */
+function convertServiceLogTimestamps($output)
+{
+    return preg_replace_callback(
+        '/^\[(\d{2}-\d{2}-\d{2} \d{1,2}:\d{2}:\d{2} [ap]m)\]/m',
+        function ($matches) {
+            $stamp = \DateTime::createFromFormat(
+                'm-d-y g:i:s a',
+                $matches[1],
+                FOGCore::storageTimeZone()
+            );
+            if (!$stamp) {
+                return $matches[0];
+            }
+            $stamp->setTimezone(FOGCore::displayTimeZone());
+            return '['.$stamp->format('m-d-y g:i:s a').']';
+        },
+        $output
+    );
+}
+/**
  * Returns vals.
  *
  * @param int         $reverse     Log reverse or forward.
@@ -117,6 +152,7 @@ function vals($reverse, $HookManager, $lines, $file)
         );
     }
     fclose($fh);
+    $output = convertServiceLogTimestamps($output);
     if ($reverse) {
         $output = implode(
             "\n",

--- a/tests/logviewer-service-log-timezone.test.php
+++ b/tests/logviewer-service-log-timezone.test.php
@@ -65,10 +65,10 @@ $line = '[08-31-26 3:45:12 pm] Scheduler Task queued';
 if (!preg_match($pattern, $line, $m)) {
     $results[] = [false, 'the regex matches a real Service_Log_message() line'];
 } else {
-    $utc = new DateTimeZone('UTC');
-    $ny = new DateTimeZone('America/New_York');
+    $utc = new \DateTimeZone('UTC');
+    $ny = new \DateTimeZone('America/New_York');
 
-    $stamp = DateTime::createFromFormat($format, $m[1], $utc);
+    $stamp = \DateTime::createFromFormat($format, $m[1], $utc);
     $results[] = [
         false !== $stamp,
         'the stamp round-trips through DateTime::createFromFormat() -- the '
@@ -95,7 +95,7 @@ if (!preg_match($pattern, $line, $m)) {
     }
 
     // A stamp already in the viewer's own zone must come back unchanged.
-    $same = DateTime::createFromFormat($format, $m[1], $utc);
+    $same = \DateTime::createFromFormat($format, $m[1], $utc);
     if (false !== $same) {
         $same->setTimezone($utc);
         $results[] = [

--- a/tests/logviewer-service-log-timezone.test.php
+++ b/tests/logviewer-service-log-timezone.test.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * FOG's service-log lines should render in the viewer's display zone, not
+ * whatever zone the daemon happened to write them in.
+ *
+ * Service_Log_message() (packages/service/lib/service_lib.php) stamps every
+ * service-log line via FOGCore::formatTime('now', 'm-d-y g:i:s a') with no
+ * signed-in user to convert for, so it always lands in the storage zone --
+ * UTC once the storage boundary is crossed. The log viewer (status/
+ * logtoview.php) is read by a signed-in, authenticated request, so it is the
+ * one place that CAN know the viewer's own display zone -- and re-labeling
+ * the stamp there, rather than at write time, is what lets the exact same
+ * on-disk bytes read correctly for two viewers in two different zones.
+ *
+ * Apache/nginx/syslog/etc. lines never match this stamp shape and so must be
+ * left untouched -- their software chose whatever zone it carries, which
+ * this code cannot know and must not guess at.
+ *
+ * This is a static check (logtoview.php boots the whole app on require, so
+ * it cannot be included directly from a standalone test) plus a live replay
+ * of the exact regex/format pair the source uses, against the exact string
+ * Service_Log_message() produces, to catch a parsing regression the static
+ * check alone would miss.
+ *
+ * Usage: php tests/logviewer-service-log-timezone.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$repo = dirname(__DIR__);
+$src = (string)file_get_contents($repo . '/packages/web/status/logtoview.php');
+
+// [passed, what it means]
+$results = [];
+
+$results[] = [
+    (bool)preg_match('#function\s+convertServiceLogTimestamps\s*\(#', $src),
+    'logtoview.php declares convertServiceLogTimestamps()',
+];
+$results[] = [
+    (bool)preg_match('#\$output\s*=\s*convertServiceLogTimestamps\(\$output\)#', $src),
+    'vals() runs the raw file text through convertServiceLogTimestamps() '
+        . 'before returning it',
+];
+$results[] = [
+    (bool)preg_match('#FOGCore::storageTimeZone\(\)#', $src),
+    'the stamp is parsed in the zone it was actually written in, not '
+        . 'assumed to be UTC outright -- storageTimeZone() still answers a '
+        . 'pre-boundary install correctly',
+];
+$results[] = [
+    (bool)preg_match('#FOGCore::displayTimeZone\(\)#', $src),
+    'the stamp is shown in the requesting viewer\'s own display zone, the '
+        . 'same preference every other date in the UI already uses',
+];
+
+// The exact regex and DateTime format the source uses, copied rather than
+// required (see docblock) so this exercises the real parsing logic, not a
+// paraphrase of it.
+$pattern = '/^\[(\d{2}-\d{2}-\d{2} \d{1,2}:\d{2}:\d{2} [ap]m)\]/m';
+$format = 'm-d-y g:i:s a';
+
+// The exact shape Service_Log_message() writes: "[m-d-y g:i:s a] name msg".
+$line = '[08-31-26 3:45:12 pm] Scheduler Task queued';
+
+if (!preg_match($pattern, $line, $m)) {
+    $results[] = [false, 'the regex matches a real Service_Log_message() line'];
+} else {
+    $utc = new DateTimeZone('UTC');
+    $ny = new DateTimeZone('America/New_York');
+
+    $stamp = DateTime::createFromFormat($format, $m[1], $utc);
+    $results[] = [
+        false !== $stamp,
+        'the stamp round-trips through DateTime::createFromFormat() -- the '
+            . 'dash-separated m-d-y shape is NOT the same as ISO Y-m-d, and '
+            . "PHP's loose string parsing (niceDate()/toDisplay()) reads "
+            . 'dashed dates as European d-m-y, which would silently corrupt '
+            . 'this exact format',
+    ];
+
+    if (false !== $stamp) {
+        $stamp->setTimezone($ny);
+        // 2026-08-31 is EDT (UTC-4): 3:45:12 pm UTC -> 11:45:12 am EDT.
+        $results[] = [
+            '11:45:12 am' === $stamp->format('g:i:s a'),
+            'converting a known UTC stamp into America/New_York lands on '
+                . 'the correct wall-clock time (got '
+                . $stamp->format('g:i:s a') . ')',
+        ];
+        $results[] = [
+            '08-31-26' === $stamp->format('m-d-y'),
+            'the date itself is unaffected when the zone shift does not '
+                . 'cross midnight',
+        ];
+    }
+
+    // A stamp already in the viewer's own zone must come back unchanged.
+    $same = DateTime::createFromFormat($format, $m[1], $utc);
+    if (false !== $same) {
+        $same->setTimezone($utc);
+        $results[] = [
+            $m[1] === $same->format($format),
+            'a viewer whose display zone is UTC (the common, unconfigured '
+                . 'case) sees the exact same stamp -- no accidental drift '
+                . 'when there is nothing to convert',
+        ];
+    }
+}
+
+// A line from a different log entirely must never match and never be
+// touched -- this code has no idea what zone Apache or syslog wrote in.
+$apacheLine = '[Mon Aug 31 15:45:12.123456 2026] [core:error] some message';
+$results[] = [
+    !preg_match($pattern, $apacheLine),
+    'an Apache/nginx-style stamp does not match the service-log pattern '
+        . 'and so is left alone',
+];
+
+$fails = array_filter($results, function ($r) {
+    return !$r[0];
+});
+
+foreach ($results as list($passed, $desc)) {
+    printf("%s %s\n", $passed ? 'PASS:' : 'FAIL:', $desc);
+}
+
+if ($fails) {
+    exit(1);
+}
+
+echo "PASS: service-log timestamps convert into the viewer's display zone, "
+    . "other logs are left alone\n";
+exit(0);


### PR DESCRIPTION
## Summary

- FOG's service logs (Scheduler, Multicast, Image Replicator, ...) are stamped by `Service_Log_message()` (`packages/service/lib/service_lib.php`), which runs with no signed-in user to convert for and so always writes in the storage zone — UTC once the storage boundary is crossed. That's why log-viewer timestamps for these logs now read UTC regardless of the viewer.
- The log viewer (`packages/web/status/logtoview.php`) *is* an authenticated request, so it's the one place that can re-label that stamp for the actual viewer. Added `convertServiceLogTimestamps()`, called from `vals()`: it matches the exact `[m-d-y g:i:s a]` shape `Service_Log_message()` writes, re-parses it in `FOGCore::storageTimeZone()` (the zone it was actually written in), and re-renders it in `FOGCore::displayTimeZone()` — the same per-user preference (`display.timezone`) already used everywhere else in the UI.
- Lines from other logs shown in the same viewer (Apache, nginx, PHP-FPM, syslog, dnf) never match that stamp shape and are left untouched — their own software chose whatever zone they carry, which this code has no way to know.

## Test plan

- [x] `php -l packages/web/status/logtoview.php`
- [x] Added `tests/logviewer-service-log-timezone.test.php` — verifies the wiring (function exists, is called, uses `storageTimeZone()`/`displayTimeZone()`) and replays the exact regex/format pair against a real `Service_Log_message()`-shaped line: correct UTC→`America/New_York` conversion, no-op when the viewer is already UTC, and an Apache-style line is correctly ignored. `php tests/logviewer-service-log-timezone.test.php` passes.
- [ ] `phpstan` — could not run locally in this sandbox (composer install hit a GitHub auth wall); relying on CI for this one.

No REST route or `$databaseFields` changes, so no `OpenAPI::document()` update needed.

Co-Authored-By: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01T8DYNcPCuiD9EhXcpNRE1p)_