### PR TITLE
Add SECURITY.md, and the 1.6.0 release and 1.5 EOL drafts

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,95 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Report privately through GitHub Security Advisories**, not as a public
+issue and not on the forums:
+
+> <https://github.com/FOGProject/fogproject/security/advisories/new>
+
+That is the "Report a vulnerability" button under the repository's **Security**
+tab. It opens a private thread visible only to you and the maintainers, and it
+is the channel every FOG advisory to date has gone through.
+
+If you cannot use GitHub advisories for any reason, open a normal issue saying
+only that you have a security report and asking for a private contact —
+**no details in the public issue**.
+
+### What to include
+
+The more of this you can give, the faster it can be confirmed:
+
+- the FOG version (`FOG_VERSION`, shown at the bottom of the web UI) and how
+  it was installed — release tarball, `dev-branch`, or a git checkout;
+- what an attacker gains, and what access they need to start: unauthenticated,
+  an enrolled host, a low-privileged API user, a logged-in admin;
+- reproduction steps, or a request/response pair, or the file and line;
+- anything that limits it — a non-default setting, a particular plugin, a
+  particular database or web server.
+
+A report with no reproduction is still worth sending. A precise file and line
+is worth more than a proof-of-concept exploit, and we would rather not receive
+a weaponized one.
+
+### What happens next
+
+- **Acknowledgement:** we will confirm we have the report and say whether we
+  can reproduce it.
+- **Fix:** developed in the private advisory, so the patch and the disclosure
+  land together.
+- **Credit:** you are credited in the advisory by whatever name and link you
+  ask for, unless you would rather not be. Say which when you report.
+- **Disclosure:** the advisory is published when the fix ships. If you have a
+  disclosure deadline of your own, tell us at the start rather than at the end
+  — we would rather plan around it than be surprised by it.
+
+FOG is a volunteer project. Nobody here is on call, and response time depends
+on who is available; a report that has gone quiet is being worked on or has
+been missed, and a nudge on the advisory thread is welcome rather than rude.
+
+## Supported versions
+
+| Version | Supported | Notes |
+|---|---|---|
+| 1.6.x | ✅ | Current release. Security fixes land here. |
+| 1.5.x | ❌ | **End of life.** No further fixes of any kind, security included. |
+| Earlier | ❌ | Unsupported and long superseded. |
+
+**1.5.x reached end of life with the 1.6.0 release.** A report that affects
+1.5 only will be acknowledged, and recorded so that anyone reading later can
+find it — but it will not be fixed, and there will be no further 1.5 release.
+If the same issue affects 1.6, it is fixed in 1.6. Nothing is being deleted:
+`dev-branch`, `stable` and every 1.5 tag remain in this repository. See the
+[1.5 support statement](docs/release/1.5-support-statement.DRAFT.md) for the full
+wording.
+
+## Scope
+
+**In scope** — anything in this repository and the project's own components:
+the web application, the REST API, the installer and its shell library, the
+background daemons, the FOG client protocol endpoints, the iPXE boot chain and
+the storage node interfaces.
+
+**Out of scope**, because they are not ours to fix — please report them
+upstream instead:
+
+- vulnerabilities in third-party dependencies, unless FOG's use of one is
+  itself what creates the exposure;
+- third-party plugins that do not ship in `FOGProject/*`;
+- the operating system, web server, PHP or database FOG is installed on;
+- findings that only restate FOG's documented design. A FOG server is
+  deliberately powerful: it images machines over the network, so anyone who
+  can administer it can already run code on everything it manages. "An admin
+  can do X" is only a vulnerability if X escapes the admin boundary, and
+  "a machine on the imaging network can PXE boot" is how FOG works.
+
+Scanner output pasted without a working path to impact is not a report, and
+we do not run a bug bounty — there is no money in this project to pay one
+with.
+
+## Hardening
+
+If you are looking for how to *deploy* FOG safely rather than reporting a
+flaw in it, the imaging network's isolation is the single biggest lever: FOG
+hands out boot images and credentials to anything that asks on it, by design.
+See the project documentation at <https://docs.fogproject.org>.

