### PR TITLE
Let HTTPS netboot be addressed by an IP, and stop moving FOG_WEB_HOST

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -819,7 +819,7 @@ recordGitUpdateSettings() {
     mysql $sqloptionsuser --password="${DB_password}" --execute="INSERT INTO globalSettings (settingKey, settingDesc, settingValue, settingCategory) VALUES ('SERVICE_LOG_PATH', 'Where the linux side fog services write their logs. Recorded automatically by installfog.sh from the install path -- editing it here has no effect. To move the logs, re-run the installer with a different base path.', \"${servicelogs%/}/\", 'FOG Linux Service Logs') ON DUPLICATE KEY UPDATE settingValue=\"${servicelogs%/}/\", settingDesc=VALUES(settingDesc)" ${DB_name} >>$error_log 2>&1
     errorStat $?
 }
-# Keeps FOG_WEB_HOST in step with the name netboot uses.
+# Keeps FOG_WEB_HOST to something the netboot certificate can prove.
 #
 # A boot is two hops with two host sources. default.ipxe names the server for
 # the fetch of boot.php; IpxeBootMenu builds everything after it -- the iPXE menu,
@@ -833,12 +833,51 @@ recordGitUpdateSettings() {
 # install FOG_WEB_HOST is a name plenty of admins set deliberately and no
 # certificate has to match it, so rewriting it there would be a regression
 # dressed as a fix.
+#
+# The same argument applies under HTTPS to a value the certificate DOES carry,
+# which is why this corrects rather than overwrites -- see the check below. An
+# address is a legitimate answer there: iPXE verifies one against an iPAddress
+# SAN exactly as it verifies a name, so "netboot needs a name" was never true.
+# _resolveNetbootHost() has the detail.
 recordNetbootWebHost() {
+    local currentwebhost=""
     [[ ${BOOT_url_proto} == https ]] || return 0
+    # An existing value the served certificate ALREADY serves is left alone.
+    #
+    # This row is not only netboot's. It is the canonical address of the
+    # server: ClientManagement hands it to every FOG client, FOGService,
+    # PingHosts and FOGURLRequests identify themselves by it, and a plugin
+    # building a browser-facing absolute URL -- OIDC's start, callback and
+    # post-logout among them -- resolves against it. Overwriting it therefore
+    # moved an admin's whole install onto whichever name the certificate
+    # happened to lead with, silently, on every run. It is how a server
+    # deliberately addressed as https://<ip>/ ended up bouncing its
+    # administrators to a DNS name at sign-in.
+    #
+    # What this function is FOR is narrower: making sure the boot URLs iPXE
+    # fetches after boot.php name something the certificate can prove. A value
+    # that already satisfies that needs no correction, whether it is a name or
+    # an address -- so check it, and only overwrite when it fails.
+    #
+    # Fail-safe in the direction that matters: a value that cannot be read (no
+    # globalSettings yet on a first install, a query that errors) is empty, so
+    # this falls through and records the certificate name exactly as before.
+    currentwebhost=$(mysql $sqloptionsuser --password="${DB_password}" -N -B \
+        --execute="SELECT settingValue FROM globalSettings WHERE settingKey='FOG_WEB_HOST'" \
+        ${DB_name} 2>>$error_log)
+    currentwebhost="${currentwebhost#"${currentwebhost%%[![:space:]]*}"}"
+    currentwebhost="${currentwebhost%"${currentwebhost##*[![:space:]]}"}"
+    [[ $currentwebhost == NULL ]] && currentwebhost=""
+    if [[ -n $currentwebhost ]] && _servedCertServes "$currentwebhost"; then
+        dots "Keeping FOG_WEB_HOST as $currentwebhost"
+        errorStat 0
+        echo "   The served certificate carries it, so netboot can prove it."
+        return 0
+    fi
     _resolveNetbootHost || return 1
     [[ -n $netboothost ]] || return 0
     dots "Pointing FOG_WEB_HOST at the netboot certificate name"
-    mysql $sqloptionsuser --password="${DB_password}" --execute="INSERT INTO globalSettings (settingKey, settingDesc, settingValue, settingCategory) VALUES ('FOG_WEB_HOST', 'This setting defines the hostname or ip address of the web server used with fog. Under HTTPS netboot it is recorded automatically from the served certificate name, because every boot URL iPXE fetches after boot.php is built from it -- an edit here is overwritten on the next install.', \"$netboothost\", 'Web Server') ON DUPLICATE KEY UPDATE settingValue=\"$netboothost\", settingDesc=VALUES(settingDesc)" ${DB_name} >>$error_log 2>&1
+    mysql $sqloptionsuser --password="${DB_password}" --execute="INSERT INTO globalSettings (settingKey, settingDesc, settingValue, settingCategory) VALUES ('FOG_WEB_HOST', 'This setting defines the hostname or ip address of the web server used with fog. Under HTTPS netboot it must be a name or address the served certificate carries, because every boot URL iPXE fetches after boot.php is built from it. An edit the certificate vouches for is kept; one it does not is replaced by the certificate name on the next install.', \"$netboothost\", 'Web Server') ON DUPLICATE KEY UPDATE settingValue=\"$netboothost\", settingDesc=VALUES(settingDesc)" ${DB_name} >>$error_log 2>&1
     errorStat $?
     echo "   FOG_WEB_HOST is now $netboothost. Every boot URL after boot.php is"
     echo "   built from it, and HTTPS netboot needs them to match the certificate."
@@ -5774,6 +5813,27 @@ _certServesName() {
     done <<< "$sans"
     return 1
 }
+# Does the SERVED certificate vouch for $1, whether it is a name or an address?
+#
+# The two are separate questions to a TLS client and so they are separate
+# functions here -- an address is matched against iPAddress SANs only and a
+# name against dNSName (or a lone commonName), with no crossover in either
+# direction. This is the one place that does not care which kind it was handed,
+# because its caller is asking about a host an admin chose rather than about a
+# name it derived.
+_servedCertServes() {
+    local host="$1" cert
+    [[ -n $host ]] || return 1
+    cert=$(_vhostCertPath)
+    [[ -n $cert && -f $cert ]] || cert="${PKI_web_vhost_cert}"
+    [[ -n $cert && -f $cert ]] || cert="$sslfullchain"
+    [[ -n $cert && -f $cert ]] || return 1
+    if [[ $(validip "$host") -eq 0 ]]; then
+        _certServesAddress "$cert" "$host"
+        return $?
+    fi
+    _certServesName "$cert" "$host" >/dev/null
+}
 # The single name HTTPS netboot addresses this server by. Sets $netboothost.
 #
 # Not local, on purpose. A boot is two hops with two host sources: default.ipxe
@@ -5801,8 +5861,28 @@ _resolveNetbootHost() {
     [[ -n $cert && -f $cert ]] || cert="$sslfullchain"
     [[ -n $cert && -f $cert ]] || cert=""
     # validip echoes 0 for a valid IPv4 literal, 1 otherwise.
-    if [[ -z $netboothost || $(validip "$netboothost") -eq 0 ]]; then
+    #
+    # An address is allowed, but only when the certificate carries it as an
+    # iPAddress SAN. It used to be refused outright, on the belief that HTTPS
+    # netboot needs a NAME -- that is not what iPXE does. x509_check_name()
+    # walks the subjectAltName list and dispatches X509_GENERAL_NAME_IP to
+    # x509_check_ipaddress(), which parses the requested host with sock_aton()
+    # and compares the binary address against the SAN. An IP literal verifies
+    # exactly as a name does, provided the SAN is there; what it cannot do is
+    # match a commonName, which is why _certServesAddress() has no CN
+    # fallback.
+    #
+    # The blanket refusal cost more than a missing feature. FOG_WEB_HOST is
+    # this row's other job -- the canonical address of the server, read by
+    # ClientManagement, the services and every browser-facing absolute URL a
+    # plugin builds -- so refusing an address here forced an install that is
+    # addressed by IP onto a name for everything else too.
+    if [[ -z $netboothost ]]; then
         reason="address"
+    elif [[ $(validip "$netboothost") -eq 0 ]]; then
+        if [[ -z $cert ]] || ! _certServesAddress "$cert" "$netboothost"; then
+            reason="addressnotincert"
+        fi
     elif [[ -n $cert ]] && ! match=$(_certServesName "$cert" "$netboothost"); then
         reason="mismatch"
     fi
@@ -5821,6 +5901,16 @@ _resolveNetbootHost() {
             echo
             echo "   Set a resolvable name with --hostname, or put netboot back on"
             echo "   HTTP with --netboot-proto http."
+        elif [[ $reason == addressnotincert ]]; then
+            echo "   Resolved address: $netboothost"
+            echo "   Certificate:     $cert"
+            echo "   It carries:      $(_certDnsNames "$cert" | tr '\n' ' ')"
+            echo
+            echo "   An address has to appear as an iPAddress SAN -- iPXE compares"
+            echo "   the binary address and will not read it out of a commonName or"
+            echo "   a DNS entry. Re-issue the certificate with $netboothost in its"
+            echo "   SAN list, address this server by a name instead, or put netboot"
+            echo "   back on HTTP with --netboot-proto http."
         else
             echo "   Resolved name: $netboothost"
             echo "   Certificate:   $cert"

--- a/tests/netboot-host-may-be-an-address.test.sh
+++ b/tests/netboot-host-may-be-an-address.test.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+#
+# HTTPS netboot may be addressed by an IP, when the certificate carries it.
+#
+#   tests/netboot-host-may-be-an-address.test.sh
+#
+# _resolveNetbootHost() used to refuse an IP literal outright -- "This server
+# has no name to use, only the address" -- and exit the installer. The belief
+# behind it was that HTTPS netboot needs a NAME. That is not what iPXE does:
+# x509_check_name() walks the subjectAltName list and dispatches
+# X509_GENERAL_NAME_IP to x509_check_ipaddress(), which parses the requested
+# host with sock_aton() and compares the binary address against the SAN. An
+# address verifies exactly as a name does when the SAN is there.
+#
+# The refusal was not a missing feature so much as a forced rename. FOG_WEB_HOST
+# is the canonical address of the server -- ClientManagement hands it to every
+# FOG client, the services identify themselves by it, and every browser-facing
+# absolute URL a plugin builds resolves against it -- so refusing an address for
+# netboot moved an install addressed by IP onto a DNS name for everything else
+# too, on every run, silently.
+#
+# What must NOT relax is the crossover rule: an address is matched against
+# iPAddress SANs only. iPXE will not read an address out of a commonName or a
+# dNSName, so neither may FOG -- a check laxer than the validator it is standing
+# in for blesses an install that completes and then cannot boot.
+#
+# Functions are extracted from lib/common/functions.sh and eval'd, the same way
+# node-cert-external-ca.test.sh does it, so the shipped file is what is tested.
+# Needs openssl. No install, no database, no network, no root.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl is not installed"; exit 0; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+# --- the code under test ----------------------------------------------------
+for fn in validip _certDnsNames _certServesAddress _certServesName \
+          _servedCertServes _resolveNetbootHost; do
+    body=$(awk "/^${fn}\(\) \{/,/^\}/" "$FUNCS")
+    [[ -n $body ]] || { echo "ERROR: could not extract $fn from $FUNCS" >&2; exit 1; }
+    eval "$body" || { echo "ERROR: could not eval $fn" >&2; exit 1; }
+done
+
+# _resolveNetbootHost asks these two for the world around it. Stubbed so each
+# case can put the installer in a known state without an install.
+_servedCertName() { echo "$STUB_SERVED_NAME"; }
+_vhostCertPath()  { echo "$STUB_CERT"; }
+# Set, so the refusal path returns instead of exiting this test.
+exitFail=yes
+PKI_web_vhost_cert=""
+sslfullchain=""
+NET_fog_server_ip="10.255.20.1"
+
+# --- fixtures ---------------------------------------------------------------
+# withip:   a name AND the address, the shape FOG's own installer produces
+# nameonly: the same name, no iPAddress SAN
+# cnaddr:   the address as the commonName and as a dNSName, and NOT as an
+#           iPAddress SAN -- the shape that must still be refused
+mkleaf() {
+    local name="$1" san="$2" cn="${3:-$1}"
+    openssl req -x509 -new -nodes -newkey rsa:2048 -sha256 -days 5 \
+        -subj "/CN=$cn" -keyout "$WORK/$name.key" -out "$WORK/$name.pem" \
+        -addext "subjectAltName=$san" >/dev/null 2>&1
+}
+mkleaf withip   "IP:10.255.20.1,DNS:fogserver.test" || exit 1
+mkleaf nameonly "DNS:fogserver.test"                || exit 1
+mkleaf cnaddr   "DNS:10.255.20.1"                   "10.255.20.1" || exit 1
+
+# --- A. an address the certificate carries is accepted ----------------------
+STUB_CERT="$WORK/withip.pem"; STUB_SERVED_NAME="10.255.20.1"; netboothost=""
+if _resolveNetbootHost >/dev/null 2>&1; then
+    ok "an IP in the certificate's iPAddress SAN is accepted"
+else
+    bad "an IP in the certificate's iPAddress SAN was refused"
+fi
+
+# --- B. an address it does not carry is refused -----------------------------
+STUB_CERT="$WORK/nameonly.pem"; STUB_SERVED_NAME="10.255.20.1"; netboothost=""
+if _resolveNetbootHost >/dev/null 2>&1; then
+    bad "an IP absent from the certificate was accepted; netboot would fail the handshake"
+else
+    ok "an IP absent from the certificate is refused"
+fi
+
+# --- C. THE crossover guard -------------------------------------------------
+# The address appears as the commonName and as a dNSName. iPXE compares a
+# binary address against iPAddress SANs and will find neither, so accepting
+# this would produce an install that completes and cannot boot.
+STUB_CERT="$WORK/cnaddr.pem"; STUB_SERVED_NAME="10.255.20.1"; netboothost=""
+if _resolveNetbootHost >/dev/null 2>&1; then
+    bad "an address carried only as a commonName/dNSName was accepted as an iPAddress SAN"
+else
+    ok "an address is not matched against commonName or dNSName"
+fi
+
+# --- D. names still behave exactly as before --------------------------------
+STUB_CERT="$WORK/nameonly.pem"; STUB_SERVED_NAME="fogserver.test"; netboothost=""
+if _resolveNetbootHost >/dev/null 2>&1; then
+    ok "a name in the certificate is still accepted"
+else
+    bad "a name in the certificate was refused"
+fi
+
+STUB_CERT="$WORK/nameonly.pem"; STUB_SERVED_NAME="elsewhere.test"; netboothost=""
+if _resolveNetbootHost >/dev/null 2>&1; then
+    bad "a name absent from the certificate was accepted"
+else
+    ok "a name absent from the certificate is still refused"
+fi
+
+# --- E. _servedCertServes answers for both kinds ----------------------------
+# This is what recordNetbootWebHost() asks before deciding whether an existing
+# FOG_WEB_HOST needs correcting, so it has to be right for a name and an
+# address alike.
+STUB_CERT="$WORK/withip.pem"
+_servedCertServes "10.255.20.1"  && ok "_servedCertServes accepts a carried address" \
+                                 || bad "_servedCertServes rejected a carried address"
+_servedCertServes "fogserver.test" && ok "_servedCertServes accepts a carried name" \
+                                   || bad "_servedCertServes rejected a carried name"
+_servedCertServes "10.9.9.9"     && bad "_servedCertServes accepted an address not in the certificate" \
+                                 || ok "_servedCertServes rejects an address not in the certificate"
+_servedCertServes "elsewhere.test" && bad "_servedCertServes accepted a name not in the certificate" \
+                                   || ok "_servedCertServes rejects a name not in the certificate"
+
+# --- F. recordNetbootWebHost keeps a value the certificate vouches for ------
+# This is the half that stops the row moving under the admin. mysql, and the
+# two output helpers, are stubbed: the question is which branch runs, not what
+# the database does. WROTE records whether an UPDATE was issued at all.
+body=$(awk '/^recordNetbootWebHost\(\) \{/,/^\}/' "$FUNCS")
+[[ -n $body ]] || { echo "ERROR: could not extract recordNetbootWebHost" >&2; exit 1; }
+eval "$body" || { echo "ERROR: could not eval recordNetbootWebHost" >&2; exit 1; }
+
+BOOT_url_proto=https
+sqloptionsuser=""; DB_password=""; DB_name="fog"; error_log="$WORK/err.log"
+dots() { :; }
+errorStat() { :; }
+mysql() {
+    # The SELECT answers with the case's stored value; anything else is the
+    # write this test exists to detect.
+    if [[ "$*" == *SELECT*FOG_WEB_HOST* ]]; then
+        echo "$STORED"
+        return 0
+    fi
+    WROTE=yes
+    return 0
+}
+
+recorded() {
+    STORED="$1"; WROTE=""; netboothost=""
+    recordNetbootWebHost >/dev/null 2>&1
+    echo "${WROTE:-no}"
+}
+
+STUB_CERT="$WORK/withip.pem"; STUB_SERVED_NAME="fogserver.test"
+
+[[ $(recorded "10.255.20.1") == no ]] \
+    && ok "an address the certificate carries is left alone" \
+    || bad "FOG_WEB_HOST was overwritten despite the certificate carrying it"
+
+[[ $(recorded "fogserver.test") == no ]] \
+    && ok "a name the certificate carries is left alone" \
+    || bad "FOG_WEB_HOST was overwritten despite the certificate carrying it"
+
+[[ $(recorded "somewhere.else") == yes ]] \
+    && ok "a value the certificate cannot prove is corrected" \
+    || bad "a FOG_WEB_HOST the certificate does not carry was left in place; netboot would fail the handshake"
+
+[[ $(recorded "NULL") == yes ]] \
+    && ok "an unset value is recorded, as on a fresh install" \
+    || bad "an unset FOG_WEB_HOST was not recorded"
+
+[[ $(recorded "") == yes ]] \
+    && ok "an unreadable value falls through and records the certificate name" \
+    || bad "an unreadable FOG_WEB_HOST was treated as satisfactory"
+
+# --- report -----------------------------------------------------------------
+echo
+if [[ $FAIL -gt 0 ]]; then
+    echo "FAIL: $FAIL of $((PASS + FAIL)) checks failed"
+    exit 1
+fi
+echo "ok: $PASS checks passed"
+exit 0


### PR DESCRIPTION
An administrator who browses to `https://<ip>/fog/` is redirected to a DNS name at sign-in, on a different origin with a different session. Two installer behaviors combine to cause it.

## 1. An IP was refused for no real reason

`_resolveNetbootHost()` exits the installer on an IP literal — *"This server has no name to use, only the address"* — on the belief that HTTPS netboot needs a name.

iPXE disagrees. `x509_check_name()` walks the subjectAltName list and dispatches `X509_GENERAL_NAME_IP` to `x509_check_ipaddress()`, which parses the requested host with `sock_aton()` and compares the **binary address** against the SAN:

```c
case X509_GENERAL_NAME_IP :
    return x509_check_ipaddress ( cert, &alt_name, name );
```

An address verifies exactly as a name does when the SAN is there. FOG has had `_certServesAddress()` for precisely this since the name-constraints work — with **zero callers**.

## 2. `FOG_WEB_HOST` was rewritten on every install

`recordNetbootWebHost()` wrote the certificate's name over the row every run, and the description it stored said so: *"an edit here is overwritten on the next install."*

That row is not netboot's alone. It is the canonical address of the server:

| Reader | Uses it for |
|---|---|
| `ClientManagement` | the address every FOG client is told to dial |
| `FOGService`, `PingHosts`, `FOGURLRequests` | how the services identify this server |
| `IpxeBootMenu`, `UbootBootMenu` | boot URLs after `boot.php` |
| plugins (OIDC's start / callback / post-logout) | the canonical browser-facing origin |

So an install deliberately addressed by IP was moved onto a DNS name **for all of those at once**, silently, on every run.

## The change

Both parts narrow what the installer takes upon itself:

- an IP netboot host is accepted when the served certificate carries it as an iPAddress SAN, and refused with a message naming that requirement when it does not;
- an existing `FOG_WEB_HOST` the served certificate already vouches for — name **or** address — is kept. Only a value the certificate cannot prove is corrected, which is the guarantee the function exists for.

Neither loosens what netboot demands. **The crossover rule is unchanged and tested:** an address is matched against iPAddress SANs only, never a commonName or dNSName, because iPXE will not read one out of either — a check laxer than the validator it stands in for blesses an install that completes and then cannot boot.

Reading the current value fails safe: unreadable or unset falls through and records the certificate name exactly as before, so a first install is unchanged. A plain-HTTP install is untouched, as before.

## Tests

`tests/netboot-host-may-be-an-address.test.sh` — 14 checks against generated certificates. No install, no database, no network, no root.

Five mutations, each goes red:

| Mutation | Caught by |
|---|---|
| restore the blanket IP refusal | an IP in the iPAddress SAN is accepted |
| let an address match dNSName/commonName too | an address is not matched against commonName or dNSName |
| make `_servedCertServes` always agree | rejects a host not in the certificate |
| restore the unconditional overwrite | a carried value is left alone |
| keep any existing value regardless of the certificate | a value the certificate cannot prove is corrected |

253/253 suite green.

## For an admin who wants an IP-only server

Set `FOG_WEB_HOST` to the address once; it now survives installs, provided the certificate carries it as an iPAddress SAN (FOG's own leaf already includes the detected addresses). The IdP client's registered redirect URI needs updating to match.