### PR TITLE
Derive the plugin asset URL, and drop the dead Import Reports form

### DIFF
--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -4312,14 +4312,6 @@ msgid "Import Partially Succeeded"
 msgstr "Datenbank importieren"
 
 #, fuzzy
-msgid "Import Report"
-msgstr "Berichte importieren"
-
-#, fuzzy
-msgid "Import Reports"
-msgstr "Berichte importieren"
-
-#, fuzzy
 msgid "Import Subnet Groups"
 msgstr "Gruppen importieren"
 
@@ -9358,9 +9350,6 @@ msgstr ""
 msgid "This section allows you to update"
 msgstr "In diesem Abschnitt können Sie den Linux-Kernel"
 
-msgid "This section allows you to upload user defined reports that may not be a part of the base FOG install."
-msgstr ""
-
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
@@ -11729,6 +11718,14 @@ msgstr ""
 
 #~ msgid "Import Printers"
 #~ msgstr "Drucker importieren"
+
+#, fuzzy
+#~ msgid "Import Report"
+#~ msgstr "Berichte importieren"
+
+#, fuzzy
+#~ msgid "Import Reports"
+#~ msgstr "Berichte importieren"
 
 #, fuzzy
 #~ msgid "Import Roles"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -4313,14 +4313,6 @@ msgid "Import Partially Succeeded"
 msgstr "Date"
 
 #, fuzzy
-msgid "Import Report"
-msgstr "Import Hosts"
-
-#, fuzzy
-msgid "Import Reports"
-msgstr "Import Hosts"
-
-#, fuzzy
 msgid "Import Subnet Groups"
 msgstr "Import Groups"
 
@@ -9352,9 +9344,6 @@ msgstr ""
 msgid "This section allows you to update"
 msgstr ""
 
-msgid "This section allows you to upload user defined reports that may not be a part of the base FOG install."
-msgstr ""
-
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
@@ -11703,6 +11692,14 @@ msgstr ""
 
 #~ msgid "Import Printers"
 #~ msgstr "Import Printers"
+
+#, fuzzy
+#~ msgid "Import Report"
+#~ msgstr "Import Hosts"
+
+#, fuzzy
+#~ msgid "Import Reports"
+#~ msgstr "Import Hosts"
 
 #, fuzzy
 #~ msgid "Import Roles"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -4391,14 +4391,6 @@ msgid "Import Partially Succeeded"
 msgstr "Fecha"
 
 #, fuzzy
-msgid "Import Report"
-msgstr "Importar"
-
-#, fuzzy
-msgid "Import Reports"
-msgstr "Importar"
-
-#, fuzzy
 msgid "Import Subnet Groups"
 msgstr "grupo está"
 
@@ -9534,9 +9526,6 @@ msgstr ""
 msgid "This section allows you to update"
 msgstr ""
 
-msgid "This section allows you to upload user defined reports that may not be a part of the base FOG install."
-msgstr ""
-
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
@@ -11890,6 +11879,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Import Printers"
 #~ msgstr "Impresora TCP / IP Port"
+
+#, fuzzy
+#~ msgid "Import Report"
+#~ msgstr "Importar"
+
+#, fuzzy
+#~ msgid "Import Reports"
+#~ msgstr "Importar"
 
 #, fuzzy
 #~ msgid "Import Roles"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -4312,14 +4312,6 @@ msgid "Import Partially Succeeded"
 msgstr "Datenbank importieren"
 
 #, fuzzy
-msgid "Import Report"
-msgstr "Berichte importieren"
-
-#, fuzzy
-msgid "Import Reports"
-msgstr "Berichte importieren"
-
-#, fuzzy
 msgid "Import Subnet Groups"
 msgstr "Gruppen importieren"
 
@@ -9359,9 +9351,6 @@ msgstr ""
 msgid "This section allows you to update"
 msgstr "In diesem Abschnitt können Sie den Linux-Kernel"
 