--- a/docs/release/1.5-support-statement.DRAFT.md
+++ b/docs/release/1.5-support-statement.DRAFT.md
@@ -1,0 +1,65 @@
+<!--
+DRAFT — the support policy is settled (end of life, no further releases;
+Tom, 2026-08-31), as is the SECURITY.md question: yes, and it is drafted at
+docs/release/SECURITY.DRAFT.md for the repository root. The release date is
+October 2026, month only, deliberately — see below. Everything else is
+factual and verified against the repo on 2026-08-31.
+-->
+
+# FOG Project 1.5 support after 1.6.0
+
+**Release: FOG Project 1.6.0, October 2026.**
+
+FOG Project 1.6.0 is now the current release, and 1.5.x has reached end of
+life. Development of 1.5.x has stopped.
+
+Nothing is being deleted. `dev-branch`, `stable` and every 1.5 tag stay in
+this repository exactly as they are, so the source of any 1.5 release you are
+running remains available to read, clone and build from. They are simply no
+longer maintained.
+<!-- verified: `dev-branch` and `stable` exist as `remotes/origin/*`
+(`git -C /home/telliott/fogproject branch -a`). Tom, 2026-08-31: "master will
+become 1.6.0 only while history will exist, we aren't spending resources." -->
+
+## What this means for 1.5
+
+**1.5.x is no longer supported as of this release.** No further fixes will be
+made to it — not features, not bugs, and **not security fixes**. There will be
+no further 1.5 releases.
+
+If you are still running 1.5.x, treat it as end-of-life and plan your upgrade
+now. A 1.5 server will keep working; it will simply not receive another fix of
+any kind, including for a vulnerability reported after this date.
+
+FOG is a small volunteer project. Maintaining two lines in parallel costs
+effort that 1.6 needs, and that is the whole reason for the decision — it is
+not a judgment about how many people are still on 1.5.
+
+## Reporting a security issue
+
+Security reports are still very much wanted — **for 1.6**. Report them
+privately through **GitHub Security Advisories** on `FOGProject/fogproject`
+— "Report a vulnerability" under the Security tab. Please do not open a
+public issue for a security problem.
+
+A report that affects 1.5 only will be acknowledged but not fixed, per the
+policy above. If it affects both lines, it is fixed in 1.6.
+<!-- verified: the repository has 30 advisories, 29 of them published, via
+`gh api repos/FOGProject/fogproject/security-advisories`. That is the channel
+in practice, whatever the repo does or does not document. -->
+
+The repository's [`SECURITY.md`](../../SECURITY.md) carries this policy in
+full, including what to put in a report and what happens after you send one.
+<!-- The file did not exist when this was first drafted; it now lives at
+the repository root, committed alongside this statement. Private reporting was already enabled on the repo before it
+(`gh api repos/FOGProject/fogproject/private-vulnerability-reporting` ->
+`{"enabled":true}`) — the file is what points a finder at the button. -->
+
+## What a 1.5 user should do
+
+If you're still on 1.5.x, upgrade by running `installfog.sh` from a 1.6
+checkout against your existing server — the installer detects the existing
+database and takes you through the schema update. Before you upgrade: **the move to 1.6.0 is one-way** — there
+is no supported downgrade, so back up your database and web tree first. See
+the [1.6.0 release notes](./1.6.0-release-notes.DRAFT.md) for the exact
+backup commands.

