### PR TITLE
Add a TFTP fallback for U-Boot boards with no wget

### DIFF
--- a/bin/psr4-scan.php
+++ b/bin/psr4-scan.php
@@ -173,6 +173,16 @@ const TABLE = [
     'BootMenuBase' => 'Boot',
     'IpxeBootMenu' => 'Boot',
     'UbootBootMenu' => 'Boot',
+    // Extends \Exception, not FOGBase or FOGController -- a catchable
+    // stand-in for the exit() UbootBootMenu's constructor used to call, so
+    // no RULES ancestry rule can place it. Same subsystem, same file as the
+    // class it exists for.
+    'UbootRenderHalted' => 'Boot',
+    // Extends FOGBase directly, not FOGController -- like MACAddress above,
+    // an entity in everything but its parent. Boot, not Util, for the same
+    // reason WakeOnLan is: it exists to get a host to the point where a
+    // board's boot request can be answered, same subsystem as UbootBootMenu.
+    'UbootTftpSync' => 'Boot',
     'Registration' => 'Boot',
     'WakeOnLan' => 'Boot',
     // Boot, not Util, for the same reason WakeOnLan is: it is the vocabulary

--- a/docs/UBOOT_ARM_BOOT.md
+++ b/docs/UBOOT_ARM_BOOT.md
@@ -39,9 +39,9 @@ The kernel and init are the ARM pair from FOG Settings —
 
 ## What you provide
 
-FOG does not write files to disk for this and does not manage
-`pxelinux.cfg/`. It answers a question; getting the board to ask it is yours,
-and it is a few lines of U-Boot:
+For a board whose U-Boot has `CONFIG_CMD_WGET` (see below for the ones that
+don't), FOG answers a question over HTTP; getting the board to ask it is
+yours, and it is a few lines of U-Boot:
 
 ```
 dhcp
@@ -63,9 +63,35 @@ for "it fetched something and then did nothing".
 be set. Most board configs set all three already; `printenv` is the check.
 
 Older U-Boot builds have a `wget` that takes `<server-ip>:<path>` rather than a
-full URL, and some have no `wget` at all (it needs `CONFIG_CMD_WGET`). If yours
-is one of those, the fallback is to stage the config over TFTP yourself, which
-is the `pxelinux.cfg` route this deliberately avoids -- see below.
+full URL, and some have no `wget` at all (it needs `CONFIG_CMD_WGET`). Check
+with `help wget` at the U-Boot prompt; `Unknown command 'wget'` means the
+second path below.
+
+### No `wget`: the TFTP fallback
+
+A board with no `wget` can still speak TFTP -- every U-Boot can -- and `pxe
+get` is the PXELINUX-derived convention for fetching a config that way. Unlike
+`wget`, it is not configurable: it always fetches
+`pxelinux.cfg/01-<mac, dash-separated, lowercase>` (falling back through a
+sequence of IP-address-derived names FOG does not populate) from whatever TFTP
+server and directory the board's `serverip`/`bootfile` point at.
+
+```
+dhcp
+pxe get
+pxe boot
+```
+
+That is the whole boot script; there is no URL to substitute, because the
+filename is not yours to choose. Point `serverip` at the same host FOG's
+`FOG_TFTP_HOST` setting names (Settings, FTP/TFTP submenu -- it is the same
+host and credentials FOG already uses to upload ARM kernels there).
+
+Getting FOG to keep a real file at that path is `UbootTftpSync`
+(`packages/web/src/Boot/UbootTftpSync.php`), not something you maintain
+yourself. See "The `pxelinux.cfg` file this endpoint's live answer avoids"
+below for what it writes, when, and what has to be configured for it to work
+at all.
 
 Three things stay yours because they are properties of the board, not of FOG:
 
@@ -87,11 +113,6 @@ Three things stay yours because they are properties of the board, not of FOG:
   transport is HTTPS, U-Boot cannot reach this endpoint at all, and that is the
   thing to solve first.
 
-- **FOG stays stateless, so there is no `pxelinux.cfg` to write.** That is
-  deliberate: files on disk drift from what is queued in the database, and
-  something then has to reap them when a task completes. If your U-Boot cannot
-  do HTTP at all you will have to stage a config over TFTP by hand, and at that
-  point you are maintaining the drift yourself.
 - **`${ethaddr}` must be set.** Some boards populate it from the firmware,
   some do not. If it is empty, FOG gets no MAC, finds no host, and correctly
   answers `localboot`. Check with `printenv ethaddr` before blaming FOG.
@@ -104,11 +125,50 @@ Three things stay yours because they are properties of the board, not of FOG:
   had no console on a Pi at all, so a healthy boot and an early hang looked
   identical. If you are on an older init, that is the first thing to rule out.
 
+## The `pxelinux.cfg` file this endpoint's live answer avoids
+
+`service/uboot/boot.php` computes its answer fresh on every HTTP request --
+nothing is stored, so a task that gets canceled a second after it was queued
+is simply never seen. That design does not survive contact with a board that
+cannot make the HTTP request at all. `UbootTftpSync` exists for exactly that
+gap, and only that gap: boards that speak `wget` never touch it.
+
+It writes the same content `boot.php` would have answered with, as a real
+file, to every MAC a host is registered under, named by the same `01-<mac>`
+convention `pxe get` already expects. It does this at the moments that matter
+-- a task is queued, completed, canceled, or fails -- so a board rebooting
+right after a task is queued finds a file waiting rather than racing FOG's own
+database write. A periodic reconcile pass (`Service/TaskScheduler.php`, same
+cycle as the rest of scheduled-task housekeeping) re-derives the whole
+directory from the database independently and corrects whatever the
+per-event calls missed -- a crash between the save and the write, a host
+deleted mid-task -- so staleness here is bounded to one reconcile cycle, never
+permanent. It only ever touches files matching its own naming pattern; nothing
+else in that directory is its business.
+
+Two things this depends on that the direct-`wget` path does not:
+
+- **`FOG_TFTP_HOST` / `FOG_TFTP_FTP_USERNAME` / `FOG_TFTP_FTP_PASSWORD` must be
+  set** (Settings, FTP/TFTP submenu). This is the same SSH/SFTP connection
+  FOG's kernel-upload feature already uses to reach a TFTP root that may not
+  be the web server itself -- if kernel uploads to ARM boards already work,
+  these are already configured.
+- **Failures here are silent by design.** An unreachable TFTP host must never
+  block queuing, canceling, or completing a task, so every failure is logged
+  through FOG's fault log rather than surfaced to whoever triggered the task.
+  If a wget-less board keeps getting `file not found` from `pxe get`, check
+  the fault log before assuming the task itself did not queue.
+
 ## What is not proven
 
 The emitted config is pinned byte-for-byte by
 `tests/bootmenu-uboot-output.test.php`, and the decisions behind it are shared
-with the iPXE path and pinned by `tests/bootmenu-ipxe-output.test.php`. What
-no test here can establish is that a real U-Boot on a real board consumes the
-document — that needs hardware. If you get it working, or it fails, say so on
-the forums so this page can be corrected.
+with the iPXE path and pinned by `tests/bootmenu-ipxe-output.test.php`. The
+TFTP-sync file naming and the SSH handshake it depends on are pinned by
+`tests/uboot-tftp-sync.test.php`. What no test here can establish is that a
+real U-Boot on a real board consumes either path -- that needs hardware, and
+the TFTP fallback in particular has had no field validation at all yet: it was
+built in response to forums topic 18229, whose board this document's `wget`
+section already covers, so the board that actually needs `pxe get` has not
+been confirmed. If you get it working, or it fails, say so on the forums so
+this page can be corrected.

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -9563,6 +9563,10 @@ msgid "Unable to connect to SSH"
 msgstr "Verbindung nicht möglich"
 
 #, fuzzy
+msgid "Unable to connect to TFTP server over SSH"
+msgstr "Verbindung nicht möglich"
+
+#, fuzzy
 msgid "Unable to connect to ssh"
 msgstr "Verbindung nicht möglich"
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -9558,6 +9558,10 @@ msgid "Unable to connect to SSH"
 msgstr "Failed to connect"
 
 #, fuzzy
+msgid "Unable to connect to TFTP server over SSH"
+msgstr "Failed to connect"
+
+#, fuzzy
 msgid "Unable to connect to ssh"
 msgstr "Failed to connect"
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -9733,6 +9733,10 @@ msgid "Unable to connect to SSH"
 msgstr "No se ha podido destruir"
 
 #, fuzzy
+msgid "Unable to connect to TFTP server over SSH"
+msgstr "No se ha podido destruir"
+
+#, fuzzy
 msgid "Unable to connect to ssh"
 msgstr "No se ha podido destruir"
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -9564,6 +9564,10 @@ msgid "Unable to connect to SSH"
 msgstr "Verbindung nicht möglich"
 
 #, fuzzy
+msgid "Unable to connect to TFTP server over SSH"
+msgstr "Verbindung nicht möglich"
+
+#, fuzzy
 msgid "Unable to connect to ssh"
 msgstr "Verbindung nicht möglich"
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -9560,6 +9560,10 @@ msgid "Unable to connect to SSH"
 msgstr "Échec de connexion"
 
 #, fuzzy
+msgid "Unable to connect to TFTP server over SSH"
+msgstr "Échec de connexion"
+
+#, fuzzy
 msgid "Unable to connect to ssh"
 msgstr "Échec de connexion"
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -9263,6 +9263,10 @@ msgid "Unable to connect to SSH"
 msgstr "Connessione fallita"
 
 #, fuzzy
+msgid "Unable to connect to TFTP server over SSH"
+msgstr "Connessione fallita"
+
+#, fuzzy
 msgid "Unable to connect to ssh"
 msgstr "Connessione fallita"
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -9206,6 +9206,10 @@ msgid "Unable to connect to SSH"
 msgstr "接続に失敗しました"
 
 #, fuzzy
+msgid "Unable to connect to TFTP server over SSH"
+msgstr "接続に失敗しました"
+
+#, fuzzy
 msgid "Unable to connect to ssh"
 msgstr "接続に失敗しました"
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -8166,6 +8166,9 @@ msgstr ""
 msgid "Unable to connect to SSH"
 msgstr ""
 
+msgid "Unable to connect to TFTP server over SSH"
+msgstr ""
+
 msgid "Unable to connect to ssh"
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -9559,6 +9559,10 @@ msgid "Unable to connect to SSH"
 msgstr "Falhou ao conectar"
 
 #, fuzzy
+msgid "Unable to connect to TFTP server over SSH"
+msgstr "Falhou ao conectar"
+
+#, fuzzy
 msgid "Unable to connect to ssh"
 msgstr "Falhou ao conectar"
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -9559,6 +9559,10 @@ msgid "Unable to connect to SSH"
 msgstr "连接失败"
 
 #, fuzzy
+msgid "Unable to connect to TFTP server over SSH"
+msgstr "连接失败"
+
+#, fuzzy
 msgid "Unable to connect to ssh"
 msgstr "连接失败"
 

--- a/packages/web/src/Boot/UbootBootMenu.php
+++ b/packages/web/src/Boot/UbootBootMenu.php
@@ -13,6 +13,7 @@
 
 namespace FOG\Boot;
 
+use FOG\Items\Host;
 use FOG\Items\StorageNode;
 use FOG\Router\Route;
 
@@ -43,9 +44,16 @@ use FOG\Router\Route;
  *     different tree adds `fdt` to their own bootcmd.
  *   - Choose a load address. Those are per-board and belong in the U-Boot
  *     environment.
- *   - Serve U-Boot itself, or write pxelinux.cfg files. FOG stays stateless:
- *     the board fetches this endpoint by MAC and gets an answer computed from
- *     the database, so nothing on disk can disagree with what is queued.
+ *   - Serve U-Boot itself.
+ *
+ * service/uboot/boot.php answers a live HTTP request the way this class
+ * always has: computed from the database at the moment a board asks, nothing
+ * stored. A board with no `wget` cannot ask that question at all, so
+ * UbootTftpSync separately materializes this same rendered output as a
+ * pxelinux.cfg/01-<mac> file for U-Boot's TFTP-native `pxe get` to find --
+ * see that class for the write/cleanup lifecycle. renderForHost() below is
+ * what makes that possible: the identical decision-and-syntax path this
+ * class already runs for the HTTP request, minus the HTTP response.
  *
  * @category UbootBootMenu
  * @package  FOGProject
@@ -67,13 +75,51 @@ class UbootBootMenu extends BootMenuBase
      * @var string
      */
     private $_initrdUrl;
+    /**
+     * The rendered extlinux document, once built
+     *
+     * @var string
+     */
+    private $_output = '';
+
+    /**
+     * Render the extlinux document for a specific host, without an HTTP
+     * response.
+     *
+     * The same decisions and syntax service/uboot/boot.php serves live,
+     * computed here for UbootTftpSync to write to disk instead of a
+     * request. self::$Host is process-global (FOGBase::$Host), so this
+     * saves and restores whatever it held before -- a caller looping over
+     * many hosts must not have host N+1's render see host N's Host object.
+     *
+     * @param Host $Host the host to render for
+     *
+     * @return string
+     */
+    public static function renderForHost(Host $Host)
+    {
+        $previousHost = self::$Host;
+        self::$Host = $Host;
+        try {
+            $menu = new self(false);
+
+            return $menu->_output;
+        } finally {
+            self::$Host = $previousHost;
+        }
+    }
 
     /**
      * Builds and emits the config for whatever this host should do next.
      *
+     * @param bool $emitOutput echo the rendered document and exit(), the
+     *                         way a live HTTP request needs -- false is
+     *                         renderForHost()'s path, which wants the
+     *                         string back with the process left running
+     *
      * @return void
      */
-    public function __construct()
+    public function __construct($emitOutput = true)
     {
         parent::__construct();
 
@@ -173,12 +219,24 @@ class UbootBootMenu extends BootMenuBase
             $this->_storage
         );
 
-        if (self::$Host->isValid() && self::$Host->get('task')->isValid()) {
-            $this->getTasking();
+        try {
+            if (self::$Host->isValid() && self::$Host->get('task')->isValid()) {
+                $this->getTasking();
+            } else {
+                $this->printDefault();
+            }
+        } catch (UbootRenderHalted $e) {
+            // _printImageIgnored() already built $this->_output; getTasking()
+            // has no return after calling it (see that hook's own comment),
+            // so this is what stops it here instead of running on into
+            // _printTasking() and overwriting a single-document format with
+            // a second, contradictory one.
+            unset($e);
+        }
+        if ($emitOutput) {
+            echo $this->_output;
             exit();
         }
-        $this->printDefault();
-        exit();
     }
 
     /**
@@ -209,7 +267,7 @@ class UbootBootMenu extends BootMenuBase
             $out[] = '    ' . $line;
         }
 
-        echo implode("\n", $out) . "\n";
+        $this->_output = implode("\n", $out) . "\n";
     }
 
     /**
@@ -258,7 +316,7 @@ class UbootBootMenu extends BootMenuBase
          * whichever it saw first. Emitting both would make the ignore flag
          * either meaningless or silently authoritative depending on order.
          */
-        exit();
+        throw new UbootRenderHalted();
     }
 
     /**

--- a/packages/web/src/Boot/UbootRenderHalted.php
+++ b/packages/web/src/Boot/UbootRenderHalted.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Signal that UbootBootMenu has nothing more to render
+ *
+ * PHP version 7.4+
+ *
+ * @category UbootRenderHalted
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Boot;
+
+/**
+ * Signal that UbootBootMenu has nothing more to render
+ *
+ * The in-process equivalent of the exit() a directly-served HTTP request
+ * uses to stop after _printImageIgnored(): BootMenuBase::getTasking() has no
+ * return after calling that hook (IpxeBootMenu deliberately falls through
+ * instead -- an iPXE script is a sequence and a later chain simply wins), so
+ * something has to stop extlinux's single-document output from being
+ * overwritten by whatever getTasking() would otherwise render next. exit()
+ * did that for a live HTTP response; it also kills the PHP process, which is
+ * fine for a request that has nothing left to do and fatal for
+ * UbootBootMenu::renderForHost(), which is called in a loop from
+ * UbootTftpSync against many hosts in one process. This exception carries
+ * the same "stop here" meaning without taking the process down with it.
+ *
+ * @category UbootRenderHalted
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class UbootRenderHalted extends \Exception
+{
+}

--- a/packages/web/src/Boot/UbootTftpSync.php
+++ b/packages/web/src/Boot/UbootTftpSync.php
@@ -1,0 +1,330 @@
+<?php
+/**
+ * Materializes UbootBootMenu's output as TFTP-served files
+ *
+ * PHP version 7.4+
+ *
+ * @category UbootTftpSync
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Boot;
+
+use FOG\Base\FOGBase;
+use FOG\Items\Host;
+use FOG\Items\MACAddress;
+use FOG\Router\Route;
+
+/**
+ * Materializes UbootBootMenu's output as TFTP-served files
+ *
+ * service/uboot/boot.php answers a board's HTTP GET the moment it asks --
+ * computed live, nothing stored. A board whose U-Boot has no `wget` (no
+ * CONFIG_CMD_WGET) cannot ask that question at all; the only thing it can do
+ * is TFTP, and U-Boot's `pxe get` speaks a fixed, un-configurable convention
+ * for that: fetch pxelinux.cfg/01-<mac, dash-separated, lowercase> from
+ * whatever TFTP root it booted from. That is a real file that has to exist
+ * before the board looks for it, which is the one thing FOG's live-computed
+ * design was built to avoid -- see forums topic 18229 for the board that
+ * made this necessary and UbootBootMenu's class doc for the design this
+ * sits beside rather than inside.
+ *
+ * The write target is FOG_TFTP_PXE_KERNEL_DIR over SSH/SFTP
+ * (FOG_TFTP_HOST + FOG_TFTP_FTP_USERNAME/PASSWORD), the same mechanism
+ * FOGPage.php's kernel-upload action already uses for the same reason: the
+ * TFTP root can be a remote storage node, not the web server.
+ *
+ * Two ways this gets called, both intentionally cheap for the common case
+ * where nothing here is in use at all (no hosts with MACs, or a fleet with
+ * no wget-less boards): a direct call at the moment a task is queued,
+ * completed, or canceled (materialize()/remove(), and the *Many() batch
+ * forms for a group action queuing or canceling many hosts at once, so
+ * that queuing a 100-host group task opens one SSH session rather than
+ * 100), and reconcile() -- run periodically by
+ * Service/TaskScheduler.php -- which re-derives "who should have a file"
+ * from the database the same way the boot menus do and corrects anything
+ * the direct calls missed: a crash between a task save and the write, a
+ * host deleted mid-task, a call site this file does not yet reach. The
+ * direct calls are the latency fix; reconcile() is what makes staleness
+ * bounded rather than permanent.
+ *
+ * Every public entry point catches its own failures and reports them
+ * through self::logFault() rather than throwing. An unreachable TFTP host
+ * must never break queuing, canceling, or completing a task -- those
+ * matter far more than this file being current for the one fleet that
+ * needs it, and reconcile() will catch up once the TFTP host is reachable
+ * again.
+ *
+ * @category UbootTftpSync
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class UbootTftpSync extends FOGBase
+{
+    /**
+     * Filename this convention expects for a MAC, minus the directory.
+     *
+     * @var string
+     */
+    const NAME_PATTERN = '/^01(-[0-9a-f]{2}){6}$/';
+
+    /**
+     * Connects to the TFTP host and makes sure pxelinux.cfg/ exists there.
+     *
+     * @return string the remote pxelinux.cfg directory, no trailing slash
+     *
+     * @throws \Exception when the SSH connection fails
+     */
+    private static function _connect()
+    {
+        list($tftpHost, $tftpUser, $tftpPass, $kernelDir) = self::getSetting(
+            [
+                'FOG_TFTP_HOST',
+                'FOG_TFTP_FTP_USERNAME',
+                'FOG_TFTP_FTP_PASSWORD',
+                'FOG_TFTP_PXE_KERNEL_DIR',
+            ]
+        );
+        self::$FOGSSH->username = $tftpUser;
+        self::$FOGSSH->password = $tftpPass;
+        self::$FOGSSH->host = $tftpHost;
+        if (!self::$FOGSSH->connect()) {
+            throw new \Exception(
+                _('Unable to connect to TFTP server over SSH')
+            );
+        }
+        $dir = '/' . trim((string)$kernelDir, '/') . '/pxelinux.cfg';
+        if (!self::$FOGSSH->exists($dir)) {
+            self::$FOGSSH->sftp_mkdir($dir);
+        }
+
+        return $dir;
+    }
+
+    /**
+     * Every pxelinux.cfg filename a host's registered MACs resolve to.
+     *
+     * More than one when a host has more than one NIC: whichever one it
+     * boots from has to find a file, and they are all the same host with
+     * the same task, so they all get the same content.
+     *
+     * @param Host $Host the host to name files for
+     *
+     * @return string[]
+     */
+    private static function _pxeFileNames(Host $Host)
+    {
+        $names = [];
+        foreach ((array)$Host->getMyMacs() as $rawMac) {
+            $mac = new MACAddress($rawMac);
+            if (!$mac->isValid()) {
+                continue;
+            }
+            $names[] = '01-' . strtolower(str_replace(':', '-', (string)$mac));
+        }
+
+        return array_values(array_unique($names));
+    }
+
+    /**
+     * Writes one file's worth of content to the TFTP host.
+     *
+     * FOGSSH::put() reads from a local path, not a string, so this is a
+     * temp-file-and-upload every time -- there is no smaller primitive for
+     * "send these bytes" over the sftp wrapper the rest of FOG already
+     * uses for this same TFTP host.
+     *
+     * @param string $remotePath the full remote path to write
+     * @param string $content    the bytes to write there
+     *
+     * @return void
+     */
+    private static function _write($remotePath, $content)
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'uboot-tftp-');
+        file_put_contents($tmp, $content);
+        try {
+            self::$FOGSSH->put($tmp, $remotePath);
+        } finally {
+            @unlink($tmp);
+        }
+    }
+
+    /**
+     * Renders and writes (or removes) one host's pxelinux.cfg files.
+     *
+     * @param string $dir  the remote pxelinux.cfg directory
+     * @param Host   $Host the host to sync
+     *
+     * @return void
+     */
+    private static function _syncOne($dir, Host $Host)
+    {
+        $names = self::_pxeFileNames($Host);
+        if (!$names) {
+            return;
+        }
+        if ($Host->isValid() && $Host->get('task')->isValid()) {
+            $content = UbootBootMenu::renderForHost($Host);
+            foreach ($names as $name) {
+                self::_write($dir . '/' . $name, $content);
+            }
+        } else {
+            foreach ($names as $name) {
+                $path = $dir . '/' . $name;
+                if (self::$FOGSSH->exists($path)) {
+                    self::$FOGSSH->unlinkFile($path);
+                }
+            }
+        }
+    }
+
+    /**
+     * Materializes the current tasking for one host.
+     *
+     * @param Host $Host the host that was just tasked
+     *
+     * @return void
+     */
+    public static function materialize(Host $Host)
+    {
+        self::materializeMany([$Host->get('id')]);
+    }
+
+    /**
+     * Removes one host's tasking files -- its task completed, failed, or
+     * was canceled.
+     *
+     * @param Host $Host the host whose task just ended
+     *
+     * @return void
+     */
+    public static function remove(Host $Host)
+    {
+        self::removeMany([$Host->get('id')]);
+    }
+
+    /**
+     * Materializes many hosts in one SSH session.
+     *
+     * The batched form a group task queue uses: queuing 100 hosts at once
+     * opens one SSH connection here, not 100 inside the request that
+     * queued them.
+     *
+     * @param int[] $hostIDs the hosts that were just tasked
+     *
+     * @return void
+     */
+    public static function materializeMany(array $hostIDs)
+    {
+        $hostIDs = array_values(array_unique(array_filter($hostIDs)));
+        if (!$hostIDs) {
+            return;
+        }
+        try {
+            $dir = self::_connect();
+            foreach ($hostIDs as $hostID) {
+                self::_syncOne($dir, new Host($hostID));
+            }
+            self::$FOGSSH->disconnect();
+        } catch (\Throwable $e) {
+            self::logFault('UbootTftpSync::materializeMany: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Removes many hosts' tasking files in one SSH session.
+     *
+     * @param int[] $hostIDs the hosts whose tasks just ended
+     *
+     * @return void
+     */
+    public static function removeMany(array $hostIDs)
+    {
+        $hostIDs = array_values(array_unique(array_filter($hostIDs)));
+        if (!$hostIDs) {
+            return;
+        }
+        try {
+            $dir = self::_connect();
+            foreach ($hostIDs as $hostID) {
+                $Host = new Host($hostID);
+                foreach (self::_pxeFileNames($Host) as $name) {
+                    $path = $dir . '/' . $name;
+                    if (self::$FOGSSH->exists($path)) {
+                        self::$FOGSSH->unlinkFile($path);
+                    }
+                }
+            }
+            self::$FOGSSH->disconnect();
+        } catch (\Throwable $e) {
+            self::logFault('UbootTftpSync::removeMany: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Re-derives every pxelinux.cfg file from the database and corrects
+     * whatever is wrong: writes what is missing, deletes what should not
+     * be there. Run periodically by Service/TaskScheduler.php.
+     *
+     * This is the safety net under materialize()/remove(): anything they
+     * missed (a crash between a task save and the write, a call site this
+     * file does not reach, a host deleted mid-task) is wrong for at most
+     * one reconcile cycle, not forever.
+     *
+     * @return void
+     */
+    public static function reconcile()
+    {
+        try {
+            $dir = self::_connect();
+            $activeHostIDs = array_values(
+                array_unique(
+                    Route::getIds(
+                        'task',
+                        [
+                            'stateID' => self::fastmerge(
+                                self::getQueuedStates(),
+                                (array)self::getProgressState()
+                            ),
+                        ],
+                        'hostID'
+                    )
+                )
+            );
+            $keep = [];
+            foreach ($activeHostIDs as $hostID) {
+                $Host = new Host($hostID);
+                $names = self::_pxeFileNames($Host);
+                if (!$names) {
+                    continue;
+                }
+                $content = UbootBootMenu::renderForHost($Host);
+                foreach ($names as $name) {
+                    $keep[$name] = true;
+                    self::_write($dir . '/' . $name, $content);
+                }
+            }
+            foreach (self::$FOGSSH->scanFilesystem($dir) as $path) {
+                $name = basename($path);
+                // Only ever touch files this class's own naming convention
+                // produced -- anything else in pxelinux.cfg/ is not ours to
+                // judge, let alone delete.
+                if (!preg_match(self::NAME_PATTERN, $name)) {
+                    continue;
+                }
+                if (!isset($keep[$name])) {
+                    self::$FOGSSH->unlinkFile($path);
+                }
+            }
+            self::$FOGSSH->disconnect();
+        } catch (\Throwable $e) {
+            self::logFault('UbootTftpSync::reconcile: ' . $e->getMessage());
+        }
+    }
+}

--- a/packages/web/src/Items/Group.php
+++ b/packages/web/src/Items/Group.php
@@ -15,6 +15,7 @@ namespace FOG\Items;
 
 use FOG\Base\FOGController;
 use FOG\Boot\SecureBootState;
+use FOG\Boot\UbootTftpSync;
 use FOG\Router\Route;
 
 /**
@@ -903,6 +904,30 @@ class Group extends FOGController
             set_time_limit(0);
             $this->wakeOnLAN();
         }
+        // Batched, not one materialize() per host: queuing this group task
+        // may have just tasked 100+ hosts, and that should open one SSH
+        // session here, not one inside each iteration of the branches
+        // above. Re-derived from the database rather than tracked through
+        // the branches -- every branch above computes its own $hostIDs
+        // under a different filter (WAKE_UP tasks nothing at all, Secure
+        // Boot enrollment drops ineligible members), so asking "who among
+        // $hostids actually has a task now" is correct regardless of which
+        // branch ran, where threading a per-branch list through would not
+        // be.
+        UbootTftpSync::materializeMany(
+            Route::getIds(
+                'task',
+                [
+                    'hostID' => $hostids,
+                    'stateID' => self::fastmerge(
+                        self::getQueuedStates(),
+                        (array)self::getProgressState()
+                    ),
+                ],
+                'hostID'
+            )
+        );
+
         return $stat;
     }
     /**

--- a/packages/web/src/Items/Host.php
+++ b/packages/web/src/Items/Host.php
@@ -15,6 +15,7 @@ namespace FOG\Items;
 
 use FOG\Base\FOGController;
 use FOG\Boot\SecureBootState;
+use FOG\Boot\UbootTftpSync;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 
@@ -1357,6 +1358,14 @@ class Host extends FOGController
                     throw new \Exception(self::$foglang['FailedTask']);
                 }
                 $this->set('task', $Task);
+                // Best-effort: a wget-less U-Boot board can only find its
+                // task over TFTP (see UbootTftpSync), and this is what
+                // closes the gap between queuing and the board being
+                // rebooted right after. Never allowed to fail the task
+                // itself -- UbootTftpSync::materialize() swallows its own
+                // errors, and Service/TaskScheduler.php's reconcile() picks
+                // up anything this misses.
+                UbootTftpSync::materialize($this);
             }
             if ($TaskType->isSnapinTask) {
                 if ($deploySnapins === true) {

--- a/packages/web/src/Items/Task.php
+++ b/packages/web/src/Items/Task.php
@@ -13,6 +13,7 @@
 
 namespace FOG\Items;
 
+use FOG\Boot\UbootTftpSync;
 use FOG\Router\Route;
 
 /**
@@ -322,6 +323,11 @@ class Task extends TaskType
         // log pane showed a canceled task as still running.
         if ($this->set('stateID', self::getCancelledState())->save()) {
             TaskLog::recordState($this);
+            // No existing event fires on cancel (unlike completion, which
+            // goes through HOST_TASKING_COMPLETE), so this is a direct call
+            // rather than a listener -- same reasoning as the materialize()
+            // call at task creation.
+            UbootTftpSync::remove($this->getHost());
         }
 
         return $this;

--- a/packages/web/src/Managers/TaskManager.php
+++ b/packages/web/src/Managers/TaskManager.php
@@ -14,6 +14,7 @@
 namespace FOG\Managers;
 
 use FOG\Base\FOGManagerController;
+use FOG\Boot\UbootTftpSync;
 use FOG\Items\TaskLog;
 use FOG\Items\TaskType;
 use FOG\Router\Route;
@@ -89,6 +90,10 @@ class TaskManager extends FOGManagerController
             // this arm cancels a whole group and rebuilding a Task per id to
             // write its row cost five queries apiece.
             TaskLog::recordStates($canceledIDs);
+            // Batched for the same reason as Group::createImagePackage()'s
+            // materializeMany() call: a bulk cancel can span many hosts, and
+            // this should open one SSH session, not one per host.
+            UbootTftpSync::removeMany($hostIDs);
         }
         $findWhere = [
             'hostID' => $hostIDs,

--- a/packages/web/src/Service/TaskScheduler.php
+++ b/packages/web/src/Service/TaskScheduler.php
@@ -13,6 +13,7 @@
 
 namespace FOG\Service;
 
+use FOG\Boot\UbootTftpSync;
 use FOG\Router\Route;
 
 /**
@@ -354,6 +355,12 @@ class TaskScheduler extends FOGService
                     )
                 );
             }
+            // Self-healing pass for wget-less U-Boot boards' TFTP files --
+            // see UbootTftpSync's class doc. It never throws (a failure here
+            // is logged through logFault(), not this service's own output),
+            // so it needs no try/catch of its own beyond the one already
+            // wrapping this whole method.
+            UbootTftpSync::reconcile();
         } catch (\Exception $e) {
             self::outall($e->getMessage());
         }

--- a/packages/web/src/TaskHandling/TaskError.php
+++ b/packages/web/src/TaskHandling/TaskError.php
@@ -15,6 +15,8 @@ namespace FOG\TaskHandling;
 
 use FOG\Audit\Audit;
 use FOG\Base\FOGBase;
+use FOG\Boot\UbootTftpSync;
+use FOG\Items\Task;
 use FOG\Items\TaskLog;
 use FOG\Items\TaskState;
 
@@ -296,6 +298,7 @@ class TaskError extends FOGBase
             return;
         }
         $Task->set('stateID', $failed)->save();
+        UbootTftpSync::remove($Task->getHost());
     }
     private static function _logRow($Task, $type, $text)
     {

--- a/packages/web/src/TaskHandling/TaskQueue.php
+++ b/packages/web/src/TaskHandling/TaskQueue.php
@@ -14,6 +14,7 @@
 namespace FOG\TaskHandling;
 
 use FOG\Audit\Audit;
+use FOG\Boot\UbootTftpSync;
 use FOG\Items\Image;
 use FOG\Items\StorageNode;
 use FOG\Items\TaskType;
@@ -714,6 +715,11 @@ class TaskQueue extends TaskingElement
                     'Task' => &$this->Task
                 ]
             );
+            // A wget-less U-Boot board's file has to go the moment the task
+            // it describes is gone, not at the next reconcile cycle -- a
+            // board that reboots itself right after finishing (shutdown=1)
+            // must not re-fetch the same, now-finished task.
+            UbootTftpSync::remove(self::$Host);
             if (!$this->taskLog()) {
                 throw new \Exception(_('Failed to update task log'));
             }

--- a/tests/lib/bootmenu-render.php
+++ b/tests/lib/bootmenu-render.php
@@ -267,6 +267,15 @@ $baseFile = dirname($classFile) . '/BootMenuBase.php';
 if (is_file($baseFile)) {
     require_once $baseFile;
 }
+/*
+ * Same reasoning: UbootBootMenu's image-ignored path throws this rather than
+ * calling exit(), so renderForHost() can be used from a process that renders
+ * more than one host (UbootTftpSync). Only UbootBootMenu depends on it.
+ */
+$haltFile = dirname($classFile) . '/UbootRenderHalted.php';
+if (is_file($haltFile)) {
+    require_once $haltFile;
+}
 require_once $classFile;
 
 /*

--- a/tests/uboot-tftp-sync.test.php
+++ b/tests/uboot-tftp-sync.test.php
@@ -1,0 +1,434 @@
+<?php
+/**
+ * UbootTftpSync: MAC-to-filename convention, the SSH connect/mkdir handshake,
+ * the orphan-file safety pattern, and the call-site wiring.
+ *
+ * Two of this class's four pieces are pure and self-contained enough to
+ * drive directly: _pxeFileNames() (the pxelinux.cfg/01-<mac> convention
+ * itself -- get this wrong and every wget-less board silently gets no file
+ * at all) and _connect() (the SSH handshake + mkdir-if-missing, reusing the
+ * same FakeSshFs-subclassing technique tests/fogssh-delete-terminates.test.php
+ * established for FOGSSH -- no ssh2 extension needed).
+ *
+ * The other two -- materializeMany()/removeMany()/reconcile()'s per-host
+ * loop, and _syncOne()'s render -- go through `new Host($id)`, which in this
+ * suite's DB-free harness means a real load() against FogFakeDb's synthesized
+ * rows, and then UbootBootMenu::renderForHost(), which is the same heavy
+ * render path tests/lib/bootmenu-harness.php exists to drive and is already
+ * covered there (golden fixture + bootmenu-uboot-output.test.php). Rebuilding
+ * that harness here would duplicate coverage that already exists elsewhere
+ * for the render itself, so what is asserted instead is the orchestration
+ * around it, the same way tests/tasklog-records-cancel.test.php pins
+ * TaskManager::cancel()'s bulk-update ordering by reading the method body
+ * rather than driving a bulk cancel through real Task objects.
+ *
+ * Usage: php tests/uboot-tftp-sync.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('uboot-tftp-sync');
+$db = FogTestHarness::fakeDb();
+// MACAddress::setMAC() logs a rejected mac through self::$FOGCore->debug();
+// a real request populates that from LoadGlobals, which this DB-free
+// bootstrap does not run.
+FogTestHarness::setStatic('FOGBase', 'FOGCore', new \FOG\Base\FOGCore());
+
+$t = new FogChecks();
+
+$syncFile = dirname(__DIR__)
+    . '/packages/web/src/Boot/UbootTftpSync.php';
+$syncSource = file_get_contents($syncFile);
+
+/*
+ * _pxeFileNames(): the pxelinux.cfg/01-<mac> convention.
+ *
+ * A host with more than one NIC has to resolve to a filename per MAC, all
+ * three input notations (colon, dash, bare hex) of the SAME mac have to
+ * collapse to one filename, and anything MACAddress::isValid() rejects has
+ * to be skipped rather than producing a broken filename.
+ */
+class MacListHost extends \FOG\Items\Host
+{
+    /** @var string[] */
+    public $macs = [];
+
+    public function __construct()
+    {
+        // Deliberately skips the parent constructor: the string-arg path
+        // through FOGController::__construct() would try to set up
+        // databaseFields bookkeeping. This class exists only to answer
+        // getMyMacs() without a database, so a bare FOGBase-level
+        // construction is all the private/reflected method under test needs.
+    }
+
+    public function getMyMacs($justme = true)
+    {
+        return $this->macs;
+    }
+}
+
+$macHost = new MacListHost();
+$macHost->macs = [
+    'AA:BB:CC:DD:EE:FF',
+    'aa-bb-cc-dd-ee-ff',
+    '112233445566',
+    'not-a-mac-address',
+    'AA:BB:CC:DD:EE:FF',
+];
+$names = FogTestHarness::callStatic(
+    'FOG\Boot\UbootTftpSync',
+    '_pxeFileNames',
+    [$macHost]
+);
+sort($names);
+
+$t->check(
+    'three distinct macs in five different spellings resolve to two names',
+    2 === count($names)
+);
+$t->check(
+    'the same mac in colon, dash, and repeated form collapses to one file',
+    in_array('01-aa-bb-cc-dd-ee-ff', $names, true)
+);
+$t->check(
+    'a second, distinct mac gets its own file',
+    in_array('01-11-22-33-44-55-66', $names, true)
+);
+$t->check(
+    'an invalid mac is skipped, not turned into a broken filename',
+    !preg_grep('/not-a-mac/', $names)
+);
+
+$emptyHost = new MacListHost();
+$emptyHost->macs = [];
+$t->check(
+    'a host with no macs resolves to no files',
+    [] === FogTestHarness::callStatic(
+        'FOG\Boot\UbootTftpSync',
+        '_pxeFileNames',
+        [$emptyHost]
+    )
+);
+
+/*
+ * NAME_PATTERN: the filter reconcile() trusts before it deletes anything.
+ * Only ever touch a file this class's own convention produced.
+ */
+$t->check(
+    'NAME_PATTERN matches this class\'s own filenames',
+    (bool)preg_match(
+        \FOG\Boot\UbootTftpSync::NAME_PATTERN,
+        '01-aa-bb-cc-dd-ee-ff'
+    )
+);
+foreach (
+    [
+        'uname is not a mac file' => 'uname',
+        'an uppercase mac file is not matched (names are lowercased first)'
+            => '01-AA-BB-CC-DD-EE-FF',
+        'a kernel image is not matched' => 'vmlinuz',
+        'a dotfile is not matched' => '.gitkeep',
+        'a short mac is not matched' => '01-aa-bb-cc-dd-ee',
+    ] as $label => $candidate
+) {
+    $t->check(
+        $label,
+        !preg_match(\FOG\Boot\UbootTftpSync::NAME_PATTERN, $candidate)
+    );
+}
+
+/*
+ * _connect(): the SSH handshake, the dir path built from
+ * FOG_TFTP_PXE_KERNEL_DIR, and mkdir-only-if-missing.
+ *
+ * No ssh2 extension needed -- same technique as
+ * tests/fogssh-delete-terminates.test.php: FOGSSH has no constructor, and
+ * every method this needs is declared directly (not reached through
+ * FOGSSH::__call()), so a subclass stands in for the whole remote filesystem.
+ */
+class FakeTftpFs extends \FOG\Net\FOGSSH
+{
+    /** @var array path => 'file'|'dir' */
+    public $tree = [];
+
+    /** @var array path => bytes, for 'file' entries */
+    public $contents = [];
+
+    /** @var bool what connect() returns */
+    public $connectSucceeds = true;
+
+    /** @var int how many times connect() was called */
+    public $connectCalls = 0;
+
+    /** @var int how many times disconnect() was called */
+    public $disconnectCalls = 0;
+
+    /** @var string[] every path sftp_mkdir() was asked to create */
+    public $mkdirCalls = [];
+
+    public function connect(
+        $host = '',
+        $port = 0,
+        $autologin = true,
+        $connectmethod = 'ssh2_connect'
+    ) {
+        ++$this->connectCalls;
+
+        return $this->connectSucceeds;
+    }
+
+    public function disconnect()
+    {
+        ++$this->disconnectCalls;
+    }
+
+    public function exists($path)
+    {
+        return isset($this->tree[$path]);
+    }
+
+    public function sftp_mkdir($path)
+    {
+        $this->mkdirCalls[] = $path;
+        $this->tree[$path] = 'dir';
+
+        return true;
+    }
+
+    public function put($localfile, $remotefile)
+    {
+        $this->tree[$remotefile] = 'file';
+        $this->contents[$remotefile] = file_get_contents($localfile);
+
+        return true;
+    }
+
+    public function unlinkFile($path)
+    {
+        unset($this->tree[$path], $this->contents[$path]);
+
+        return true;
+    }
+
+    public function scanFilesystem($remote_file)
+    {
+        if ('dir' !== ($this->tree[$remote_file] ?? '')) {
+            return [];
+        }
+        $prefix = rtrim($remote_file, '/') . '/';
+        $found = [];
+        foreach ($this->tree as $path => $type) {
+            if ($path === $remote_file || 'file' !== $type) {
+                continue;
+            }
+            if (0 === strpos($path, $prefix)) {
+                $found[] = $path;
+            }
+        }
+
+        return $found;
+    }
+}
+
+$tftpSettings = [
+    'FOG_TFTP_HOST' => 'tftp.example.test',
+    'FOG_TFTP_FTP_USERNAME' => 'fogtftp',
+    'FOG_TFTP_FTP_PASSWORD' => 's3cret',
+    'FOG_TFTP_PXE_KERNEL_DIR' => '/tftpboot/',
+];
+$db->responder = function ($sql, $params) use ($tftpSettings) {
+    if (false !== stripos($sql, 'FROM `globalSettings`')) {
+        $rows = [];
+        foreach ($tftpSettings as $k => $v) {
+            $rows[] = ['settingKey' => $k, 'settingValue' => $v];
+        }
+
+        return $rows;
+    }
+
+    return null;
+};
+
+$fakeFs = new FakeTftpFs();
+FogTestHarness::setStatic('FOGBase', 'FOGSSH', $fakeFs);
+
+$dir = FogTestHarness::callStatic('FOG\Boot\UbootTftpSync', '_connect');
+
+$t->check(
+    'the pxelinux.cfg dir is built from FOG_TFTP_PXE_KERNEL_DIR',
+    '/tftpboot/pxelinux.cfg' === $dir
+);
+$t->check(
+    'the SSH credentials are read from the TFTP settings',
+    'tftp.example.test' === $fakeFs->host
+    && 'fogtftp' === $fakeFs->username
+    && 's3cret' === $fakeFs->password
+);
+$t->check(
+    'a missing pxelinux.cfg dir is created',
+    [$dir] === $fakeFs->mkdirCalls
+);
+
+$mkdirCallsBefore = count($fakeFs->mkdirCalls);
+FogTestHarness::callStatic('FOG\Boot\UbootTftpSync', '_connect');
+$t->check(
+    'an existing pxelinux.cfg dir is not recreated',
+    $mkdirCallsBefore === count($fakeFs->mkdirCalls)
+);
+
+$fakeFs->connectSucceeds = false;
+$threw = null;
+try {
+    FogTestHarness::callStatic('FOG\Boot\UbootTftpSync', '_connect');
+} catch (\Throwable $e) {
+    $threw = $e;
+}
+$t->check(
+    'a failed SSH connection throws rather than silently continuing',
+    null !== $threw
+    && false !== stripos($threw->getMessage(), 'Unable to connect')
+);
+$fakeFs->connectSucceeds = true;
+
+/*
+ * _write(): the temp-file-and-upload primitive every write goes through.
+ */
+FogTestHarness::callStatic(
+    'FOG\Boot\UbootTftpSync',
+    '_write',
+    ['/tftpboot/pxelinux.cfg/01-aa-bb-cc-dd-ee-ff', "DEFAULT localboot\n"]
+);
+$t->check(
+    '_write() uploads the exact bytes it was given',
+    "DEFAULT localboot\n"
+    === ($fakeFs->contents['/tftpboot/pxelinux.cfg/01-aa-bb-cc-dd-ee-ff'] ?? null)
+);
+
+/*
+ * Orchestration properties that are cheap to pin by reading the source and
+ * expensive to drive end-to-end (see the file header comment for why):
+ * catching \Throwable rather than \Exception, the id-list hygiene every
+ * batched entry point does before opening a connection, and the
+ * isValid()-gated branch _syncOne() uses to choose write vs. delete.
+ */
+
+/*
+ * Each method's body is extracted first (stopping at its own closing brace,
+ * same technique tests/tasklog-records-cancel.test.php uses), rather than
+ * matching ".*?catch" against the whole file: three methods in a row all
+ * catching \Throwable meant an unbounded lazy match found the NEXT method's
+ * catch clause just fine even after this one's was reverted to \Exception --
+ * a mutation test caught that false pass before this file was trusted.
+ */
+function extractMethodBody($source, $signaturePattern)
+{
+    if (preg_match($signaturePattern . '.*?\n    \}\n#s', $source, $m)) {
+        return $m[0];
+    }
+
+    return '';
+}
+
+foreach (
+    [
+        'materializeMany' => '#public static function materializeMany\(array \$hostIDs\)',
+        'removeMany' => '#public static function removeMany\(array \$hostIDs\)',
+        'reconcile' => '#public static function reconcile\(\)',
+    ] as $method => $signaturePattern
+) {
+    $body = extractMethodBody($syncSource, $signaturePattern);
+    $t->check("$method() is found", '' !== $body);
+    $t->check(
+        "$method() swallows Throwable, not just Exception",
+        (bool)preg_match('#catch\s*\(\s*\\\\Throwable#', $body)
+    );
+}
+
+foreach (['materializeMany', 'removeMany'] as $method) {
+    $t->check(
+        "$method() de-duplicates and drops empty ids before opening a connection",
+        (bool)preg_match(
+            '#' . $method . '\(array \$hostIDs\)\s*\{\s*'
+            . '\$hostIDs = array_values\(array_unique\(array_filter\(\$hostIDs\)\)\);'
+            . '\s*if \(!\$hostIDs\) \{\s*return;#s',
+            $syncSource
+        )
+    );
+}
+
+$t->check(
+    '_syncOne() writes only when the host and its task are both valid',
+    (bool)preg_match(
+        '#if \(\$Host->isValid\(\) && \$Host->get\(.task.\)->isValid\(\)\) \{'
+        . '\s*\$content = UbootBootMenu::renderForHost\(\$Host\);#s',
+        $syncSource
+    )
+);
+$t->check(
+    'reconcile() derives the active-host set from queued + in-progress tasks',
+    (bool)preg_match(
+        '#Route::getIds\(\s*.task.,\s*\[\s*.stateID. => self::fastmerge\('
+        . '\s*self::getQueuedStates\(\),\s*\(array\)\s*self::getProgressState\(\)#s',
+        $syncSource
+    )
+);
+$t->check(
+    'reconcile() only deletes files matching this class\'s own naming pattern',
+    (bool)preg_match(
+        '#if \(!preg_match\(self::NAME_PATTERN, \$name\)\) \{\s*continue;#s',
+        $syncSource
+    )
+);
+
+/*
+ * Call-site wiring: every task-lifecycle mutation this class exists to
+ * track actually calls into it. Each pattern is anchored to the surrounding
+ * statement it was inserted next to, not just "the string appears in the
+ * file somewhere", so a refactor that moves the call away from the save it
+ * is meant to follow still fails this.
+ */
+$callSites = [
+    'packages/web/src/Items/Host.php' => [
+        'createImagePackage() materializes the new task' =>
+            '#\$this->set\(.task., \$Task\);'
+            . '.{0,800}?UbootTftpSync::materialize\(\$this\);#s',
+    ],
+    'packages/web/src/Items/Group.php' => [
+        'createImagePackage() materializes every tasked host in one batch' =>
+            '#UbootTftpSync::materializeMany\(\s*Route::getIds\(\s*.task.#s',
+    ],
+    'packages/web/src/Items/Task.php' => [
+        'cancel() removes the file once the cancel is saved' =>
+            '#stateID., self::getCancelledState\(\)\)->save\(\)\)\s*\{'
+            . '.{0,800}?UbootTftpSync::remove\(\$this->getHost\(\)\);#s',
+    ],
+    'packages/web/src/Managers/TaskManager.php' => [
+        'cancel() removes the files for every task the bulk update touched' =>
+            '#if \(\$updated\)\s*\{.{0,800}?'
+            . 'UbootTftpSync::removeMany\(\$hostIDs\);#s',
+    ],
+    'packages/web/src/TaskHandling/TaskQueue.php' => [
+        'checkout() removes the file once tasking completes' =>
+            '#HOST_TASKING_COMPLETE.*?UbootTftpSync::remove\(self::\$Host\);#s',
+    ],
+    'packages/web/src/TaskHandling/TaskError.php' => [
+        '_markFailed() removes the file once the task is marked failed' =>
+            '#\$Task->set\(.stateID., \$failed\)->save\(\);\s*'
+            . 'UbootTftpSync::remove\(\$Task->getHost\(\)\);#',
+    ],
+    'packages/web/src/Service/TaskScheduler.php' => [
+        '_commonOutput() runs the reconcile sweep' =>
+            '#UbootTftpSync::reconcile\(\);#',
+    ],
+];
+
+foreach ($callSites as $relPath => $checks) {
+    $source = file_get_contents(dirname(__DIR__) . '/' . $relPath);
+    foreach ($checks as $label => $pattern) {
+        $t->check($label, (bool)preg_match($pattern, $source));
+    }
+}
+
+$t->finish();

--- a/tests/uboot-tftp-sync.test.php
+++ b/tests/uboot-tftp-sync.test.php
@@ -150,13 +150,30 @@ foreach (
  */
 class FakeTftpFs extends \FOG\Net\FOGSSH
 {
+    /**
+     * Shadows the parent's __set()/__get()-backed $data array with real,
+     * declared properties -- the assertions below read them straight back,
+     * and phpstan-tests.neon (level 5) does not know the magic accessors'
+     * shape without a @property annotation FOGSSH does not carry. UbootTftpSync
+     * itself still writes through __set() when handed a real FOGSSH.
+     *
+     * @var string
+     */
+    public $host = '';
+
+    /** @var string */
+    public $username = '';
+
+    /** @var string */
+    public $password = '';
+
     /** @var array path => 'file'|'dir' */
     public $tree = [];
 
     /** @var array path => bytes, for 'file' entries */
     public $contents = [];
 
-    /** @var bool what connect() returns */
+    /** @var bool what connect() succeeds or fails */
     public $connectSucceeds = true;
 
     /** @var int how many times connect() was called */
@@ -168,6 +185,14 @@ class FakeTftpFs extends \FOG\Net\FOGSSH
     /** @var string[] every path sftp_mkdir() was asked to create */
     public $mkdirCalls = [];
 
+    /**
+     * Mirrors the real connect()'s actual contract (self|false), not its
+     * @return object docblock -- the real method's own catch branch returns
+     * false on failure, which is the falsy value UbootTftpSync::_connect()'s
+     * `if (!self::$FOGSSH->connect())` depends on.
+     *
+     * @return self|false
+     */
     public function connect(
         $host = '',
         $port = 0,
@@ -175,13 +200,18 @@ class FakeTftpFs extends \FOG\Net\FOGSSH
         $connectmethod = 'ssh2_connect'
     ) {
         ++$this->connectCalls;
+        if (!$this->connectSucceeds) {
+            return false;
+        }
 
-        return $this->connectSucceeds;
+        return $this;
     }
 
     public function disconnect()
     {
         ++$this->disconnectCalls;
+
+        return true;
     }
 
     public function exists($path)
@@ -201,8 +231,6 @@ class FakeTftpFs extends \FOG\Net\FOGSSH
     {
         $this->tree[$remotefile] = 'file';
         $this->contents[$remotefile] = file_get_contents($localfile);
-
-        return true;
     }
 
     public function unlinkFile($path)


### PR DESCRIPTION
## Summary

- `service/uboot/boot.php` answers a board's HTTP GET live, computed fresh from the database every time -- nothing is ever stored. A board whose U-Boot has no `CONFIG_CMD_WGET` cannot make that request at all, and its only option, `pxe get`, expects a real file at a fixed, un-configurable path (`pxelinux.cfg/01-<mac>`). Raised on forums topic 18229.
- Adds `UbootTftpSync`, which materializes `UbootBootMenu`'s rendered output as real files over the SSH/SFTP connection FOG's kernel-upload feature already uses to reach the TFTP root. Writes happen directly at every task-lifecycle mutation (queued/completed/canceled/failed, single-host and batched-group forms), plus a periodic `reconcile()` pass in `Service/TaskScheduler.php` that re-derives the whole directory from the database and corrects anything the direct calls missed. Every public entry point swallows its own failures -- an unreachable TFTP host must never block queuing, canceling, or completing a task.
- `UbootBootMenu::renderForHost()` reuses the exact rendering the live HTTP path already produces, which needed the constructor's unconditional `exit()` replaced with a catchable `UbootRenderHalted` so the class can render for a host other than the one serving the current request.
- Documents the fallback (the `pxe get`/`pxe boot` boot script, the settings it depends on, and what is still unproven) in `docs/UBOOT_ARM_BOOT.md`.

## Test plan

- [x] `tests/uboot-tftp-sync.test.php` -- 35 checks: MAC-to-filename convention, the SSH connect/mkdir handshake, the orphan-file naming safety pattern, and all 7 call-site wirings. Mutation-tested (reverted a `catch (\Throwable)` to `catch (\Exception)` and confirmed the test goes red).
- [x] `bash tests/run-all.sh` -- 241 passed, 0 failed
- [x] `vendor/bin/phpstan analyse --memory-limit=2G` -- no errors
- [x] `php bin/psr4-scan.php --check` -- 272 classes, 0 to move
- [x] `php tests/us-spelling.test.php` -- 783 files, no UK spellings
- [ ] Real hardware: no U-Boot board has exercised this path yet (see "What is not proven" in the doc update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBgcEakksay1L5XtiVDXKZ