-msgid "This section allows you to upload user defined reports that may not be a part of the base FOG install."
-msgstr ""
-
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
@@ -11730,6 +11719,14 @@ msgstr ""
 
 #~ msgid "Import Printers"
 #~ msgstr "Drucker importieren"
+
+#, fuzzy
+#~ msgid "Import Report"
+#~ msgstr "Berichte importieren"
+
+#, fuzzy
+#~ msgid "Import Reports"
+#~ msgstr "Berichte importieren"
 
 #, fuzzy
 #~ msgid "Import Roles"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -4315,14 +4315,6 @@ msgid "Import Partially Succeeded"
 msgstr "date"
 
 #, fuzzy
-msgid "Import Report"
-msgstr "Hôtes d'importation"
-
-#, fuzzy
-msgid "Import Reports"
-msgstr "Hôtes d'importation"
-
-#, fuzzy
 msgid "Import Subnet Groups"
 msgstr "Importer des groupes"
 
@@ -9354,9 +9346,6 @@ msgstr ""
 msgid "This section allows you to update"
 msgstr ""
 
-msgid "This section allows you to upload user defined reports that may not be a part of the base FOG install."
-msgstr ""
-
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
@@ -11709,6 +11698,14 @@ msgstr ""
 
 #~ msgid "Import Printers"
 #~ msgstr "Imprimantes d'importation"
+
+#, fuzzy
+#~ msgid "Import Report"
+#~ msgstr "Hôtes d'importation"
+
+#, fuzzy
+#~ msgid "Import Reports"
+#~ msgstr "Hôtes d'importation"
 
 #, fuzzy
 #~ msgid "Import Roles"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -4194,13 +4194,6 @@ msgid "Import Partially Succeeded"
 msgstr "Importa database"
 
 #, fuzzy
-msgid "Import Report"
-msgstr "Importa Report"
-
-msgid "Import Reports"
-msgstr "Importa Report"
-
-#, fuzzy
 msgid "Import Subnet Groups"
 msgstr "Gruppi di importazione"
 
@@ -9065,9 +9058,6 @@ msgstr ""
 msgid "This section allows you to update"
 msgstr "Questa sezione ti consente di aggiornare"
 
-msgid "This section allows you to upload user defined reports that may not be a part of the base FOG install."
-msgstr ""
-
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
@@ -11347,6 +11337,13 @@ msgstr ""
 
 #~ msgid "Import Printers"
 #~ msgstr "Stampanti di importazione"
+
+#, fuzzy
+#~ msgid "Import Report"
+#~ msgstr "Importa Report"
+
+#~ msgid "Import Reports"
+#~ msgstr "Importa Report"
 
 #, fuzzy
 #~ msgid "Import Roles"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -4159,13 +4159,6 @@ msgid "Import Partially Succeeded"
 msgstr "インポートに失敗しました"
 
 #, fuzzy
-msgid "Import Report"
-msgstr "レポートをインポートしますか？"
-
-msgid "Import Reports"
-msgstr "レポートをインポート"
-
-#, fuzzy
 msgid "Import Subnet Groups"
 msgstr "サブネットグループをインポート"
 
@@ -9008,9 +9001,6 @@ msgstr ""
 msgid "This section allows you to update"
 msgstr "このセクションでは更新を行えます"
 
-msgid "This section allows you to upload user defined reports that may not be a part of the base FOG install."
-msgstr ""
-
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
@@ -11872,6 +11862,13 @@ msgstr ""
 
 #~ msgid "Import Printers"
 #~ msgstr "プリンターをインポート"
+
+#, fuzzy
+#~ msgid "Import Report"
+#~ msgstr "レポートをインポートしますか？"
+
+#~ msgid "Import Reports"
+#~ msgstr "レポートをインポート"
 
 #~ msgid "Import Sites"
 #~ msgstr "サイトをインポート"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -3669,12 +3669,6 @@ msgstr ""
 msgid "Import Partially Succeeded"
 msgstr ""
 
