### PR TITLE
Repair the two shape drifts the rehearsal found: msShutdown's enum and roles.rName's missing UNIQUE

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -10033,3 +10033,198 @@ $this->schema[] = [
         return true;
     },
 ];
+
+// 400
+$this->schema[] = [
+    // `multicastSessions`.`msShutdown` survived as enum('0','1') on any
+    // server that came from 1.5, which is every server the boolean
+    // conversion was written for.
+    //
+    // WHY IT ESCAPED. The column is `msAnon3` renamed, and the two branches'
+    // schema step arrays share positions up to 263 and diverge from 264. A
+    // 1.5 database's schemaVersion counts against dev-branch's array, so an
+    // upgrade to 1.6 treats 264-277 as already applied and skips them --
+    // including that rename. When the boolean sweep ran it looked for
+    // `msShutdown`, found no such column, and moved on; SchemaReconciler's
+    // rename pass then produced the column afterward, preserving the enum
+    // type it had all along. Observed on a real 1.5.10 upgrade, reported by
+    // SchemaReconciler::shapeDrift() as
+    // `enum('0','1') NOT NULL` where the manifest says `tinyint(1) NOT NULL`.
+    //
+    // ONLY THIS COLUMN, and that is checked rather than assumed: of every
+    // rename in the skipped range -- plugins pAnon1..pAnon4 and
+    // multicastSessions msAnon3/msAnon4 -- `msShutdown` is the one whose
+    // target column also appears in the boolean map. The rest are LONGTEXT
+    // and INTEGER, whose types no later step changes.
+    //
+    // Safe to run on a server that is already correct: enumToTinyint()
+    // matches `enum('0','1')` exactly and skips anything else, so this is a
+    // single information_schema read and no ALTER on a healthy database.
+    // That idempotence is why the fix is a re-run of the shared helper
+    // rather than a bespoke ALTER -- ADR 0028's three-statement rule (widen
+    // to VARCHAR, normalize the values, narrow to TINYINT) is not
+    // re-implemented here.
+    function () {
+        return Schema::enumToTinyint(
+            ['multicastSessions' => ['msShutdown']]
+        );
+    },
+];
+// 401
+$this->schema[] = [
+    // `roles`.`rName` is declared UNIQUE by the manifest and is missing that
+    // index on any server whose `roles` table was created by the 1.5
+    // accesscontrol plugin, which did not declare one. Native RBAC adopted
+    // the existing table rather than rebuilding it, so the gap came across
+    // the upgrade intact and nothing since has restored it.
+    //
+    // DUPLICATES ARE RENAMED, NEVER DELETED, and that is the whole design.
+    // Six tables reference `roles`.`rID` with ON DELETE CASCADE --
+    // rolePermissions, roleUserAssoc, roleUserGroupAssoc, siteRoleGrants,
+    // and the plugins' ldapGroupRoleAssoc and oidcGroupRoleAssoc. Deleting
+    // one duplicate row would therefore silently remove that role's
+    // permissions, its user and group assignments, its site grants and its
+    // directory-group mappings. That is an access-control change, and a
+    // schema step running unattended in the middle of an upgrade is the
+    // worst possible place to make one. Renaming keeps every row and every
+    // grant exactly as it was: nobody gains or loses access, and the admin
+    // is left with two distinguishable roles to merge by hand if they want.
+    //
+    // The FIRST holder of a name keeps it, so anything resolving a role by
+    // name still finds the row it finds today. (Nothing in core does -- every
+    // reference is by rID -- but the plugins are a separate repository and
+    // this costs nothing to guarantee.)
+    //
+    // COLLATION MATTERS HERE. `rName` is utf8mb3_general_ci, so the UNIQUE
+    // index treats 'Admins' and 'admins' as the same value. The duplicate
+    // search below is a plain GROUP BY for exactly that reason: it inherits
+    // the column's own collation and so finds precisely the pairs the index
+    // will reject. A binary or case-sensitive comparison would pass over
+    // case-variant duplicates and leave ADD UNIQUE to fail with 1062.
+    //
+    // IT NEVER ABORTS THE UPGRADE. If anything still collides after the
+    // renames -- a name too long to disambiguate, or a rename that lands on
+    // a name someone already used -- the index is skipped and the reason is
+    // logged, following schema step 332's precedent with the site tables. A
+    // missing UNIQUE index means FOG carries on as it has for years; an
+    // aborted schema update strands the admin on ?node=schema over data that
+    // is entirely intact.
+    function () {
+        $has = function ($table) {
+            $row = self::$DB->query(
+                "SELECT COUNT(*) AS `n` FROM `information_schema`.`TABLES`"
+                . " WHERE `TABLE_SCHEMA` = DATABASE()"
+                . " AND LOWER(`TABLE_NAME`) = :t",
+                [],
+                [':t' => $table]
+            )->fetch(\PDO::FETCH_ASSOC)->get();
+            return (int)($row['n'] ?? 0) > 0;
+        };
+        if (!$has('roles')) {
+            return true;
+        }
+        // Probed rather than guarded with IF NOT EXISTS, which ADD INDEX
+        // does not have on the server versions FOG supports.
+        $idx = self::$DB->query(
+            "SELECT DISTINCT `INDEX_NAME` AS `i`"
+            . " FROM `information_schema`.`STATISTICS`"
+            . " WHERE `TABLE_SCHEMA` = DATABASE()"
+            . " AND LOWER(`TABLE_NAME`) = 'roles' AND `NON_UNIQUE` = 0"
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        foreach ((array)$idx as $row) {
+            if (isset($row['i']) && 0 === strcasecmp($row['i'], 'rName')) {
+                return true;
+            }
+        }
+
+        // Every row except the lowest-id holder of each repeated name. The
+        // GROUP BY runs in the column's own collation, so this is exactly
+        // the set the UNIQUE index would reject.
+        $dupes = self::$DB->query(
+            "SELECT `r`.`rID` AS `id`, `r`.`rName` AS `name`"
+            . " FROM `roles` `r`"
+            . " JOIN (SELECT `rName`, MIN(`rID`) AS `keep` FROM `roles`"
+            . " GROUP BY `rName` HAVING COUNT(*) > 1) `d`"
+            . " ON `d`.`rName` = `r`.`rName`"
+            . " WHERE `r`.`rID` <> `d`.`keep`"
+            . " ORDER BY `r`.`rID`"
+        )->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+
+        $renamed = [];
+        foreach ((array)$dupes as $row) {
+            if (!isset($row['id'], $row['name'])) {
+                continue;
+            }
+            // rID is unique, so the suffix is too. Truncated to fit
+            // varchar(255) from the LEFT, keeping the tail: the suffix is
+            // what makes the value unique, so it is the part that must
+            // survive.
+            $suffix = sprintf(' (duplicate %d)', (int)$row['id']);
+            $base = (string)$row['name'];
+            $keep = 255 - strlen($suffix);
+            if (strlen($base) > $keep) {
+                $base = substr($base, 0, $keep);
+            }
+            $new = $base . $suffix;
+            self::$DB->query(
+                "UPDATE `roles` SET `rName` = :n WHERE `rID` = :id",
+                [],
+                [':n' => $new, ':id' => (int)$row['id']]
+            );
+            $renamed[] = sprintf('%s -> %s', $row['name'], $new);
+        }
+
+        if (count($renamed)) {
+            error_log(
+                sprintf(
+                    'FOG schema 401: renamed %d duplicate role name(s) so'
+                    . ' that the UNIQUE index the manifest declares could be'
+                    . ' restored. No role, permission or assignment was'
+                    . ' removed: %s',
+                    count($renamed),
+                    implode('; ', $renamed)
+                )
+            );
+            Audit::record(
+                [
+                    'type' => 'schema.role.rename',
+                    'subjectType' => 'schema',
+                    'subjectId' => 401,
+                    'summary' => sprintf(
+                        /* translators: %d is a count of roles */
+                        _('Renamed %d duplicate role name(s) to restore the'
+                        . ' unique-name guarantee. No access was changed.'),
+                        count($renamed)
+                    ),
+                    'detail' => json_encode(['renamed' => $renamed]),
+                    'affectedCount' => count($renamed),
+                    'renderable' => 1,
+                ]
+            );
+        }
+
+        // Re-checked rather than assumed: a rename can in principle collide
+        // with a name that was already in use.
+        $still = self::$DB->query(
+            "SELECT COUNT(*) AS `n` FROM (SELECT `rName` FROM `roles`"
+            . " GROUP BY `rName` HAVING COUNT(*) > 1) `d`"
+        )->fetch(\PDO::FETCH_ASSOC)->get();
+        if ((int)($still['n'] ?? 0) > 0) {
+            error_log(
+                sprintf(
+                    'FOG schema 401: %d role name(s) still collide after'
+                    . ' renaming, so the UNIQUE index was NOT added. Nothing'
+                    . ' was deleted and the upgrade continues; rename them by'
+                    . ' hand and the index is added on the next update.',
+                    (int)$still['n']
+                )
+            );
+            return true;
+        }
+
+        self::$DB->query(
+            "ALTER TABLE `roles` ADD UNIQUE KEY `rName` (`rName`)"
+        );
+        return true;
+    },
+];

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -7119,6 +7119,10 @@ msgid "Rename or remove one of them."
 msgstr "Fehler beim Aktualisieren des Tasks"
 
 #, php-format
+msgid "Renamed %d duplicate role name(s) to restore the unique-name guarantee. No access was changed."
+msgstr ""
+
+#, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
 msgstr ""
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -7116,6 +7116,10 @@ msgid "Rename or remove one of them."
 msgstr "Failed to update task"
 
 #, php-format
+msgid "Renamed %d duplicate role name(s) to restore the unique-name guarantee. No access was changed."
+msgstr ""
+
+#, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
 msgstr ""
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -7259,6 +7259,10 @@ msgid "Rename or remove one of them."
 msgstr "No se pudo crear la tarea"
 
 #, php-format
+msgid "Renamed %d duplicate role name(s) to restore the unique-name guarantee. No access was changed."
+msgstr ""
+
+#, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
 msgstr ""
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -7120,6 +7120,10 @@ msgid "Rename or remove one of them."
 msgstr "Fehler beim Aktualisieren des Tasks"
 
 #, php-format
+msgid "Renamed %d duplicate role name(s) to restore the unique-name guarantee. No access was changed."
+msgstr ""
+
+#, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
 msgstr ""
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -7118,6 +7118,10 @@ msgid "Rename or remove one of them."
 msgstr "Impossible de mettre à jour la tâche"
 
 #, php-format
+msgid "Renamed %d duplicate role name(s) to restore the unique-name guarantee. No access was changed."
+msgstr ""
+
+#, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
 msgstr ""
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -6907,6 +6907,10 @@ msgid "Rename or remove one of them."
 msgstr "Impossibile aggiornare compito"
 
 #, php-format
+msgid "Renamed %d duplicate role name(s) to restore the unique-name guarantee. No access was changed."
+msgstr ""
+
+#, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
 msgstr ""
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -6873,6 +6873,10 @@ msgid "Rename or remove one of them."
 msgstr ""
 
 #, php-format
+msgid "Renamed %d duplicate role name(s) to restore the unique-name guarantee. No access was changed."
+msgstr ""
+
+#, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
 msgstr ""
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -6058,6 +6058,10 @@ msgid "Rename or remove one of them."
 msgstr ""
 
 #, php-format
+msgid "Renamed %d duplicate role name(s) to restore the unique-name guarantee. No access was changed."
+msgstr ""
+
+#, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -7117,6 +7117,10 @@ msgid "Rename or remove one of them."
 msgstr "Falha ao atualizar tarefa"
 
 #, php-format
+msgid "Renamed %d duplicate role name(s) to restore the unique-name guarantee. No access was changed."
+msgstr ""
+
+#, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
 msgstr ""
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -7117,6 +7117,10 @@ msgid "Rename or remove one of them."
 msgstr "无法更新任务"
 
 #, php-format
+msgid "Renamed %d duplicate role name(s) to restore the unique-name guarantee. No access was changed."
+msgstr ""
+
+#, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
 msgstr ""
 

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -130,7 +130,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 399);
+        define('FOG_SCHEMA', 401);
         define('FOG_BCACHE_VER', 353);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -81,7 +81,7 @@ parameters:
 		-
 			message: '#^Accessing self\:\:\$DB outside of class scope\.$#'
 			identifier: outOfClass.self
