### PR TITLE
Fix three class names held in strings, and gate the shape

### DIFF
--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -144,7 +144,7 @@ class System
         // installer reads this to pick which release to download, so a given
         // FOG release ships a known set of plugins rather than whatever the
         // default branch held on the day someone installed.
-        define('FOG_PLUGINS_VERSION', 'v1.6.21');
+        define('FOG_PLUGINS_VERSION', 'v1.6.22');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already

--- a/packages/web/src/Items/Plugin.php
+++ b/packages/web/src/Items/Plugin.php
@@ -1075,9 +1075,19 @@ class Plugin extends FOGController
         if (!$this->get('name')) {
             return parent::getManager();
         }
-        $classManager = sprintf(
-            '%sManager',
-            $this->get('name')
+        // Built from the plugins.pName database value, which is a bare short
+        // name, then qualified -- a plugin's manager declares
+        // FOG\Plugins\<Plugin>\<Name>Manager (ADR 0013). Without this the
+        // class_exists() below is false for every namespaced plugin and this
+        // falls back to PluginManager, which install() then correctly reports
+        // as a broken manager file: every plugin install throws "<X>Manager
+        // could not be loaded". A plugin still in the global namespace passes
+        // through qualify() untouched.
+        $classManager = self::qualify(
+            sprintf(
+                '%sManager',
+                $this->get('name')
+            )
         );
         if (!class_exists($classManager)) {
             return parent::getManager();

--- a/packages/web/src/Router/OpenAPI.php
+++ b/packages/web/src/Router/OpenAPI.php
@@ -1734,9 +1734,16 @@ class OpenAPI extends FOGBase
      */
     private static function _permission($routeName, $class)
     {
-        if (!method_exists('Authorization', 'resolveApiPermission')) {
-            return null;
-        }
+        // Called directly. This used to be guarded by
+        // method_exists('Authorization', ...) -- a class name in a STRING,
+        // which PHP resolves as written from the global namespace, ignoring
+        // the `use` above. Core stopped answering its bare names when the
+        // global aliases were retired (ADR 0013 §2), so the guard was false
+        // on every call: _permission() returned null for every operation and
+        // the published spec said the whole REST API needs no permission.
+        // Silently, plus an autoloader line in the error log per render.
+        // The guard bought nothing even when it worked -- the method is
+        // declared in this repository, beside this file.
         $permission = Authorization::resolveApiPermission($routeName, $class);
         return ('' === $permission || null === $permission) ? null : $permission;
     }

--- a/packages/web/src/Service/PluginRunner.php
+++ b/packages/web/src/Service/PluginRunner.php
@@ -228,7 +228,15 @@ class PluginRunner extends FOGService
                 continue;
             }
             foreach ((array)glob($dir . DS . '*.task.php') as $file) {
-                $class = basename($file, '.task.php');
+                // qualify(), because the basename is a BARE name and both
+                // uses below resolve a string. A plugin task declares
+                // FOG\Plugins\<Plugin>\<Class> (ADR 0013), so the bare name
+                // is not a class -- is_subclass_of() is then false for every
+                // task and the runner skips all of them, which is the exact
+                // failure the comment below records for the SECOND argument.
+                // A plugin still in the global namespace passes through
+                // unchanged, so both shapes work.
+                $class = self::qualify(basename($file, '.task.php'));
                 // is_subclass_of() rather than class_exists() alone. The
                 // autoloader resolves a class by basename across every
                 // scanned root, so a plugin shipping tasks/host.task.php

--- a/tests/plugin-namespace.test.php
+++ b/tests/plugin-namespace.test.php
@@ -155,6 +155,29 @@ $legacy = fixture(
     null,
     'LegacyThing'
 );
+// A manager named after the PLUGIN, not after a model. Plugin::getManager()
+// builds plugins.pName . 'Manager', so this is the name that call site looks
+// for. Deliberately a plain class: getManager() only instantiates it, and a
+// real FOGManagerController wants a database this test does not have.
+fixture(
+    $tmp,
+    'alphaplugin',
+    'class',
+    'alphapluginmanager.class.php',
+    'FOG\\Plugins\\Alphaplugin',
+    'AlphapluginManager'
+);
+// A plugin task. PluginRunner derives its class name from the FILENAME, so
+// this is the shape that broke: see section 9.
+$task = fixture(
+    $tmp,
+    'alphaplugin',
+    'tasks',
+    'alphaheartbeat.task.php',
+    'FOG\\Plugins\\Alphaplugin',
+    'AlphaHeartbeat extends \\FOG\\Base\\PluginTask',
+    "    public function run()\n    {\n    }\n"
+);
 // A plugin trying to claim a CORE name from inside its own namespace. It is
 // entitled to the class; it is not entitled to the bare spelling.
 $shadow = fixture(
@@ -185,6 +208,14 @@ if (!defined('FOG_LOG_DIR')) {
 }
 if (!defined('FOG_PLUGIN_DIR')) {
     define('FOG_PLUGIN_DIR', $tmp . '/extplugins');
+}
+// FOGBase::info() is on the path of every get(), and its file-logging gate is
+// `self::$mySchema >= FOG_SCHEMA` -- a constant System.php defines, and this
+// test does not boot System.php. Any value above $mySchema (0 when no database
+// was read) keeps the gate shut, which is the state this test wants: the
+// alternative branch calls getSetting() and dies on a null $DB.
+if (!defined('FOG_SCHEMA')) {
+    define('FOG_SCHEMA', 1);
 }
 
 // Divert error_log() so the diagnostics themselves can be asserted on.
@@ -497,6 +528,93 @@ check(
 check(
     'but the basename collision is NOT reported as shadowing',
     strpos($log, 'two files claim the class name "widget"') === false,
+    $failures,
+    $checks
+);
+
+/*
+ * 9. The two call sites that build a class name and then RESOLVE it as a
+ *    string. Both were broken by namespacing the plugins and both failed
+ *    without an error:
+ *
+ *      - PluginRunner::_discoverTasks() takes basename($file, '.task.php')
+ *        and hands it to is_subclass_of(). That is false for a namespaced
+ *        task, so every plugin task is skipped and the daemon logs
+ *        "Skipping, not a PluginTask" -- the identical failure ADR 0013 §2
+ *        records for the SECOND argument of the same call.
+ *      - Plugin::getManager() builds plugins.pName . 'Manager' and hands it
+ *        to class_exists(). That is false too, so it falls back to
+ *        PluginManager -- and installdb() then correctly reports a manager
+ *        file it cannot load, so EVERY plugin install throws.
+ *
+ *    The mechanism first, executed rather than read: a name derived from a
+ *    filename is bare, and only qualify() turns it into the class.
+ */
+$bareTask = basename($task, '.task.php');
+check(
+    'a name derived from a task FILENAME is not a class on its own',
+    !is_subclass_of($bareTask, 'FOG\\Base\\PluginTask'),
+    $failures,
+    $checks
+);
+check(
+    'qualify() turns it into the PluginTask subclass it names',
+    is_subclass_of(
+        call_user_func($qualify, $bareTask),
+        'FOG\\Base\\PluginTask'
+    ),
+    $failures,
+    $checks
+);
+
+/*
+ *    _discoverTasks() itself needs a database -- it walks Route::getList()
+ *    over the installed plugins -- so its call site is anchored rather than
+ *    executed, and the whole expression is anchored, not the word qualify:
+ *    an anchor on the symbol alone would stay green if the argument moved.
+ *    The end-to-end proof was a run of the daemon against a live install.
+ */
+$runnerSrc = (string)file_get_contents(
+    dirname(__DIR__) . '/packages/web/src/Service/PluginRunner.php'
+);
+check(
+    'PluginRunner derives a task class through qualify(), not from the '
+    . 'bare basename',
+    strpos(
+        $runnerSrc,
+        '$class = self::qualify(basename($file, \'.task.php\'));'
+    ) !== false,
+    $failures,
+    $checks
+);
+
+/*
+ *    Then the call sites themselves. Plugin::getManager() is reachable
+ *    without a database: it reads one field and resolves a name, so the
+ *    object is built without its constructor and its data set directly.
+ *    This executes the real method -- deleting its qualify() reds this.
+ */
+$pref = new \ReflectionClass('FOG\Items\Plugin');
+$plugin = $pref->newInstanceWithoutConstructor();
+$dataProp = new \ReflectionProperty('FOG\Base\FOGController', 'data');
+$dataProp->setAccessible(true);
+$dataProp->setValue($plugin, ['name' => 'alphaplugin']);
+// isLoaded is FOGController's recursion guard for its lazy loader: marking
+// the key loaded is what stops get('name') going to the database for a field
+// that has just been supplied. Nothing else here touches one.
+$loadedProp = new \ReflectionProperty('FOG\Base\FOGController', 'isLoaded');
+$loadedProp->setAccessible(true);
+$loadedProp->setValue($plugin, ['name' => true]);
+$resolvedManager = null;
+try {
+    $resolvedManager = get_class($plugin->getManager());
+} catch (\Throwable $e) {
+    $resolvedManager = 'threw ' . get_class($e) . ': ' . $e->getMessage();
+}
+check(
+    'Plugin::getManager() resolves a namespaced plugin manager, not the '
+    . 'PluginManager fallback (got ' . $resolvedManager . ')',
+    $resolvedManager === 'FOG\\Plugins\\Alphaplugin\\AlphapluginManager',
     $failures,
     $checks
 );

--- a/tests/string-class-literals-are-qualified.test.php
+++ b/tests/string-class-literals-are-qualified.test.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * A class named in a STRING must be spelled the way the class is declared.
+ *
+ *   tests/string-class-literals-are-qualified.test.php
+ *
+ * PHP resolves a class name held in a string from the GLOBAL namespace,
+ * always. The enclosing `namespace` is not applied and `use` is not
+ * consulted -- so inside `namespace FOG\Router;`, the literal in
+ * `method_exists('Authorization', 'resolveApiPermission')` names
+ * `\Authorization`, not `FOG\Auth\Authorization`. Since ADR 0013 §2 retired
+ * the reverse aliases, nothing declares the global spelling and the
+ * predicate is simply FALSE.
+ *
+ * That is the whole failure mode: these functions do not throw and do not
+ * warn. They answer "no such class" the same way they answer a genuine
+ * absence, so the caller takes its fallback branch and reports nothing.
+ * Found in the wild twice while namespacing:
+ *
+ *   - `OpenAPI::_permission()` returned null for every operation, so the
+ *     published API document described no permissions at all;
+ *   - `PluginRunner::_discoverTasks()` had the same shape recorded in a
+ *     comment for `is_subclass_of($class, 'PluginTask')` -- every plugin
+ *     task skipped, with "Skipping, not a PluginTask" as the only trace.
+ *
+ * The fix is `Foo::class` (resolved at compile time, `use`-aware) or a
+ * leading-backslash FQCN. Both are accepted here.
+ *
+ * Token-driven, not regex: the same text inside a comment or an unrelated
+ * string is not a call, and one of those already exists in the tree
+ * (FOGURLRequests.php recounts this exact bug in prose).
+ *
+ * A literal naming a class PHP itself declares -- class_exists('PDO') -- is
+ * accepted: those genuinely live in the global namespace.
+ *
+ * Usage: php tests/string-class-literals-are-qualified.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+// Zero, and it stays zero. Same discipline as tests/global-class-prefix:
+// the assertion is only worth anything because the two sites above made it
+// fail before they were fixed.
+const EXPECT_SITES = 0;
+
+$root = dirname(__DIR__);
+
+/*
+ * Argument positions that are a class name, per function. Position 1 for
+ * is_subclass_of()/is_a() is the PARENT -- the argument whose literal cost
+ * PluginRunner every one of its tasks.
+ */
+$funcs = [
+    'method_exists' => [0],
+    'property_exists' => [0],
+    'class_exists' => [0],
+    'interface_exists' => [0],
+    'trait_exists' => [0],
+    'enum_exists' => [0],
+    'get_class_vars' => [0],
+    'get_class_methods' => [0],
+    'get_parent_class' => [0],
+    'class_implements' => [0],
+    'class_parents' => [0],
+    'is_subclass_of' => [1],
+    'is_a' => [1],
+];
+
+$files = [];
+foreach (['packages/web', 'packages/service'] as $sub) {
+    $dir = $root . '/' . $sub;
+    if (!is_dir($dir)) {
+        continue;
+    }
+    $it = new \RecursiveIteratorIterator(
+        new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+    );
+    foreach ($it as $f) {
+        if (!$f->isFile() || strtolower($f->getExtension()) !== 'php') {
+            continue;
+        }
+        $path = $f->getPathname();
+        // lib/plugins is installed artifact, not repo source (ADR 0009), and
+        // vendor/ is not ours to spell.
+        if (strpos($path, '/lib/plugins/') !== false
+            || strpos($path, '/vendor/') !== false
+        ) {
+            continue;
+        }
+        $files[] = $path;
+    }
+}
+sort($files);
+
+if (!$files) {
+    fwrite(STDERR, "FAIL: found no PHP to scan\n");
+    exit(1);
+}
+
+$bad = [];
+foreach ($files as $path) {
+    $tokens = token_get_all((string)file_get_contents($path));
+    $count = count($tokens);
+    for ($i = 0; $i < $count; $i++) {
+        $t = $tokens[$i];
+        if (!is_array($t) || $t[0] !== T_STRING) {
+            continue;
+        }
+        $name = strtolower($t[1]);
+        if (!isset($funcs[$name])) {
+            continue;
+        }
+        // A method call ($x->method_exists(...), Foo::method_exists(...)) is
+        // not the built-in.
+        for ($p = $i - 1; $p >= 0; $p--) {
+            if (is_array($tokens[$p]) && $tokens[$p][0] === T_WHITESPACE) {
+                continue;
+            }
+            break;
+        }
+        if ($p >= 0 && is_array($tokens[$p])
+            && in_array(
+                $tokens[$p][0],
+                [T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_FUNCTION, T_NEW],
+                true
+            )
+        ) {
+            continue;
+        }
+        // Find the opening paren.
+        for ($j = $i + 1; $j < $count; $j++) {
+            if (is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
+                continue;
+            }
+            break;
+        }
+        if ($j >= $count || $tokens[$j] !== '(') {
+            continue;
+        }
+        // Walk the arguments, tracking nesting so a nested call's commas do
+        // not shift the positions.
+        $depth = 0;
+        $arg = 0;
+        $literals = [];
+        for ($k = $j; $k < $count; $k++) {
+            $tk = $tokens[$k];
+            if ($tk === '(' || $tk === '[' || $tk === '{') {
+                $depth++;
+                continue;
+            }
+            if ($tk === ')' || $tk === ']' || $tk === '}') {
+                $depth--;
+                if ($depth === 0) {
+                    break;
+                }
+                continue;
+            }
+            if ($depth === 1 && $tk === ',') {
+                $arg++;
+                continue;
+            }
+            if ($depth === 1 && is_array($tk)
+                && $tk[0] === T_CONSTANT_ENCAPSED_STRING
+            ) {
+                // Only a lone literal counts. A concatenation is a
+                // constructed name and out of this test's reach.
+                $literals[$arg] = [trim($tk[1], "'\""), $tk[2]];
+            }
+        }
+        foreach ($funcs[$name] as $pos) {
+            if (!isset($literals[$pos])) {
+                continue;
+            }
+            list($lit, $line) = $literals[$pos];
+            if (strpos($lit, '\\') !== false) {
+                continue;
+            }
+            // Declared by PHP itself: this process has loaded no FOG code, so
+            // anything class_exists() knows here is an internal class, and
+            // those really are global.
+            if (class_exists($lit, false)
+                || interface_exists($lit, false)
+                || trait_exists($lit, false)
+            ) {
+                continue;
+            }
+            $bad[] = sprintf(
+                '%s:%d  %s(%s)',
+                substr($path, strlen($root) + 1),
+                $line,
+                $name,
+                "'" . $lit . "'"
+            );
+        }
+    }
+}
+
+if (count($bad) !== EXPECT_SITES) {
+    fwrite(
+        STDERR,
+        sprintf(
+            "FAIL: %d unqualified class literal(s), expected %d\n",
+            count($bad),
+            EXPECT_SITES
+        )
+    );
+    foreach ($bad as $b) {
+        fwrite(STDERR, "  - $b\n");
+    }
+    fwrite(
+        STDERR,
+        "Use Foo::class, or a leading-backslash FQCN in the string.\n"
+    );
+    exit(1);
+}
+
+fwrite(
+    STDOUT,
+    sprintf("PASS (%d files scanned, %d sites)\n", count($files), count($bad))
+);
+exit(0);


### PR DESCRIPTION
Follow-up to #1535, found by running the namespaced plugin tree against a live install rather than reasoning about it. Three separate sites, one mistake.

**A class name held in a string is resolved as written, from the global namespace.** The enclosing `namespace` is not applied and `use` is not consulted. Since ADR 0013 §2 retired the reverse aliases, nothing declares the global spellings any more — so each of these named a class that does not exist. None of them throw: the predicate answers "no such class" exactly as it would for a genuine absence, and the caller quietly takes its fallback.

| Site | Was | Symptom |
|---|---|---|
| `PluginRunner::_discoverTasks()` | `is_subclass_of(basename($file, '.task.php'), …)` | every plugin task skipped; the only trace is `Skipping, not a PluginTask` |
| `Plugin::getManager()` | `class_exists(pName . 'Manager')` | falls back to `PluginManager`; `installdb()` then correctly reports a manager file it cannot load, so **every plugin install throws** |
| `OpenAPI::_permission()` | `method_exists('Authorization', …)` | returned null for every operation — the published API document described the whole REST API as needing no permission |

The same call in `_discoverTasks()` already carried a comment recording this exact failure for its **second** argument. It was written for one argument and not the other.

## The fixes

The two plugin sites go through `FOGBase::qualify()`, which leaves a plugin still in the global namespace untouched — both spellings work, which is the compatibility guarantee #1535 is built on.

`OpenAPI::_permission()`'s guard is **deleted** rather than qualified. It bought nothing even when it worked: the method it tests for is declared in this repository, beside the file that was testing for it. (PHPStan says the same thing once the name resolves — `function.alreadyNarrowedType`.)

## The gate

`tests/string-class-literals-are-qualified.test.php` is new and general: a token-driven scan of `packages/` for a bare class literal in `method_exists()`, `class_exists()`, `is_subclass_of()`, `property_exists()` and friends, checking argument 0 — and argument **1** for `is_subclass_of()`/`is_a()`, which is the position that cost `_discoverTasks()` its tasks. A literal PHP itself declares (`class_exists('PDO')`) is allowed; those really are global.

Token-driven rather than regex on purpose: the same text already appears inside a comment in `FOGURLRequests.php`, recounting this exact bug in prose.

It counts **2** with the fixes reverted and **0** now.

`tests/plugin-namespace.test.php` gains the two plugin call sites — `getManager()` **executed** against a fixture plugin (the mutation returns `FOG\Managers\PluginManager`, which is the reported symptom), and `_discoverTasks()` anchored on its whole expression, because the method itself needs a database.

## Verification

- Both new call-site assertions and the new gate were mutation-verified — each reversion observed red, restored from a scratchpad copy rather than `git checkout --`.
- Full suite 242/242; both `phpstan` passes clean, unscoped.
- Against the lab (podman MariaDB from a dump of the 1.6 server, shadow web tree, namespaced plugin tree on disk): `getManager()` + `installdb()` now succeed for all seven installed plugins (ldap, location, windowskey, ou, ntfy, helloworld, oidc) — this is what threw before the fix. The one real `.task.php` in fog-plugins resolves: `helloworldheartbeat` is not a `PluginTask`, `FOG\Plugins\Helloworld\HelloWorldHeartbeat` is.

## Downstream

No change to `Route::$validClasses`, so nothing for FogApi to sync. The OpenAPI change alters the *content* of the published document — every operation now carries the permission it always required — without changing which paths it describes.

## Also here: the `FOG_PLUGINS_VERSION` bump

`v1.6.21` → `v1.6.22`, the fog-plugins release that carries the namespaces (FOGProject/fog-plugins#33). It rides in this PR rather than one of its own **because the two fixes above are its precondition** — on a core without them, every plugin install throws and every plugin task is skipped. A pin bump landing first would ship that combination for however long it sat alone.
