### PR TITLE
Name the retired accesscontrol plugin, with the opposite advice

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -10457,9 +10457,52 @@ EOF
 # not a hand-kept list that would drift the moment a plugin joins or leaves
 # fog-plugins.
 #
+# Remove the retired accesscontrol plugin from the backup, remembering that it
+# was there.
+#
+# The removal itself is old behavior and is right: 1.6 replaces that plugin with
+# core roles and permissions, its registration row is deleted by schema step 307,
+# and --oldcopy restoring its PHP into a 1.6 tree would lay a retired plugin back
+# down beside the core that retired it.
+#
+# What was missing is the record. This runs inside the backup step, which is
+# BEFORE _warnUnrecognizedPlugins scans that same backup -- so by the time
+# anything could name accesscontrol, the directory is already gone. No scan of
+# the backup can find it however it is written, which is why the fact is carried
+# in a variable instead.
+_stripRetiredAccessControl() {
+    local ac="${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/accesscontrol"
+    [[ -d $ac ]] && accesscontrolstripped=1
+    rm -rf "$ac"
+    # Never fatal, and never the step's exit status: this sits between a cp and
+    # an errorStat $? that is reporting on the BACKUP, not on this.
+    return 0
+}
 # Detection only -- nothing here copies, deletes or blocks anything.
 _warnUnrecognizedPlugins() {
     local oldplugins="${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins"
+    # accesscontrol is named FIRST and outside every guard below, because it is
+    # not an unrecognized plugin -- it is a RETIRED one, and the advice the rest
+    # of this function gives would be wrong for it. Its 1.6 equivalent is core
+    # roles and permissions, so copying it to $fogprogramdir/plugins would
+    # reinstall the thing the upgrade just replaced.
+    #
+    # Outside the guards for two reasons. It cannot come from the scan at all
+    # (_stripRetiredAccessControl deleted it from the backup already), and it is
+    # not a comparison against the bundled set -- so neither "no old plugins
+    # directory" nor "nothing bundled to compare against" has any bearing on
+    # whether this is worth saying.
+    if [[ -n ${accesscontrolstripped:-} ]]; then
+        echo
+        echo "  The retired accesscontrol plugin was in the old web tree."
+        echo "  1.6 replaces it with core roles and permissions -- your roles and"
+        echo "  user assignments were migrated into them by the schema update, and"
+        echo "  the plugin's own registration row was removed."
+        echo "  Do NOT copy it to ${fogprogramdir:-/opt/fog}/plugins: it is not a"
+        echo "  plugin to relocate, and it is not carried into the backup either."
+        echo "  Review what came across under Role Management once this finishes."
+        echo
+    fi
     [[ -d $oldplugins ]] || return 0
     # "Unrecognized" is decided by comparison, so with nothing to compare
     # against there is no finding to report -- only a list of every plugin
@@ -10637,13 +10680,18 @@ configureHttpd() {
     # ${WEB_docroot}fog was a symlink this run removed. See the report at the end
     # of this step for why that has to be said out loud.
     webbackedup=""
+    # Whether the retired accesscontrol plugin was in the tree just backed
+    # up. Set by _stripRetiredAccessControl below, read by
+    # _warnUnrecognizedPlugins, because by the time that runs the evidence
+    # has been deleted.
+    accesscontrolstripped=""
     if [[ -d ${DB_backup_path}/fog_web_${version}.BACKUP ]]; then
         rm -rf ${DB_backup_path}/fog_web_${version}.BACKUP >>$error_log 2>&1
     fi
     if [[ -d $webdirdest ]]; then
         cp -RT "$webdirdest" "${DB_backup_path}/fog_web_${version}.BACKUP" >>$error_log 2>&1
         webbackedup=1
-        rm -rf ${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/accesscontrol
+        _stripRetiredAccessControl
         rm -rf "$webdirdest" >>$error_log 2>&1
     elif [[ -n $priorwebdir && -d $priorwebdir ]]; then
         # Copy only, no removal. The branch above deletes $webdirdest because
@@ -10653,7 +10701,7 @@ configureHttpd() {
         # and deleting it would be a new behavior nobody asked for.
         cp -RT "$priorwebdir" "${DB_backup_path}/fog_web_${version}.BACKUP" >>$error_log 2>&1
         webbackedup=1
-        rm -rf ${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/accesscontrol
+        _stripRetiredAccessControl
     fi
     if [[ ${FOG_os_id} -eq 2 ]]; then
         # GH-953: this removed ${WEB_docroot} -- the whole document root, taking any

--- a/tests/unrecognized-plugin-notice.test.sh
+++ b/tests/unrecognized-plugin-notice.test.sh
@@ -34,6 +34,14 @@
 #   4. Nothing here is fatal -- the function returns 0 in every case, so it
 #      can never abort an install (matches the pattern _warnClientRepin sets
 #      for a non-fatal, informational check).
+#   5. accesscontrol is named SEPARATELY and given the OPPOSITE advice. It is
+#      retired rather than relocated -- 1.6 replaces it with core roles and
+#      permissions -- so the "copy it to $fogprogramdir/plugins" line the rest
+#      of this notice gives would tell an admin to reinstall the thing the
+#      upgrade just removed. It is also unreachable by the scan: the backup
+#      step deletes it out of the backup before this function ever runs, so
+#      the notice keys on a flag _stripRetiredAccessControl sets, and is
+#      emitted ahead of both guards that exist only for the comparison.
 #
 # No install, no network, no root.
 #
@@ -173,6 +181,121 @@ if [[ $rc -eq 0 ]]; then
 else
     bad "should never be fatal, returned $rc"
 fi
+
+# --- 8. the RETIRED accesscontrol plugin is named, with different advice -----
+#
+# accesscontrol is not a plugin to relocate. 1.6 replaces it with core roles
+# and permissions (schema steps 302-306 migrate the roles and the user
+# assignments; step 307 deletes its `plugins` row), so telling an admin to copy
+# it into $fogprogramdir/plugins would reinstall the thing the upgrade just
+# retired.
+#
+# It also cannot come from the scan the rest of this function does. The backup
+# step calls _stripRetiredAccessControl, which DELETES the directory out of the
+# backup, and only then does configureHttpd call _warnUnrecognizedPlugins --
+# so at scan time there is nothing on disk to find. The flag is the only record.
+reset_old_tree
+accesscontrolstripped=1
+mkdir -p "${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/hostext"
+out="$(_warnUnrecognizedPlugins)"
+if [[ $out == *"accesscontrol"* ]]; then
+    ok "the retired accesscontrol plugin is named"
+else
+    bad "expected 'accesscontrol' in output, got: $out"
+fi
+if [[ $out == *"Do NOT copy it to ${fogprogramdir}/plugins"* ]]; then
+    ok "accesscontrol is told NOT to be relocated"
+else
+    bad "expected the do-not-relocate line for accesscontrol, got: $out"
+fi
+if [[ $out == *"Role Management"* ]]; then
+    ok "accesscontrol points at core Role Management"
+else
+    bad "expected 'Role Management' in output, got: $out"
+fi
+accesscontrolstripped=""
+
+# --- 9. no accesscontrol, no accesscontrol notice ----------------------------
+reset_old_tree
+mkdir -p "${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/mycompanytool"
+out="$(_warnUnrecognizedPlugins)"
+if [[ $out == *"accesscontrol"* ]]; then
+    bad "named accesscontrol when it was never there: $out"
+else
+    ok "no accesscontrol in the old tree produces no accesscontrol notice"
+fi
+
+# --- 10. the accesscontrol notice survives both guards on the scan below -----
+#
+# The two early returns exist for the COMPARISON -- no old lib/plugins/, and no
+# bundled set to compare against. Neither has any bearing on a retired plugin
+# whose advice is not a comparison, and a storage-node install (which reaches
+# configureHttpd with an empty $webdirsrc/lib/plugins, installfog.sh:1353)
+# would otherwise swallow it.
+reset_old_tree
+accesscontrolstripped=1
+out="$(_warnUnrecognizedPlugins)"
+if [[ $out == *"accesscontrol"* ]]; then
+    ok "accesscontrol is named with no old lib/plugins/ left to scan"
+else
+    bad "the no-backup guard swallowed the accesscontrol notice: $out"
+fi
+mkdir -p "${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/hostext"
+saved_src="$webdirsrc"
+webdirsrc="$WORK/emptysrc2"
+mkdir -p "$webdirsrc/lib/plugins"
+out="$(_warnUnrecognizedPlugins)"
+if [[ $out == *"accesscontrol"* ]]; then
+    ok "accesscontrol is named with an empty bundled set"
+else
+    bad "the empty-bundled-set guard swallowed the accesscontrol notice: $out"
+fi
+webdirsrc="$saved_src"
+accesscontrolstripped=""
+
+# --- 11. _stripRetiredAccessControl: removes it, records it, never fails -----
+#
+# The removal is not new -- it predates this notice and is correct. What is
+# pinned here is that it still happens, that the flag is set only when the
+# directory was really there, and that it returns 0: it sits between a cp and
+# an `errorStat $?` reporting on the BACKUP, so a non-zero here would report a
+# failed backup that did not fail.
+reset_old_tree
+accesscontrolstripped=""
+mkdir -p "${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/accesscontrol/class"
+_stripRetiredAccessControl
+rc=$?
+if [[ ! -d "${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/accesscontrol" ]]; then
+    ok "accesscontrol is removed from the backup"
+else
+    bad "accesscontrol was left in the backup"
+fi
+[[ -n $accesscontrolstripped ]] && ok "the strip records that it happened" \
+    || bad "the strip did not record that accesscontrol was there"
+[[ $rc -eq 0 ]] && ok "the strip returns 0 (it feeds an errorStat for the backup)" \
+    || bad "the strip returned $rc"
+
+reset_old_tree
+accesscontrolstripped=""
+mkdir -p "${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/hostext"
+_stripRetiredAccessControl
+rc=$?
+if [[ -z $accesscontrolstripped ]]; then
+    ok "the strip records nothing when accesscontrol was not there"
+else
+    bad "the strip claimed accesscontrol was there when it was not"
+fi
+[[ $rc -eq 0 ]] && ok "the strip returns 0 with nothing to remove" \
+    || bad "the strip returned $rc with nothing to remove"
+
+# --- 12. still never fatal with the accesscontrol notice to print -----------
+reset_old_tree
+accesscontrolstripped=1
+_warnUnrecognizedPlugins >/dev/null
+rc=$?
+[[ $rc -eq 0 ]] && ok "the accesscontrol notice is non-fatal too" \
+    || bad "should never be fatal, returned $rc"
+accesscontrolstripped=""
 
 echo
 echo "  $PASS passed, $FAIL failed"


### PR DESCRIPTION
`_warnUnrecognizedPlugins()` names every directory under the old tree's `lib/plugins/` that the bundled release did not fetch, and tells the admin to copy it to `$fogprogramdir/plugins`. For `accesscontrol` that advice is wrong, and the plugin was silent in the notice either way.

## Two problems

**The advice is wrong for this one name.** `accesscontrol` is retired, not relocated. 1.6 replaces it with core roles and permissions — schema steps 302-306 migrate its roles and user assignments natively, step 307 deletes its `plugins` row — so copying the directory into the new plugin root reinstalls what the upgrade just removed.

**It could never have been named anyway.** `configureHttpd()` removes `accesscontrol` from the backup and only *then* calls `_warnUnrecognizedPlugins`, which scans that same backup. Verified: the two `rm -rf …BACKUP/lib/plugins/accesscontrol` lines are at `lib/common/functions.sh:10646`/`10656`, the call is at `10700`, and there is no `return` or `exit` between them. Nothing is on disk to find by the time anything could look.

The removal itself is correct and older than this notice — `--oldcopy` restoring the plugin's PHP into a 1.6 tree would lay a retired plugin back beside the core that retired it. So the removal stays; it now runs through `_stripRetiredAccessControl`, which records that it happened, and the notice keys on that flag.

## Placement

The stanza is emitted **ahead of both early returns**, not beside the third-party list. Those guards exist for the *comparison* — no old `lib/plugins/`, and no bundled set to compare against — and neither bears on a retired plugin whose advice is not a comparison. Without that, a storage-node install (`configureMinHttpd`, `installfog.sh:1353`, which reaches `configureHttpd` with an empty bundled set) would swallow the notice.

`_stripRetiredAccessControl` returns 0 unconditionally: it sits between a `cp` and an `errorStat $?` reporting on the *backup*, so a non-zero status here would report a failed backup that did not fail.

## Unchanged

The bundled set is still derived from `$webdirsrc/lib/plugins/` — what `downloadplugins()` actually fetched this run — not a hardcoded list. `accesscontrol` is a special *message*, not a hardcoded entry in the comparison.

## Testing

12 new assertions in `tests/unrecognized-plugin-notice.test.sh` (10 → 22), **proven by mutation**. Each of these turns the expected checks red and only those:

| Mutation | Red |
|---|---|
| stanza deleted | 5 |
| stanza moved below the no-old-plugins guard | 1 |
| stanza moved below the empty-bundled-set guard | 2 |
| strip no longer records the flag | 1 |
| advice inverted to "Copy it to" | 1 |

Restored: 22/22. Both PHPStan passes clean, every `tests/*.test.sh` green.