-			count: 110
+			count: 116
 			path: packages/web/commons/schema.php
 
 		-
@@ -129,7 +129,7 @@ parameters:
 		-
 			message: '#^Variable \$this might not be defined\.$#'
 			identifier: variable.undefined
-			count: 369
+			count: 371
 			path: packages/web/commons/schema.php
 
 		-

--- a/tests/multicast-shutdown-is-tinyint.test.php
+++ b/tests/multicast-shutdown-is-tinyint.test.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Schema step 400 converts `multicastSessions`.`msShutdown` off enum('0','1').
+ *
+ * The column is `msAnon3` renamed, and the two branches' schema step arrays
+ * share positions up to 263 and diverge from 264. A 1.5 database's
+ * schemaVersion counts against dev-branch's array, so an upgrade to 1.6 treats
+ * 264-277 as already applied and skips them -- including that rename. When the
+ * boolean sweep at step 368 ran it looked for `msShutdown`, found no such
+ * column, and moved on. SchemaReconciler's rename pass then produced the
+ * column afterward, preserving the enum it had all along.
+ *
+ * Observed, not predicted: a real 1.5.10 database upgraded to the current
+ * schema came out with `enum('0','1') NOT NULL` where the manifest says
+ * `tinyint(1) NOT NULL DEFAULT 0`. Every other rename in the skipped range is
+ * LONGTEXT or INTEGER, whose types no later step changes, which is why this is
+ * one column rather than a sweep.
+ *
+ * Why an enum boolean is a bug rather than a preference: in MySQL an
+ * enum('0','1') indexes from 1, so the integer 1 selects the member '0'.
+ * `->set('msShutdown', 1)` therefore means FALSE if the value ever reaches the
+ * server as an integer. See ADR 0028 and fogproject#1361.
+ *
+ * Usage: php tests/multicast-shutdown-is-tinyint.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+use FOG\Items\Schema;
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('multicast-shutdown-is-tinyint');
+
+$t = new FogChecks();
+$root = dirname(__DIR__);
+
+// -------------------------------------------------------------------------
+// 1. The repair itself, driven through the REAL shared helper against a
+//    server described exactly as the drifted one was.
+// -------------------------------------------------------------------------
+
+/**
+ * Runs the conversion against a server whose msShutdown has $type.
+ *
+ * @param string $type      COLUMN_TYPE as information_schema reports it
+ * @param mixed  $default   COLUMN_DEFAULT
+ * @param string $nullable  IS_NULLABLE
+ *
+ * @return array the statements issued
+ */
+$convert = static function ($type, $default = '0', $nullable = 'NO') {
+    $db = FogTestHarness::fakeDb();
+    $db->responder = static function ($sql) use ($db, $type, $default, $nullable) {
+        $db->error = false;
+        if (false !== strpos($sql, 'information_schema')) {
+            return [[
+                'c' => 'msShutdown',
+                'ty' => $type,
+                'd' => $default,
+                'n' => $nullable,
+            ]];
+        }
+        return null;
+    };
+    $mark = count($db->log);
+    Schema::enumToTinyint(['multicastSessions' => ['msShutdown']]);
+    return array_slice($db->log, $mark);
+};
+
+$alters = static function (array $log) {
+    return array_values(
+        array_filter(
+            $log,
+            static function ($sql) {
+                return (bool)preg_match('/^\s*(ALTER|UPDATE)\b/i', $sql);
+            }
+        )
+    );
+};
+
+// The drifted server.
+$log = $alters($convert("enum('0','1')"));
+$t->check(
+    'the drifted enum column is converted',
+    count($log) === 3
+);
+$t->check(
+    'and it lands on TINYINT(1) NOT NULL DEFAULT 0, as the manifest says',
+    isset($log[2])
+        && false !== stripos($log[2], '`multicastSessions`')
+        && false !== stripos($log[2], '`msShutdown`')
+        && false !== stripos($log[2], 'TINYINT(1)')
+        && false !== stripos($log[2], 'NOT NULL')
+        && false !== stripos($log[2], 'DEFAULT 0')
+);
+$t->check(
+    'via VARCHAR first, so no value is reinterpreted by its enum index',
+    isset($log[0]) && false !== stripos($log[0], 'VARCHAR(1)')
+);
+
+// A server that is already correct. This is the property that makes the step
+// safe to ship to everybody rather than only to upgraded 1.5 servers: it must
+// cost one information_schema read and nothing else.
+$t->check(
+    'a server already on tinyint(1) gets no ALTER at all',
+    $alters($convert('tinyint(1)')) === []
+);
+// The same guarantee for a shape that is neither -- a hand-altered server
+// must not be silently rewritten by a step aimed at one specific drift.
+$t->check(
+    'an unrelated column type is left alone',
+    $alters($convert("enum('yes','no')")) === []
+);
+
+// -------------------------------------------------------------------------
+// 2. That step 400 is what asks for it.
+//    The behavioral half above exercises the helper, so it would stay green
+//    if the step named the wrong table or column. This is the half that
+//    would not.
+// -------------------------------------------------------------------------
+$src = (string)file_get_contents($root . '/packages/web/commons/schema.php');
+$from = strpos($src, "\n// 400\n");
+$to = strpos($src, "\n// 401\n");
+$t->check(
+    'step 400 is present and bounded by step 401',
+    false !== $from && false !== $to && $to > $from
+);
+$body = false !== $from && false !== $to
+    ? substr($src, $from, $to - $from)
+    : '';
+
+// Comments stripped, so the explanation above the step -- which necessarily
+// names the column -- cannot be what satisfies this.
+$code = '';
+foreach (token_get_all('<?php ' . $body) as $tok) {
+    if (is_array($tok) && in_array($tok[0], [T_COMMENT, T_DOC_COMMENT], true)) {
+        continue;
+    }
+    $code .= is_array($tok) ? $tok[1] : $tok;
+}
+$t->check(
+    'step 400 converts multicastSessions.msShutdown',
+    (bool)preg_match(
+        '/enumToTinyint\(\s*\[\s*[\'"]multicastSessions[\'"]\s*=>\s*'
+        . '\[\s*[\'"]msShutdown[\'"]\s*\]/',
+        $code
+    )
+);
+$t->check(
+    'it reuses the shared helper rather than hand-rolling the ALTERs',
+    false === stripos($code, 'ALTER TABLE')
+);
+// ...and the strip is real, or the check above passes for the wrong reason.
+$t->check(
+    'the comment explaining why it drifted is still there',
+    false !== stripos($body, 'msAnon3')
+);
+
+$t->finish();

