### PR TITLE
Qualify a plugin route's handler class, or OIDC login is unreachable

### DIFF
--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -1327,6 +1327,38 @@ class Route extends FOGBase
                 sprintf('a plugin route must live under %s', self::PLUGIN_ROUTE_PREFIX)
             );
         }
+        /*
+         * Qualify the handler's class before testing it.
+         *
+         * A plugin declares its handler as [class, method] and the class is
+         * routinely the BARE name -- that is the spelling the plugin guide
+         * promises core will resolve, and what every getClass() literal in
+         * FOG already relies on. is_callable() does NOT resolve it: a class
+         * name inside a string is looked up in the GLOBAL namespace, and
+         * since ADR 0035 the class is really
+         * FOG\Plugins\OIDC\Util\OIDCFlow.
+         *
+         * So the test failed for a handler that was perfectly valid, and the
+         * route was dropped with nothing but an error_log line to say so.
+         * That took OIDC's /ext/oidc/start and /ext/oidc/callback off the
+         * router: a signed-out browser was redirected to start by
+         * LOGIN_PAGE_REDIRECT, got 401 because the route no longer existed,
+         * and the sign-in loop had no exit but management/login.php.
+         *
+         * Qualifying here rather than at dispatch fixes both halves at once
+         * -- the stored handler is what _registerRoute() is later called
+         * with -- and matches how Authorization::_pageClassFor() and
+         * Plugin::installdb() already treat a class name they were handed as
+         * a string.
+         */
+        if (isset($entry['handler'])
+            && is_array($entry['handler'])
+            && 2 === count($entry['handler'])
+            && isset($entry['handler'][0])
+            && is_string($entry['handler'][0])
+        ) {
+            $entry['handler'][0] = self::qualify($entry['handler'][0]);
+        }
         if (!isset($entry['handler']) || !is_callable($entry['handler'])) {
             return $reject('the handler is not callable');
         }

--- a/tests/plugin-extension-points.test.php
+++ b/tests/plugin-extension-points.test.php
@@ -39,6 +39,35 @@ define('FOG_PLUGIN_DIR', $tmp . '/plugins');
 $errLog = $tmp . '/php-error.log';
 ini_set('error_log', $errLog);
 
+/*
+ * A fixture plugin, laid out exactly as ADR 0035 requires:
+ * <plugin>/src/<Bucket>/<Class>.php declaring
+ * FOG\Plugins\<Segment>\<Bucket>\<Class>, with the directory name being the
+ * lowercased segment.
+ *
+ * It exists so one case below can declare a route handler the way a real
+ * plugin does -- ['BareName', 'method'] -- rather than the way every fixture
+ * in this file used to: 'strlen', a global function. That difference is not
+ * cosmetic. A global function is callable under its bare name and a plugin
+ * class is not, so the whole handler arm of this gate was green against a
+ * shape no plugin has ever used, and it stayed green while OIDC's two routes
+ * were being dropped on every request.
+ */
+@mkdir($tmp . '/plugins/fixtureplug/config', 0777, true);
+@mkdir($tmp . '/plugins/fixtureplug/src/Util', 0777, true);
+file_put_contents(
+    $tmp . '/plugins/fixtureplug/config/plugin.config.php',
+    '<?php' . "\n" . '$fog_plugin[\'name\'] = \'fixtureplug\';' . "\n"
+);
+file_put_contents(
+    $tmp . '/plugins/fixtureplug/src/Util/FixtureFlow.php',
+    '<?php' . "\n"
+    . 'namespace FOG\\Plugins\\FixturePlug\\Util;' . "\n"
+    . 'class FixtureFlow' . "\n" . '{' . "\n"
+    . '    public static function start()' . "\n" . '    {' . "\n"
+    . '    }' . "\n" . '}' . "\n"
+);
+
 require $web . '/commons/init.php';
 new Initiator();
 
@@ -172,16 +201,37 @@ $got = $offer([
         'path' => '/ext/demo/broken',
         'handler' => 'no_such_function_anywhere',
     ],
+    // THE shape every real plugin uses: [class, method] with the class
+    // spelled BARE. is_callable() resolves a class name in a string against
+    // the GLOBAL namespace, so this is not callable as written -- the router
+    // has to qualify it first, exactly as getClass() does everywhere else.
+    // Must be registered, with the handler normalized to the FQCN so the
+    // later dispatch calls something that exists.
+    [
+        'name' => 'bareClass',
+        'path' => '/ext/demo/bare',
+        'handler' => ['FixtureFlow', 'start'],
+        'auth' => 'public',
+    ],
+    // A [class, method] naming a class no plugin declares. Qualifying passes
+    // an unknown name through unchanged, so this must still be dropped --
+    // resolving bare names must not become a way to register a handler that
+    // does not exist.
+    [
+        'name' => 'ghostClass',
+        'path' => '/ext/demo/ghost',
+        'handler' => ['NoSuchPluginClassAnywhere', 'start'],
+    ],
 ]);
 
-$expectDropped = ['ext:escapee', 'ext:traversal', 'ext:broken'];
+$expectDropped = ['ext:escapee', 'ext:traversal', 'ext:broken', 'ext:ghostClass'];
 foreach ($expectDropped as $name) {
     if (isset($got[$name])) {
         $fails[] = "$name should have been rejected but was registered at "
             . $got[$name]['path'];
     }
 }
