### PR TITLE
Say what a FOG_WEB_HOST correction just invalidated

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -881,6 +881,22 @@ recordNetbootWebHost() {
     errorStat $?
     echo "   FOG_WEB_HOST is now $netboothost. Every boot URL after boot.php is"
     echo "   built from it, and HTTPS netboot needs them to match the certificate."
+    # Say what else just moved. Anything a plugin derives from this row derives
+    # a NEW value from here on, and the one that fails hardest is an external
+    # identity provider: a redirect URI is computed from FOG_WEB_HOST on every
+    # request and never stored, so it is now a string the provider has not been
+    # told about -- and a provider rejects an unregistered redirect URI outright.
+    # Sign-in breaks at the next attempt with nothing on this server explaining
+    # why, which is a bad thing to learn from a locked-out admin rather than
+    # from the install that caused it.
+    if [[ -n $currentwebhost && $currentwebhost != "$netboothost" ]]; then
+        echo
+        echo "   It was $currentwebhost. Anything registered elsewhere against that"
+        echo "   value has to be updated to match -- an external identity provider's"
+        echo "   redirect URI in particular, which FOG derives from this setting and"
+        echo "   a provider refuses if it was not registered."
+        echo
+    fi
 }
 backupDB() {
     # ---------------------------------------------------------

--- a/tests/netboot-host-may-be-an-address.test.sh
+++ b/tests/netboot-host-may-be-an-address.test.sh
@@ -185,6 +185,32 @@ STUB_CERT="$WORK/withip.pem"; STUB_SERVED_NAME="fogserver.test"
     && ok "an unreadable value falls through and records the certificate name" \
     || bad "an unreadable FOG_WEB_HOST was treated as satisfactory"
 
+# --- G. a correction says what else it just moved --------------------------
+# The redirect URI an identity provider holds is computed from FOG_WEB_HOST and
+# never stored, so a correction silently invalidates it and sign-in breaks at
+# the next attempt. Whoever ran the installer is the only person positioned to
+# fix that, and only while they are still looking at the output.
+said() {
+    STORED="$1"; WROTE=""; netboothost=""
+    recordNetbootWebHost 2>&1
+}
+
+STUB_CERT="$WORK/withip.pem"; STUB_SERVED_NAME="fogserver.test"
+
+case "$(said 'somewhere.else')" in
+    *"It was somewhere.else"*"redirect URI"*)
+        ok "a correction names the old value and what it invalidates" ;;
+    *)  bad "a correction did not warn that a registered redirect URI is now stale" ;;
+esac
+
+# No warning where nothing moved: an unset value has no registration behind it,
+# and crying wolf on every fresh install is how a real warning gets ignored.
+case "$(said 'NULL')" in
+    *"has to be updated to match"*)
+        bad "a fresh install warned about a value that never existed" ;;
+    *)  ok "no stale-registration warning when there was no previous value" ;;
+esac
+
 # --- report -----------------------------------------------------------------
 echo
 if [[ $FAIL -gt 0 ]]; then


### PR DESCRIPTION
Follows #1551, which stopped the installer moving `FOG_WEB_HOST` gratuitously. This covers the one case where it legitimately still has to.

## Why it matters

An external identity provider's redirect URI is **computed from `FOG_WEB_HOST` on every request and never stored** — `OIDC::redirectUri()` calls `absoluteUrl()`, which is `FOG_WEB_HOST` plus `FOG_WEB_ROOT`. Its docblock is explicit that this is deliberate:

> Built from FOG_WEB_HOST and FOG_WEB_ROOT rather than from the request, on purpose. The value has to be registered at the provider ahead of time and has to match byte for byte…

So the moment this row is corrected, FOG begins presenting a `redirect_uri` the provider was never told about, and a provider refuses an unregistered one outright. Sign-in breaks at the next attempt with nothing on the server saying why.

Before #1551 this fired on **every** install, which is how an admin ends up repeatedly repairing an IdP client for no visible reason.

## The change

When the correction actually changes the value, the installer names the old one and says what it invalidated — at the moment it happens, to the person who just ran it and can act on it, rather than leaving it to be discovered by a locked-out admin later.

Deliberately silent when nothing moved: a fresh install has no previous value and nothing registered behind it, and a warning printed on every run is one nobody reads.

Core stays generic — it does not name the OIDC plugin, only the class of thing that breaks.

## Tests

Two cases added to `tests/netboot-host-may-be-an-address.test.sh` (now 16 checks), both mutation-verified:

| Mutation | Caught by |
|---|---|
| drop the warning | a correction names the old value and what it invalidates |
| warn unconditionally | no stale-registration warning when there was no previous value |

253/253 suite green.