-msgid "Import Report"
-msgstr ""
-
-msgid "Import Reports"
-msgstr ""
-
 msgid "Import Subnet Groups"
 msgstr ""
 
@@ -7978,9 +7972,6 @@ msgid "This page documents the FOG REST API, which is currently switched off. En
 msgstr ""
 
 msgid "This section allows you to update"
-msgstr ""
-
-msgid "This section allows you to upload user defined reports that may not be a part of the base FOG install."
 msgstr ""
 
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -4314,14 +4314,6 @@ msgid "Import Partially Succeeded"
 msgstr "Encontro"
 
 #, fuzzy
-msgid "Import Report"
-msgstr "Hosts de importação"
-
-#, fuzzy
-msgid "Import Reports"
-msgstr "Hosts de importação"
-
-#, fuzzy
 msgid "Import Subnet Groups"
 msgstr "Grupos de importação"
 
@@ -9353,9 +9345,6 @@ msgstr ""
 msgid "This section allows you to update"
 msgstr ""
 
-msgid "This section allows you to upload user defined reports that may not be a part of the base FOG install."
-msgstr ""
-
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
@@ -11708,6 +11697,14 @@ msgstr ""
 
 #~ msgid "Import Printers"
 #~ msgstr "importação Impressoras"
+
+#, fuzzy
+#~ msgid "Import Report"
+#~ msgstr "Hosts de importação"
+
+#, fuzzy
+#~ msgid "Import Reports"
+#~ msgstr "Hosts de importação"
 
 #, fuzzy
 #~ msgid "Import Roles"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -4314,14 +4314,6 @@ msgid "Import Partially Succeeded"
 msgstr "日期"
 
 #, fuzzy
-msgid "Import Report"
-msgstr "进口主机"
-
-#, fuzzy
-msgid "Import Reports"
-msgstr "进口主机"
-
-#, fuzzy
 msgid "Import Subnet Groups"
 msgstr "导入组"
 
@@ -9353,9 +9345,6 @@ msgstr ""
 msgid "This section allows you to update"
 msgstr ""
 
-msgid "This section allows you to upload user defined reports that may not be a part of the base FOG install."
-msgstr ""
-
 msgid "This server becomes the platform owner, so Microsoft's published CA certificates are enrolled alongside FOG's own. That is not optional: Microsoft signs the shim in FOG's own Secure Boot PXE chain, so a database without it would stop this server from booting the very clients it enrolled, as well as breaking Windows."
 msgstr ""
 
@@ -11708,6 +11697,14 @@ msgstr ""
 
 #~ msgid "Import Printers"
 #~ msgstr "进口打印机"
+
+#, fuzzy
+#~ msgid "Import Report"
+#~ msgstr "进口主机"
+
+#, fuzzy
+#~ msgid "Import Reports"
+#~ msgstr "进口主机"
 
 #, fuzzy
 #~ msgid "Import Roles"

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -1126,7 +1126,21 @@ abstract class FOGPage extends FOGBase
                         ] = ReportManagement::titleFor($report);
                     }
                 }
-                $menu['upload'] = _('Import Reports');
+                // No 'Import Reports' entry. The page behind it rendered a
+                // file-upload form with no POST handler behind it -- FOG has
+                // never had one, in 1.5 or 1.6 -- so the button ran, answered
+                // 200 with the form's own HTML, and imported nothing.
+                //
+                // Not reinstated, because a report is PHP that this server
+                // executes: an upload endpoint for one is an arbitrary-code
+                // door, and FOG already has exactly one of those, built with
+                // the gate such a thing needs. PluginManagement's archive
+                // upload is off unless FOG_PLUGIN_UI_INSTALL_ENABLED is set
+                // AND root has made FOG_PLUGIN_DIR writable, stages outside
+                // the autoload path, and shows the admin the manifest before
+                // anything is installed. Under ADR 0035 a custom report is
+                // <plugin>/src/Reports/<Class>.php, so that route already
+                // delivers one -- through the door with the locks on it.
         }
 
         $menu = array_filter($menu);