--- a/tests/role-name-unique-on-a-real-server.test.php
+++ b/tests/role-name-unique-on-a-real-server.test.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * Schema step 401 restores `roles`.`rName`'s UNIQUE index on a REAL server.
+ *
+ * tests/role-name-unique-restored.test.php drives the step against a stub and
+ * pins its policy: rename, never delete, first holder keeps the name, skip the
+ * index rather than abort. That stub computes duplicates in PHP, so there is
+ * one property it cannot test and must not claim to -- whether the duplicate
+ * search agrees with the index about what a duplicate IS.
+ *
+ * It has to, and the reason is collation. `rName` is utf8mb3_general_ci, so
+ * `ADD UNIQUE KEY` rejects 'Techs' alongside 'techs'. If the search were
+ * case-sensitive it would pass over that pair, and the ALTER would then fail
+ * with errno 1062 partway through an upgrade -- on a table the step had
+ * already renamed rows in. Only a real server can say whether the two agree,
+ * because only a real server applies the collation.
+ *
+ * Runs on every server CI covers -- MariaDB 10.5, MariaDB 11.8 and MySQL 8.0
+ * -- which also makes it the check that a dialect difference between them
+ * cannot hide in.
+ *
+ * Skips without FOG_TEST_DSN, exactly as tests/schema-executes.test.php does.
+ *
+ * Usage: FOG_TEST_DSN=... php tests/role-name-unique-on-a-real-server.test.php
+ * Exit status 0 = pass or skip, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$dsn = getenv('FOG_TEST_DSN');
+if ($dsn === false || $dsn === '') {
+    echo "SKIP  no FOG_TEST_DSN set; role index not checked on a server\n";
+    exit(0);
+}
+if (!in_array('mysql', \PDO::getAvailableDrivers(), true)) {
+    fwrite(STDERR, "FAIL: FOG_TEST_DSN is set but the pdo_mysql driver is missing.\n");
+    exit(1);
+}
+
+$user = getenv('FOG_TEST_USER');
+$pass = getenv('FOG_TEST_PASS');
+$user = ($user === false) ? 'root' : $user;
+$pass = ($pass === false) ? '' : $pass;
+
+$db = 'fog_role_index_test';
+
+require __DIR__ . '/lib/fog-schema-collector.php';
+
+$root = dirname(__DIR__);
+$fogSchema = 0;
+if (preg_match(
+    "/define\('FOG_SCHEMA',\s*(\d+)\)/",
+    (string)file_get_contents($root . '/packages/web/src/Base/System.php'),
+    $m
+)) {
+    $fogSchema = (int)$m[1];
+}
+$steps = fogCollectSchemaSteps(
+    $root . '/packages/web/commons/schema.php',
+    $db,
+    $fogSchema
+);
+
+// The step under test, pinned by number rather than taken as the last one.
+define('ROLE_INDEX_STEP', 401);
+
+$checks = 0;
+$failures = [];
+$check = static function ($what, $ok) use (&$checks, &$failures) {
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+};
+
+try {
+    $pdo = new \PDO($dsn, $user, $pass, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+} catch (\PDOException $e) {
+    fwrite(STDERR, 'FAIL: cannot connect: ' . $e->getMessage() . "\n");
+    exit(1);
+}
+
+/**
+ * A `self::$DB` that speaks to the real server through PDO.
+ */
+class RealSchemaDB extends SchemaStubDB
+{
+    /** @var \PDO */
+    public $pdo;
+
+    /** @var \PDOStatement|null */
+    private $_stmt = null;
+
+    /** @var bool whether the last statement returned rows */
+    private $_rows = false;
+
+    public function query($query = null, ...$rest)
+    {
+        $params = [];
+        foreach ($rest as $arg) {
+            if (is_array($arg) && count($arg)) {
+                $params = $arg;
+            }
+        }
+        $this->_stmt = $this->pdo->prepare((string)$query);
+        $this->_stmt->execute($params ?: null);
+        $this->_rows = (bool)preg_match('/^\s*SELECT\b/i', (string)$query);
+        return $this;
+    }
+
+    public function fetch($what = null, ...$rest)
+    {
+        $this->_all = in_array('fetch_all', $rest, true)
+            || 'fetch_all' === $what;
+        return $this;
+    }
+
+    /** @var bool */
+    private $_all = false;
+
+    public function get($key = null)
+    {
+        if (!$this->_rows || null === $this->_stmt) {
+            return null;
+        }
+        return $this->_all
+            ? $this->_stmt->fetchAll(\PDO::FETCH_ASSOC)
+            : $this->_stmt->fetch(\PDO::FETCH_ASSOC);
+    }
+}
+
+// A scratch database, not the one the DSN names: this test plants duplicate
+// roles and drops them again, which must never touch a real FOG database.
+// A FOG service account deliberately has no CREATE DATABASE right, so that is
+// a SKIP rather than a failure -- the same distinction schema-executes.test.php
+// draws.
+try {
+    $pdo->exec("DROP DATABASE IF EXISTS `$db`");
+    $pdo->exec("CREATE DATABASE `$db`");
+} catch (\PDOException $e) {
+    printf("SKIP  %s may not CREATE DATABASE; role index not checked\n", $user);
+    exit(0);
+}
+$pdo->exec("USE `$db`");
+
+// The table as the 1.5 accesscontrol plugin left it: no UNIQUE on rName.
+// That absence is the whole defect, so it is built rather than assumed.
+$pdo->exec(
+    "CREATE TABLE `roles` ("
+    . " `rID` int(11) NOT NULL AUTO_INCREMENT,"
+    . " `rName` varchar(255) NOT NULL,"
+    . " `rDesc` longtext NOT NULL,"
+    . " PRIMARY KEY (`rID`)"
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci"
+);
+// Case-variant duplicates: the pair a case-sensitive search would miss.
+$pdo->exec(
+    "INSERT INTO `roles` (`rID`, `rName`, `rDesc`) VALUES"
+    . " (1, 'Administrators', ''),"
+    . " (2, 'Techs', ''),"
+    . " (3, 'techs', ''),"
+    . " (4, 'TECHS', '')"
+);
+
+$sdb = new RealSchemaDB();
+$sdb->pdo = $pdo;
+$prev = SchemaCollector::$DB;
+SchemaCollector::$DB = $sdb;
+foreach ((array)$steps[ROLE_INDEX_STEP - 1] as $update) {
+    if (is_callable($update)) {
+        $update();
+    }
+}
+SchemaCollector::$DB = $prev;
+
+// 1. The index exists. This is the assertion that could only pass if the
+//    duplicate search agreed with the collation -- ADD UNIQUE would have
+//    thrown 1062 otherwise.
+$idx = $pdo->query(
+    "SELECT COUNT(*) AS n FROM information_schema.STATISTICS"
+    . " WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'roles'"
+    . " AND INDEX_NAME = 'rName' AND NON_UNIQUE = 0"
+)->fetch(\PDO::FETCH_ASSOC);
+$check(
+    'the UNIQUE index is created on a server that had case-variant duplicates',
+    (int)($idx['n'] ?? 0) === 1
+);
+
+// 2. Nothing was deleted. Six tables CASCADE off roles.rID, so a delete here
+//    would silently strip permissions and assignments.
+$rows = $pdo->query('SELECT `rID`, `rName` FROM `roles` ORDER BY `rID`')
+    ->fetchAll(\PDO::FETCH_ASSOC);
+$check('every role survived', count($rows) === 4);
+
+// 3. The first holder kept its name, so a by-name lookup is unchanged.
+$check(
+    'the first holder of the name keeps it',
+    ($rows[1]['rName'] ?? '') === 'Techs'
+);
+$check(
+    'the untouched role is untouched',
+    ($rows[0]['rName'] ?? '') === 'Administrators'
+);
+
+// 4. And the renames really are distinct UNDER THE COLLATION, which is a
+//    different statement from being distinct as PHP strings.
+$dupes = $pdo->query(
+    'SELECT COUNT(*) AS n FROM (SELECT `rName` FROM `roles`'
+    . ' GROUP BY `rName` HAVING COUNT(*) > 1) d'
+)->fetch(\PDO::FETCH_ASSOC);
+$check('no two names collide under the column collation', (int)($dupes['n'] ?? 0) === 0);
+
+// 5. The index is enforced from here on -- the guarantee the whole step is
+//    for. Without this the four checks above could all hold on a table that
+//    still accepted a duplicate tomorrow.
+$rejected = false;
+try {
+    $pdo->exec("INSERT INTO `roles` (`rName`, `rDesc`) VALUES ('administrators', '')");
+} catch (\PDOException $e) {
+    $rejected = '23000' === $e->getCode();
+}
+$check(
+    'the server now REJECTS a case-variant duplicate insert',
+    true === $rejected
+);
+
+// 6. Re-running is a no-op rather than an error: ADD UNIQUE has no
+//    IF NOT EXISTS on these servers, so the step must probe.
+$again = true;
+try {
+    SchemaCollector::$DB = $sdb;
+    foreach ((array)$steps[ROLE_INDEX_STEP - 1] as $update) {
+        if (is_callable($update)) {
+            $update();
+        }
+    }
+    SchemaCollector::$DB = $prev;
+} catch (\Throwable $e) {
+    $again = false;
+    $failures[] = 're-running step 401 threw: ' . $e->getMessage();
+    $checks++;
+}
+if ($again) {
+    $check('re-running the step on a converged server is a no-op', true);
+}
+
+$pdo->exec("DROP DATABASE IF EXISTS `$db`");
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL: ' . count($failures) . " of $checks check(s):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+printf("ok  %d checks passed\n", $checks);
+exit(0);

--- a/tests/role-name-unique-restored.test.php
+++ b/tests/role-name-unique-restored.test.php
@@ -1,0 +1,322 @@
+<?php
+/**
+ * Schema step 401 restores `roles`.`rName`'s UNIQUE index without deleting.
+ *
+ * The manifest declares the index; a server whose `roles` table came from the
+ * 1.5 accesscontrol plugin does not have it, because that plugin never
+ * declared one and native RBAC adopted the table rather than rebuilding it.
+ * SchemaReconciler::shapeDrift() reports the gap; nothing repaired it.
+ *
+ * What is pinned here is the SAFETY of the repair, not merely that it runs.
+ * Six tables reference `roles`.`rID` with ON DELETE CASCADE -- rolePermissions,
+ * roleUserAssoc, roleUserGroupAssoc, siteRoleGrants, and the plugins'
+ * ldapGroupRoleAssoc and oidcGroupRoleAssoc -- so deleting a duplicate role
+ * would silently strip that role's permissions, assignments, site grants and
+ * directory mappings. That is an access-control change, and this step must
+ * never make one. Hence: rename, never delete, and the first holder of a name
+ * keeps it so that a by-name lookup still resolves to the row it does today.
+ *
+ * Usage: php tests/role-name-unique-restored.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+require_once __DIR__ . '/lib/fog-schema-collector.php';
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+$root = dirname(__DIR__);
+$schemaFile = $root . '/packages/web/commons/schema.php';
+
+$fogSchema = 0;
+if (preg_match(
+    "/define\('FOG_SCHEMA',\s*(\d+)\)/",
+    (string)file_get_contents($root . '/packages/web/src/Base/System.php'),
+    $m
+)) {
+    $fogSchema = (int)$m[1];
+}
+
+$steps = fogCollectSchemaSteps($schemaFile, 'fogtest', $fogSchema);
+$t = new FogChecks();
+
+// The step this test is about, pinned by number.
+define('ROLE_INDEX_STEP', 401);
+
+/**
+ * A `self::$DB` standing in for a server holding a `roles` table.
+ */
+class RoleIndexDB extends SchemaStubDB
+{
+    /** @var bool whether the server has a `roles` table */
+    public $hasRoles = true;
+
+    /** @var bool whether `rName` already carries a UNIQUE index */
+    public $hasIndex = false;
+
+    /** @var array rows as ['id' => int, 'name' => string] */
+    public $roles = [];
+
+    /** @var array every statement issued, in order */
+    public $log = [];
+
+    /** @var mixed what the next get() returns */
+    private $_answer = null;
+
+    public function query($query = null, ...$rest)
+    {
+        $sql = (string)$query;
+        $this->log[] = $sql;
+        $params = [];
+        foreach ($rest as $arg) {
+            if (is_array($arg) && count($arg)) {
+                $params = $arg;
+            }
+        }
+
+        if (false !== strpos($sql, 'information_schema`.`TABLES')) {
+            $this->_answer = ['n' => $this->hasRoles ? 1 : 0];
+            return $this;
+        }
+        if (false !== strpos($sql, 'STATISTICS')) {
+            $this->_answer = $this->hasIndex
+                ? [['i' => 'rName']]
+                : [['i' => 'PRIMARY']];
+            return $this;
+        }
+        if (0 === strpos(ltrim($sql), 'UPDATE `roles`')) {
+            // Apply it, so the collision re-check further down sees the
+            // renamed data rather than the original. A fake that ignored the
+            // write would let the "still colliding" branch pass for the
+            // wrong reason.
+            foreach ($this->roles as $i => $row) {
+                if ((int)$row['id'] === (int)($params[':id'] ?? 0)) {
+                    $this->roles[$i]['name'] = (string)($params[':n'] ?? '');
+                }
+            }
+            $this->_answer = null;
+            return $this;
+        }
+        // Order matters: BOTH statements end in `HAVING COUNT(*) > 1) `d``,
+        // so the row-returning one must be recognized first or the step is
+        // handed a count where it expects rows and silently renames nothing.
+        if (false !== strpos($sql, 'FROM `roles` `r`')) {
+            // Every row but the lowest id of each repeated name. Compared
+            // case-insensitively, because rName is utf8mb3_general_ci and
+            // that is what the real index enforces.
+            $out = [];
+            foreach ($this->_dupeNames() as $key => $ids) {
+                sort($ids);
+                array_shift($ids);
+                foreach ($ids as $id) {
+                    $out[] = ['id' => $id, 'name' => $this->_nameOf($id)];
+                }
+            }
+            usort(
+                $out,
+                static function ($a, $b) {
+                    return $a['id'] <=> $b['id'];
+                }
+            );
+            $this->_answer = $out;
+            return $this;
+        }
+        if (false !== strpos($sql, 'SELECT COUNT(*) AS `n` FROM (SELECT')) {
+            // The post-rename collision count.
+            $this->_answer = ['n' => count($this->_dupeNames())];
+            return $this;
+        }
+        $this->_answer = null;
+        return $this;
+    }
+
+    /** @return array lowercased name => list of ids, repeats only */
+    private function _dupeNames()
+    {
+        $by = [];
+        foreach ($this->roles as $row) {
+            $by[strtolower((string)$row['name'])][] = (int)$row['id'];
+        }
+        return array_filter(
+            $by,
+            static function ($ids) {
+                return count($ids) > 1;
+            }
+        );
+    }
+
+    /** @param int $id role id @return string */
+    private function _nameOf($id)
+    {
+        foreach ($this->roles as $row) {
+            if ((int)$row['id'] === (int)$id) {
+                return (string)$row['name'];
+            }
+        }
+        return '';
+    }
+
+    public function fetch($what = null, ...$rest)
+    {
+        return $this;
+    }
+
+    public function get($key = null)
+    {
+        return $this->_answer;
+    }
+}
+
+/**
+ * Runs step 401 against a fake server.
+ *
+ * @param array $roles   rows as ['id' => int, 'name' => string]
+ * @param bool  $hasIdx  whether the UNIQUE index already exists
+ * @param bool  $hasTbl  whether the `roles` table exists at all
+ *
+ * @return RoleIndexDB the server, after the step
+ */
+function runRoleStep(array $roles, $hasIdx = false, $hasTbl = true)
+{
+    global $steps, $fogSchema;
+    $db = new RoleIndexDB();
+    $db->roles = $roles;
+    $db->hasIndex = $hasIdx;
+    $db->hasRoles = $hasTbl;
+    $prev = SchemaCollector::$DB;
+    SchemaCollector::$DB = $db;
+    // Indexed by the step's own number rather than by $fogSchema, which is
+    // only the same thing until the next step lands.
+    $step = $steps[ROLE_INDEX_STEP - 1];
+    foreach ((array)$step as $update) {
+        if (is_callable($update)) {
+            $update();
+        }
+    }
+    SchemaCollector::$DB = $prev;
+    return $db;
+}
+
+/** @param array $log statements @return bool whether the index was added */
+function addedIndex(array $log)
+{
+    foreach ($log as $sql) {
+        if (false !== stripos($sql, 'ADD UNIQUE KEY `rName`')) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/** @param array $log statements @return bool whether anything was deleted */
+function deletedAnything(array $log)
+{
+    foreach ($log as $sql) {
+        if (preg_match('/^\s*(DELETE|TRUNCATE|DROP)\b/i', $sql)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// --- the clean case --------------------------------------------------------
+$db = runRoleStep([
+    ['id' => 1, 'name' => 'Administrators'],
+    ['id' => 2, 'name' => 'Operators'],
+]);
+$t->check('the index is added when no name repeats', addedIndex($db->log));
+$t->check(
+    'nothing is renamed when no name repeats',
+    'Administrators' === $db->roles[0]['name']
+        && 'Operators' === $db->roles[1]['name']
+);
+
+// --- already correct -------------------------------------------------------
+$db = runRoleStep(
+    [['id' => 1, 'name' => 'Administrators']],
+    true
+);
+$t->check(
+    'a server that already has the index is left alone',
+    !addedIndex($db->log)
+);
+
+// --- no roles table --------------------------------------------------------
+$db = runRoleStep([], false, false);
+$t->check(
+    'a server with no roles table is left alone',
+    !addedIndex($db->log)
+);
+
+// --- duplicates: renamed, never deleted ------------------------------------
+$db = runRoleStep([
+    ['id' => 3, 'name' => 'Techs'],
+    ['id' => 7, 'name' => 'Techs'],
+    ['id' => 9, 'name' => 'Techs'],
+]);
+$t->check('the index is added once duplicates are resolved', addedIndex($db->log));
+$t->check(
+    'NOTHING is deleted -- six tables CASCADE off roles.rID',
+    !deletedAnything($db->log)
+);
+$t->check(
+    'every role still exists',
+    count($db->roles) === 3
+);
+$t->check(
+    'the FIRST holder keeps the name, so a by-name lookup is unchanged',
+    'Techs' === $db->roles[0]['name']
+);
+$t->check(
+    'each later duplicate gets a distinct name',
+    $db->roles[1]['name'] === 'Techs (duplicate 7)'
+        && $db->roles[2]['name'] === 'Techs (duplicate 9)'
+);
+
+// Case-variant duplicates ('Techs' vs 'techs') are NOT checked here, on
+// purpose. rName is utf8mb3_general_ci, so the UNIQUE index treats them as the
+// same value and the step's duplicate search has to agree -- but this stub
+// computes duplicates in PHP, so it would be testing its own strtolower()
+// rather than the SQL. Proved instead against a real server, where the
+// collation is applied by the thing that enforces it:
+// tests/role-name-unique-on-a-real-server.test.php.
+
+// --- a name too long to carry a suffix -------------------------------------
+$long = str_repeat('r', 255);
+$db = runRoleStep([
+    ['id' => 1, 'name' => $long],
+    ['id' => 2, 'name' => $long],
+]);
+$t->check(
+    'a 255-char name is truncated to make room for the suffix',
+    strlen($db->roles[1]['name']) <= 255
+        && $db->roles[1]['name'] !== $long
+);
+$t->check('the index is still added after truncation', addedIndex($db->log));
+
+// --- it never aborts the upgrade -------------------------------------------
+// Step 332's precedent: a schema step that cannot finish its job logs and
+// returns true rather than stranding the admin on ?node=schema over data that
+// is entirely intact. Here the rename lands on a name already in use, so a
+// collision survives and the index must be SKIPPED rather than attempted.
+$db = runRoleStep([
+    ['id' => 1, 'name' => 'Techs'],
+    ['id' => 2, 'name' => 'Techs'],
+    ['id' => 3, 'name' => 'Techs (duplicate 2)'],
+]);
+$t->check(
+    'the index is skipped when a collision survives the rename',
+    !addedIndex($db->log)
+);
+$t->check(
+    'and still nothing is deleted',
+    !deletedAnything($db->log) && count($db->roles) === 3
+);
+
+$t->finish();

--- a/tests/site-plugin-row-retired.test.php
+++ b/tests/site-plugin-row-retired.test.php
@@ -51,6 +51,10 @@ if (preg_match(
 $steps = fogCollectSchemaSteps($schemaFile, 'fogtest', $fogSchema);
 $t = new FogChecks();
 
+// The step this test is about. Pinned, so that adding step 402 cannot quietly
+// point these assertions somewhere else.
+define('SITE_RETIRE_STEP', 399);
+
 /**
  * A `self::$DB` that answers the table probes and records what was written.
  */
@@ -120,7 +124,11 @@ function runRetireStep(array $tables)
     $db->tables = $tables;
     $prev = SchemaCollector::$DB;
     SchemaCollector::$DB = $db;
-    $step = end($steps);
+    // Indexed by the step's OWN number, not end($steps). Keying on the last
+    // step means every future step silently retargets this test at itself --
+    // which is exactly what steps 400 and 401 did, turning it red on code it
+    // does not test.
+    $step = $steps[SITE_RETIRE_STEP - 1];
     foreach ((array)$step as $update) {
         if (is_callable($update)) {
             $update();
@@ -190,7 +198,12 @@ $t->check(
 // prose from code would force the explanation out of the file -- which is the
 // one part of it a future reader most needs.
 $src = (string)file_get_contents($schemaFile);
-$tail = substr($src, (int)strrpos($src, '// 399'));
+$tail = substr(
+    $src,
+    (int)strpos($src, "\n// " . SITE_RETIRE_STEP . "\n"),
+    (int)strpos($src, "\n// " . (SITE_RETIRE_STEP + 1) . "\n")
+        - (int)strpos($src, "\n// " . SITE_RETIRE_STEP . "\n")
+);
 $code = '';
 foreach (token_get_all('<?php ' . $tail) as $tok) {
     if (is_array($tok) && in_array($tok[0], [T_COMMENT, T_DOC_COMMENT], true)) {


### PR DESCRIPTION
The two findings #1542's shape pass reported on real 1.5 data, now repaired as
schema steps 400 and 401. #1542 deliberately reports and never repairs — this
is the follow-up it said was the right remedy.

Both come from the same root cause, already established in #1549: **the two
branches' schema step arrays share positions up to 263 and diverge from 264.**
A 1.5 database's `schemaVersion` counts against *dev-branch's* array, so an
upgrade to 1.6 skips 264–277 as "already applied".

## Step 400 — `multicastSessions`.`msShutdown` off `enum('0','1')`

The column is `msAnon3` renamed, and that rename is in the skipped range. When
the boolean conversion at step 368 ran it looked for `msShutdown`, found no such
column, and moved on; `SchemaReconciler`'s rename pass produced the column
afterward, preserving the type it had all along.

Not cosmetic: in MySQL an `enum('0','1')` indexes from 1, so the integer `1`
selects the member `'0'`. `set('msShutdown', 1)` means **false** the moment the
value reaches the server as an integer. FOG survives it only because `PDODB`
binds everything `PARAM_STR`. (ADR 0028, #1361.)

**One column, checked rather than assumed.** Of every rename in the skipped
range — plugins `pAnon1`..`pAnon4`, `multicastSessions` `msAnon3`/`msAnon4` —
`msShutdown` is the only one whose target also appears in the boolean map. The
rest are `LONGTEXT` and `INTEGER`, whose types no later step changes.

It re-runs the shared `Schema::enumToTinyint()`, which matches `enum('0','1')`
exactly and skips anything else — so a correct server pays one
`information_schema` read and gets no `ALTER`.

## Step 401 — `roles`.`rName`'s UNIQUE index

Absent on any server whose `roles` came from the 1.5 `accesscontrol` plugin,
which never declared one; native RBAC adopted the table rather than rebuilding
it. Confirmed on the real 1.5.10 database: `roles` present, zero unique indexes
on `rName`.

**Duplicates are renamed, never deleted — that is the design, not a detail.**
Six tables reference `roles`.`rID` with `ON DELETE CASCADE`: `rolePermissions`,
`roleUserAssoc`, `roleUserGroupAssoc`, `siteRoleGrants`, and the plugins'
`ldapGroupRoleAssoc` and `oidcGroupRoleAssoc`. Deleting one duplicate would
silently strip that role's permissions, assignments, site grants and directory
mappings — an access-control change, made unattended, mid-upgrade. Renaming
keeps every row and every grant; the first holder of a name keeps it, so a
by-name lookup still resolves to the row it does today.

**Collation is load-bearing.** `rName` is `utf8mb3_general_ci`, so the UNIQUE
index treats `Techs` and `techs` as the same value. The duplicate search is a
plain `GROUP BY` precisely so it inherits the column's collation and finds
exactly the pairs the index will reject. A case-sensitive search would pass over
them and leave `ADD UNIQUE` to fail with 1062 partway through — on a table it
had already renamed rows in.

**It never aborts the upgrade.** If anything still collides after the renames,
the index is skipped and the reason logged — step 332's precedent with the site
tables. A missing UNIQUE means FOG carries on as it has for years; an aborted
schema update strands the admin on `?node=schema` over intact data.

## Verification

**End to end on the real data.** The 1.5.10.2189 dump restored into a fresh
database (schema 278, `msAnon3` `varchar(250)`, `roles` with no unique index),
then upgraded with `--to=399` to reproduce the "before", then completed:

| | shape drift | `msShutdown` | `rName` UNIQUE |
|---|---|---|---|
| upgraded to 399 (as merged) | **2** | `enum('0','1') NOT NULL` | absent |
| upgraded to 401 (this PR) | **0** | `tinyint(1) NOT NULL DEFAULT 0` | present |

All three roles survived; `rolePermissions` (31) and `roleUserAssoc` (2)
unchanged — nothing CASCADE-deleted.

As a side check, the shape pass finds **all six** drifts the rehearsal seeder
deliberately plants (`upgrade-rehearsal.php:549-562` and the hostMAC index drops
at :487-505) and **zero** on the unseeded control — independent evidence that
#1542's pass reports real state rather than noise.

**Gates.** Full suite 255 files, 0 failures, run both with and without
`FOG_TEST_DSN` and with everything `git add`ed first. phpstan pass 1 clean;
baseline counts bumped 110→116 and 369→371 for what the new steps add (counts,
not a regenerated baseline).

**Seven mutations, all caught**: converting the wrong column; hand-rolling the
`ALTER` instead of the shared helper; deleting duplicates instead of renaming;
making the duplicate search case-sensitive; skipping the post-rename collision
re-check; dropping the length truncation; removing the existing-index probe.
The case-sensitivity one is **only** caught by the real-server test — against
the stub it stayed green, because the stub computes duplicates in PHP and would
have been testing its own `strtolower()`. That fake assertion was removed rather
than left green.

Also pins all three schema-step tests to their step **number** instead of
`end($steps)`/`$fogSchema`. Keying on the last step means each new step silently
retargets the test at itself — which is exactly what these two did to the site
retirement test, turning it red on code it does not test.

## Note, not part of this change ~~(a phpstan discrepancy)~~ — WITHDRAWN

~~`tests/lib/rehearsal-runner.php:72` reports 4 `include.fileNotFound` errors in
phpstan pass 2 on unmodified `working-1.6`, while CI reports that same commit
green. Worth a separate look, since one of the two is wrong.~~

**Withdrawn: CI was right and this claim was wrong.** The errors were a stale
PHPStan cache. `phpstan clear-result-cache` removes `/tmp/phpstan/resultCache.php`
but leaves `/tmp/phpstan/cache/` (~26 MB of reflection and container state), so
the clear I ran before making the claim did not rule the cache out. `rm -rf
/tmp/phpstan` and both passes are clean on the merged tip. Nothing in that file
needed changing. Written up as a documented trap in CLAUDE.md.

## Downstream

None. No route class added or removed.

---

### Correction: which servers this actually runs on

The commit message for step 401 says CI "already stands one up on MariaDB 10.5,
MariaDB 11.8 and MySQL 8.0". That is true of the schema **execution** step and
**not** of the real-server test, and I could not amend the commit — the branch
hook declines a force-push.

Verified on this branch's own run: the `Run the DB-backed tests` step reports
**`skipped`** on `schema on mariadb:10.5` and `schema on mysql:8.0`, and runs
only on `schema on mariadb:11.8` (where it passes, 7 checks). And
`schema-executes`, which does run on all three, replays DDL only — it reports
`48 closure step(s) skipped`, steps 400 and 401 among them.

So these two steps get behavioral coverage on **MariaDB 11.8 only**, and none
on MySQL 8.0. Nothing here is untested, but the breadth is narrower than that
sentence claims. Widening the DB-backed step to the other two servers is a
fog-workflows change, not one this branch can make.

