### PR TITLE
Report schema shape drift, and retire the site plugin row on a gate 1.5 data can pass

### DIFF
--- a/bin/upgrade-rehearsal.php
+++ b/bin/upgrade-rehearsal.php
@@ -81,7 +81,7 @@ foreach (array_slice($argv, 1) as $arg) {
 
 $db = $opts['db'] ?? '';
 if ($web === '' || $cmd === '' || $db === '') {
-    fwrite(STDERR, "usage: php bin/upgrade-rehearsal.php <web-root> <build|seed|upgrade|report|census> --db=D [--to=N] [--profile=P]\n");
+    fwrite(STDERR, "usage: php bin/upgrade-rehearsal.php <web-root> <build|seed|upgrade|report|census|shape> --db=D [--to=N] [--profile=P]\n");
     exit(2);
 }
 
@@ -682,6 +682,26 @@ switch ($cmd) {
             printf("    %-44s %s\n", $f['name'], $f['reason']);
         }
         exit(count($out['errors']) ? 1 : 0);
+
+    case 'shape':
+        // GH-1542. plan() repairs existence, never shape, so a drifted column
+        // type or an absent UNIQUE index survives every upgrade unreported.
+        // The rehearsal is the only place that can say how often that is
+        // actually true, because it is the only place a decade of real data
+        // meets the current manifest.
+        $drift = \FOG\Db\SchemaReconciler::shapeDrift();
+        printf("shape   %s (schema %d)\n", $db, $runner->version());
+        printf("  differences from the manifest: %d\n", count($drift));
+        foreach ($drift as $d) {
+            printf(
+                "    %-28s %-22s %s -> %s\n",
+                $d['table'],
+                $d['name'],
+                $d['expected'],
+                $d['actual']
+            );
+        }
+        exit(0);
 
     case 'report':
         // What the upgrade actually achieved, read from the database rather

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -9977,3 +9977,59 @@ $this->schema[] = [
     . "audit trail records every impersonation either way; this controls only "
     . "whether the person is told.','1','Logging Settings')",
 ];
+// 399
+$this->schema[] = [
+    // Retire the stale `site` plugins row -- GH-1543.
+    //
+    // Step 334 already tried this and CANNOT succeed on an upgrade, which is
+    // the only path it exists for. Its gate reads `plugins`.`pLocation` and
+    // returns early when that is empty:
+    //
+    //     if ('' === $loc || 0 !== strncmp($loc, $bundled, strlen($bundled)))
+    //
+    // but `pLocation` is a RENAME of `pAnon3` (the CHANGE earlier in this
+    // file), and 1.5 never wrote `pAnon3` -- it declares the column in
+    // plugin.class.php's field map and assigns it nothing. So on every row
+    // carried across from 1.5 the value is the empty string, the first arm
+    // matches, and the DELETE is unreachable. Verified against a real 1.5.10
+    // database: the one `plugins` row has `pAnon3` of length 0.
+    //
+    // A step runs once, so 334 cannot be corrected in place -- anything
+    // already past it will never revisit it. Hence a new step, and one that
+    // reaches the same conclusion without `pLocation`.
+    //
+    // THE GATE IS THE TABLES, NOT THE FILESYSTEM. Step 332 migrates the
+    // plugin's rows into core's `sites` and then DROPS `site` and its
+    // association tables, but only when the migrated counts match exactly --
+    // when they disagree it keeps them deliberately. So `sites` present AND
+    // `site` absent is precisely "the migration ran and was believed", which
+    // is the condition under which the plugin's row is stale. If the counts
+    // disagreed, `site` still exists, this does nothing, and the row stays --
+    // which is the right answer, because an admin whose data did not migrate
+    // needs the plugin listed.
+    //
+    // Reading tables rather than the plugin directory also drops step 334's
+    // one genuine worry -- an unmounted external plugin root making every
+    // plugin look absent at once -- since no path is consulted at all. The
+    // plugin's code no longer ships: it was deleted from fog-plugins when
+    // core took over sites.
+    function () {
+        $has = function ($table) {
+            $row = self::$DB->query(
+                "SELECT COUNT(*) AS `n` FROM `information_schema`.`TABLES`"
+                . " WHERE `TABLE_SCHEMA` = DATABASE()"
+                . " AND LOWER(`TABLE_NAME`) = :t",
+                [],
+                [':t' => $table]
+            )->fetch(\PDO::FETCH_ASSOC)->get();
+            return (int)($row['n'] ?? 0) > 0;
+        };
+        if (!$has('sites') || $has('site')) {
+            return true;
+        }
+        self::$DB->query(
+            "DELETE FROM `plugins` WHERE LOWER(`pName`) = 'site'"
+        );
+        return true;
+    },
+];

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -7452,6 +7452,10 @@ msgstr ""
 msgid "Schema row seed"
 msgstr ""
 
+#, fuzzy
+msgid "Schema shape"
+msgstr "Drucker-Update fehlgeschlagen!"
+
 msgid "Schema sweep"
 msgstr ""
 
@@ -10528,6 +10532,9 @@ msgstr "Tag"
 msgid "deploy task occurs for it"
 msgstr "es eine Verteilungs-Task gibt."
 
+msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
+msgstr ""
+
 msgid "directive in php.ini"
 msgstr "Richtlinie in der php.ini"
 
@@ -10802,12 +10809,19 @@ msgstr ""
 msgid "instead, which uses iPXE's built-in NIC drivers rather than the firmware's. Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
+#, php-format
+msgid "is `%s` but the manifest says `%s`"
+msgstr ""
+
 #, fuzzy
 msgid "is already being sent by another node"
 msgstr "Die MAC-Adresse wird bereits von einem andern Host verwendet"
 
 msgid "is already running with pid"
 msgstr "läuft bereits mit PID"
+
+msgid "is missing -- a UNIQUE index the manifest declares"
+msgstr ""
 
 #, fuzzy
 msgid "is new"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -7449,6 +7449,10 @@ msgstr ""
 msgid "Schema row seed"
 msgstr ""
 
+#, fuzzy
+msgid "Schema shape"
+msgstr "Printer update failed!"
+
 msgid "Schema sweep"
 msgstr ""
 
@@ -10521,6 +10525,9 @@ msgstr ""
 msgid "deploy task occurs for it"
 msgstr ""
 
+msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
+msgstr ""
+
 msgid "directive in php.ini"
 msgstr ""
 
@@ -10795,11 +10802,18 @@ msgstr ""
 msgid "instead, which uses iPXE's built-in NIC drivers rather than the firmware's. Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
+#, php-format
+msgid "is `%s` but the manifest says `%s`"
+msgstr ""
+
 #, fuzzy
 msgid "is already being sent by another node"
 msgstr "MAC address is already in use by another host"
 
 msgid "is already running with pid"
+msgstr ""
+
+msgid "is missing -- a UNIQUE index the manifest declares"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -7596,6 +7596,10 @@ msgstr ""
 msgid "Schema row seed"
 msgstr ""
 
+#, fuzzy
+msgid "Schema shape"
+msgstr "actualización de la impresora ha fallado!"
+
 msgid "Schema sweep"
 msgstr ""
 
@@ -10702,6 +10706,9 @@ msgstr ""
 msgid "deploy task occurs for it"
 msgstr ""
 
+msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
+msgstr ""
+
 msgid "directive in php.ini"
 msgstr ""
 
@@ -10979,11 +10986,18 @@ msgstr ""
 msgid "instead, which uses iPXE's built-in NIC drivers rather than the firmware's. Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
+#, php-format
+msgid "is `%s` but the manifest says `%s`"
+msgstr ""
+
 #, fuzzy
 msgid "is already being sent by another node"
 msgstr "La dirección MAC ya está en uso por otro host"
 
 msgid "is already running with pid"
+msgstr ""
+
+msgid "is missing -- a UNIQUE index the manifest declares"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -7453,6 +7453,10 @@ msgstr ""
 msgid "Schema row seed"
 msgstr ""
 
+#, fuzzy
+msgid "Schema shape"
+msgstr "Drucker-Update fehlgeschlagen!"
+
 msgid "Schema sweep"
 msgstr ""
 
@@ -10529,6 +10533,9 @@ msgstr "Tag"
 msgid "deploy task occurs for it"
 msgstr "es eine Verteilungs-Task gibt."
 
+msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
+msgstr ""
+
 msgid "directive in php.ini"
 msgstr "Richtlinie in der php.ini"
 
@@ -10803,12 +10810,19 @@ msgstr ""
 msgid "instead, which uses iPXE's built-in NIC drivers rather than the firmware's. Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
+#, php-format
+msgid "is `%s` but the manifest says `%s`"
+msgstr ""
+
 #, fuzzy
 msgid "is already being sent by another node"
 msgstr "Liste der MAC-Adressen"
 
 msgid "is already running with pid"
 msgstr "läuft bereits mit PID"
+
+msgid "is missing -- a UNIQUE index the manifest declares"
+msgstr ""
 
 #, fuzzy
 msgid "is new"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -7451,6 +7451,10 @@ msgstr ""
 msgid "Schema row seed"
 msgstr ""
 
+#, fuzzy
+msgid "Schema shape"
+msgstr "mise à jour de l'imprimante a échoué!"
+
 msgid "Schema sweep"
 msgstr ""
 
@@ -10523,6 +10527,9 @@ msgstr ""
 msgid "deploy task occurs for it"
 msgstr ""
 
+msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
+msgstr ""
+
 msgid "directive in php.ini"
 msgstr ""
 
@@ -10797,11 +10804,18 @@ msgstr ""
 msgid "instead, which uses iPXE's built-in NIC drivers rather than the firmware's. Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
+#, php-format
+msgid "is `%s` but the manifest says `%s`"
+msgstr ""
+
 #, fuzzy
 msgid "is already being sent by another node"
 msgstr "L'adresse MAC est déjà utilisée par un autre hôte"
 
 msgid "is already running with pid"
+msgstr ""
+
+msgid "is missing -- a UNIQUE index the manifest declares"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -7229,6 +7229,10 @@ msgstr ""
 msgid "Schema row seed"
 msgstr ""
 
+#, fuzzy
+msgid "Schema shape"
+msgstr "Aggiornamento della stampante non riuscito"
+
 msgid "Schema sweep"
 msgstr ""
 
@@ -10196,6 +10200,9 @@ msgstr "giorno"
 msgid "deploy task occurs for it"
 msgstr "attività di distribuzione avviene per esso"
 
+msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
+msgstr ""
+
 msgid "directive in php.ini"
 msgstr "direttiva in php.ini"
 
@@ -10455,12 +10462,19 @@ msgstr ""
 msgid "instead, which uses iPXE's built-in NIC drivers rather than the firmware's. Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
+#, php-format
+msgid "is `%s` but the manifest says `%s`"
+msgstr ""
+
 #, fuzzy
 msgid "is already being sent by another node"
 msgstr "L'indirizzo MAC è già in uso da un altro host"
 
 msgid "is already running with pid"
 msgstr "è già in esecuzione con pid"
+
+msgid "is missing -- a UNIQUE index the manifest declares"
+msgstr ""
 
 msgid "is new"
 msgstr "è nuovo"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -7188,6 +7188,10 @@ msgstr ""
 msgid "Schema row seed"
 msgstr ""
 
+#, fuzzy
+msgid "Schema shape"
+msgstr "サイトの更新に失敗しました"
+
 msgid "Schema sweep"
 msgstr ""
 
@@ -10137,6 +10141,9 @@ msgstr "日"
 msgid "deploy task occurs for it"
 msgstr "展開タスクが実行されたとき"
 
+msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
+msgstr ""
+
 msgid "directive in php.ini"
 msgstr "php.ini のディレクティブ"
 
@@ -10400,6 +10407,10 @@ msgstr ""
 msgid "instead, which uses iPXE's built-in NIC drivers rather than the firmware's. Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
+#, php-format
+msgid "is `%s` but the manifest says `%s`"
+msgstr ""
+
 #, fuzzy
 msgid "is already being sent by another node"
 msgstr "MAC アドレスは別のホストで既に使用されています"
@@ -10407,6 +10418,9 @@ msgstr "MAC アドレスは別のホストで既に使用されています"
 #, fuzzy
 msgid "is already running with pid"
 msgstr "は既に次の PID で実行中です: "
+
+msgid "is missing -- a UNIQUE index the manifest declares"
+msgstr ""
 
 msgid "is new"
 msgstr "新規です"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -6344,6 +6344,9 @@ msgstr ""
 msgid "Schema row seed"
 msgstr ""
 
+msgid "Schema shape"
+msgstr ""
+
 msgid "Schema sweep"
 msgstr ""
 
@@ -9001,6 +9004,9 @@ msgstr ""
 msgid "deploy task occurs for it"
 msgstr ""
 
+msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
+msgstr ""
+
 msgid "directive in php.ini"
 msgstr ""
 
@@ -9231,10 +9237,17 @@ msgstr ""
 msgid "instead, which uses iPXE's built-in NIC drivers rather than the firmware's. Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
+#, php-format
+msgid "is `%s` but the manifest says `%s`"
+msgstr ""
+
 msgid "is already being sent by another node"
 msgstr ""
 
 msgid "is already running with pid"
+msgstr ""
+
+msgid "is missing -- a UNIQUE index the manifest declares"
 msgstr ""
 
 msgid "is new"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -7450,6 +7450,10 @@ msgstr ""
 msgid "Schema row seed"
 msgstr ""
 
+#, fuzzy
+msgid "Schema shape"
+msgstr "atualização da impressora falhou!"
+
 msgid "Schema sweep"
 msgstr ""
 
@@ -10522,6 +10526,9 @@ msgstr ""
 msgid "deploy task occurs for it"
 msgstr ""
 
+msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
+msgstr ""
+
 msgid "directive in php.ini"
 msgstr ""
 
@@ -10796,11 +10803,18 @@ msgstr ""
 msgid "instead, which uses iPXE's built-in NIC drivers rather than the firmware's. Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
+#, php-format
+msgid "is `%s` but the manifest says `%s`"
+msgstr ""
+
 #, fuzzy
 msgid "is already being sent by another node"
 msgstr "O endereço MAC já está sendo usado por outro host"
 
 msgid "is already running with pid"
+msgstr ""
+
+msgid "is missing -- a UNIQUE index the manifest declares"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -7450,6 +7450,10 @@ msgstr ""
 msgid "Schema row seed"
 msgstr ""
 
+#, fuzzy
+msgid "Schema shape"
+msgstr "打印机更新失败！"
+
 msgid "Schema sweep"
 msgstr ""
 
@@ -10522,6 +10526,9 @@ msgstr ""
 msgid "deploy task occurs for it"
 msgstr ""
 
+msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
+msgstr ""
+
 msgid "directive in php.ini"
 msgstr ""
 
@@ -10796,11 +10803,18 @@ msgstr ""
 msgid "instead, which uses iPXE's built-in NIC drivers rather than the firmware's. Arm64 clients use the files under secureboot/arm64-efi/"
 msgstr ""
 
+#, php-format
+msgid "is `%s` but the manifest says `%s`"
+msgstr ""
+
 #, fuzzy
 msgid "is already being sent by another node"
 msgstr "MAC地址已被其他主机使用"
 
 msgid "is already running with pid"
+msgstr ""
+
+msgid "is missing -- a UNIQUE index the manifest declares"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -130,7 +130,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 398);
+        define('FOG_SCHEMA', 399);
         define('FOG_BCACHE_VER', 353);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/src/Db/SchemaReconciler.php