--- a/packages/web/src/Base/Hook.php
+++ b/packages/web/src/Base/Hook.php
@@ -125,7 +125,16 @@ abstract class Hook extends FOGBase
             return;
         }
         $case = $cases[$node];
-        $base = "../lib/plugins/{$this->node}/js/";
+        // Not a literal path. The bundled plugin root is spelled out in
+        // several places and this is the only one the BROWSER sees, so a move
+        // that missed it would 404 every plugin's JS with nothing failing on
+        // the server -- Plugin owns both spellings, and
+        // plugin-asset-path.test.php pins them to the same directory.
+        //
+        // Also correct for a plugin installed under FOG_PLUGIN_DIR: those are
+        // symlinked into this root on every boot by Plugin::syncAssetLinks(),
+        // so there is one asset path rather than one per root.
+        $base = \FOG\Items\Plugin::bundledWebRoot() . "{$this->node}/js/";
         if (!empty($case['secondary'])) {
             $stub = "fog.{$this->node}.{$node}";
         } else {

--- a/packages/web/src/Items/Plugin.php
+++ b/packages/web/src/Items/Plugin.php
@@ -97,6 +97,32 @@ class Plugin extends FOGController
         return rtrim(BASEPATH, DS) . DS . 'lib' . DS . 'plugins' . DS;
     }
     /**
+     * The same directory as bundledRoot(), spelled as the browser sees it.
+     *
+     * Plugin assets are fetched by URL, not read off disk, so the path a
+     * <script src> needs is relative to the document root -- management/ --
+     * rather than absolute on the filesystem. The two spellings are the same
+     * directory reached two ways, which is exactly why they belong beside
+     * each other: they have to move together, and nothing else in the tree
+     * would notice if they did not.
+     *
+     * This is correct for an EXTERNAL plugin as well. FOG_PLUGIN_DIR is
+     * outside the document root by design, so its assets are unreachable by
+     * URL -- syncAssetLinks() closes that by putting a symlink for every
+     * external plugin inside this directory. There is deliberately only one
+     * asset path, and it is this one.
+     *
+     * Relative rather than rooted at a leading slash: FOG is routinely served
+     * from a subdirectory (/fog/management/), and the alias an admin chooses
+     * is not knowable here.
+     *
+     * @return string with a trailing separator
+     */
+    public static function bundledWebRoot()
+    {
+        return '../lib/plugins/';
+    }
+    /**
      * True only if a REAL bundled plugin of this name exists.
      *
      * Not just is_dir(): syncAssetLinks() puts a symlink at

--- a/packages/web/src/Pages/ReportManagement.php
+++ b/packages/web/src/Pages/ReportManagement.php
@@ -92,10 +92,10 @@ class ReportManagement extends FOGPage
      * precisely so that rendering a sidebar does not load fourteen classes,
      * and a `const REPORT_GROUP` on each would give that up for a label.
      *
-     * Anything not named here -- an uploaded report, a plugin's -- lands
-     * under Lists, which is what a FOG report has always been. A plugin that
-     * disagrees can move its entry with the SUB_MENULINK_DATA hook, the
-     * same seam it used to add the entry.
+     * A report not named here -- a plugin's -- lands under Lists, which is
+     * what a FOG report has always been. A plugin that disagrees can move
+     * its entry with the SUB_MENULINK_DATA hook, the same seam it used to
+     * add the entry.
      *
      * @var array
      */
