### PR TITLE
Let a plugin declare its own namespace, and stop asking for an alias

### DIFF
--- a/docs/adr/0013-flat-fog-namespace-and-the-reverse-alias-abi.md
+++ b/docs/adr/0013-flat-fog-namespace-and-the-reverse-alias-abi.md
@@ -4,6 +4,90 @@
 
 accepted
 
+## Amended 2026-08-31 — plugins are namespaced too, and the alias advice is withdrawn
+
+**Every bundled plugin class declares `FOG\Plugins\<Plugin>\<Class>`.** The
+`<Plugin>` segment is `ucfirst()` of the plugin's own directory name, applied
+mechanically with no lookup table and no exceptions, so `ldap/class/
+ldapmanager.class.php` declares `FOG\Plugins\Ldap\LDAPManager` and
+`helloworld/` gets `FOG\Plugins\Helloworld`. The subdirectory is not part of
+it: every class in one plugin shares one flat namespace, for the same reason
+core's models and managers share one — `FOGController::getManager()` is
+`qualify(shortName($this) . 'Manager')`, so a `Model\` / `Manager\` split
+would stop resolving.
+
+This reverses the clause in the 2026-08-30 amendment below:
+
+> **Nothing changes for plugins.** They keep the
+> `<plugin>/<dir>/<name>.<type>.php` shape, keep the global namespace (ADR
+> 0009), and a namespaced plugin page still requires its own `class_alias`.
+
+The first half stands and the second half does not. The file shape is
+unchanged — the discovery extensions are how a page, hook, event, report or
+task is *found*, so this is namespacing and not a second PSR-4 move — but
+plugins are no longer global and no longer need an alias.
+
+**Why the alias advice had to go rather than merely being tidied.** It was a
+rule whose failure mode was the whole admin UI. A plugin page that declared a
+namespace without aliasing itself back did not declare the class its filename
+promised; `FOGPageManager::loadPageClasses()` then called `get_class_vars()` on
+a name nothing declares, which is an uncaught `TypeError` in PHP 8, thrown from
+a constructor `management/index.php` builds before it can render anything. One
+third-party plugin, 500 on every page, recovery only from a shell. Documenting
+a footgun more clearly is not the same as removing it.
+
+**What made removing it possible.** Discovery had already been taught to route
+every derived name through `FOGBase::qualify()` (previous amendment), so there
+was exactly one place that had to learn a second map — and `qualify()` is also
+what `getClass()`'s ~520 literals, `getManager()`, `FOGPage::$childClass`,
+`Route::_newEntity()` and `Authorization::_scopeClassVars()` all go through.
+Teaching that one function meant no call site changed, in core or in the
+plugins: the roughly 150 `self::getClass('LDAPGroupManager')` literals inside
+`fog-plugins` still read exactly as they did.
+
+**Core is consulted first, and that order is the guarantee.**
+`Initiator::srcClassMap()` then `Initiator::pluginShortMap()`. Before plugins
+were namespaced the same property came from `autoload()` answering `src/` ahead
+of the plugin roots; it now has to hold one layer up, where the name is still a
+string. Its failure mode is the worst in the tree and is completely silent:
+`Authorization::_scopeClassVars()` resolves a node to its model through
+`qualify()`, so a plugin winning the bare name `host` is access control testing
+the wrong table, with nothing logged.
+
+**The map is READ from each file, never derived from its path.** This is the
+one implementation decision that is invisible in the code and load-bearing in
+the field. The path says what a plugin class *should* be called; only the file
+says whether it declares that name. Deriving would hand `qualify()` a
+`FOG\Plugins\` name for a plugin still written globally, and the
+`class_exists()` that follows would be false for a class sitting right there —
+breaking every unconverted third-party plugin at once. Because the declaration
+is read, such a plugin produces no entry, falls through to the bare-name
+`$classMap`, and loads exactly as before. **Plugins are installable artifacts
+FOG does not control (ADR 0009), so this change is additive or it is wrong.**
+
+**What plugins gain.** Two plugins may now each ship `class/settings.class.php`.
+Under the global namespace those folded to one key in `Initiator::$classMap`,
+the autoloader picked one, and the loser silently got the wrong class. Today's
+bundled tree happens to have zero duplicate basenames across all 176 plugin
+classes — that was luck, not a property. A consequence worth naming: the
+basename-collision warning in `autoload()` is now *suppressed* when both
+colliding files are namespaced plugin classes, because nothing is shadowed and
+a warning for a legal configuration is how a log stops being read.
+
+**What is unchanged, and deliberately.** Plugins still reference core by
+leading-backslash FQCN — all 403 references across the tree already did, and a
+leading backslash means the same thing inside a namespace, which is why the
+plugin-side diff is one line per file. `FOG\Plugins\` is the only prefix core
+claims: a plugin under a namespace of its own keeps the older contract and must
+still `class_alias()` itself back, because discovery still finds it by filename.
+
+**Gated by** `tests/plugin-namespace.test.php` here (the derivation, the
+autoload arm, `qualify()`'s precedence, the diagnostics, cache invalidation, and
+that a global-namespace plugin still resolves) and
+`tests/plugins-are-namespaced.test.php` in `fog-plugins` (every class file
+declares the namespace its path implies, and none declares a `class_alias`).
+Both were mutation-verified rather than merely observed green.
+
 ## Amended 2026-08-31 — decision 3's "no swap is coming" is superseded for the router
 
 **The AltoRouter fork is gone.** `lib/router/altorouter.class.php` and

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -186,6 +186,8 @@ existed keeps working untouched.
 ### 4.2 Model — `class/helloworld.class.php`
 
 ```php