+++ b/packages/web/src/Db/SchemaReconciler.php
@@ -677,10 +677,237 @@ class SchemaReconciler extends FOGBase
         // way forward from the browser. Logged and reported instead.
         self::applyConstraints(null, $map);
 
+        // Reports, never repairs -- GH-1542. The four passes above all ask
+        // "is this thing PRESENT?" and create it when it is not. Nothing
+        // asks whether a column or an index that IS present has the right
+        // SHAPE, so drift is invisible: a column whose type no longer
+        // matches its parent's refuses its foreign key with errno 1005 on
+        // every upgrade from now on, and a UNIQUE index that is absent for
+        // any reason is never put back, taking its guarantee with it
+        // silently.
+        //
+        // Repairing either is a bigger decision than this pass is allowed to
+        // make -- MODIFY COLUMN on a populated column can truncate, and
+        // ADD UNIQUE on a table that has since acquired duplicates fails
+        // outright and needs a sweep in front of it, in the shape ADR 0031
+        // decision 8 gives the constraint groups. So this turns an invisible
+        // condition into a readable one and settles how often it actually
+        // happens before anything starts issuing ALTERs.
+        self::reportShapeDrift($manifest);
+
         if (count($errors ?: [])) {
             return implode('; ', $errors);
         }
         return true;
