### PR TITLE
Have all-classes-load clean up the temp dir it forks

### DIFF
--- a/tests/all-classes-load.test.php
+++ b/tests/all-classes-load.test.php
@@ -134,6 +134,31 @@ function _childLoad($start, $listFile, $progressFile)
     foreach (['cache', 'log', 'plugins'] as $sub) {
         @mkdir($tmp . '/' . $sub, 0700, true);
     }
+    // The child is resumed after every fatal, so one run of this test forks
+    // several of these and each got a directory named after a pid that is
+    // never reused. Left behind they accumulate one tree per run, forever --
+    // and sys_get_temp_dir() is a tmpfs on a normal Linux box, so the leak is
+    // resident memory rather than disk. Registered before init.php loads
+    // anything, because a declaration error is fatal and shutdown functions
+    // are the only cleanup that still runs on that path.
+    register_shutdown_function(
+        function () use ($tmp) {
+            if (!is_dir($tmp)) {
+                return;
+            }
+            $it = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator(
+                    $tmp,
+                    \FilesystemIterator::SKIP_DOTS
+                ),
+                \RecursiveIteratorIterator::CHILD_FIRST
+            );
+            foreach ($it as $f) {
+                $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+            }
+            @rmdir($tmp);
+        }
+    );
     define('FOG_CACHE_DIR', $tmp . '/cache');
     define('FOG_LOG_DIR', $tmp . '/log');
     define('FOG_PLUGIN_DIR', $tmp . '/plugins');


### PR DESCRIPTION
Housekeeping, found while clearing up after the plugin-namespace work.

`_childLoad()` creates `/tmp/fog-load-test-<pid>` for `FOG_CACHE_DIR`, `FOG_LOG_DIR` and `FOG_PLUGIN_DIR` and never removes it. The parent resumes the child after every fatal, so one run of the test leaves **several** — each named after a pid that will not be reused, so nothing reclaims them on a later run either. Seventeen had accumulated on my box from a single morning of suite runs.

The cost is not disk. `sys_get_temp_dir()` is a tmpfs on a normal Linux box, so every one of these is resident memory, and a full `/tmp` takes the shell down with it.

`register_shutdown_function` rather than a tidy-up at the end of `_childLoad()`: the interesting ways out of that function are a fatal declaration error (which is the whole reason the parent has a resume loop) and an explicit `exit(1)`. A shutdown function is the only cleanup that runs on either path. It is also the shape `page-discovery-survives-bad-file.test.php` and `plugin-namespace.test.php` already use for their own fixtures.

## Verification

Seventeen directories before, `rm`'d, then one full run of the test: `ok: all 275 declared class(es) load`, and zero directories left behind. Both phpstan passes clean.