-foreach (['ext:silent', 'ext:guarded', 'ext:callback'] as $name) {
+foreach (['ext:silent', 'ext:guarded', 'ext:callback', 'ext:bareClass'] as $name) {
     if (!isset($got[$name])) {
         $fails[] = "$name should have been registered and was not";
     }
@@ -198,6 +248,32 @@ foreach (['ext:silent', 'ext:typo', 'ext:paramPublic'] as $name) {
 if (isset($got['ext:callback']) && 'public' !== $got['ext:callback']['auth']) {
     $fails[] = 'a correctly declared public route was not treated as public,'
         . ' so a callback that cannot carry credentials is unreachable';
+}
+
+/*
+ * The bare [class, method] handler survives, AND comes back qualified.
+ *
+ * Both halves are the assertion. Registering it while leaving the class bare
+ * would move the failure from validation to dispatch, where it is a fatal on
+ * a live request rather than a dropped route -- so checking only that the
+ * route exists would pass a fix that is still broken.
+ *
+ * This is the regression that took OIDC's /ext/oidc/start and
+ * /ext/oidc/callback off the router entirely under ADR 0035. A signed-out
+ * browser was redirected to start by LOGIN_PAGE_REDIRECT, got 401 because
+ * the route was no longer registered, and had no way back in but
+ * management/login.php.
+ */
+if (isset($got['ext:bareClass'])) {
+    $handler = $got['ext:bareClass']['handler'];
+    if (!is_array($handler) || !is_callable($handler)) {
+        $fails[] = 'a bare [class, method] handler was registered but is not'
+            . ' callable as stored, so dispatch would fatal: '
+            . var_export($handler, true);
+    } elseif ('FOG\\Plugins\\FixturePlug\\Util\\FixtureFlow' !== $handler[0]) {
+        $fails[] = 'a bare handler class was not qualified; got '
+            . var_export($handler[0], true);
+    }
 }
 
 // ------------------------------------------------- what the router enforces


### PR DESCRIPTION
**Regression from ADR 0035. OIDC sign-in is completely dead on `working-1.6`, and the failure presents as a redirect loop the user cannot escape.**

## Symptom

A signed-out browser navigation is redirected to the IdP by `LOGIN_PAGE_REDIRECT`, and the redirect target answers 401. Reproduced against a live `1.6.0-beta.4760`:

```
system/status                    200
ext/oidc/start?provider=3        401
ext/oidc/callback                401
```

Core's public route answers unauthenticated; both of OIDC's `'auth' => 'public'` routes do not.

## Cause

`Route::_validatePluginRoute()` tested the declaration with `is_callable($entry['handler'])`. A plugin declares `['OIDCFlow', 'start']` — the **bare** name, which is the spelling `plugin-development.md` §7a promises core resolves. `is_callable()` resolves a class name in a string against the **global** namespace, and since ADR 0035 the class is `FOG\Plugins\OIDC\Util\OIDCFlow`.

So a valid handler failed the test and the route was dropped, leaving one line in the error log:

```
FOG plugin route: ignoring /ext/oidc/start -- the handler is not callable
FOG plugin route: ignoring /ext/oidc/callback -- the handler is not callable
```

`management/login.php` still works — it is exempt from the redirect by construction — which is the only reason this is a lockout with a way back.

## Fix

Qualify the class before the callable test. Here rather than at dispatch, because the stored handler is what `_registerRoute()` is later called with, so one change fixes validation and dispatch together. It matches how `Authorization::_pageClassFor()`, `Plugin::installdb()` and `FOGURLRequests` already handle a class name they were handed as a string. `qualify()` passes an unknown name through unchanged, so a handler naming a class nothing declares is still dropped.

No plugin change needed — bare names resolving *is* the documented ABI.

## Why the gate did not catch it

Every fixture in `tests/plugin-extension-points.test.php` declared `'handler' => 'strlen'`. A global function is callable under its bare name; a plugin class is not. The handler arm has only ever been tested against a shape **no plugin has ever used**, and stayed green while both OIDC routes were being dropped on every request.

The test now builds a fixture plugin laid out per ADR 0035 and declares a handler the way a real plugin does. Two assertions, because checking only that the route survives would pass a fix that is still broken:

| Fixture | Must |
|---|---|
| `bareClass` — `['FixtureFlow', 'start']` | be registered **and** come back with `handler[0]` qualified to the FQCN — otherwise the failure just moves from validation to a dispatch-time fatal |
| `ghostClass` — `['NoSuchPluginClassAnywhere', 'start']` | still be dropped — resolving bare names must not become a way to register a handler that does not exist |

Mutation-verified: reverting the fix fails on `ext:bareClass should have been registered and was not`; qualifying only a throwaway probe and storing the bare name fails on `registered but is not callable as stored`.

## Verification

- Live: a copy of the deployed webroot with only `Route.php` replaced returns both routes, `auth: public`, handler `FOG\Plugins\OIDC\Util\OIDCFlow`.
- 252/252 tests, both `phpstan` passes unscoped, clean.