@@ -233,10 +233,10 @@ class ReportManagement extends FOGPage
     /**
      * The label for one report, by name.
      *
-     * FALLS BACK TO THE OLD DERIVATION rather than to an empty entry. An
-     * uploaded report, or one a plugin drops in, is not in the map and must
-     * still get a menu entry -- and the entry it gets is exactly the one it
-     * got before this map existed, so nothing outside core changes.
+     * FALLS BACK TO THE OLD DERIVATION rather than to an empty entry. A
+     * report a plugin drops in is not in the map and must still get a menu
+     * entry -- and the entry it gets is exactly the one it got before this
+     * map existed, so nothing outside core changes.
      *
      * @param string $report the report name, e.g. 'pending mac list'
      *
@@ -545,104 +545,5 @@ class ReportManagement extends FOGPage
         set_time_limit(0);
         $this->name = _('Report Management');
         parent::__construct($this->name);
-    }
-    /**
-     * Allows the user to upload new reports if they created one.
-     *
-     * @return void
-     */
-    public function upload()
-    {
-        $this->title = _('Import Reports');
-
-        $buttons = self::makeButton(
-            'import-send',
-            _('Import'),
-            'btn btn-primary float-end'
-        );
-
-        $labelClass = 'col-sm-3 col-form-label';
-
-        $fields = [
-            self::makeLabel(
-                $labelClass,
-                'import',
-                _('Import Report')
-                . '<br/>('
-                . _('Max Size')
-                . ': '
-                . ini_get('post_max_size')
-                . ')'
-            ) => '<div class="input-group">'
-            . self::makeLabel(
-                'btn btn-info',
-                'import',
-                _('Browse')
-                . self::makeInput(
-                    'd-none',
-                    'report',
-                    '',
-                    'file',
-                    'import',
-                    '',
-                    true
-                )
-            )
-            . self::makeInput(
-                'form-control filedisp',
-                '',
-                '',
-                'text',
-                'reportfiledisp',
-                '',
-                false,
-                false,
-                -1,
-                -1,
-                '',
-                true
-            )
-            . '</div>'
-        ];
-
-        self::$HookManager->processEvent(
-            'IMPORT_REPORT_FIELDS',
-            [
-                'fields' => &$fields,
-                'buttons' => &$buttons
-            ]
-        );
-        $rendered = self::formFields($fields);
-        unset($fields);
-
-        echo self::makeFormTag(
-            '',
-            'import-form',
-            $this->formAction,
-            'post',
-            'multipart/form-data',
-            true
-        );
-        echo '<div class="card card-primary card-outline">';
-        echo '<div class="card-header">';
-        echo '<h4 class="card-title">';
-        echo $this->title;
-        echo '</h4>';
-        echo '<p class="form-text">';
-        echo _(
-            'This section allows you to upload user '
-            . 'defined reports that may not be a part of '
-            . 'the base FOG install.'
-        );
-        echo '</p>';
-        echo '</div>';
-        echo '<div class="card-body">';
-        echo $rendered;
-        echo '</div>';
-        echo '<div class="card-footer">';
-        echo $buttons;
-        echo '</div>';
-        echo '</div>';
-        echo '</form>';
     }
 }