+namespace FOG\Plugins\Helloworld;
+
 class HelloWorld extends \FOG\Base\FOGController
 {
     protected $databaseTable = 'helloWorld';
@@ -208,6 +210,8 @@ The manager owns table creation and **schema evolution**. This is the most
 important part to get right, so it gets its own section (§5). The shape:
 
 ```php
+namespace FOG\Plugins\Helloworld;
+
 class HelloWorldManager extends \FOG\Base\FOGManagerController
 {
     public $tablename = 'helloWorld';
@@ -503,14 +507,26 @@ Global configuration lives in the `globalSettings` table.
 
 **Read this before you write a class.** Core moved to PSR-4 under
 `packages/web/src/` and is now reachable **only by its fully qualified name**.
-Bare `FOGController`, `Host`, `Hook` no longer resolve to anything.
+Bare `FOGController`, `Host`, `Hook` no longer resolve to anything. Plugins
+have since followed core: every plugin class now declares its own namespace
+too.
 
 ### The rule
 
-**Stay in the global namespace. Reference core by its FQCN, with a leading
-backslash.** That is what every one of the bundled plugins does:
+**Declare `namespace FOG\Plugins\<Ucfirst-plugin-directory>;` at the top of
+every file, and reference core by its FQCN with a leading backslash.** The
+namespace segment is `ucfirst()` of the plugin's directory name — mechanical,
+no lookup table, no exceptions: `helloworld/` → `FOG\Plugins\Helloworld`,
+`ldap/` → `FOG\Plugins\Ldap`. The **subdirectory is not part of it** — every
+class in a plugin, whatever mix of `class/`, `pages/`, `hooks/`, `events/`,
+`reports/` and `tasks/` it ships, shares that one flat namespace.
+(`FOGController::getManager()` derives a model's manager class as
+`qualify(shortName($this) . 'Manager')`, so a model and its manager have to
+resolve in the same namespace or the derivation breaks.)
 
 ```php
+namespace FOG\Plugins\Helloworld;
+
 class HelloWorld           extends \FOG\Base\FOGController {}
 class HelloWorldManager    extends \FOG\Base\FOGManagerController {}
 class HelloWorldManagement extends \FOG\Base\FOGPage {}
@@ -518,8 +534,9 @@ class AddHelloWorldMenuItem extends \FOG\Base\Hook {}
 class HelloWorldHeartbeat  extends \FOG\Base\PluginTask {}
 ```
 
-The names are **bucketed**, matching the directory they live in — there is no
-flat `FOG\Host`. The ones a plugin actually reaches for:
+This is what every bundled plugin does now — copying one gets you the house
+style. The names you reference on core stay **bucketed**, matching the
+directory they live in under `src/` — there is no flat `FOG\Host`:
 
 | Bare name you used to write | Now |
 |---|---|
@@ -536,45 +553,75 @@ flat `FOG\Host`. The ones a plugin actually reaches for:
 | `Host`, `Image`, `User`, `TaskType`, … | `\FOG\Items\<Name>` |
 | `HostManager`, `TaskTypeManager`, … | `\FOG\Managers\<Name>Manager` |
 
-A `use` import at the top of a global-namespace file works too, and is the
-better shape if you name a class many times:
+A `use` import works too, and is the better shape if you name a class many
+times — it sits below your own `namespace` declaration, not instead of it:
 
 ```php
+namespace FOG\Plugins\Helloworld;
+
 use FOG\Base\FOGController;
 
 class HelloWorld extends FOGController {}
 ```
 
-Both are correct. The FQCN form is what the bundled plugins use, so copying one
-of them gets you the house style.
+Both forms are correct. The FQCN form is what most of the bundled plugins use,
+so copying one of them gets you the house style.
 
-### ⚠️ If you declare a namespace, you must alias yourself back
+### Discovery still works by filename
 
-The autoloader finds a **page, hook, event, report or task** by lowercasing the
-filename and expecting a class of that exact name. Those files are discovered,
-not imported — nothing ever writes their name in a `use` statement. So if you
-put one in your own namespace, the class FOG looks for does not exist and your
-page silently never registers.
+File layout does not change, and neither does the rule about it: a **page,
+hook, event, report or task** is still found by its filename, and the class
+it declares must still be named after that file — `class
+HelloWorldManagement` in `helloworldmanagement.page.php`, same as always. The
+`.page.php` / `.hook.php` / `.event.php` / `.report.php` / `.task.php` suffix
+is how the file gets found at all, so nothing moved and nothing was renamed.
+This is namespacing, not a move to PSR-4 autoloading.
 
-This is a rule about **plugin** files, and core is no longer an example of it.
-Core's pages, hooks, reports and events moved to `src/{Pages,Hooks,Reports,
-Events}` and dropped their aliases: they are found by their bucketed namespace
-now, not by basename. Your files keep the discovered shape, so they still need
-the alias. If you want a namespace, end each such file like this:
+What changed is what core does once it has found the bare name. It now reads
+each plugin file's actual `namespace` declaration and maps the plugin's bare
+short name to its namespaced FQCN, so discovery, `getClass('HelloWorld')`,
+`FOGController::getManager()`, `FOGPage::$childClass`, `Route::_newEntity()`
+and `Authorization`'s object-scope lookup all keep resolving the class from
+the bare spelling you've always used. You never have to spell the namespace
+out anywhere except the `namespace` declaration itself.
 
-```php
-namespace Vendor\HelloWorld;
+**`class_alias()` is no longer needed, and should not be used.** It used to
+be the workaround for exactly this gap: discovery derived a bare class name
+from `basename($file)`, so a plugin that declared its own namespace had to
+alias itself back into the global one or its page/hook/event/report silently
+never registered. That gap is closed at the source now — core builds the
+bare-name → FQCN map from the declaration itself — so there is nothing left
+for an alias to do, and shipping one just adds a second, redundant name for
+the same class.
 
-class HelloWorldManagement extends \FOG\Base\FOGPage { /* ... */ }
+### Backwards compatible
 
-class_alias(__NAMESPACE__ . '\\HelloWorldManagement', 'HelloWorldManagement');
-```
+A plugin that declares **no** namespace keeps working exactly as it did
+before this change. Core reads each plugin file's actual `namespace`
+declaration rather than assuming every plugin has one now — an unconverted
+third-party plugin produces no entry in the map and keeps resolving by its
+bare name, in the global namespace, same as always. Nothing here requires a
+third-party author to do anything before their plugin keeps loading.
 
-Model and manager classes are reached through `FOGBase::getClass('HelloWorld')`,
-which resolves by short name, so they have the same requirement.
+### Two plugins, one class name, no collision
 
-**The simplest correct answer is not to declare a namespace at all**, which is
-why none of the bundled plugins do.
+Because the namespace segment comes from the plugin's own directory, two
+plugins can now each ship a class called `Settings` without one shadowing the
+other. Before this, every plugin class shared one global basename keyspace —
+whichever plugin's `Settings` loaded first silently won, and the other's was
+unreachable.
+
+### The one place a bare name still bites
+
+Core resolves a bare name wherever *it* does the resolving: `getClass()`,
+`getManager()`, discovery, `$childClass`, `Route::_newEntity()`,
+`Authorization`. A class name **your own code** holds in a plain string is
+resolved exactly as written, with no such mapping behind it. So
+`self::getClass('LDAPGroupManager')` inside a plugin is fine — core resolves
+it — but a raw `new $someString` or `is_subclass_of($x, 'SomeClass')` naming
+a bare plugin class in your own code is not. Spell those fully qualified
+(`\FOG\Plugins\Ldap\LDAPGroupManager`) or route them through
+`self::getClass()` instead.
 
 ### What the failure looks like
 
@@ -600,16 +647,17 @@ line is why, and this section is the fix.
 
 ### `get_class($this)` returns a namespaced name
 
-Unchanged advice, and still the one thing that bites plugins which *produce* a
-class name rather than consume one — comparing it to a literal, building a
-column name or an array key from it, putting it in a filename or a log line:
+Unchanged advice, and now true of plugin classes too — it bites whatever
+*produces* a class name rather than consumes one: comparing it to a literal,
+building a column name or an array key from it, putting it in a filename or a
+log line:
 
 ```php
-// Wrong: 'FOG\Items\Host', and the comparison silently fails.
-if (get_class($obj) === 'Host') { /* ... */ }
+// Wrong: 'FOG\Plugins\Helloworld\HelloWorld', and the comparison silently fails.
+if (get_class($obj) === 'HelloWorld') { /* ... */ }
 
-// Right: 'Host', namespaced or not.
-if (self::shortName($obj) === 'Host') { /* ... */ }
+// Right: 'HelloWorld', namespaced or not.
+if (self::shortName($obj) === 'HelloWorld') { /* ... */ }
 ```
 
 `FOGBase::shortName()` takes an object or a class-name string, strips any
@@ -621,7 +669,10 @@ ADR 0013 originally kept a `class_alias()` in every core file re-exporting it
 into the global namespace, and called that alias the 1.6 plugin ABI. **All 202
 were deleted before 1.6.0 shipped and the ADR is amended accordingly** — there
 was no released 1.6 for the promise to have been made to, and carrying the shim
-through a major version bought compatibility with nothing.
+through a major version bought compatibility with nothing. Plugins have now
+followed the same path: the `class_alias()` a plugin author would once have
+had to write to stay reachable is gone too, for the same reason — core
+resolves the namespaced class directly instead of leaning on a shim to do it.
 
 ## 7b. Composer dependencies
 
@@ -1038,11 +1089,12 @@ an error.
 - **Core is FQCN-only.** `extends FOGController` is a fatal error, not a
   deprecation — see §7a. The autoloader logs one line naming the class and the
   name to use before the request dies, so check the error log first.
-- **A namespace of your own means aliasing yourself back.** Pages, hooks,
-  events, reports and tasks are found by filename and must declare exactly that
-  class name in the global namespace. Put one in a namespace without a
-  `class_alias()` and it never registers — no error, the feature simply is not
-  there. §7a has the shape. Not declaring a namespace avoids the whole question.
+- **Every plugin class declares `namespace FOG\Plugins\<Ucfirst-directory>;`.**
+  One flat namespace per plugin, whatever subdirectory the file lives in — a
+  model and its manager must resolve in the same one. No `class_alias()`
+  needed, not even for a page/hook/event/report/task: core maps the bare name
+  to the namespaced FQCN for you. §7a has the shape. A plugin with no
+  namespace declared keeps working unchanged.
 - **Filename = `strtolower(ClassName)` + suffix.** A mismatch means the class
   won't autoload. Silently, for most classes — but not for your manager:
   install refuses outright if `class/<name>manager.class.php` exists and does

--- a/packages/web/commons/init.php
+++ b/packages/web/commons/init.php
@@ -394,6 +394,16 @@ class Initiator
      */
     private const BRIDGE_NS = 'FOG\\';
 
+    /**
+     * The namespace prefix core hands out to plugins.
+     *
+     * A plugin class declares FOG\Plugins\<Plugin>\<Class>, where <Plugin>
+     * is its own directory name. Core claims only this prefix: a plugin under
+     * a namespace of its own, or under none at all, resolves exactly as it did
+     * before (ADR 0013).
+     */
+    private const PLUGIN_NS = 'FOG\\Plugins\\';
+
     /** In-process memo of the class-source file list. */
     private static ?array $fileList = null;
 
@@ -479,8 +489,19 @@ class Initiator
         self::$classMap = null;
         self::$srcMap = null;
         self::$srcClassMap = null;
+        self::$pluginClassMap = null;
+        self::$pluginShortMap = null;
         @unlink(
             FOG_CACHE_DIR . DS . 'filelist.'
+            . md5(implode('|', self::_scanRoots())) . '.json'
+        );
+        // The plugin map keys on the same roots and heals on the same TTL, so
+        // leaving it would mean an uploaded plugin's classes resolving by their
+        // bare name (the file list is fresh) but not by their namespaced one
+        // (this map is not) -- the plugin half-loading for up to five minutes,
+        // which is the exact failure the function above exists to prevent.
+        @unlink(
+            FOG_CACHE_DIR . DS . 'pluginmap.'
             . md5(implode('|', self::_scanRoots())) . '.json'
         );
         // src/ too. Nothing writes there at runtime today -- the plugin
@@ -586,11 +607,12 @@ class Initiator
      * TTL and its refusal to serve a name two files both claim. Under PSR-4
      * the path IS the name: src/<Bucket>/<Class>.php is FOG\<Bucket>\<Class>.
      *
-     * Only src/ is covered, and deliberately. The 46 discovery-named classes
-     * under lib/ carry their own class_alias and are not part of the alias
-     * set being retired; plugins are global-namespace by design (ADR 0009)
-     * and must keep resolving as bare names. Both fall through untouched --
-     * see FOGBase::qualify().
+     * Only src/ is covered, and deliberately. Plugins have a map of their
+     * own -- pluginClassMap() below -- because they are found by reading
+     * what each file declares rather than by deriving a name from its path,
+     * and because core has to be consulted FIRST so a plugin cannot answer a
+     * core name. Anything in neither map falls through untouched; see
+     * FOGBase::qualify().
      *
      * A useful side effect: because this is built from FOG's own tree rather
      * than from Composer's classmap, a vendored package sharing a short name
@@ -611,6 +633,286 @@ class Initiator
                 . basename($path, '.php');
         }
         return self::$srcClassMap = $map;
+    }
+
+    /**
+     * Every namespaced plugin class, by lowercased FQCN => absolute path.
+     *
+     * Plugins were the last global-namespace code in the tree. They declare
+     * `namespace FOG\Plugins\<Plugin>;` now, and this is the map that makes
+     * that name resolvable -- the mirror of srcClassMap() for the half of the
+     * tree Composer cannot see, because a plugin is installed at runtime into
+     * a directory that did not exist when the classmap was dumped (ADR 0009).
+     *
+     * Read from the file rather than derived from the path, which is the one
+     * design decision here worth stating. The path says what a plugin class
+     * SHOULD be called; only the file says whether it actually declares that
+     * name. Deriving it would hand qualify() a FOG\Plugins\ name for a plugin
+     * still written in the global namespace, and the lookup that follows would
+     * then fail on a class nothing declares -- breaking every third-party
+     * plugin that has not been converted. Those keep working precisely because
+     * a file with no FOG\Plugins\ namespace produces no entry here and falls
+     * through to the bare-name $classMap exactly as before.
+     *
+     * @var array<string, string>|null
+     */
+    private static ?array $pluginClassMap = null;
+
+    /**
+     * Lowercased short name => cased FQCN, for FOGBase::qualify().
+     *
+     * The reason this exists is the same reason srcClassMap() exists: almost
+     * nothing NAMES a class with its namespace. Roughly 150 getClass('X')
+     * literals live inside the plugins themselves, discovery derives a bare
+     * name from basename($file), and plugin models reach the REST API as the
+     * lowercase strings a plugin pushes into Route::$validClasses through the
+     * API_VALID_CLASSES hook. One lookup keeps all of them working, instead of
+     * rewriting every call site.
+     *
+     * @var array<string, string>|null
+     */
+    private static ?array $pluginShortMap = null;
+
+    /**
+     * Every namespaced plugin class, by lowercased FQCN => absolute path.
+     *
+     * @return array<string, string>
+     */
+    public static function pluginClassMap(): array
+    {
+        self::_buildPluginMaps();
+        return self::$pluginClassMap;
+    }
+
+    /**
+     * Every namespaced plugin class, by lowercased short name => cased FQCN.
+     *
+     * @return array<string, string>
+     */
+    public static function pluginShortMap(): array
+    {
+        self::_buildPluginMaps();
+        return self::$pluginShortMap;
+    }
+
+    /**
+     * Build both plugin maps from one scan, memoised and cached.
+     *
+     * Cached on the same TTL and invalidated by the same forgetClassFileList()
+     * as the file list it is built from, so a plugin installed while the
+     * server is running becomes resolvable at the same moment its files do.
+     *
+     * @return void
+     */
+    private static function _buildPluginMaps(): void
+    {
+        if (self::$pluginClassMap !== null) {
+            return;
+        }
+        $cacheFile = FOG_CACHE_DIR . DS . 'pluginmap.'
+            . md5(implode('|', self::_scanRoots())) . '.json';
+        $declared = self::_readPluginMapCache($cacheFile);
+        if ($declared === null) {
+            $declared = self::_scanPluginNamespaces();
+            self::_writeFileListCache($cacheFile, $declared);
+        }
+        $byFqcn = [];
+        $byShort = [];
+        foreach ($declared as $fqcn => $path) {
+            $byFqcn[strtolower($fqcn)] = $path;
+            $short = strtolower(substr($fqcn, strrpos($fqcn, '\\') + 1));
+            if (isset($byShort[$short])) {
+                // Two plugins declaring the same class name. This is what
+                // namespacing is FOR -- both classes exist, both resolve, and
+                // neither shadows the other -- so it is not an error. What is
+                // ambiguous is only the SHORT spelling, so say which one the
+                // short name will answer to and name the cure.
+                error_log(
+                    sprintf(
+                        'FOG autoloader: two plugins declare a class named '
+                        . '"%s" (%s and %s). Both resolve under their own '
+                        . 'namespace; the bare name resolves to the first. '
+                        . 'Spell it fully qualified where you mean the other.',
+                        $short,
+                        $byShort[$short],
+                        $fqcn
+                    )
+                );
+                continue;
+            }
+            $byShort[$short] = $fqcn;
+        }
+        self::$pluginClassMap = $byFqcn;
+        self::$pluginShortMap = $byShort;
+    }
+
+    /**
+     * Scan the plugin roots for classes declaring a FOG\Plugins\ namespace.
+     *
+     * Whole-file reads, not a bounded prefix: the namespace is always a
+     * leading statement, but the class declaration it applies to is not, and
+     * a prefix that missed the declaration would silently drop a converted
+     * class out of the map -- which is the one failure mode this method has
+     * to avoid, because such a class then resolves under NEITHER name. The
+     * whole bundled plugin tree is about a megabyte and this runs once per
+     * FILELIST_TTL, alongside a directory walk that stats the entire tree.
+     *
+     * Only the FOG\Plugins\ prefix is claimed. A plugin under a namespace of
+     * its own keeps the pre-existing contract -- it must class_alias() itself
+     * back into the global namespace, because discovery still finds it by
+     * filename -- and a plugin with no namespace at all is untouched.
+     *
+     * @return array<string, string> cased FQCN => absolute path
+     */
+    private static function _scanPluginNamespaces(): array
+    {
+        $nsPattern = '#^[ \t]*namespace[ \t]+('
+            . preg_quote(self::PLUGIN_NS, '#')
+            . '[A-Za-z0-9_\x80-\xff\\\\]+)[ \t]*;#m';
+        $clsPattern = '#^[ \t]*(?:(?:final|abstract|readonly)[ \t]+)*'
+            . '(?:class|interface|trait|enum)[ \t]+'
+            . '([A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*)#m';
+        $map = [];
+        $seen = [];
+        foreach (self::classFileList() as $path) {
+            if (!self::_isPluginPath($path)) {
+                continue;
+            }
+            $source = @file_get_contents($path);
+            if ($source === false || !preg_match($nsPattern, $source, $ns)) {
+                continue;
+            }
+            if (!preg_match($clsPattern, $source, $cls)) {
+                // A namespace with nothing to put in it. Loud, because the
+                // file is now unreachable by either spelling and the symptom
+                // surfaces as a missing feature rather than as an error.
+                error_log(
+                    sprintf(
+                        'FOG autoloader: %s declares namespace %s but no '
+                        . 'class, interface, trait or enum.',
+                        $path,
+                        $ns[1]
+                    )
+                );
+                continue;
+            }
+            $expected = self::PLUGIN_NS . ucfirst(self::_pluginOf($path));
+            if (strcasecmp($ns[1], $expected) !== 0) {
+                // Not refused -- what a file declares is what resolves, and
+                // narrowing that here would make a working plugin stop
+                // loading over a naming opinion. But the per-plugin segment is
+                // what guarantees two plugins cannot collide, and a plugin
+                // that opts out of it has opted out of the guarantee.
+                error_log(
+                    sprintf(
+                        'FOG autoloader: %s declares namespace %s; the plugin '
+                        . 'directory it sits in makes it %s. It will resolve '
+                        . 'as declared, but only the directory-derived name '
+                        . 'is guaranteed unique across plugins.',
+                        $path,
+                        $ns[1],
+                        $expected
+                    )
+                );
+            }
+            $fqcn = $ns[1] . '\\' . $cls[1];
+            $key = strtolower($fqcn);
+            if (isset($seen[$key])) {
+                error_log(
+                    sprintf(
+                        'FOG autoloader: two files declare the plugin class '
+                        . '"%s" (%s and %s); using the first.',
+                        $fqcn,
+                        $seen[$key],
+                        $path
+                    )
+                );
+                continue;
+            }
+            $seen[$key] = $path;
+            $map[$fqcn] = $path;
+        }
+        return $map;
+    }
+
+    /**
+     * The plugin directory name a path sits under.
+     *
+     * The first path segment below whichever plugin root contains the file --
+     * bundled at lib/plugins, or the external FOG_PLUGIN_DIR. That segment is
+     * the plugin's machine name: it is what plugin.config.php's 'name' must
+     * equal, what ?node= addresses, and what plugins.pName holds. Using it,
+     * rather than anything inside the file, is what makes two plugins
+     * structurally unable to claim the same namespace.
+     *
+     * @param string $path an absolute path known to be under a plugin root
+     *
+     * @return string the directory name, or '' if the path has no segment
+     */
+    private static function _pluginOf(string $path): string
+    {
+        foreach (self::_pluginRoots() as $root) {
+            if (strncmp($path, $root, strlen($root)) !== 0) {
+                continue;
+            }
+            $rest = substr($path, strlen($root));
+            $cut = strpos($rest, DS);
+            return $cut === false ? '' : substr($rest, 0, $cut);
+        }
+        return '';
+    }
+
+    /**
+     * Read a cached plugin map, or null when it is missing, stale or suspect.
+     *
+     * Same validation as _readFileListCache -- FOG_CACHE_DIR is
+     * world-writable, so a persisted map is trusted only while every value
+     * still sits under a scanned root -- with one deliberate difference: an
+     * EMPTY map is a valid answer here and is served from cache.
+     *
+     * That difference is the whole reason this is not _readFileListCache. A
+     * tree whose plugins are all still global-namespace, or a server with no
+     * plugins installed, legitimately yields no entries; treating that as a
+     * cache miss would re-read every plugin file on every single request,
+     * forever, on exactly the installs that gain nothing from the scan.
+     *
+     * @param string $file the cache file
+     *
+     * @return array<string, string>|null
+     */
+    private static function _readPluginMapCache(string $file): ?array
+    {
+        clearstatcache(true, $file);
+        if (!is_file($file)
+            || (time() - (int) filemtime($file)) > self::FILELIST_TTL
+        ) {
+            return null;
+        }
+        $json = @file_get_contents($file);
+        if ($json === false) {
+            return null;
+        }
+        $data = json_decode($json, true);
+        if (!is_array($data)) {
+            return null;
+        }
+        $roots = self::_scanRoots();
+        foreach ($data as $fqcn => $path) {
+            if (!is_string($fqcn) || !is_string($path)) {
+                return null;
+            }
+            $inRoot = false;
+            foreach ($roots as $root) {
+                if (strncmp($path, $root, strlen($root)) === 0) {
+                    $inRoot = true;
+                    break;
+                }
+            }
+            if (!$inRoot) {
+                return null;
+            }
+        }
+        return $data;
     }
 
     /**
@@ -669,13 +971,62 @@ class Initiator
      *
      * @return bool
      */
-    private static function _isPluginPath(string $path): bool
+    /**
+     * The directories plugins are loaded from, with a trailing separator.
+     *
+     * Bundled plugins live inside BASEPATH at lib/plugins; an install may
+     * also carry an external root at FOG_PLUGIN_DIR (ADR 0009). One
+     * definition, because two callers derive different things from the same
+     * list -- whether a path is plugin code at all, and which plugin it
+     * belongs to -- and a list that drifted between them would classify the
+     * same file two ways.
+     *
+     * The trailing separator is not cosmetic: every caller compares by string
+     * prefix, and without it a root would also match a sibling directory
+     * whose name merely starts the same way.
+     *
+     * @return string[]
+     */
+    private static function _pluginRoots(): array
     {
         $roots = [rtrim(BASEPATH, DS) . DS . 'lib' . DS . 'plugins' . DS];
         if (defined('FOG_PLUGIN_DIR') && FOG_PLUGIN_DIR) {
             $roots[] = rtrim(FOG_PLUGIN_DIR, DS) . DS;
         }
-        foreach ($roots as $root) {
+        return $roots;
+    }
+
+    /**
+     * Are both of these files namespaced plugin classes?
+     *
+     * Answers the one question autoload()'s basename-collision branch needs:
+     * is this collision real. Two plugin files folding to one bare key used
+     * to mean one class silently replaced the other, because the bare name
+     * was the only name either had. Since plugins declare
+     * FOG\Plugins\<Plugin>\<Class> that is no longer true -- each has a
+     * name of its own, and the shared key is simply not the key anything
+     * looks either of them up by.
+     *
+     * Consulting pluginClassMap() here is safe despite being called from
+     * inside autoload(): the map is built from classFileList(), which is
+     * already in hand by this point, and building it reads files with
+     * file_get_contents() and preg_match(), neither of which can re-enter
+     * the autoloader.
+     *
+     * @param string $a first path
+     * @param string $b second path
+     *
+     * @return bool true only when BOTH declare a FOG\Plugins\ namespace
+     */
+    private static function _bothNamespacedPlugins(string $a, string $b): bool
+    {
+        $paths = self::pluginClassMap();
+        return in_array($a, $paths, true) && in_array($b, $paths, true);
+    }
+
+    private static function _isPluginPath(string $path): bool
+    {
+        foreach (self::_pluginRoots() as $root) {
             if (strncmp($path, $root, strlen($root)) === 0) {
                 return true;
             }
@@ -927,6 +1278,21 @@ class Initiator
                 if (self::_isPluginPath($held) && !self::_isPluginPath($path)) {
                     $map[$base] = $path;
                 }
+                // Unless both files are namespaced plugin classes, in which
+                // case nothing is shadowed and there is nothing to report.
+                // Two plugins each shipping class/settings.class.php is the
+                // configuration namespacing exists to make legal: both
+                // classes are declared, both resolve under their own
+                // FOG\Plugins\<Plugin>\ name, and this key is never the one
+                // consulted for either -- qualify() hands the caller an FQCN
+                // and pluginClassMap() answers it. Warning anyway would put a
+                // line reading "a shadowed class resolves to whichever file
+                // this rule picks" in the log on every cold request, for a
+                // tree that is behaving exactly as designed, which is how a
+                // log stops being read.
+                if (self::_bothNamespacedPlugins($held, $path)) {
+                    continue;
+                }
                 $loser = ($map[$base] === $held) ? $path : $held;
                 error_log(
                     sprintf(
@@ -1002,6 +1368,28 @@ class Initiator
             // something else.
             include_once self::$classMap[$key];
             return;
+        }
+
+        // A namespaced plugin class -- FOG\Plugins\<Plugin>\<Class>.
+        //
+        // Nothing above can answer it. Composer claims the FOG\ prefix and
+        // maps it onto src/, so it looks for src/Plugins/<Plugin>/<Class>.php
+        // and misses; the classMap above is keyed on bare basenames, so
+        // 'fog\plugins\ldap\ldapmanager' is not a key it holds; and
+        // _bridgeNamespaced() refuses any name carrying a second backslash.
+        // Before this arm existed a namespaced plugin simply did not resolve,
+        // which is why ADR 0013 told plugin authors to class_alias()
+        // themselves back into the global namespace.
+        //
+        // Answered LAST, and only for this one prefix. Core is already served,
+        // and served first; the bare-name classMap is untouched, which is what
+        // keeps an unconverted third-party plugin loading exactly as it did.
+        if (strncasecmp($class, self::PLUGIN_NS, strlen(self::PLUGIN_NS)) === 0) {
+            $file = self::pluginClassMap()[$key] ?? null;
+            if ($file !== null) {
+                include_once $file;
+                return;
+            }
         }
 
         self::_bridgeNamespaced($class);

--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -630,28 +630,36 @@ abstract class FOGBase
         return self::shortName($this);
     }
     /**
-     * Resolves a bare core class name to its fully qualified name.
+     * Resolves a bare class name to its fully qualified one.
      *
-     * Every FOG class under src/ is namespaced, but almost nothing that
-     * NAMES one is: `getClass('Host')`, `new $short.'Manager'`, the 52
-     * lowercase strings in Route::$validClasses and FOGPage's $childClass all
-     * spell the bare name. `new $string` and a class name in a string resolve
-     * from the GLOBAL namespace -- `use` is not consulted and the enclosing
-     * namespace is not applied -- so they worked only while each file under
-     * src/ ended in a class_alias() re-exporting itself there. Those aliases
-     * are retired (ADR 0013 §2), and this is the one place the translation
-     * happens, so retiring them did not mean editing every caller.
+     * Every FOG class under src/ is namespaced, and so is every bundled
+     * plugin class, but almost nothing that NAMES one is: `getClass('Host')`,
+     * `new $short.'Manager'`, the 52 lowercase strings in
+     * Route::$validClasses and FOGPage's $childClass all spell the bare name.
+     * `new $string` and a class name in a string resolve from the GLOBAL
+     * namespace -- `use` is not consulted and the enclosing namespace is not
+     * applied -- so they worked only while each file under src/ ended in a
+     * class_alias() re-exporting itself there. Those aliases are retired
+     * (ADR 0013 §2), and this is the one place the translation happens, so
+     * retiring them did not mean editing every caller.
      *
-     * Three things pass through untouched, each on purpose:
+     * Two maps, consulted in that order:
      *
-     *  - a plugin class, which is global-namespace by design (ADR 0009) and
-     *    is resolved by Initiator::autoload() from a directory that did not
-     *    exist at build time;
-     *  - a name src/ does not declare at all -- \DateTimeZone reaches here
-     *    from a real caller, and the 46 discovery-named classes under lib/
-     *    carry their own aliases;
+     *  - Initiator::srcClassMap(), core, under src/;
+     *  - Initiator::pluginShortMap(), the plugin classes that declare a
+     *    FOG\Plugins\<Plugin>\ namespace.
+     *
+     * Core first is a guarantee, not a preference -- see the comment in the
+     * body.
+     *
+     * Two things still pass through untouched, each on purpose:
+     *
+     *  - a name neither map declares -- \DateTimeZone reaches here from a
+     *    real caller, and a plugin still written in the global namespace
+     *    resolves by its bare name through Initiator::autoload() exactly as
+     *    it did before;
      *  - a name that is already qualified. That needs no guard of its own:
-     *    the map is keyed on lowercased SHORT names, so 'fog\items\host'
+     *    both maps are keyed on lowercased SHORT names, so 'fog\items\host'
      *    matches nothing and falls through. An explicit early return for it
      *    was written first and removed -- mutation testing showed deleting
      *    it changed no behavior, which is the definition of a branch
@@ -663,12 +671,34 @@ abstract class FOGBase
      *
      * @param string $class the class name, bare or qualified
      *
-     * @return string the FQCN where src/ declares one, else $class unchanged
+     * @return string the FQCN where core or a plugin declares one, else
+     *                $class unchanged
      */
     public static function qualify(string $class): string
     {
+        $key = strtolower($class);
         $map = \Initiator::srcClassMap();
-        return $map[strtolower($class)] ?? $class;
+        if (isset($map[$key])) {
+            return $map[$key];
+        }
+        // Then the plugins, which are namespaced too now -- FOG\Plugins\
+        // <Plugin>\<Class>. Same problem, same shape of answer: roughly 150
+        // getClass('X') literals live inside the plugins themselves, discovery
+        // derives a bare name from basename($file), and a plugin model reaches
+        // the REST API as the lowercase string the plugin pushed into
+        // Route::$validClasses through API_VALID_CLASSES. One lookup here
+        // serves all of them.
+        //
+        // Core is consulted FIRST and that order is load-bearing, not
+        // stylistic: it is what stops a plugin answering a core name. Before
+        // plugins were namespaced the same guarantee came from autoload()
+        // resolving src/ ahead of the plugin roots; this preserves it one
+        // layer up, where the name is still a string.
+        //
+        // A plugin still in the global namespace produces no entry in this map
+        // at all (Initiator reads the declaration, it does not assume one), so
+        // it falls through and resolves by its bare name exactly as before.
+        return \Initiator::pluginShortMap()[$key] ?? $class;
     }
 
     /**
@@ -4825,21 +4855,25 @@ abstract class FOGBase
     /**
      * The name of the class a discovered file declares.
      *
-     * Two file shapes reach discovery now and they answer to different names.
-     * A core class is src/<Bucket>/<Class>.php and, since the global aliases
-     * were retired, answers ONLY to its namespaced name. A plugin class is
-     * <plugin>/<dir>/<name>.<type>.php, is global-namespace by design and
-     * answers to its bare basename.
+     * Two file shapes reach discovery and they are named differently. A core
+     * class is src/<Bucket>/<Class>.php declaring FOG\<Bucket>\<Class>. A
+     * plugin class keeps the <plugin>/<dir>/<name>.<type>.php shape -- the
+     * discovery extension is how it is FOUND, so it did not move -- and
+     * declares FOG\Plugins\<Plugin>\<Name>.
      *
-     * qualify() spans both without a branch on where the file came from: it
-     * maps a name src/ declares onto its FQCN and passes anything else
-     * through untouched. So a plugin keeps resolving exactly as it did, and
-     * core resolves under the only name it now has.
+     * Neither answers to a bare name any more, and this method never learns
+     * the difference between them. It strips the extension to get the short
+     * name the FILENAME carries and hands that to qualify(), which owns both
+     * maps. A plugin still written in the global namespace is in neither, so
+     * its bare name passes through and resolves exactly as it always did --
+     * which is the whole reason a third-party plugin does not have to be
+     * converted before it will load.
      *
      * @param string $file      Absolute path to the discovered file.
      * @param string $extension The discovery extension, e.g. '.page.php'.
      *
-     * @return string FQCN for a core class, bare name for a plugin's.
+     * @return string the FQCN where core or a plugin declares one, else the
+     *                bare name the filename carries.
      */
     public static function classFromDiscoveredFile(
         string $file,

--- a/packages/web/src/Base/FOGPageManager.php
+++ b/packages/web/src/Base/FOGPageManager.php
@@ -335,8 +335,8 @@ class FOGPageManager extends FOGBase
             //
             // Reachable from outside the tree since ADR 0009: a third-party
             // plugin whose page file does not declare the class its name
-            // promises (a namespace with no class_alias back to the global
-            // name is the easy way to get there) takes the whole UI down for
+            // promises (a namespace that is not the one its directory implies
+            // is the easy way to get there) takes the whole UI down for
             // everyone, and the only way out is a shell. Observed exactly
             // that way while verifying the PSR-4 move -- a probe plugin
             // uploaded through Plugin Management, 500 on every page, and the
@@ -367,14 +367,11 @@ class FOGPageManager extends FOGBase
                         . ' declare a class named after the file: a core page'
                         . ' is src/Pages/<Class>.php declaring'
                         . ' FOG\Pages\<Class>, and a plugin page is'
-                        . ' <plugin>/pages/<name>.page.php declaring the bare'
-                        . ' <name> -- a namespaced plugin page needs'
-                        . ' class_alias(__NAMESPACE__ . \'\\%s\', \'%s\');'
-                        . ' see ADR 0013.',
+                        . ' <plugin>/pages/<name>.page.php declaring'
+                        . ' FOG\Plugins\<Plugin>\<Name>, where <Plugin> is'
+                        . ' the plugin\'s own directory name. See ADR 0013.',
                         $file,
-                        $className,
-                        basename($file, '.php'),
-                        basename($file, '.php')
+                        $className
                     )
                 );
                 continue;

--- a/phpstan-tests-baseline.neon
+++ b/phpstan-tests-baseline.neon
@@ -523,6 +523,24 @@ parameters:
 			path: tests/plugin-list-scope-events.test.php
 
 		-
+			message: '#^Call to an undefined static method Initiator\:\:forgetClassFileList\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: tests/plugin-namespace.test.php
+
+		-
+			message: '#^Call to an undefined static method Initiator\:\:pluginClassMap\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 2
+			path: tests/plugin-namespace.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/plugin-namespace.test.php
+
+		-
 			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
 			identifier: new.resultUnused
 			count: 1

--- a/tests/getclass-resolves-without-aliases.test.php
+++ b/tests/getclass-resolves-without-aliases.test.php
@@ -33,10 +33,18 @@ $fails = [];
  * ------------------------------------------------------------------
  * 1. qualify() itself, executed against a map we control.
  *
- * FOGBase only reaches \Initiator::srcClassMap(), so a stub is enough to
- * load it standalone. Executing beats grepping here: a grep for "qualify"
- * passes just as happily when the method has been gutted to `return
- * $class;`.
+ * FOGBase only reaches \Initiator::srcClassMap() and
+ * \Initiator::pluginShortMap(), so a stub is enough to load it standalone.
+ * Executing beats grepping here: a grep for "qualify" passes just as happily
+ * when the method has been gutted to `return $class;`.
+ *
+ * The plugin half of the stub is deliberately hostile. Plugins are namespaced
+ * too now -- FOG\Plugins\<Plugin>\<Class> -- so qualify() consults a second
+ * map, and the ORDER it consults them in is a guarantee rather than a
+ * preference: Authorization::_scopeClassVars() resolves a node to its model
+ * through this function, so a plugin winning the bare name 'host' is access
+ * control silently testing the wrong table. The stub therefore ships a rogue
+ * plugin claiming exactly that.
  * ------------------------------------------------------------------
  */
 class Initiator
@@ -48,11 +56,25 @@ class Initiator
             'hostmanager' => 'FOG\Managers\HostManager',
         ];
     }
+
+    public static function pluginShortMap(): array
+    {
+        return [
+            'caponetasking' => 'FOG\Plugins\Capone\CaponeTasking',
+            // A plugin that declares its own Host. It is entitled to the
+            // class; it is not entitled to the bare spelling.
+            'host'          => 'FOG\Plugins\Rogue\Host',
+        ];
+    }
 }
 require $web . '/src/Base/FOGBase.php';
 
 $expect = [
-    // A bare core name becomes qualified. This is the whole point.
+    // A bare core name becomes qualified. This is the whole point -- and,
+    // since the stub's plugin map claims 'host' too, it is simultaneously
+    // the check that core is consulted FIRST. That order is what stands
+    // between a plugin and Authorization::_scopeClassVars() resolving the
+    // 'host' node to the plugin's table.
     'Host'           => 'FOG\Items\Host',
     // Case-insensitively, because Route::$validClasses spells them lowercase
     // and the tree is inconsistent (both 'location' and 'Location' appear).
@@ -63,11 +85,15 @@ $expect = [
     'HostManager'    => 'FOG\Managers\HostManager',
     // Already qualified: untouched, never double-prefixed.
     'FOG\Items\Host' => 'FOG\Items\Host',
-    // Unknown names pass through, so this widens resolution and never
-    // narrows it: a plugin class, a lib/ discovery class and a PHP built-in
-    // all still reach the autoloader as themselves.
+    // A bare PLUGIN name becomes qualified the same way a core one does,
+    // which is what keeps the ~150 getClass('X') literals inside the plugins
+    // working without editing one of them.
+    'CaponeTasking'  => 'FOG\Plugins\Capone\CaponeTasking',
+    'caponetasking'  => 'FOG\Plugins\Capone\CaponeTasking',
+    // Unknown names still pass through, so this widens resolution and never
+    // narrows it: a PHP built-in, a lib/ discovery class and a plugin still
+    // written in the global namespace all reach the autoloader as themselves.
     'DateTimeZone'   => 'DateTimeZone',
-    'CaponeTasking'  => 'CaponeTasking',
     'ServerInfo'     => 'ServerInfo',
 ];
 foreach ($expect as $in => $want) {

--- a/tests/page-discovery-survives-bad-file.test.php
+++ b/tests/page-discovery-survives-bad-file.test.php
@@ -21,10 +21,12 @@
  *      expires rather than fixing it.
  *   2. The file is present and declares something else. Since ADR 0009 that
  *      is reachable from outside this repository: a third-party plugin
- *      uploaded through Plugin Management whose page file declares
- *      `namespace FOG; class Foo` with no class_alias back to the global
- *      name. The bare name never exists, and the whole UI dies for everyone
- *      with `rm` plus clearing /opt/fog/cache as the only way out.
+ *      uploaded through Plugin Management whose page file declares a class
+ *      under a namespace nothing will look in -- `namespace FOG; class Foo`
+ *      is the easy way there now that plugins declare
+ *      FOG\Plugins\<Plugin>\<Class>. The name discovery derives never
+ *      exists, and the whole UI dies for everyone with `rm` plus clearing
+ *      /opt/fog/cache as the only way out.
  *
  * Observed both ways while verifying the PSR-4 move.
  *
@@ -102,8 +104,11 @@ function check($label, $cond, array &$failures, &$checks)
  * probealiased is emitted LAST for that reason: a guard that threw instead of
  * continuing would never reach it, so "probealiased was loaded and NOT
  * complained about" is simultaneously the proof that the walk continued and
- * the proof that the guard does not over-reject the forward-compatible
- * spelling ADR 0013 tells plugin authors to use.
+ * the proof that the guard does not over-reject a namespace-plus-alias file.
+ * That spelling is no longer what ADR 0013 recommends -- a plugin declares
+ * FOG\Plugins\<Plugin>\<Class> and needs no alias -- but it remains valid
+ * for a plugin that picks a namespace of its own, and these fixtures do not
+ * sit under a plugin root, so it is the shape that belongs here.
  */
 $pages = $tmp . '/pages/';
 file_put_contents(
@@ -178,18 +183,23 @@ check(
     $failures,
     $checks
 );
+// The message is asserted, not just its existence. It is the only thing a
+// plugin author gets, and it used to tell them to write a class_alias() --
+// advice that is now wrong, since core resolves FOG\Plugins\<Plugin>\<Class>
+// directly. A diagnostic that names the wrong cure is worse than a terse one.
 check(
-    'the mis-declared file was reported, and the message names class_alias',
+    'the mis-declared file was reported, and the message names the fix',
     strpos($logged, 'probebadns.page.php') !== false
     && strpos($logged, 'does not declare') !== false
-    && strpos($logged, 'class_alias') !== false,
+    && strpos($logged, 'FOG\\Plugins\\<Plugin>\\<Name>') !== false
+    && strpos($logged, 'class_alias') === false,
     $failures,
     $checks
 );
 // The walk reached the third file: it was loaded (so the guard let it past)
-// and nothing was logged about it (so the guard did not reject the
-// namespaced-plus-alias spelling, which is what ADR 0013 tells plugin
-// authors to write).
+// and nothing was logged about it (so the guard did not reject a
+// namespaced-plus-alias file, which a plugin outside FOG\Plugins\ still
+// legitimately ships).
 check(
     'the walk continued to the last file and loaded it',
     class_exists('probealiased', false),

--- a/tests/plugin-namespace.test.php
+++ b/tests/plugin-namespace.test.php
@@ -1,0 +1,512 @@
+<?php
+/**
+ * Plugins are namespaced, and an unnamespaced one still loads.
+ *
+ * Core finished its own migration first: every class under packages/web/src/
+ * declares FOG\<Bucket>\<Class> and answers to nothing else. Plugins were
+ * left in the global namespace, which cost three things -- two plugins
+ * shipping class/settings.class.php shared one keyspace and one silently
+ * shadowed the other; a plugin that wanted a namespace had to class_alias()
+ * itself back, and getting that wrong took the whole admin UI down; and
+ * plugin authors had to learn a second convention. They declare
+ * FOG\Plugins\<Plugin>\<Class> now.
+ *
+ * Four mechanisms make that work and this test pins each of them, because
+ * every one of them fails SILENTLY:
+ *
+ *  1. Initiator::_scanPluginNamespaces() reads each plugin file's actual
+ *     namespace declaration. It does not DERIVE one from the path -- that
+ *     distinction is the whole backwards-compatibility story, and it is
+ *     invisible in the code. Deriving would hand qualify() a FOG\Plugins\
+ *     name for a plugin still written globally, and the class_exists() that
+ *     follows would then be false for a class that is sitting right there.
+ *  2. Initiator::autoload() answers the FOG\Plugins\ prefix. Nothing else
+ *     can: Composer maps FOG\ onto src/ and misses, the bare-name classMap
+ *     is keyed on basenames, and _bridgeNamespaced() refuses any name with a
+ *     second backslash. Without this arm a namespaced plugin does not
+ *     resolve at all.
+ *  3. FOGBase::qualify() consults the plugin map, which is what keeps the
+ *     ~150 getClass('X') literals inside the plugins, all of page/hook/event/
+ *     report/task discovery, FOGController::getManager(), FOGPage::$childClass
+ *     and Route::_newEntity() working without editing a single call site.
+ *  4. qualify() consults CORE FIRST. That order is the guarantee that a
+ *     plugin cannot answer a core name -- and its failure mode is the worst
+ *     one in the tree, because Authorization::_scopeClassVars() resolves a
+ *     node to its model through qualify(): a wrong answer there is access
+ *     control silently testing the wrong table.
+ *
+ * Everything is exercised against fixture plugins written into a throwaway
+ * FOG_PLUGIN_DIR rather than against the bundled tree, so the test says the
+ * same thing on a fresh clone (where lib/plugins is empty -- it is gitignored
+ * staging, ADR 0009) as it does on a deployed server.
+ *
+ * DB-free, same shape as autoload-core-wins.test.php: the Initiator
+ * constructor only registers the autoloader, so the cache dir is redirected
+ * somewhere throwaway and startInit() -- the part that needs MySQL -- is
+ * never called.
+ *
+ * Usage: php tests/plugin-namespace.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__) . '/packages/web';
+$init = $root . '/commons/init.php';
+if (!is_readable($init)) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+
+$tmp = sys_get_temp_dir() . '/fog-plugin-ns-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
+@mkdir($tmp . '/extplugins', 0700, true);
+register_shutdown_function(
+    function () use ($tmp) {
+        if (!is_dir($tmp)) {
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($tmp, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $f) {
+            $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+        }
+        @rmdir($tmp);
+    }
+);
+
+/**
+ * Write one fixture plugin class file.
+ *
+ * @param string      $tmp    the throwaway root
+ * @param string      $plugin the plugin directory name
+ * @param string      $dir    the subdirectory (class, pages, hooks, ...)
+ * @param string      $file   the file basename, including its suffix
+ * @param string|null $ns     the namespace to declare, or null for global
+ * @param string      $class  the class name to declare
+ * @param string      $body   extra class body
+ *
+ * @return string the absolute path written
+ */
+function fixture($tmp, $plugin, $dir, $file, $ns, $class, $body = '')
+{
+    $path = $tmp . '/extplugins/' . $plugin . '/' . $dir;
+    @mkdir($path, 0700, true);
+    $path .= '/' . $file;
+    $src = "<?php\n/**\n * Fixture.\n */\n\n";
+    if ($ns !== null) {
+        $src .= "namespace {$ns};\n\n";
+    }
+    $src .= "/**\n * Fixture.\n */\nclass {$class}\n{\n"
+        . "    const MARK = '{$plugin}';\n{$body}\n}\n";
+    file_put_contents($path, $src);
+    return $path;
+}
+
+// A converted plugin: namespace derived from its directory name.
+$widgetA = fixture(
+    $tmp,
+    'alphaplugin',
+    'class',
+    'widget.class.php',
+    'FOG\\Plugins\\Alphaplugin',
+    'Widget'
+);
+// Its manager, so the model -> manager derivation can be exercised. Both
+// live in ONE flat namespace per plugin, which is exactly why: getManager()
+// is qualify(shortName($this) . 'Manager'), so a Model\ / Manager\ split
+// would not resolve.
+$widgetManagerA = fixture(
+    $tmp,
+    'alphaplugin',
+    'class',
+    'widgetmanager.class.php',
+    'FOG\\Plugins\\Alphaplugin',
+    'WidgetManager'
+);
+// A page, to prove the discovery suffixes still work unchanged -- this is
+// namespacing, not a PSR-4 move.
+$pageA = fixture(
+    $tmp,
+    'alphaplugin',
+    'pages',
+    'alphamanagement.page.php',
+    'FOG\\Plugins\\Alphaplugin',
+    'AlphaManagement'
+);
+// A SECOND plugin shipping a class of the same short name. Under the global
+// namespace exactly one of these could exist; both must now.
+$widgetB = fixture(
+    $tmp,
+    'betaplugin',
+    'class',
+    'widget.class.php',
+    'FOG\\Plugins\\Betaplugin',
+    'Widget'
+);
+// An unconverted third-party plugin. ADR 0009 makes plugins installable
+// artifacts FOG does not control, so this one must keep working untouched.
+$legacy = fixture(
+    $tmp,
+    'legacyplugin',
+    'class',
+    'legacything.class.php',
+    null,
+    'LegacyThing'
+);
+// A plugin trying to claim a CORE name from inside its own namespace. It is
+// entitled to the class; it is not entitled to the bare spelling.
+$shadow = fixture(
+    $tmp,
+    'shadowplugin',
+    'class',
+    'host.class.php',
+    'FOG\\Plugins\\Shadowplugin',
+    'Host'
+);
+// A plugin whose declared namespace disagrees with its directory. Resolves
+// as declared -- refusing it would stop a working plugin loading over a
+// naming opinion -- but forfeits the uniqueness the directory guarantees.
+$offRule = fixture(
+    $tmp,
+    'oddplugin',
+    'class',
+    'oddthing.class.php',
+    'FOG\\Plugins\\SomethingElse',
+    'OddThing'
+);
+
+if (!defined('FOG_CACHE_DIR')) {
+    define('FOG_CACHE_DIR', $tmp . '/cache');
+}
+if (!defined('FOG_LOG_DIR')) {
+    define('FOG_LOG_DIR', $tmp . '/log');
+}
+if (!defined('FOG_PLUGIN_DIR')) {
+    define('FOG_PLUGIN_DIR', $tmp . '/extplugins');
+}
+
+// Divert error_log() so the diagnostics themselves can be asserted on.
+// Three of them are load-bearing: two must fire, and one must NOT, and the
+// one that must not is a line that used to fire for a configuration that is
+// now legal.
+$errlog = $tmp . '/php-error.log';
+ini_set('log_errors', '1');
+ini_set('error_log', $errlog);
+
+require_once $init;
+new Initiator();
+
+$failures = [];
+$checks = 0;
+
+function check($label, $cond, array &$failures, &$checks)
+{
+    $checks++;
+    if (!$cond) {
+        $failures[] = $label;
+    }
+}
+
+/*
+ * 1. _pluginOf() -- the derivation the whole scheme rests on. The plugin's
+ *    directory name is its machine name: plugin.config.php's 'name' must
+ *    equal it, ?node= addresses it, plugins.pName holds it. Deriving the
+ *    namespace segment from anything inside the file instead would let two
+ *    plugins claim one namespace and put us back where we started.
+ */
+$m = new \ReflectionMethod('Initiator', '_pluginOf');
+$m->setAccessible(true);
+$pluginOf = function ($path) use ($m) {
+    return $m->invoke(null, $path);
+};
+
+$base = rtrim(BASEPATH, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+$ext = rtrim(FOG_PLUGIN_DIR, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+$derivations = [
+    // Bundled root.
+    $base . 'lib/plugins/ldap/class/ldapmanager.class.php' => 'ldap',
+    $base . 'lib/plugins/capone/reg-task/caponetasking.class.php' => 'capone',
+    $base . 'lib/plugins/ou/pages/oumanagement.page.php' => 'ou',
+    // External root.
+    $ext . 'alphaplugin/class/widget.class.php' => 'alphaplugin',
+    // Not plugin code at all.
+    $base . 'src/Items/Host.php' => '',
+];
+foreach ($derivations as $path => $expect) {
+    check(
+        sprintf('_pluginOf(%s) should be "%s"', $path, $expect),
+        $pluginOf($path) === $expect,
+        $failures,
+        $checks
+    );
+}
+
+/*
+ * 2. The map holds what the FILES declare, and nothing else.
+ *
+ *    The legacy plugin is the load-bearing case. It must produce NO entry:
+ *    an entry would make qualify('LegacyThing') hand back
+ *    FOG\Plugins\Legacyplugin\LegacyThing, which nothing declares, and every
+ *    third-party plugin in the field would stop resolving.
+ */
+$fqcnMap = Initiator::pluginClassMap();
+$shortMap = Initiator::pluginShortMap();
+
+check(
+    'alphaplugin Widget is in the FQCN map',
+    ($fqcnMap['fog\\plugins\\alphaplugin\\widget'] ?? null) === $widgetA,
+    $failures,
+    $checks
+);
+check(
+    'betaplugin Widget is in the FQCN map too -- no shadowing',
+    ($fqcnMap['fog\\plugins\\betaplugin\\widget'] ?? null) === $widgetB,
+    $failures,
+    $checks
+);
+check(
+    'a discovery-suffixed page file is mapped like any other class',
+    ($fqcnMap['fog\\plugins\\alphaplugin\\alphamanagement'] ?? null) === $pageA,
+    $failures,
+    $checks
+);
+check(
+    'a plugin declaring NO namespace produces no FQCN entry',
+    !isset($fqcnMap['fog\\plugins\\legacyplugin\\legacything']),
+    $failures,
+    $checks
+);
+check(
+    'a plugin declaring NO namespace produces no short-name entry',
+    !isset($shortMap['legacything']),
+    $failures,
+    $checks
+);
+check(
+    'a namespace disagreeing with its directory still resolves as declared',
+    ($fqcnMap['fog\\plugins\\somethingelse\\oddthing'] ?? null) === $offRule,
+    $failures,
+    $checks
+);
+
+/*
+ * 3. autoload() answers the FOG\Plugins\ prefix.
+ *
+ *    Nothing above it in the chain can. Before this arm existed, a plugin
+ *    that declared a namespace was simply unreachable, which is why ADR 0013
+ *    told authors to class_alias() themselves back into the global namespace.
+ */
+check(
+    'a namespaced plugin class resolves under its FQCN',
+    class_exists('FOG\\Plugins\\Alphaplugin\\Widget'),
+    $failures,
+    $checks
+);
+check(
+    'the second plugin\'s same-named class resolves independently',
+    class_exists('FOG\\Plugins\\Betaplugin\\Widget'),
+    $failures,
+    $checks
+);
+// Each fixture carries a MARK naming the plugin whose file declares it, so
+// this asserts which FILE each loaded class came from -- the anti-shadowing
+// property itself, rather than the map that is supposed to produce it.
+check(
+    'each same-named class is the one from its OWN plugin\'s file',
+    class_exists('FOG\\Plugins\\Alphaplugin\\Widget')
+    && class_exists('FOG\\Plugins\\Betaplugin\\Widget')
+    && constant('FOG\\Plugins\\Alphaplugin\\Widget::MARK') === 'alphaplugin'
+    && constant('FOG\\Plugins\\Betaplugin\\Widget::MARK') === 'betaplugin',
+    $failures,
+    $checks
+);
+check(
+    'an UNNAMESPACED plugin class still resolves by its bare name',
+    class_exists('LegacyThing'),
+    $failures,
+    $checks
+);
+check(
+    'a plugin FQCN core does not hold resolves to nothing, quietly',
+    !class_exists('FOG\\Plugins\\Alphaplugin\\NoSuchClass'),
+    $failures,
+    $checks
+);
+
+/*
+ * 4. qualify() -- the seam every string-driven lookup goes through.
+ */
+$qualify = ['FOG\\Base\\FOGBase', 'qualify'];
+
+check(
+    'qualify() maps a bare plugin class to its FQCN',
+    call_user_func($qualify, 'Widget') === 'FOG\\Plugins\\Alphaplugin\\Widget'
+    || call_user_func($qualify, 'Widget') === 'FOG\\Plugins\\Betaplugin\\Widget',
+    $failures,
+    $checks
+);
+check(
+    'qualify() is case-insensitive on the bare plugin name',
+    strtolower(call_user_func($qualify, 'widgetmanager'))
+    === 'fog\\plugins\\alphaplugin\\widgetmanager',
+    $failures,
+    $checks
+);
+check(
+    'the model -> manager derivation resolves inside one plugin namespace',
+    class_exists(call_user_func($qualify, 'WidgetManager')),
+    $failures,
+    $checks
+);
+check(
+    'qualify() leaves an unknown name alone',
+    call_user_func($qualify, 'DateTimeZone') === 'DateTimeZone',
+    $failures,
+    $checks
+);
+check(
+    'qualify() leaves an already-qualified name alone',
+    call_user_func($qualify, 'FOG\\Items\\Host') === 'FOG\\Items\\Host',
+    $failures,
+    $checks
+);
+
+/*
+ * 5. CORE WINS. shadowplugin declares its own Host; the bare name must still
+ *    be core's. This is the check that stands between a plugin and
+ *    Authorization::_scopeClassVars() resolving 'host' to the wrong table.
+ */
+check(
+    'shadowplugin\'s own Host exists under its own namespace',
+    isset($fqcnMap['fog\\plugins\\shadowplugin\\host']),
+    $failures,
+    $checks
+);
+check(
+    'but the BARE name Host still qualifies to core',
+    call_user_func($qualify, 'Host') === 'FOG\\Items\\Host',
+    $failures,
+    $checks
+);
+check(
+    'and a bare core name a plugin does not claim is untouched',
+    call_user_func($qualify, 'Image') === 'FOG\\Items\\Image',
+    $failures,
+    $checks
+);
+
+/*
+ * 6. An empty result is CACHED. A tree whose plugins are all still global --
+ *    which is every server until the converted plugins ship, and every
+ *    server that installs none -- legitimately produces no entries.
+ *    _readFileListCache() treats [] as a miss, so reusing it here would
+ *    re-read every plugin file on every request forever, on exactly the
+ *    installs that gain nothing from the scan. _readPluginMapCache() exists
+ *    for that one difference and nothing else.
+ */
+$cacheName = 'pluginmap.' . md5(
+    implode(
+        '|',
+        [
+            rtrim(BASEPATH, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR,
+            rtrim(FOG_PLUGIN_DIR, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR,
+        ]
+    )
+) . '.json';
+check(
+    'the plugin map is persisted to its own cache file',
+    is_file(FOG_CACHE_DIR . DIRECTORY_SEPARATOR . $cacheName),
+    $failures,
+    $checks
+);
+
+$readCache = new \ReflectionMethod('Initiator', '_readPluginMapCache');
+$readCache->setAccessible(true);
+$emptyCache = FOG_CACHE_DIR . DIRECTORY_SEPARATOR . 'pluginmap.empty.json';
+file_put_contents($emptyCache, '[]');
+check(
+    'an empty cached map is served, not treated as a miss',
+    $readCache->invoke(null, $emptyCache) === [],
+    $failures,
+    $checks
+);
+$poisoned = FOG_CACHE_DIR . DIRECTORY_SEPARATOR . 'pluginmap.poisoned.json';
+file_put_contents(
+    $poisoned,
+    json_encode(['FOG\\Plugins\\Evil\\Thing' => '/etc/passwd'])
+);
+check(
+    'a cached map pointing outside the scanned roots is refused',
+    $readCache->invoke(null, $poisoned) === null,
+    $failures,
+    $checks
+);
+
+/*
+ * 7. Invalidation. The plugin uploader calls forgetClassFileList() when it
+ *    writes a plugin into a scanned root while the server is running. If
+ *    this map is not dropped with the others the plugin half-loads for up to
+ *    FILELIST_TTL: its classes resolve by their bare name and not by their
+ *    namespaced one.
+ */
+Initiator::forgetClassFileList();
+check(
+    'forgetClassFileList() removes the plugin map cache',
+    !is_file(FOG_CACHE_DIR . DIRECTORY_SEPARATOR . $cacheName),
+    $failures,
+    $checks
+);
+$newPlugin = fixture(
+    $tmp,
+    'lateplugin',
+    'class',
+    'latething.class.php',
+    'FOG\\Plugins\\Lateplugin',
+    'LateThing'
+);
+check(
+    'a plugin written after the first scan is picked up after the flush',
+    (Initiator::pluginClassMap()['fog\\plugins\\lateplugin\\latething'] ?? null)
+    === $newPlugin,
+    $failures,
+    $checks
+);
+
+/*
+ * 8. The diagnostics. Each of these is the only signal its condition
+ *    produces, so an assertion on the CODE without one on the MESSAGE leaves
+ *    the operator-facing half untested.
+ */
+$log = is_file($errlog) ? (string) file_get_contents($errlog) : '';
+
+check(
+    'a namespace disagreeing with its directory is reported',
+    strpos($log, 'the plugin directory it sits in makes it') !== false
+    && strpos($log, 'FOG\Plugins\Oddplugin') !== false,
+    $failures,
+    $checks
+);
+check(
+    'an ambiguous SHORT name across two plugins is reported',
+    strpos($log, 'two plugins declare a class named "widget"') !== false,
+    $failures,
+    $checks
+);
+check(
+    'but the basename collision is NOT reported as shadowing',
+    strpos($log, 'two files claim the class name "widget"') === false,
+    $failures,
+    $checks
+);
+
+if ($failures) {
+    fwrite(STDERR, "FAIL (" . count($failures) . "/$checks checks)\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+fwrite(STDOUT, "PASS ($checks checks)\n");
+exit(0);


### PR DESCRIPTION
Plugins were the last global-namespace code in the tree. Core finished its own migration on 2026-08-30 — every class under `packages/web/src/` declares `FOG\<Bucket>\<Class>` and answers to nothing else — and ADR 0013 recorded that **nothing changed for plugins**: they kept the global namespace, and a plugin wanting one of its own had to `class_alias()` itself back, because discovery derives a class name from `basename($file)`.

This closes that gap. A plugin class declares `FOG\Plugins\<Plugin>\<Class>`, where `<Plugin>` is `ucfirst()` of its own directory name, and needs no alias.

## Why it was worth doing

- **The alias rule's failure mode was the whole admin UI.** A plugin page in a namespace with no alias does not declare the class its filename promises, so `FOGPageManager::loadPageClasses()` calls `get_class_vars()` on a name nothing declares — an uncaught `TypeError` in PHP 8, thrown from a constructor `management/index.php` builds before it can render anything. One third-party plugin, a bodyless 500 on every page, recovery only from a shell.
- **Two plugins could not ship a class of the same name.** Those folded to one key in `Initiator::$classMap`; the autoloader picked one and the loser silently got the wrong class. Today's bundled tree has zero duplicate basenames across all 176 plugin classes — luck, not a property.
- **It was a second convention to learn.** `docs/plugin-development.md` §7a spent 80 lines on it.

## What changed

File layout is untouched. The `.class.php` / `.page.php` / `.hook.php` suffixes are how a file is *found*, so this is namespacing, not a second PSR-4 move.

| | |
|---|---|
| `Initiator::pluginClassMap()` / `pluginShortMap()` | new; built from the file list that is already scanned and already cached, on the same TTL and the same `forgetClassFileList()` invalidation |
| `Initiator::autoload()` | new arm for the `FOG\Plugins\` prefix — nothing else could answer it |
| `FOGBase::qualify()` | consults the plugin map **after** `src/` |
| `Initiator::_pluginRoots()` | one definition of the plugin-root list, replacing what `_isPluginPath()` and the new `_pluginOf()` would each have derived |

`qualify()` is the seam every string-driven lookup already goes through — discovery, `getClass()`'s ~520 literals, `getManager()`, `FOGPage::$childClass`, `Route::_newEntity()`, `Authorization::_scopeClassVars()` — so **no call site changed**, including the ~150 `self::getClass('X')` literals inside the plugins themselves.

### Two things worth reviewing closely

**Core is consulted first, and that order is a guarantee.** `_scopeClassVars()` resolves a node to its model through `qualify()`, so a plugin winning the bare name `host` is access control testing the wrong table — silently, with nothing logged.

**The map is READ from each file, never derived from its path.** This is the whole backwards-compatibility story and it is invisible in the code. Deriving would hand `qualify()` a `FOG\Plugins\` name for a plugin still written globally, and the `class_exists()` that follows would be false for a class sitting right there. Because the declaration is read, such a plugin produces no entry, falls through to the bare-name `classMap`, and loads exactly as before. Plugins are installable artifacts FOG does not control (ADR 0009), so this is additive or it is wrong.

### Diagnostics

- `autoload()`'s basename-collision warning is **suppressed** when both colliding files are namespaced plugin classes — nothing is shadowed, and a warning for a legal configuration is how a log stops being read.
- `loadPageClasses()` no longer tells an author to write a `class_alias()`; it names `FOG\Plugins\<Plugin>\<Name>`. `page-discovery-survives-bad-file.test.php` now pins the new text and refuses the old.

## Verification

- `tests/plugin-namespace.test.php` (new, 36 checks) covers the derivation, the autoload arm, `qualify()`'s precedence, the diagnostics, cache invalidation, the two call sites fixed below, and **that a global-namespace plugin still resolves** — against fixtures in a throwaway `FOG_PLUGIN_DIR`, so it says the same thing on a fresh clone as on a deployed server.
- **Every new assertion was mutation-verified** — each reversion observed red, restored from a scratchpad copy rather than `git checkout --`.
- Verified separately against the real tree: all **176** classes in `FOGProject/fog-plugins` resolve under their FQCN, and every bare name qualifies to its own.
- Full suite 242/242; both `phpstan` passes clean.

### Three bugs the lab found, and one gate for the shape of all three

An isolated lab (podman MariaDB from a dump of the 1.6 server, a shadow web tree, the namespaced plugin tree on disk) turned up three live defects. All three are the same mistake: **a class name held in a string is resolved as written, from the global namespace** — the enclosing `namespace` is not applied and `use` is not consulted — so each named a class that stopped existing when ADR 0013 §2 retired the reverse aliases. None of them throw. The predicate answers "no such class" exactly as it would for a genuine absence, and the caller quietly takes its fallback.

| Site | Was | Symptom |
|---|---|---|
| `PluginRunner::_discoverTasks()` | `is_subclass_of(basename($file, '.task.php'), …)` | every plugin task skipped; the only trace is `Skipping, not a PluginTask` |
| `Plugin::getManager()` | `class_exists(pName . 'Manager')` | falls back to `PluginManager`; `installdb()` then correctly reports a manager file it cannot load, so **every plugin install throws** |
| `OpenAPI::_permission()` | `method_exists('Authorization', …)` | returned null for every operation — the published API document described the whole REST API as needing no permission |

The first two now go through `qualify()`, which leaves a global-namespace plugin untouched, so both spellings work. The third's guard is deleted rather than qualified: the method it tests for is declared in this repository, beside the file testing for it.

`tests/string-class-literals-are-qualified.test.php` (new) is the general gate — a token-driven scan for a bare class literal in `method_exists()`, `class_exists()`, `is_subclass_of()` and friends across `packages/`, allowing classes PHP itself declares. It counts **2** with the fixes reverted and **0** now. Token-driven rather than regex because the same text already appears in a comment in `FOGURLRequests.php`, recounting this exact bug in prose.

### Run against a live install

Against the lab, with the namespaced plugin tree in place:

- all six installed plugin pages register and resolve to their FQCN (`?node=ldap` → `FOG\Plugins\Ldap\LDAPManagement`, and so on);
- the hook/event graph is identical to the pre-namespace control arm — 46 events, 109 listeners — run by branch-switching **in the same directory**, since `plugins.pLocation` holds absolute paths;
- every plugin model and manager resolves through the ORM;
- `getManager()` + `installdb()` succeed for all seven installed plugins (ldap, location, windowskey, ou, ntfy, helloworld, oidc) — this is what threw before the fix;
- the one real `.task.php` in fog-plugins resolves: `helloworldheartbeat` is not a `PluginTask`, `FOG\Plugins\Helloworld\HelloWorldHeartbeat` is. The daemon's own loop needs `Route::getList()`, which returns nothing in a CLI harness, so the corrected expression was lifted out rather than the loop driven.

## Ordering

`FOGProject/fog-plugins` ships the matching change. **This PR merges first** — a plugin declaring `FOG\Plugins\…` does not resolve on a core without the autoload arm. Then fog-plugins releases, then `FOG_PLUGINS_VERSION` is bumped here; without that last step the change never reaches a server.

## Downstream

No change to `Route::$validClasses`, so nothing for FogApi to sync.