--- a/docs/release/1.6.0-release-notes.DRAFT.md
+++ b/docs/release/1.6.0-release-notes.DRAFT.md
@@ -1,0 +1,334 @@
+<!--
+DRAFT — not published yet, but no longer carrying open questions. Tom settled
+the four that were his on 2026-08-31: version 1.6.0, release October 2026,
+yes to a changelog link, yes to a SECURITY.md (now at the
+repository root).
+
+The `TODO(verify)` items have all been resolved against the source rather
+than deleted; each one's source is now the HTML comment beside it. The single
+remaining placeholder is Known issues, which is genuinely a release-time read
+of the tracker and cannot be filled in advance.
+
+Facts baked into this draft were verified against the working-1.6 source on
+2026-08-31. The load-bearing ones are noted inline as HTML comments so they
+survive edits.
+-->
+
+# FOG Project 1.6.0 Release Notes
+
+**Version:** 1.6.0
+**Release date:** October 2026
+**Schema:** 401 <!-- verified: packages/web/src/Base/System.php, `define('FOG_SCHEMA', 401);` -->
+
+> The tree reports `1.6.0-beta` / channel `Beta` until the release constants in
+> `packages/web/src/Base/System.php` are bumped as part of cutting the tag.
+> See Full changelog.
+
+---
+
+## Before you upgrade: this is a one-way trip
+
+**Upgrading to 1.6.0 is not reversible by re-running the installer against an
+older release.** 1.6 carries schema steps that restructure and, in a few
+cases, delete data as part of the restructuring — most notably the `site`
+plugin's own tables, whose rows moved into a new core `sites` table and were
+then retired (`packages/web/commons/schema.php`, "Sites, moving out of the
+site plugin and into core" <!-- verified: schema.php:5166 comment and the
+`sites` table DDL at schema.php:5184-5187; the DROP of the plugin's own
+tables lives in the site plugin's own schema() in FOGProject/fog-plugins,
+not in this repo. Core's own half is verified: schema step 332 copies the
+rows, COUNTs both sides, and drops the plugin's tables only when the counts
+agree — packages/web/commons/schema.php, `DROP TABLE IF EXISTS` guarded by
+the `count($mismatch)` branch that logs "the site plugin tables have been
+KEPT rather than dropped" and returns without dropping. So the lossy step is
+conditional on the copy having been complete. -->).
+Going from 1.6 back to 1.5 does **not** replay those steps backward. There is
+no down-migration. **Back up before you upgrade — not after something looks
+wrong.**
+
+### 1. Take your own backup first — don't rely solely on the installer's
+
+The installer takes its own pre-upgrade database and web-tree backups
+automatically (see below), but that backup only exists if the upgrade step
+that makes it actually runs and succeeds. Take an independent copy before you
+start, so you have one regardless of how the upgrade goes.
+
+Find your database credentials — they're in the generated config inside your
+FOG web root (path varies by install; the default web root's config lives at
+`commons/config.class.php` under it):
+
+```bash
+sudo grep -E "define\('DATABASE_(HOST|NAME|USERNAME)'" /path/to/fog/webroot/commons/config.class.php
+```
+
+<!-- verified: the constants DATABASE_HOST/DATABASE_NAME/DATABASE_USERNAME/
+DATABASE_PASSWORD are written into commons/config.class.php's Config::_dbSettings()
+by the heredoc in lib/common/functions.sh:10841-10847. Confirmed live on this
+box at /var/www/html/fog-1.6/commons/config.class.php, owned by the web
+server account, mode 660 (not world-readable). -->
+
+That file also carries `DATABASE_PASSWORD` in the clear — deliberately not
+echoed by the command above. Read it directly (`sudo cat`) rather than
+pasting it into a shell history:
+
+```bash
+sudo grep "DATABASE_PASSWORD" /path/to/fog/webroot/commons/config.class.php
+```
+
+Then dump the database:
+
+```bash
+mysqldump -h <DATABASE_HOST> -u <DATABASE_USERNAME> -p'<DATABASE_PASSWORD>' <DATABASE_NAME> \
+  > /path/to/somewhere/safe/fog_sql_manual_$(date +%Y%m%d_%H%M%S).sql
+```
+
+If you also want a copy of the FOG installer's own persisted settings (DB
+host/name/user, web root, storage layout — everything `installfog.sh`
+remembers between runs), it lives at `<fogprogramdir>/.fogsettings`, default
+`/opt/fog/.fogsettings`, and is root-owned, mode `0600`:
+
+```bash
+sudo cp /opt/fog/.fogsettings /path/to/somewhere/safe/fogsettings.bak.$(date +%Y%m%d_%H%M%S)
+```
+
+<!-- verified: .fogsettings path is $fogprogramdir/.fogsettings
+(bin/installfog.sh:770-824), default fogprogramdir /opt/fog (installfog.sh:770
+comment, "/opt/fog the default, applied by config.sh"). Confirmed live:
+/opt/fog/.fogsettings is -rw------- root:root. -->
+
+### 2. What the installer backs up for you, automatically
+
+On an upgrade (not a fresh install — this step is skipped when there's
+nothing to back up yet), `installfog.sh` takes two backups before it touches
+anything, both under `DB_backup_path` — the path you set with `-B`/
+`--backuppath` at some point, persisted in `.fogsettings`, or `/home/` if
+you've never set it:
+
+<!-- verified: -B/--backuppath sets sDB_backup_path -> DB_backup_path
+(bin/installfog.sh:521-530, 216); default /home/ if unset at the end of flag
+processing (installfog.sh:1151-1155); DB_backup_path is one of the keys
+persisted to .fogsettings (lib/common/functions.sh:6539). -->
+
+- **Database dump:**
+  `${DB_backup_path}/fogDBbackups/fog_sql_<version>_<YYYYMMDD_HHMMSS>.sql`
+  <!-- verified: lib/common/functions.sh:895, backupDB(). The dump is produced
+  by a self-call to maintenance/backup_db.php, not a direct mysqldump — see
+  functions.sh:846-950. -->
+- **Web tree:** `${DB_backup_path}/fog_web_<version>.BACKUP`
+  <!-- verified: lib/common/functions.sh:10483-10499. -->
+
+Both are named after the version being upgraded *from*, not the one you're
+upgrading to. Check `${DB_backup_path}` (default `/home/`, or whatever you
+passed to `-B` / recorded in `.fogsettings`) after the upgrade to confirm
+both exist before you consider the run safe to walk away from.
+
+### 3. If something goes wrong: reverting
+
+`bin/revertfog.sh` restores a FOG install from the backups above. It must be
+run as root, from the `bin/` directory of a **1.5** checkout — the one you
+are going back to:
+
+```
+Usage: ./revertfog.sh [-h?y] [--list] [--dump <path>] [--kernel-generation <N>] [--dry-run]
+        --list          Show every stored database dump, newest first, with the
+                        reason any of them is not usable, and exit
+        --dump          Restore this dump instead of the newest usable one. It is
+                        checked exactly the same way -- there is no override for a
+                        dump that is not 1.5-era
+        --kernel-generation  Which kernel-backups generation to put back. Defaults
+                        to 1, the snapshot taken at the start of the LAST install
+        --dry-run       Run every check and print every action, change nothing
+  -y    --yes           Skip the confirmation prompt
+```
+
+**Run `--list` first, then `--dry-run`.** `--list` tells you whether a usable
+dump exists at all and, for each one it rejects, why. `--dry-run` prints the
+exact sequence it would carry out — including which steps it would SKIP,
+which is the part worth reading: a missing 1.5 web-tree backup or a missing
+kernel generation is reported rather than guessed at.
+
+The dump you took by hand in step 1 is accepted; pass it with `--dump`. It is
+checked the same way as the installer's own.
+
+**A revert puts you back on 1.5, which is end of life as of this release.**
+It gets a broken upgrade off your neck; it is not somewhere to stay. 1.5.x
+receives no further fixes of any kind, security included — see the 1.5 support
+statement. Treat a revert as buying time to work out what went wrong, and
+report it so the upgrade can be fixed for everyone.
+
+**It refuses rather than half-finishes.** Every check — the credentials, the
+dump, whether the dump is 1.5-era — runs before a single daemon is stopped or
+a single table dropped. If nothing usable is found, your database is
+untouched and it says so.
+
+**A revert restores your data and web tree from the dump `installfog.sh`
+took (or the one you took yourself in step 1) — it does not undo the schema
+change.** There is no down-migration path: some 1.6 schema steps are lossy
+(most notably the `site` plugin's tables, retired after their data moved into
+core's `sites` table — see the warning above), so replaying schema 401 back
+to whatever you started from is not something the installer can do
+mechanically. A revert gets you back to the pre-upgrade *state*, from the
+pre-upgrade *dump* — it is not a schema rollback.
+
+---
+
+## Highlights
+
+- **Referential integrity is now declared in the database**, not just
+  remembered in PHP. Schema steps 380–390 add real foreign-key constraints
+  across host ownership, identity (users/roles/groups/sites), storage
+  junctions, configuration references, and tasks — 101 of 117 mapped
+  relationships now have a declared constraint; the rest are deliberately
+  left undeclared (audit rows that must not constrain what they record, or
+  polymorphic columns with no single target table).
+  <!-- verified: docs/adr/0031-referential-integrity-is-declared-in-the-database.md
+  ("Status: accepted, and implemented in full... 101 of the map's 117
+  relationships are declared."). -->
+- **Plugins become installable artifacts with their own lifecycle** instead
+  of files that only survive an upgrade if they ship inside this repo. See
+  ADR 0009 for the full before/after.
+  <!-- verified: docs/adr/0009-plugins-become-installable-artifacts.md -->
+- **Site scoping moves into core.** The `sites` table and multi-site scoping
+  that used to live entirely in the `site` plugin are now first-class core
+  concepts.
+  <!-- verified: packages/web/commons/schema.php:5166-5233, ADR
+  0006-site-object-scope-boundary.md -->
+- **Native role-based access control replaces the `accesscontrol` plugin.**
+  Roles, and the rules attaching users to them, are core concepts rather than
+  a plugin that had to be installed before permissions existed at all.
+  <!-- verified: docs/adr/0005-native-rbac-retires-accesscontrol-plugin.md;
+  the plugin's own row is removed at schema.php's
+  `DELETE FROM \`plugins\` WHERE \`pName\` = 'accesscontrol'`. -->
+- **External identity providers are a first-class seam.** LDAP and OIDC sign-in
+  are authentication providers core knows about, with directory-group mapping
+  onto FOG roles, rather than a bolt-on that granted everyone full admin.
+  <!-- verified: docs/adr/0007-external-identity-provenance-and-directory-group-mapping.md
+  and 0014-authentication-seams-in-core-identity-providers-as-plugins.md -->
+- **An audit trail, and a retention policy that actually removes things.**
+  Who changed what is recorded in a shared record shape, surfaced as an
+  activity view, and aged out by a daemon named for the job.
+  <!-- verified: docs/adr/0021-the-audit-trail.md,
+  0020-event-logs-share-a-record-shape-not-a-table.md,
+  0023-activity-is-a-view-and-retention-is-a-registry.md,
+  0026-retention-runs-in-a-daemon-named-for-retention.md -->
+- **Secure Boot enrollment is a task type.** Enrolling a machine's keys is
+  scheduled and tracked like any other task instead of being a manual detour.
+  <!-- verified: docs/adr/0008-secure-boot-enrolment-task-type.md -->
+- **API tokens are a separate, hashed credential** rather than a reuse of a
+  user's password.
+  <!-- verified: docs/adr/0027-api-tokens-are-a-separate-hashed-credential.md -->
+
+## Breaking changes
+
+- **The `site` plugin's own tables are retired** once its data has moved into
+  core's `sites` table (see the one-way-upgrade warning above). Custom tooling
+  querying the old plugin tables directly must repoint at the core tables. If
+  the row counts disagree the old tables are deliberately kept and the
+  disagreement is logged, so nothing is lost silently.
+- **The `accesscontrol` plugin is retired**, replaced by native RBAC. Its
+  registration row is removed during the upgrade.
+- **Foreign keys are now declared**, which makes previously-tolerated orphan
+  rows an error rather than a curiosity. The upgrade sweeps them first —
+  nullable columns are set to `NULL`, `NOT NULL` ones have the row deleted,
+  and every sweep is logged with its row count and recorded in the audit
+  trail. Anything writing FOG's tables directly must now respect the
+  relationships.
+  <!-- verified: docs/adr/0031, SchemaReconciler::planSweep()/sweepOrphans() -->
+- **The `0` sentinel becomes `NULL`** in columns that mean "no parent". A
+  query testing `= 0` for "unset" needs to test `IS NULL`.
+  <!-- verified: docs/adr/0031 §"sentinel"; planSweep() excludes `<> 0`
+  explicitly because the sentinel is not NULL and so is not exempt from a
+  constraint either. -->
+- **Booleans stored as `enum('0','1')` become `tinyint(1)`.** Anything
+  comparing against the string `'0'` or `'1'` should compare against the
+  integer. This includes `multicastSessions`.`msShutdown`, which schema step
+  400 converts separately because an upgrade from 1.5 skipped it the first
+  time round.
+  <!-- The column is `msAnon3` renamed, and that rename sits in the step range
+  a 1.5 database skips, so the boolean sweep at 368 found no such column. See
+  GH-1553. -->
+- **Duplicate role names are renamed during the upgrade**, because
+  `roles`.`rName` regains the UNIQUE index it is supposed to have — a server
+  upgraded from 1.5 lost it with the `accesscontrol` plugin. If you have two
+  roles with the same name (or names differing only in case, which the column's
+  collation treats as the same), the first keeps its name and each later one
+  gains a ` (duplicate <id>)` suffix. **Nothing is deleted**: every role, every
+  permission and every user, group and site assignment is preserved — rename
+  them to whatever you prefer afterward. If a collision somehow survives, the
+  index is skipped and the reason logged rather than failing the upgrade.
+  <!-- Deleting a duplicate would CASCADE through rolePermissions,
+  roleUserAssoc, roleUserGroupAssoc, siteRoleGrants and the LDAP/OIDC group
+  role tables, so renaming is deliberate. Schema step 401, GH-1553. -->
+  <!-- verified: docs/adr/0028-booleans-are-tinyint-not-enum.md -->
+- **`hosts`.`hostArch` and `images`.`imageArch` are dropped**, superseded by
+  the `architectures` table.
+  <!-- verified: schema.php, `ALTER TABLE \`hosts\` DROP COLUMN \`hostArch\``
+  and the matching one on `images`. -->
+- **The `greenfog` module and the `FOG_PLUGINSYS_DIR` setting are removed**,
+  along with the `fog.approvehost` and `fog.quickdel` PXE menu entries.
+  <!-- verified: schema.php DELETE statements for `modules`.`short_name` =
+  'greenfog', globalSettings 'FOG_PLUGINSYS_DIR', and the two `pxeMenu`
+  rows. -->
+- **Plugins are installable artifacts with their own layout**, no longer files
+  that only survive an upgrade by shipping inside this repository. A plugin
+  written against 1.5's layout will not load.
+  <!-- verified: docs/adr/0009-plugins-become-installable-artifacts.md and
+  0035-a-plugin-is-laid-out-like-core.md -->
+
+## Upgrade notes
+
+- FOG_SCHEMA is 401 on this release.
+  <!-- verified: packages/web/src/Base/System.php -->
+- **Read "Before you upgrade" above before running the installer.**
+- **1.5.x is end of life as of this release** — no further fixes, security
+  included. The branches and tags stay in the repository; they are simply not
+  maintained. See the 1.5 support statement for the full wording.
+- **PHP 7.4 is the minimum**, and it is enforced — FOG refuses to serve a
+  request on anything older.
+  <!-- verified: packages/web/commons/init.php:1424,
+  `version_compare(phpversion(), '7.4', '<')` in Initiator::_verCheck(). The
+  floor is also what tests/php-version-docblocks.test.php reads, so it cannot
+  drift from what the files claim. PHPStan analyzes the tree against 7.4
+  through 8.3 (phpstan.neon `phpVersion: min 70400, max 80300`). -->
+- **MariaDB, or MySQL 5.7 and newer.** The schema is authored against MariaDB;
+  the table-creation code detects the server and adjusts where the dialects
+  differ — MySQL 8.0.13+ needs a `TEXT`/`BLOB` default written as a
+  parenthesised expression, and MySQL below 8.0.13 cannot carry one at all,
+  so those columns are created bare and backfilled.
+  <!-- verified: tests/createtable-column-defaults.test.php exercises
+  11.8.8-MariaDB, 8.0.36 and 5.7.44 explicitly, with the reasoning for each
+  branch in its own assertion messages. -->
+- **Back up before you upgrade** — the pre-upgrade backup is what a revert
+  restores from, and no down-migration exists. See "Before you upgrade"
+  above.
+
+## Deprecations
+
+- **`stable` and `dev-branch` are no longer maintained.** They stay in the
+  repository — nothing is deleted — but 1.5.x is end of life as of this
+  release. See the 1.5 support statement.
+- No API route or setting is deprecated-but-retained in this release: the 1.6
+  cycle removed what it removed outright, which is what makes the upgrade
+  one-way. The Breaking changes list above is the complete set.
+
+## Known issues
+
+_To be filled at release time_ from the open-issue triage list — deliberately
+not carried in this draft, because anything written here now would be stale by
+the tag. Pull the `ready-for-human` and unresolved `needs-info` issues at the
+cut.
+
+## Full changelog
+
+- **Full changelog:** <https://github.com/FOGProject/fogproject/compare/1.5.10...1.6.0>
+  <!-- The compare view resolves once the 1.6.0 tag exists; it is the form
+  every FOG release note has used. Substitute the exact 1.5.10.x tag being
+  compared from if you would rather pin the base than use the series tag. -->
+- **Release checklist for the cut itself:** `FOG_VERSION` and `FOG_CHANNEL`
+  are release-time constants in `packages/web/src/Base/System.php` — they
+  still read `'1.6.0-beta'` and `'Beta'` and must become `'1.6.0'` and
+  `'Stable'` in the release commit. They are the *fallback* constants: the
+  generated `packages/web/commons/version.php` shadows them on any checkout
+  with hooks enabled, which is why nothing on a branch rewrites them.
+  <!-- verified: packages/web/src/Base/System.php:97-101, and the generated-
+  file contract in tests/generated-version-file.test.sh -->


### PR DESCRIPTION
Three documents. `SECURITY.md` is a real file at the repository root; the other
two keep their `DRAFT` suffix because they describe a release that has not been
cut.

## SECURITY.md

Private vulnerability reporting **was already enabled** — the "Report a
vulnerability" button has existed all along, and all 30 advisories to date went
through it. What was missing was any file telling a finder to use it, so GitHub
surfaced no prompt to anyone who had not gone looking. This documents the
channel already in use rather than inventing one.

It covers what a report should carry, what happens after it is sent, how credit
and disclosure timing work, and a supported-versions table making 1.5's end of
life explicit.

The scope section is deliberate: a FOG server images machines over the network,
so anyone who can administer it can already run code on everything it manages.
"An admin can do X" is only a finding if X escapes the admin boundary, and "a
machine on the imaging network can PXE boot" is how FOG works. Saying that up
front is kinder than rejecting those reports one at a time, and it keeps the
real ones legible.

## docs/release/

| File | State |
|---|---|
| `1.6.0-release-notes.DRAFT.md` | 1.6.0, October 2026, schema **401** |
| `1.5-support-statement.DRAFT.md` | 1.5.x end of life, nothing deleted |

The notes carry the one-way-upgrade warning, the manual backup commands, what
`installfog.sh` backs up on its own, the `revertfog.sh` synopsis, an
eight-item breaking-change list through schema 401, and PHP/database floors
taken from the code that enforces them (`init.php`'s `_verCheck()` at 7.4, and
the three server versions `createtable-column-defaults.test.php` actually
exercises).

Two things can only be filled at the tag — the changelog compare link and the
known-issues list — and both say so where they sit rather than pretending
otherwise.

## Consistency

`SECURITY.md`'s supported-versions table and the 1.5 statement have to agree.
A note in each says so, so a future edit to one is prompted to check the other.
Every cross-link between the three was resolved against the filesystem after
the move to the root.

## Verification

Full suite 257 files, 0 failures, with the new files `git add`ed first — the
spelling gate reads `git ls-files`, so an unstaged run would not have seen
them. Both phpstan passes clean on a cold cache.