+    }
+
+    /**
+     * Logs columns and UNIQUE indexes whose shape differs from the manifest.
+     *
+     * Never alters anything and never fails the update: an upgrade that
+     * refused to finish because a column type had drifted would strand the
+     * server on ?node=schema over data that is otherwise intact.
+     *
+     * @param array|null $manifest Expected structure; defaults to the
+     *                             shipped one.
+     *
+     * @return array The drift found, for a caller that wants it.
+     */
+    public static function reportShapeDrift($manifest = null)
+    {
+        $drift = self::shapeDrift($manifest);
+        foreach ($drift as $d) {
+            error_log(
+                sprintf(
+                    '%s: %s.%s %s',
+                    _('Schema shape'),
+                    $d['table'],
+                    $d['name'],
+                    'column' === $d['kind']
+                        ? sprintf(
+                            _('is `%s` but the manifest says `%s`'),
+                            $d['actual'],
+                            $d['expected']
+                        )
+                        : _('is missing -- a UNIQUE index the manifest declares')
+                )
+            );
+        }
+        if (count($drift)) {
+            error_log(
+                sprintf(
+                    '%s: %d %s',
+                    _('Schema shape'),
+                    count($drift),
+                    _(
+                        'difference(s) from the manifest. Nothing was'
+                        . ' changed -- these are reported, not repaired.'
+                    )
+                )
+            );
+        }
+        return $drift;
+    }
+
+    /**
+     * Columns and UNIQUE indexes whose live shape differs from the manifest.
+     *
+     * Pure apart from the two reads. Compares:
+     *
+     * - a column's TYPE and its nullability. Not its DEFAULT: a drifted
+     *   default changes what a new row gets and nothing else, while a
+     *   drifted type is what refuses a foreign key, and mixing the two would
+     *   bury the second in a list of the first. Defaults also round-trip
+     *   badly through information_schema -- the quoting differs by server
+     *   version -- so comparing them produces findings that are noise.
+     * - UNIQUE indexes the manifest's CREATE statement declares. Non-unique
+     *   ones are deliberately not reported: a missing KEY costs speed, a
+     *   missing UNIQUE KEY costs a guarantee, and only the second is a
+     *   correctness question.
+     *
+     * A table or column that is ABSENT is not drift -- plan() creates those,
+     * and reporting them here would double every finding on a server that is
+     * simply behind.
+     *
+     * @param array|null $manifest Expected structure.
+     *
+     * @return array list of ['table','kind','name','expected','actual']
+     */
+    public static function shapeDrift($manifest = null)
+    {
+        if (null === $manifest) {
+            $manifest = self::manifest();
+        }
+        $tables = (array)($manifest['tables'] ?? []);
+        if (!count($tables)) {
+            return [];
+        }
+        $db = self::$DB->dbName();
+
+        $res = self::$DB->query(
+            sprintf(
+                'SELECT `TABLE_NAME`, `COLUMN_NAME`, `COLUMN_TYPE`,'
+                . ' `IS_NULLABLE` FROM `information_schema`.`COLUMNS`'
+                . ' WHERE `TABLE_SCHEMA` = %s',
+                self::$DB->escape($db)
+            )
+        );
+        if (false !== $res->error) {
+            return [];
+        }
+        $rows = $res->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        if (!is_array($rows)) {
+            return [];
+        }
+        $live = [];
+        foreach ($rows as $row) {
+            $live[strtolower((string)$row['TABLE_NAME'])]
+                [strtolower((string)$row['COLUMN_NAME'])] = [
+                    'type' => strtolower((string)$row['COLUMN_TYPE']),
+                    'null' => 'YES' === strtoupper((string)$row['IS_NULLABLE']),
+                ];
+        }
+
+        $res = self::$DB->query(
+            sprintf(
+                'SELECT `TABLE_NAME`, `INDEX_NAME` FROM'
+                . ' `information_schema`.`STATISTICS` WHERE `TABLE_SCHEMA` ='
+                . ' %s AND `NON_UNIQUE` = 0',
+                self::$DB->escape($db)
+            )
+        );
+        $liveIdx = [];
+        if (false === $res->error) {
+            $idxRows = $res->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+            foreach ((array)$idxRows as $row) {
+                $liveIdx[strtolower((string)$row['TABLE_NAME'])]
+                    [strtolower((string)$row['INDEX_NAME'])] = true;
+            }
+        }
+
+        $drift = [];
+        foreach ($tables as $table => $spec) {
+            $lt = strtolower((string)$table);
+            if (!isset($live[$lt])) {
+                // Absent entirely. plan() creates it; not drift.
+                continue;
+            }
+            foreach ((array)($spec['columns'] ?? []) as $col => $decl) {
+                $lc = strtolower((string)$col);
+                if (!isset($live[$lt][$lc])) {
+                    continue;
+                }
+                $want = self::_declShape((string)$decl);
+                $have = $live[$lt][$lc];
+                if ($want['type'] === $have['type']
+                    && $want['null'] === $have['null']
+                ) {
+                    continue;
+                }
+                $drift[] = [
+                    'table' => $table,
+                    'kind' => 'column',
+                    'name' => $col,
+                    'expected' => $want['type']
+                        . ($want['null'] ? ' NULL' : ' NOT NULL'),
+                    'actual' => $have['type']
+                        . ($have['null'] ? ' NULL' : ' NOT NULL'),
+                ];
+            }
+            $create = (string)($spec['create'] ?? '');
+            if ('' === $create) {
+                continue;
+            }
+            preg_match_all(
+                '/UNIQUE KEY `([^`]+)`/',
+                $create,
+                $m
+            );
+            foreach ($m[1] as $idx) {
+                if (isset($liveIdx[$lt][strtolower($idx)])) {
+                    continue;
+                }
+                $drift[] = [
+                    'table' => $table,
+                    'kind' => 'unique',
+                    'name' => $idx,
+                    'expected' => 'UNIQUE',
+                    'actual' => 'absent',
+                ];
+            }
+        }
+        return $drift;
+    }
+
+    /**
+     * The type and nullability a manifest column declaration describes.
+     *
+     * The declaration is what SHOW CREATE TABLE emits for the column minus
+     * its name -- `int(11) NOT NULL`, `longtext NOT NULL DEFAULT ''`. The
+     * type is everything up to the first NULL/NOT NULL/DEFAULT keyword, so a
+     * multi-word type (`int(10) unsigned`) survives intact.
+     *
+     * Nullability follows SQL's own default: a column is nullable unless the
+     * declaration says NOT NULL. Getting that backwards would report every
+     * nullable column in the manifest as drifted.
+     *
+     * @param string $decl manifest column declaration
+     *
+     * @return array ['type' => string, 'null' => bool]
+     */
+    private static function _declShape($decl)
+    {
+        $decl = trim($decl);
+        $notNull = (bool)preg_match('/\bNOT\s+NULL\b/i', $decl);
+        $type = preg_split(
+            '/\s+(?:NOT\s+NULL|NULL|DEFAULT|AUTO_INCREMENT|COMMENT|'
+            . 'CHARACTER\s+SET|COLLATE|ON\s+UPDATE|GENERATED)\b/i',
+            $decl
+        );
+        return [
+            'type' => strtolower(trim((string)($type[0] ?? $decl))),
+            'null' => !$notNull,
+        ];
     }
     /**
      * Declares the foreign keys the map has enabled.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -81,7 +81,7 @@ parameters:
 		-
 			message: '#^Accessing self\:\:\$DB outside of class scope\.$#'
 			identifier: outOfClass.self
-			count: 108
+			count: 110
 			path: packages/web/commons/schema.php
 
 		-
@@ -129,7 +129,7 @@ parameters:
 		-
 			message: '#^Variable \$this might not be defined\.$#'
 			identifier: variable.undefined
-			count: 368
+			count: 369
 			path: packages/web/commons/schema.php
 
 		-

--- a/tests/schema-shape-drift.test.php
+++ b/tests/schema-shape-drift.test.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * SchemaReconciler reports columns and UNIQUE indexes whose shape has drifted.
+ *
+ * plan()'s four passes ask "is this thing PRESENT?" and create it when it is
+ * not. Nothing asks whether something present has the right SHAPE, so drift is
+ * invisible -- and both ways it bites are silent (GH-1542):
+ *
+ *   - a column whose type no longer matches its foreign key's parent is
+ *     refused with errno 1005 on every upgrade from now on, and no orphan
+ *     scan can explain why, because no row is involved.
+ *   - a UNIQUE index that is absent for any reason is never restored, and the
+ *     guarantee it carried is simply gone.
+ *
+ * Both were then OBSERVED, not merely predicted: a real 1.5.10 database
+ * upgraded to the current schema came out with `multicastSessions`.`msShutdown`
+ * still `enum('0','1')` and `roles`.`rName` missing its UNIQUE index. The first
+ * is a renamed `msAnon3` -- the reconciler's rename pass preserves the old type
+ * and the enum conversion step had already gone by; the second came from the
+ * 1.5 accesscontrol plugin, which created `roles` without it.
+ *
+ * What is pinned here is that the pass REPORTS and never repairs, and that it
+ * is quiet on a database that matches. A pass that reported everything would
+ * be worse than none: it would be ignored.
+ *
+ * Usage: php tests/schema-shape-drift.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+use FOG\Db\SchemaReconciler;
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('schema-shape-drift');
+
+$t = new FogChecks();
+
+$manifest = [
+    'tables' => [
+        'hostMAC' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `hostMAC` ( `hmID`'
+                . ' int(11) NOT NULL AUTO_INCREMENT, `hmMAC` varchar(59) NOT'
+                . ' NULL, PRIMARY KEY (`hmID`), UNIQUE KEY `hmMAC` (`hmMAC`),'
+                . ' KEY `idxMac` (`hmMAC`) ) ENGINE=InnoDB',
+            'columns' => [
+                'hmID' => 'int(11) NOT NULL',
+                'hmMAC' => 'varchar(59) NOT NULL',
+                'hmDesc' => 'longtext NOT NULL DEFAULT \'\'',
+                // No nullability keyword at all -- SQL's own default, which
+                // is NULLABLE. Several dozen manifest columns are declared
+                // this way, so reading the absence as NOT NULL would report
+                // every one of them as drifted on a correct server.
+                'hmPending' => 'tinyint(1) DEFAULT NULL',
+            ],
+        ],
+    ],
+];
+
+// A live server, described as information_schema would answer for it.
+//
+// The index answer is filtered HERE, by reading the SQL, rather than being
+// handed back whole. Modelling the server as always returning only unique
+// indexes would make the NON_UNIQUE filter untestable -- the fixture would
+// enforce it whether or not the code did, and the "a plain KEY is not
+// reported" check below would be green against code that had dropped it.
+$serve = static function (array $cols, array $indexes) {
+    $db = FogTestHarness::fakeDb();
+    $db->responder = static function ($sql) use ($db, $cols, $indexes) {
+        $db->error = false;
+        if (false !== strpos($sql, 'STATISTICS')) {
+            $uniqueOnly = false !== strpos($sql, 'NON_UNIQUE` = 0');
+            $out = [];
+            foreach ($indexes as $idx) {
+                if ($uniqueOnly && (int)$idx['NON_UNIQUE'] !== 0) {
+                    continue;
+                }
+                $out[] = $idx;
+            }
+            return $out;
+        }
+        if (false !== strpos($sql, 'COLUMNS')) {
+            return $cols;
+        }
+        return null;
+    };
+    return $db;
+};
+
+$idx = static function ($name, $nonUnique = 0) {
+    return [
+        'TABLE_NAME' => 'hostMAC',
+        'INDEX_NAME' => $name,
+        'NON_UNIQUE' => $nonUnique,
+    ];
+};
+
+$col = static function ($name, $type, $null = 'NO') {
+    return [
+        'TABLE_NAME' => 'hostMAC',
+        'COLUMN_NAME' => $name,
+        'COLUMN_TYPE' => $type,
+        'IS_NULLABLE' => $null,
+    ];
+};
+$matching = [
+    $col('hmID', 'int(11)'),
+    $col('hmMAC', 'varchar(59)'),
+    $col('hmDesc', 'longtext'),
+    $col('hmPending', 'tinyint(1)', 'YES'),
+];
+$uniqueOk = [$idx('hmMAC'), $idx('idxMac', 1)];
+
+// --- quiet when the server matches -----------------------------------------
+$serve($matching, $uniqueOk);
+$t->check('a matching server reports no drift', SchemaReconciler::shapeDrift($manifest) === []);
+// Named separately from the line above so a regression says which half broke:
+// `hmPending` is the column carrying no nullability keyword, and it is quiet
+// only if the parser reads that absence as NULLABLE, the way SQL does.
+$serve($matching, $uniqueOk);
+$t->check(
+    'a column declared with no nullability keyword is read as nullable',
+    [] === array_filter(
+        SchemaReconciler::shapeDrift($manifest),
+        static function ($d) {
+            return 'hmPending' === ($d['name'] ?? '');
+        }
+    )
+);
+
+// --- a drifted column type -------------------------------------------------
+$serve(
+    [$col('hmID', 'int(11)'), $col('hmMAC', 'varchar(80)'), $col('hmDesc', 'longtext'), $col('hmPending', 'tinyint(1)', 'YES')],
+    $uniqueOk
+);
+$drift = SchemaReconciler::shapeDrift($manifest);
+$t->check('a widened column is reported', count($drift) === 1);
+$t->check(
+    'the report names the column and both shapes',
+    ($drift[0]['name'] ?? '') === 'hmMAC'
+        && false !== strpos((string)($drift[0]['expected'] ?? ''), 'varchar(59)')
+        && false !== strpos((string)($drift[0]['actual'] ?? ''), 'varchar(80)')
+);
+
+// --- a drifted nullability -------------------------------------------------
+// Separate from the type: a SET NULL foreign key over a NOT NULL column is
+// refused errno 150 with no row involved, which is the exact failure this
+// whole area exists to make visible.
+$serve(
+    [$col('hmID', 'int(11)'), $col('hmMAC', 'varchar(59)', 'YES'), $col('hmDesc', 'longtext'), $col('hmPending', 'tinyint(1)', 'YES')],
+    $uniqueOk
+);
+$drift = SchemaReconciler::shapeDrift($manifest);
+$t->check(
+    'a column that became nullable is reported',
+    count($drift) === 1
+        && false !== strpos((string)($drift[0]['expected'] ?? ''), 'NOT NULL')
+        && false !== strpos((string)($drift[0]['actual'] ?? ''), 'NULL')
+);
+
+// --- a missing UNIQUE index ------------------------------------------------
+$serve($matching, [$idx('idxMac', 1)]);
+$drift = SchemaReconciler::shapeDrift($manifest);
+$t->check(
+    'a missing UNIQUE index is reported',
+    count($drift) === 1
+        && ($drift[0]['kind'] ?? '') === 'unique'
+        && ($drift[0]['name'] ?? '') === 'hmMAC'
+);
+
+// --- a UNIQUE that degraded to a plain KEY is still reported ---------------
+// The case that makes the NON_UNIQUE filter load-bearing rather than
+// decorative. Here `hmMAC` EXISTS as an index -- it has simply lost its
+// uniqueness, which is the whole guarantee. A pass that asked
+// information_schema for indexes by name alone would see `hmMAC` present and
+// say nothing, and the drift it exists to find would be the one it missed.
+$serve($matching, [$idx('hmMAC', 1), $idx('idxMac', 1)]);
+$drift = SchemaReconciler::shapeDrift($manifest);
+$t->check(
+    'a UNIQUE index degraded to a plain KEY is reported',
+    count($drift) === 1
+        && ($drift[0]['kind'] ?? '') === 'unique'
+        && ($drift[0]['name'] ?? '') === 'hmMAC'
+);
+
+// --- and a plain KEY that is genuinely absent is NOT reported --------------
+// `idxMac` is declared in the manifest's CREATE statement as a plain KEY. A
+// missing one costs speed; a missing UNIQUE costs a guarantee. Only the
+// second is a correctness question, and reporting both would bury it.
+$serve($matching, [$idx('hmMAC')]);
+$t->check(
+    'a plain KEY that is absent is not reported as drift',
+    SchemaReconciler::shapeDrift($manifest) === []
+);
+
+// --- an ABSENT column is not drift -----------------------------------------
+// plan() creates those. Reporting them here would double every finding on a
+// server that is merely behind, which is every server mid-upgrade.
+$serve([$col('hmID', 'int(11)')], $uniqueOk);
+$t->check(
+    'a column plan() will create is not reported as drift',
+    SchemaReconciler::shapeDrift($manifest) === []
+);
+
+// --- an absent TABLE is not drift ------------------------------------------
+$serve([], []);
+$t->check(
+    'a table plan() will create is not reported as drift',
+    SchemaReconciler::shapeDrift($manifest) === []
+);
+
+// --- it never issues a write -----------------------------------------------
+// The property the whole change rests on. Repairing is a bigger decision than
+// this pass is allowed to make.
+$db = $serve(
+    [$col('hmID', 'int(11)'), $col('hmMAC', 'varchar(80)'), $col('hmDesc', 'longtext'), $col('hmPending', 'tinyint(1)', 'YES')],
+    [$idx('idxMac', 1)]
+);
+$mark = count($db->log);
+SchemaReconciler::reportShapeDrift($manifest);
+$wrote = array_filter(
+    array_slice($db->log, $mark),
+    static function ($sql) {
+        return preg_match('/^\s*(ALTER|CREATE|DROP|UPDATE|DELETE|INSERT)/i', $sql);
+    }
+);
+$t->check('the pass issues no write of any kind', $wrote === []);
+
+// --- and it says what it found ---------------------------------------------
+$logfile = tempnam(sys_get_temp_dir(), 'shapedrift');
+$prev = ini_get('error_log');
+ini_set('error_log', $logfile);
+SchemaReconciler::reportShapeDrift($manifest);
+ini_set('error_log', $prev);
+$logged = (string)file_get_contents($logfile);
+unlink($logfile);
+$t->check(
+    'the log names the table, the column and both shapes',
+    false !== strpos($logged, 'hostMAC.hmMAC')
+        && false !== strpos($logged, 'varchar(80)')
+        && false !== strpos($logged, 'varchar(59)')
+);
+$t->check(
+    'the log says nothing was changed',
+    false !== stripos($logged, 'reported, not repaired')
+);
+
+$t->finish();

--- a/tests/site-plugin-row-retired.test.php
+++ b/tests/site-plugin-row-retired.test.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * The stale `site` plugins row is actually removed by an upgrade.
+ *
+ * Schema step 334 was written to do this and CANNOT, on the only path it
+ * exists for. Its gate reads `plugins`.`pLocation`, which is a RENAME of
+ * `pAnon3` -- a column FOG 1.5 declares and never writes. Every row carried
+ * across from 1.5 therefore has the empty string, the gate's first arm
+ * matches, and the DELETE is unreachable. Verified against a real 1.5.10
+ * database, whose one `plugins` row has `pAnon3` of length 0. GH-1543.
+ *
+ * A step runs once, so 334 could not be corrected in place and step 399
+ * replaces it. This gates 399's DECISION rather than its presence: a grep for
+ * the step would pass with the condition inverted, which is the shape of the
+ * original bug.
+ *
+ * The step is a closure, and closures are the one thing
+ * tests/schema-executes.test.php deliberately does not run. So it is executed
+ * here against a scripted stand-in for `self::$DB` -- the collector already
+ * provides one -- which answers the two information_schema probes and records
+ * whether the DELETE was issued. No database server is needed and none of the
+ * decision is re-implemented: the real closure runs.
+ *
+ * Usage: php tests/site-plugin-row-retired.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+require_once __DIR__ . '/lib/fog-schema-collector.php';
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+$root = dirname(__DIR__);
+$schemaFile = $root . '/packages/web/commons/schema.php';
+
+$fogSchema = 0;
+if (preg_match(
+    "/define\('FOG_SCHEMA',\s*(\d+)\)/",
+    (string)file_get_contents($root . '/packages/web/src/Base/System.php'),
+    $m
+)) {
+    $fogSchema = (int)$m[1];
+}
+
+$steps = fogCollectSchemaSteps($schemaFile, 'fogtest', $fogSchema);
+$t = new FogChecks();
+
+/**
+ * A `self::$DB` that answers the table probes and records what was written.
+ */
+class SiteRetireDB extends SchemaStubDB
+{
+    /**
+     * Table names the fake server holds, lowercased.
+     *
+     * @var array
+     */
+    public $tables = [];
+
+    /**
+     * Every statement issued, in order.
+     *
+     * @var array
+     */
+    public $log = [];
+
+    /**
+     * The answer to the last COUNT probe.
+     *
+     * @var int
+     */
+    private $_answer = 0;
+
+    public function query($query = null, ...$rest)
+    {
+        $this->log[] = (string)$query;
+        // The step probes information_schema with the table name bound, so
+        // the name is in the params rather than in the SQL.
+        if (false !== strpos((string)$query, 'information_schema')) {
+            $params = [];
+            foreach ($rest as $arg) {
+                if (is_array($arg) && count($arg)) {
+                    $params = $arg;
+                }
+            }
+            $want = strtolower((string)reset($params));
+            $this->_answer = in_array($want, $this->tables, true) ? 1 : 0;
+        }
+        return $this;
+    }
+
+    public function fetch($what = null, ...$rest)
+    {
+        return $this;
+    }
+
+    public function get($key = null)
+    {
+        return ['n' => $this->_answer];
+    }
+}
+
+/**
+ * Runs the last step against a fake server holding $tables.
+ *
+ * @param array $tables lowercased table names the server has
+ *
+ * @return array statements issued
+ */
+function runRetireStep(array $tables)
+{
+    global $steps;
+    $db = new SiteRetireDB();
+    $db->tables = $tables;
+    $prev = SchemaCollector::$DB;
+    SchemaCollector::$DB = $db;
+    $step = end($steps);
+    foreach ((array)$step as $update) {
+        if (is_callable($update)) {
+            $update();
+        }
+    }
+    SchemaCollector::$DB = $prev;
+    return $db->log;
+}
+
+
+/**
+ * Whether any statement deletes the site plugins row.
+ *
+ * @param array $log statements issued
+ *
+ * @return bool
+ */
+function deleted(array $log)
+{
+    foreach ($log as $sql) {
+        if (false !== stripos($sql, 'DELETE FROM `plugins`')) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// The step under test has to BE the last one, or every assertion below is
+// about something else entirely.
+$last = end($steps);
+$hasClosure = false;
+foreach ((array)$last as $u) {
+    $hasClosure = $hasClosure || is_callable($u);
+}
+$t->check('the last schema step is a closure', $hasClosure);
+$t->check(
+    'FOG_SCHEMA matches the step count',
+    $fogSchema === count($steps)
+);
+
+// --- the migration ran: sites exists, the plugin's table is gone -----------
+$t->check(
+    'the stale row is deleted once sites exists and site is gone',
+    deleted(runRetireStep(['sites', 'plugins', 'hosts']))
+);
+
+// --- step 332 kept the plugin tables because the counts disagreed ---------
+// The row must SURVIVE: an admin whose data did not migrate needs the plugin
+// listed. This is the arm that stops the fix being "delete it always".
+$t->check(
+    'the row survives while the plugin table is still present',
+    !deleted(runRetireStep(['sites', 'site', 'plugins', 'hosts']))
+);
+
+// --- the migration never ran at all ---------------------------------------
+$t->check(
+    'the row survives when core has no sites table',
+    !deleted(runRetireStep(['site', 'plugins', 'hosts']))
+);
+
+// --- and it does not depend on pLocation ----------------------------------
+// The whole defect was a gate keyed on a column 1.5 never writes. No CODE in
+// the replacement may read it, or the fix reproduces the bug.
+//
+// Comments are stripped first, deliberately: the step's own comment quotes
+// the broken gate in order to explain it, and a check that could not tell
+// prose from code would force the explanation out of the file -- which is the
+// one part of it a future reader most needs.
+$src = (string)file_get_contents($schemaFile);
+$tail = substr($src, (int)strrpos($src, '// 399'));
+$code = '';
+foreach (token_get_all('<?php ' . $tail) as $tok) {
+    if (is_array($tok) && in_array($tok[0], [T_COMMENT, T_DOC_COMMENT], true)) {
+        continue;
+    }
+    $code .= is_array($tok) ? $tok[1] : $tok;
+}
+$t->check(
+    'the replacement step does not read pLocation',
+    false === stripos($code, 'pLocation')
+);
+// ...and the strip is real, or the check above passes for the wrong reason.
+$t->check(
+    'the comment that explains the defect is still there',
+    false !== stripos($tail, 'pLocation')
+);
+
+$t->finish();


### PR DESCRIPTION
Fixes #1542. Fixes #1543.

Both were found by the same thing — an upgrade rehearsal run against a real
1.5.10 database, cloned with a backup taken first — and both have the same
root cause behind them, so they ship together rather than as two PRs that
would each invalidate the other under the up-to-date-before-merge rule.

## The shared root cause, worth stating once

**The two branches' schema step arrays share positions up to 263 and diverge
from 264.** A 1.5 database's `schemaVersion` is a count against *dev-branch's*
array, so an upgrade to 1.6 treats steps 264–277 as already applied and skips
them. Anything those steps were going to do never happens, and
`SchemaReconciler::plan()` then papers over the gap by creating the missing
column or table itself — without advancing `schemaVersion`, and without the
type or the value the skipped step would have given it.

That is invisible today. Nothing compares what is there against what was
meant to be there.

## 1542 — report columns and UNIQUE indexes whose shape has drifted

`plan()`'s four passes all ask "is this thing PRESENT?" Nothing asks whether
something present has the right SHAPE. The two ways that bites are both
silent: a column whose type no longer matches its FK parent is refused with
errno 1005 forever (no row involved, so `bin/fk-orphan-scan.php` reports
nothing), and a missing UNIQUE index is never restored.

Observed on the real upgraded 1.5 data, exactly two differences:

| | expected | actual |
|---|---|---|
| `multicastSessions`.`msShutdown` | `tinyint(1) NOT NULL` | `enum('0','1') NOT NULL` |
| `roles`.`rName` | `UNIQUE` | absent |

The first is the divergence above: `msAnon3` → `msShutdown` is a rename in the
skipped range, so the reconciler created the column preserving the old enum
type — after the enum→tinyint conversion step had already gone by. The second
came from the 1.5 `accesscontrol` plugin, which created `roles` without it.

**It reports and never repairs**, which is the property the whole change rests
on. An `ALTER` on a large table unasked is not something an every-update pass
should do, and the right repair for the enum case is a schema step anyway.

Measured, so the noise claim is not an assertion:

| database | differences |
|---|---|
| clean build at current schema | **0** |
| real 1.5.10 upgraded | **2** (above) |
| still at schema 278 | 49 — correct; those are the conversions it has not reached |

Deliberately not reported: `DEFAULT` values (a drifted default changes what a
new row gets and nothing else, and defaults round-trip badly through
`information_schema`), non-unique indexes (a missing KEY costs speed, a
missing UNIQUE costs a guarantee), and absent tables/columns (`plan()` creates
those; reporting them would double every finding on any server mid-upgrade).

`bin/upgrade-rehearsal.php` gains a `shape` command to run the pass on demand.

## 1543 — the site plugin row could never be retired on 1.5-origin data

The step removing the `site` plugin's registration row gated on
`plugins`.`pLocation`. That column is `pAnon3` renamed, and **the rename is in
the skipped range** — so on every 1.5-origin server the column is created
empty by the reconciler, the gate reads `''`, and the step returns early. The
row survives pointing at a plugin that is gone, and the Plugins page lists it.

Step 399 asks the same question using table facts, which do not depend on
which branch counted the steps: does core have `sites`, and is the plugin's
own `site` table gone?

It stays conservative in the case that matters: step 332 *keeps* the plugin's
tables when the migrated row counts disagree, and logs that it did, because
they are the input to a forward repair. So while `site` is still present this
step leaves the row alone — the plugin genuinely is not retired yet, and
saying otherwise would hide what step 332 went out of its way to preserve.

`FOG_SCHEMA` 398 → 399.

## Verification

- Full suite: **251 files, 0 failures**, run with everything `git add`ed
  first — three gates only see tracked files, which is what failed CI on an
  earlier branch.
- Both phpstan passes unscoped (`phpstan.neon` and `phpstan-tests.neon`):
  **no errors**. The two `schema.php` baseline counts are bumped 108→110 and
  368→369 for what step 399 adds — counts, not a regenerated baseline, so no
  unrelated drift is swept up.
- **Every new assertion was mutation-tested**, and two first-cut ones turned
  out to be fake and were rebuilt:
  - the shape pass: dropping the `NON_UNIQUE = 0` filter, reporting absent
    columns, repairing instead of reporting, and inverting the nullability
    parse — all four now red. The first was green until the fixture was
    changed to honor the filter by reading the SQL, and the fourth was green
    until a column with no nullability keyword was added, since every column
    in the original fixture was `NOT NULL`.
  - step 399: reintroducing the original `pLocation` gate, deleting
    unconditionally, and inverting the `sites` test — all three red, and
    re-run after the test was refactored onto `FogChecks`, since a refactor
    can defang a gate silently.

## Downstream

None. No route class added or removed, so FogApi's hardcoded class list is
unaffected.