### PR TITLE
Fix the boot fatal and the blind gate that let it through

### DIFF
--- a/tests/getclass-resolves-without-aliases.test.php
+++ b/tests/getclass-resolves-without-aliases.test.php
@@ -199,7 +199,13 @@ foreach ($dirs as $dir) {
     }
 }
 
-/** The 46 discovery-named classes under lib/, which carry their own aliases. */
+/**
+ * The discovery-named classes that used to live under lib/{pages,hooks,
+ * reports,events}. All 52 moved to src/<Bucket>/<Class>.php, so this finds
+ * nothing on a current tree -- it is kept because a webroot upgraded rather
+ * than laid fresh can still be carrying them, and a name that resolves there
+ * and nowhere else is exactly what this file exists to name.
+ */
 $libClasses = [];
 foreach (['pages', 'hooks', 'reports', 'events'] as $dir) {
     foreach (glob($web . '/lib/' . $dir . '/*.php') as $file) {
@@ -207,15 +213,23 @@ foreach (['pages', 'hooks', 'reports', 'events'] as $dir) {
     }
 }
 
-/** Plugin classes: global-namespace by design (ADR 0009), never aliased. */
+/**
+ * Plugin classes, which are PSR-4 exactly as core is: a plugin declares
+ * FOG\Plugins\<Segment>\<Bucket>\<Class> out of
+ * <plugin>/src/<Bucket>/<Class>.php (ADR 0035), and qualify() answers the
+ * SHORT name from that path.
+ *
+ * Keyed on the basename, because the short name is what a getClass() literal
+ * holds. This block used to match the pre-1.6 discovery suffixes, and that is
+ * a mistake worth naming: lib/plugins is FETCHED rather than tracked, so it
+ * is absent in CI and in a fresh clone -- the loop found no files, every
+ * plugin literal fell through to the class_exists() escape, and the check
+ * passed by never running. It only goes red on a tree that actually has
+ * plugins, which is to say on a real server and nowhere else.
+ */
 $pluginClasses = [];
-if (is_dir($web . '/lib/plugins')) {
-    $walk = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($web . '/lib/plugins'));
-    foreach ($walk as $file) {
-        if ($file->isFile() && preg_match('/\.(class|page|hook|report|event|task)\.php$/', $file->getFilename())) {
-            $pluginClasses[strtolower(preg_replace('/\.(class|page|hook|report|event|task)\.php$/', '', $file->getFilename()))] = true;
-        }
-    }
+foreach ((array)glob($web . '/lib/plugins/*/src/*/*.php') as $file) {
+    $pluginClasses[strtolower(basename($file, '.php'))] = true;
 }
 
 $unresolved = [];


### PR DESCRIPTION
Follow-up to #1540, found by installing v1.6.23 into a worktree rather than by any run of the suite.

`tests/getclass-resolves-without-aliases.test.php` collected a plugin's declarations by matching the pre-1.6 discovery suffixes — `.class.php`, `.page.php` and friends. ADR 0035 took those away, so on a tree that actually has plugins the loop finds nothing and all **43** plugin `getClass()` literals report as resolving through an alias that no longer exists:

```
FAIL:
  - getClass() is called with 43 name(s) that resolve through nothing this tree
    declares ...: Capone, CaponeManager, HelloWorld, ..., WindowsKeyManager, location
```

**The code was right the whole time.** `qualify()` answers a short name from the derived path, so `getClass('LDAPManager')` reaches `FOG\Plugins\LDAP\Managers\LDAPManager` — verified live against the real v1.6.23 tree. Only the gate was blind.

## Why it survived the layout change

`packages/web/lib/plugins` is *fetched*, not tracked. It is absent in CI, in a fresh clone, and in every worktree I verified #1540 in — so the plugin loop found no files, every plugin literal fell through to the `class_exists()` escape, and the check passed **by never running that arm at all**. It goes red only on a tree with plugins actually installed, which is to say on a real server and nowhere else. That is the same failure shape the repo already warns about: a gate that passes for reasons the real command never touches.

## The fix

Collect from the layout that exists — `<plugin>/src/<Bucket>/<Class>.php`, keyed on the basename, which is what a `getClass()` literal holds.

Both directions mutation-verified against the installed v1.6.23 tree:

- delete `ldap/src/Managers/LDAPManager.php` → red, naming `LDAPManager`
- rename it so the class no longer matches its file → red, naming `LDAPManager`
- restored → green, 146 literals resolve

The `lib/{pages,hooks,reports,events}` collector above it keeps its suffix match deliberately and gains a comment saying why: all 52 of those classes moved to `src/`, so it finds nothing on a current tree — but a webroot upgraded rather than laid fresh can still be carrying them, and a name that resolves only there is exactly what this file exists to name.

Test-only change. `phpstan-tests.neon` clean.