--- a/tests/plugin-asset-path.test.php
+++ b/tests/plugin-asset-path.test.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * The plugin asset URL and the bundled plugin directory are the same place.
+ *
+ * Plugin JS is fetched by the browser from Plugin::bundledWebRoot(), and read
+ * off disk from Plugin::bundledRoot(). Two spellings of one directory, and
+ * only the filesystem one is exercised by anything else in the suite -- so a
+ * move that updated bundledRoot() and missed the web root would 404 every
+ * plugin's JS on every page while every other test stayed green. There is no
+ * server-side symptom at all: Page::_setJSFiles() silently drops a path that
+ * does not resolve, so the failure is a plugin whose UI quietly does nothing.
+ *
+ * Three properties:
+ *
+ *   1. The web root, resolved against the document root (management/), is the
+ *      same directory as the filesystem root. This is the coupling.
+ *   2. It is relative. FOG is routinely served from an alias (/fog/), so a
+ *      leading slash would point outside the install.
+ *   3. Hook::injectPluginJS() actually builds its paths from it, rather than
+ *      carrying its own copy of the string. Asserted by running the method,
+ *      not by grepping for the call -- a grep passes on a call whose result
+ *      is discarded.
+ *
+ * Usage: php tests/plugin-asset-path.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+
+$fails = [];
+$check = function ($ok, $what) use (&$fails) {
+    if (!$ok) {
+        $fails[] = $what;
+    }
+};
+
+// BASEPATH is what bundledRoot() is relative to; commons/init.php normally
+// defines it. Nothing here boots, so set the two constants Plugin needs and
+// load the one class -- it is PSR-4, so the path is its namespace tail.
+if (!defined('DS')) {
+    define('DS', DIRECTORY_SEPARATOR);
+}
+if (!defined('BASEPATH')) {
+    define('BASEPATH', $web);
+}
+
+// Composer's map claims FOG\ -> src/, so one require pulls Plugin and the
+// FOGController/FOGBase chain it extends. Loading a class definition runs no
+// FOG code, so this needs neither a database nor a booted Initiator.
+if (!is_readable($web . '/vendor/autoload.php')) {
+    echo "SKIP: no vendor/autoload.php in this tree\n";
+    exit(0);
+}
+require_once $web . '/vendor/autoload.php';
+
+$fsRoot = \FOG\Items\Plugin::bundledRoot();
+$webRoot = \FOG\Items\Plugin::bundledWebRoot();
+
+// ------------------------------------------------- 1. same directory
+
+// The web root is relative to management/, which is the directory every page
+// is served from and the CWD every other path in the JS list assumes.
+$resolved = $web . '/management/' . $webRoot;
+
+// realpath() would return false in a checkout with no lib/plugins (it is
+// gitignored -- ADR 0009), so normalize the '..' textually instead. That also
+// keeps the test meaningful in CI, where the directory is genuinely absent.
+$normalize = function ($path) {
+    $out = [];
+    foreach (explode('/', str_replace(DIRECTORY_SEPARATOR, '/', $path)) as $part) {
+        if ('' === $part || '.' === $part) {
+            continue;
+        }
+        if ('..' === $part) {
+            array_pop($out);
+            continue;
+        }
+        $out[] = $part;
+    }
+    return '/' . implode('/', $out);
+};
+
+$check(
+    $normalize($resolved) === $normalize($fsRoot),
+    sprintf(
+        'bundledWebRoot() resolves to %s but bundledRoot() is %s',
+        $normalize($resolved),
+        $normalize($fsRoot)
+    )
+);
+
+// ------------------------------------------------- 2. relative, trailing sep
+
+$check(
+    strpos($webRoot, '/') !== 0,
+    'bundledWebRoot() must not start with "/" -- FOG is served from an alias'
+);
+$check(
+    substr($webRoot, -1) === '/',
+    'bundledWebRoot() must end with a separator'
+);
+
+// ------------------------------------------------- 3. the hook uses it
+
+// A throwaway Hook subclass, because injectPluginJS() is protected and the
+// point is to observe what it appends rather than to read the source.
+$hook = new class extends \FOG\Base\Hook {
+    public $name = 'AssetPathProbe';
+    public $description = 'test';
+    public $active = true;
+    public $node = 'probeplugin';
+    // Hook's constructor reaches for the globals a booted FOG has; nothing
+    // here is booted, and the method under test touches none of them.
+    public function __construct()
+    {
+    }
+    public function call(&$arguments, array $cases)
+    {
+        $this->injectPluginJS($arguments, $cases);
+    }
+};
+
+$GLOBALS['node'] = 'probeplugin';
+$GLOBALS['sub'] = '';
+$arguments = ['files' => []];
+$hook->call($arguments, ['probeplugin' => []]);
+
+$check(
+    $arguments['files'] === [$webRoot . 'probeplugin/js/fog.probeplugin.js'],
+    'injectPluginJS() did not build its path from bundledWebRoot(); got '
+    . json_encode($arguments['files'])
+);
+
+// ------------------------------------------------- report
+
+if ([] !== $fails) {
+    foreach ($fails as $f) {
+        echo "FAIL: $f\n";
+    }
+    exit(1);
+}
+
+echo "ok: plugin asset URL and directory agree (" . $webRoot . ")\n";
+exit(0);


