### PR TITLE
Note that a local-only PHPStan failure is usually the cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,39 @@ error does not fail the build — nothing guards the over-count, so it is the on
 you find in CI. (#1448: one added `Route::$rows` write in
 `tests/lib/bootmenu-render.php` took a count from 2 to 3.)
 
+**A local failure CI does not show is the cache, not the code — and
+`clear-result-cache` is not enough to rule that out.** PHPStan's `tmpDir` is
+`/tmp/phpstan`, and it holds two separate things:
+
+| | cleared by `phpstan clear-result-cache`? |
+|---|---|
+| `/tmp/phpstan/resultCache.php` | yes |
+| `/tmp/phpstan/cache/` (~26 MB, reflection and container) | **no** |
+
+So the documented clear command leaves the larger half in place, and a stale
+entry there keeps reporting an error against source that no longer contains it.
+It looks exactly like a real regression: same phpstan version, same config, same
+pinned PHP range, reproducible on every run, and reproducible on an unmodified
+checkout of the branch — which is what makes it convincing rather than obviously
+wrong. Meanwhile CI, which is always cold, is green and correct.
+
+To rule it out, remove the whole directory before believing a local-only
+failure:
+
+```
+rm -rf /tmp/phpstan
+vendor/bin/phpstan analyse -c phpstan-tests.neon --memory-limit=2G --no-progress
+```
+
+Worth knowing on this box specifically: `/tmp` is tmpfs, so the cache is shared
+by every worktree and does not survive a reboot.
+
+(2026-08-31: four `include.fileNotFound` errors in
+`tests/lib/rehearsal-runner.php` were chased as a CI-versus-local discrepancy —
+version, config, stub, baseline and PHP were all compared and matched — and
+were reported in a PR body as "one of the two is wrong". `rm -rf /tmp/phpstan`
+made them vanish. The code was never at fault.)
+
 ### Commit authorship
 
 Commits are **authored by the maintainer and co-authored by the agent**, not the


### PR DESCRIPTION
Documentation only. No source change — and that is the finding.

## What this closes out

PR #1549 and #1553 both carried a note that `tests/lib/rehearsal-runner.php:72`
reported four `include.fileNotFound` errors in phpstan pass 2 locally on
unmodified `working-1.6`, while CI called the same commit green, and that "one
of the two is wrong".

**CI was right. The file was never at fault.** The errors were a stale PHPStan
cache, and `phpstan clear-result-cache` does not remove enough to rule that out:

| `/tmp/phpstan/…` | cleared by `clear-result-cache`? |
|---|---|
| `resultCache.php` | yes |
| `cache/` (~26 MB, reflection + container) | **no** |

`rm -rf /tmp/phpstan` and both passes are clean, cold, on the merged tip.

## Why it was worth an investigation rather than an obvious mistake

The failure survived the documented clear command, reproduced on every run, and
reproduced against a checkout of the branch with no local modifications at all.
phpstan version (2.2.9), PHP (8.3.33), the config, the constants stub, the
baseline and the pinned `phpVersion` range were each compared against CI and
each matched. Every signal said "real regression".

The one signal that was right the whole time was that CI — always cold — was
green.

## What is added

A short subsection under the existing "The `phpstan` check is two passes" rules
in `CLAUDE.md`, giving the table above, the command that actually clears it, and
the note that `/tmp` on a dev box is tmpfs so the cache is shared between
worktrees. Plus the war story, dated, so the next person reads it as a known
trap rather than rediscovering it.

## Verification

Both passes clean with `/tmp/phpstan` deleted first; full suite 256 files, 0
failures.