### PR DESCRIPTION
Two loose ends from the ADR 0035 plugin restructure.

## 1. `Hook::injectPluginJS()` hardcoded the plugin asset URL

`$base = "../lib/plugins/{$this->node}/js/"` was the only place the **browser** learns where plugin assets live, sitting in a base class with nothing tying it to `Plugin::bundledRoot()`, which owns the same directory's filesystem spelling.

Moving one and missing the other 404s every plugin's JS on every page **with no server-side symptom**: `Page::_setJSFiles()` silently drops a path that does not resolve, so the visible result is a plugin whose UI quietly stops responding.

`Plugin::bundledWebRoot()` now sits beside `bundledRoot()` and the hook derives from it. The emitted string is byte-identical — **no behavior change**.

`tests/plugin-asset-path.test.php` pins three properties, all mutation-verified:

| Property | Mutation that makes it red |
|---|---|
| web root and filesystem root are the same directory | change one spelling only |
| the URL stays relative (FOG is served from an alias) | make it `/lib/plugins/` |
| `injectPluginJS()` actually builds from the helper | move both roots, leave the hook's own copy |

The third executes the method rather than grepping for the call — a grep passes on a call whose result is discarded.

### Correction to an earlier note

An external plugin's JS does **not** 404. `Plugin::syncAssetLinks()` symlinks `lib/plugins/<name>` at every `FOG_PLUGIN_DIR` plugin on every boot (from `getPlugins()`, reached via `FOGBase::getActivePlugins()`), precisely so there is one asset path. I had read `Hook.php` in isolation and missed it.

## 2. `ReportManagement::upload()` — a form with no handler

"Import Reports" rendered a file-upload form posting to a handler that has never existed. No `uploadPost()` on this branch, and none on `dev-branch` either — where the form is not even `multipart/form-data`. The button answers 200 with the form's own HTML and imports nothing.

Same bug class `PluginManagement` documents at `installArchiveCommit`: a sub whose `POST` half is missing re-renders instead of acting, with no error anywhere.

**Removed rather than implemented.** A report is PHP this server executes, so an upload endpoint for one is an arbitrary-code door — and FOG already has exactly one, built with the gate such a thing needs. `PluginManagement`'s archive upload is inert unless `FOG_PLUGIN_UI_INSTALL_ENABLED` is set **and** root has made `FOG_PLUGIN_DIR` writable (`bin/fog-plugin-uploads.sh`), stages outside the autoload path, and shows the admin the manifest before installing. Under ADR 0035 a custom report is `<plugin>/src/Reports/<Class>.php`, so that route already delivers one. A second, ungated door for the same payload would be strictly worse than the dead form.

### Reviewer's attention, please

This removes the **`IMPORT_REPORT_FIELDS` hook**, which `CLAUDE.md` says not to do without confirmation. It was introduced by the 1.6 rewrite of this page, has never had a listener in core or `fog-plugins` (`git log -S` finds one commit — the one that added it), and has nothing to extend once the form is gone. One `processEvent` restores it if you disagree.

`HostManagement::pending`/`pendingMacs` and `LogViewerManagement::index` render POST forms with no `Post` handler too — checked, and all three are served by the `Ajax` arm of `FOGPageManager::render()`. Not the same bug, left alone.

## Verification

- 250/250 tests, both `phpstan` passes unscoped, clean.
- Three mutations run against the new gate; each goes red on the property it targets.