### PR TITLE
Report a node registration POST that did not land (GH-575)

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -97,6 +97,60 @@ checkDatabaseConnection() {
     fi
     errorStat $connected
 }
+# Reports one node<->master maintenance POST that did not land, and says how.
+#
+# GH-575: the two calls below post to this node's own web tier, and what
+# actually reaches that web tier is not always what the installer aimed at.
+# Three things intercept it, and none of them is a connection failure -- curl
+# exits 0 every time:
+#
+#   * an inline filtering proxy answering for the address (the reporter's was
+#     an iboss appliance returning ERR_CONNECT_FAIL as an HTML block page),
+#   * this node's own web tier bouncing every request to ?node=schema when it
+#     cannot read the master's database,
+#   * anything else in front of the server that answers 200 with markup.
+#
+# So both a status check and a body check are needed, and they catch different
+# halves: a 3xx has no markup in it, and an interception answering 200 has no
+# bad status. create_update_node.php outputs nothing at all on success -- it
+# has no echo in it, and base.inc.php emits headers only -- so a '<' in the
+# body is the response of something that is not it.
+#
+# Not fatal, in either caller. By this point the node's shares, services and
+# FTP are configured, and both operations have a normal by-hand recovery in
+# Storage Management: say plainly what failed, then carry on.
+#
+# $1 status, $2 response body, $3 what the caller was trying to do.
+_reportNodePostFailure() {
+    local status="${1:-000}" body="$2" what="$3"
+    echo "Failed"
+    echo " * ${httpproto}://${ipaddress}${webroot}maintenance/create_update_node.php"
+    case $status in
+        000)
+            # curl's own placeholder when no HTTP response arrived at all --
+            # refused, timed out, TLS handshake failed. Not an interception.
+            echo "   could not be reached, so ${what}."
+            ;;
+        *)
+            echo "   answered HTTP ${status}, so ${what}."
+            ;;
+    esac
+    case $status in
+        3*)
+            echo " * A redirect here usually means this node's own web tier cannot"
+            echo "   reach the master's database and is bouncing every request to"
+            echo "   the schema page -- check for SELinux denials with:"
+            echo "     ausearch -m avc -ts recent"
+            ;;
+    esac
+    if [[ $body == *'<'* ]]; then
+        echo " * The reply was markup, not this server's answer, so something on"
+        echo "   the network answered in its place. A filtering proxy in front of"
+        echo "   ${ipaddress} is the usual cause; exempt this server from it."
+    fi
+    echo " * Fix the cause and re-run this installer, or set it by hand under"
+    echo "   Storage Management in the web UI."
+}
 registerStorageNode() {
     # GH-529: this defaulted to "/" while installfog.sh defaults to "/fog/", so
     # the two disagreed about where the app lives whenever webroot arrived
@@ -116,13 +170,36 @@ registerStorageNode() {
     # credentials. It does NOT see the database password, which never travels
     # this way. Closing it properly needs the master to hand a node its anchor
     # out of band, which is a design change, not a flag change.
-    storageNodeExists=$(wget --no-check-certificate -qO - ${httpproto}://${ipaddress}${webroot}/maintenance/check_node_exists.php --post-data="ip=${ipaddress}")
+    storageNodeExists=$(wget --no-check-certificate -qO - ${httpproto}://${ipaddress}${webroot}maintenance/check_node_exists.php --post-data="ip=${ipaddress}")
     echo "Done"
     if [[ $storageNodeExists != exists ]]; then
         [[ -z $maxClients ]] && maxClients=10
         dots "Node being registered"
-        curl -s -k -X POST -d "newNode" -d "name=$(echo -n $ipaddress|base64)" -d "path=$(echo -n $storageLocation|base64)" -d "ftppath=$(echo -n $storageLocation|base64)" -d "snapinpath=$(echo -n $snapindir|base64)" -d "sslpath=$(echo -n $sslpath|base64)" -d "ip=$(echo -n $ipaddress|base64)" -d "maxClients=$(echo -n $maxClients|base64)" -d "user=$(echo -n $username|base64)" --data-urlencode "pass=$(echo -n $password|base64)" -d "interface=$(echo -n $interface|base64)" -d "bandwidth=1" -d "webroot=$(echo -n $webroot|base64)" -d "fogverified" ${httpproto}://${ipaddress}${webroot}/maintenance/create_update_node.php
-        echo "Done"
+        # A status check and a body check, neither of which this call had. Both
+        # matter and they catch different halves -- see _reportNodePostFailure.
+        #
+        # Deliberately NOT -L. curl reports %{http_code} for the LAST transfer
+        # it made, so following a 308 to the schema page would report that
+        # page's 200 and turn the failure back into a green "Done". There is no
+        # legitimate redirect to lose: the URL is built from ${httpproto} and
+        # ${webroot}, both of which this installer set itself.
+        regbody=$(curl -s --noproxy '*' -k -w '\n%{http_code}' -X POST -d "newNode" -d "name=$(echo -n $ipaddress|base64)" -d "path=$(echo -n $storageLocation|base64)" -d "ftppath=$(echo -n $storageLocation|base64)" -d "snapinpath=$(echo -n $snapindir|base64)" -d "sslpath=$(echo -n $sslpath|base64)" -d "ip=$(echo -n $ipaddress|base64)" -d "maxClients=$(echo -n $maxClients|base64)" -d "user=$(echo -n $username|base64)" --data-urlencode "pass=$(echo -n $password|base64)" -d "interface=$(echo -n $interface|base64)" -d "bandwidth=1" -d "webroot=$(echo -n $webroot|base64)" -d "fogverified" ${httpproto}://${ipaddress}${webroot}maintenance/create_update_node.php)
+        regstatus=${regbody##*$'\n'}
+        regbody=${regbody%$'\n'*}
+        case $regstatus in
+            2*)
+                if [[ $regbody == *'<'* ]]; then
+                    _reportNodePostFailure "$regstatus" "$regbody" \
+                        "this node did not register itself with the master and will not appear in Storage Management"
+                else
+                    echo "Done"
+                fi
+                ;;
+            *)
+                _reportNodePostFailure "$regstatus" "$regbody" \
+                    "this node did not register itself with the master and will not appear in Storage Management"
+                ;;
+        esac
     else
         echo " * Node is registered"
     fi
@@ -133,8 +210,31 @@ updateStorageNodeCredentials() {
     # -k on purpose -- see registerStorageNode. This is called from the node
     # path before any anchor exists, and from the master path after one does;
     # the shared function has to work in the earlier of the two.
-    curl -s -k -X POST -d "nodePass" -d "ip=$(echo -n $ipaddress|base64)" -d "user=$(echo -n $username|base64)" --data-urlencode "pass=$(echo -n $password|base64)" -d "fogverified" $httpproto://$ipaddress${webroot}maintenance/create_update_node.php
-    echo "Done"
+    # GH-575: this call had no -o, so whatever answered was written STRAIGHT to
+    # the installer's stdout, in the middle of the dotted line -- which is why
+    # the reporter's console read
+    #
+    #   Node being registered.....................<!doctype html>
+    #
+    # followed by a proxy's block page. Then it echoed "Done" regardless,
+    # because nothing looked at the status or at what came back.
+    credbody=$(curl -s --noproxy '*' -k -w '\n%{http_code}' -X POST -d "nodePass" -d "ip=$(echo -n $ipaddress|base64)" -d "user=$(echo -n $username|base64)" --data-urlencode "pass=$(echo -n $password|base64)" -d "fogverified" ${httpproto}://${ipaddress}${webroot}maintenance/create_update_node.php)
+    credstatus=${credbody##*$'\n'}
+    credbody=${credbody%$'\n'*}
+    case $credstatus in
+        2*)
+            if [[ $credbody == *'<'* ]]; then
+                _reportNodePostFailure "$credstatus" "$credbody" \
+                    "this node's storage credentials were not written to the master"
+            else
+                echo "Done"
+            fi
+            ;;
+        *)
+            _reportNodePostFailure "$credstatus" "$credbody" \
+                "this node's storage credentials were not written to the master"
+            ;;
+    esac
 }
 backupDB() {
     # ---------------------------------------------------------

--- a/tests/node-registration-reports-truthfully.test.sh
+++ b/tests/node-registration-reports-truthfully.test.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+#
+# Guards GH-575: a node<->master maintenance POST that did not land must not
+# report success, and must not print what came back.
+#
+#   tests/node-registration-reports-truthfully.test.sh
+#
+# registerStorageNode() and updateStorageNodeCredentials() both POST to THIS
+# node's own web tier at maintenance/create_update_node.php. Three things
+# answer in its place, and none of them is a connection failure -- curl exits 0
+# for all three, so nothing downstream noticed:
+#
+#   * an inline filtering proxy (the reporter's iboss appliance returned
+#     ERR_CONNECT_FAIL as an HTML block page, HTTP 200),
+#   * the node's own web tier bouncing to ?node=schema with a 308 when it
+#     cannot read the master's database,
+#   * a 200 carrying markup from anything else in front of the server.
+#
+# updateStorageNodeCredentials() additionally had no -o at all, so the block
+# page was written straight into the installer's dotted progress line -- which
+# is the console output the issue was filed with.
+#
+# The registration arm DID carry a status check before this, and it could not
+# work: it also carried -L, and curl reports %{http_code} for the LAST transfer
+# it made. Following the 308 to the schema page turned the exact failure the
+# check was written for into a green 200. That is why section 2 asserts on the
+# absence of -L rather than on the presence of a case block -- a gate that
+# passes on code carrying -L is a gate that would have passed on the bug.
+#
+# Section 3 is behavioral: it runs the real function bodies out of
+# functions.sh against a throwaway HTTP server that plays each interception in
+# turn, and asserts on what the installer printed. Source assertions alone
+# cannot tell "checks the status" from "checks the status wrongly".
+#
+# No root, no network beyond loopback, no FOG install.
+#
+# Exit status 0 = pass, 1 = fail.
+
+cd "$(dirname "$0")/.." || exit 1
+FUNCS="lib/common/functions.sh"
+[[ -r $FUNCS ]] || { echo "cannot read $FUNCS -- run this from the repository"; exit 1; }
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+
+# body <function-name> -- one shell function's text, comments stripped. This
+# file's own prose names -L and <!doctype html>; a gate its documentation
+# satisfies is not a gate.
+body() {
+    awk -v fn="$1" '
+        $0 ~ "^" fn "\\(\\) \\{" { inside = 1 }
+        inside { print }
+        inside && /^}/ { exit }
+    ' "$FUNCS" | grep -vE '^[[:space:]]*#'
+}
+
+echo "1. neither call lets a response body reach stdout"
+
+# The unredirected curl is the whole of the original report. Both calls must
+# capture what comes back -- into a variable here, since both now inspect it.
+for fn in registerStorageNode updateStorageNodeCredentials; do
+    stray=0
+    while IFS= read -r line; do
+        [[ $line == *create_update_node.php* ]] || continue
+        [[ $line == *curl* ]] || continue
+        # Captured by $( ), or discarded with -o. Anything else prints.
+        [[ $line == *'=$(curl'* || $line == *'-o /dev/null'* ]] && continue
+        stray=1
+        printf '        uncaptured: %s\n' "$(printf '%s' "$line" | sed 's/^ *//' | cut -c1-90)"
+    done < <(body "$fn")
+    if [[ $stray -eq 0 ]]; then
+        ok "$fn captures the response instead of printing it"
+    else
+        bad "$fn writes the endpoint's reply to the installer's own output"
+    fi
+done
+
+echo
+echo "2. the registration POST does not follow redirects"
+
+# See the header. -L and %{http_code} together cannot see a 308.
+if body registerStorageNode | grep -E 'curl.*create_update_node' \
+        | grep -qE -- '(^|[[:space:]])-[a-zA-Z]*L[a-zA-Z]*([[:space:]]|$)'; then
+    bad "the registration POST still passes -L, so %{http_code} reports the redirect TARGET's status"
+else
+    ok "the registration POST reports its own status, not a followed redirect's"
+fi
+
+echo
+echo "3. behavioral -- each interception is reported as a failure"
+
+# Sections 1 and 2 are source assertions and always run; only this one needs a
+# stand-in server. Skipping rather than failing follows secureboot-authvars.
+if ! command -v python3 >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then
+    echo "  SKIP  needs python3 and curl to stand up a local endpoint"
+    printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+    [[ $FAIL -eq 0 ]]
+    exit
+fi
+
+tmp=$(mktemp -d) || exit 1
+trap 'kill %1 2>/dev/null; rm -rf "$tmp"' EXIT
+
+# One server, three behaviors picked by the mode file it re-reads per request.
+cat > "$tmp/srv.py" <<'PY'
+import os, sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+MODE = sys.argv[2]
+class H(BaseHTTPRequestHandler):
+    def do_POST(self):
+        mode = open(MODE).read().strip()
+        if mode == 'ok':
+            self.send_response(200); self.send_header('Content-Length', '0'); self.end_headers()
+        elif mode == 'redirect':
+            # The schema page itself answers 200. That is the whole point: with
+            # -L, curl reports THAT 200 and the 308 becomes invisible.
+            if self.path.endswith('node=schema'):
+                b = b'<html><body>schema update</body></html>'
+                self.send_response(200); self.send_header('Content-Length', str(len(b))); self.end_headers()
+                self.wfile.write(b)
+                return
+            self.send_response(308); self.send_header('Location', '/management/index.php?node=schema')
+            self.send_header('Content-Length', '0'); self.end_headers()
+        else:  # proxy block page: HTTP 200 carrying markup
+            b = b'<!doctype html>\n<html><head><meta http-equiv="refresh" content="0;url=https://proxy.example/bp.html"/></head></html>'
+            self.send_response(200); self.send_header('Content-Length', str(len(b))); self.end_headers()
+            self.wfile.write(b)
+    do_GET = do_POST
+    def log_message(self, *a): pass
+HTTPServer(('127.0.0.1', int(sys.argv[1])), H).serve_forever()
+PY
+
+port=$(( 20000 + RANDOM % 20000 ))
+echo ok > "$tmp/mode"
+python3 "$tmp/srv.py" "$port" "$tmp/mode" &
+for _ in $(seq 1 40); do
+    curl -s -o /dev/null -m 1 -X POST "http://127.0.0.1:$port/" && break
+    sleep 0.1
+done
+
+# The functions under test, lifted verbatim out of functions.sh. dots() comes
+# with them so the output shape is the installer's own.
+{
+    body dots
+    body _reportNodePostFailure
+    body registerStorageNode
+    body updateStorageNodeCredentials
+} > "$tmp/under-test.sh"
+
+# Everything registerStorageNode reaches for besides the POST. The existence
+# probe is answered by the same server, whose reply is never the literal
+# "exists", so the registration branch is always the one taken. It is wget on
+# this branch rather than curl, hence the timeout below -- an unanswered probe
+# would otherwise stall the whole section rather than fail it.
+cat > "$tmp/harness.sh" <<HARNESS
+httpproto=http
+ipaddress=127.0.0.1:$port
+webroot=/
+storageLocation=/images
+snapindir=/opt/fog/snapins
+sslpath=/opt/fog/snapins/ssl
+interface=eth0
+username=fogproject
+password=hunter2
+maxClients=10
+. "$tmp/under-test.sh"
+HARNESS
+
+run_mode() {
+    echo "$1" > "$tmp/mode"
+    timeout 30 bash -c ". '$tmp/harness.sh'; $2" 2>&1
+}
+
+for mode in redirect proxy; do
+    case $mode in
+        redirect) label="a 308 to the schema page" ;;
+        proxy)    label="a 200 carrying a proxy block page" ;;
+    esac
+
+    # Asserting on the registration line specifically: the existence probe
+    # above it prints its own "Done", so a bare "no Done anywhere" test would
+    # be red no matter what the registration did.
+    out=$(run_mode "$mode" registerStorageNode)
+    regline=$(printf '%s\n' "$out" | grep 'Node being registered')
+    if [[ $regline == *Failed* && $regline != *Done* ]]; then
+        ok "registerStorageNode reports Failed on $label"
+    else
+        bad "registerStorageNode did not report a failure on $label -- got: $(printf '%s' "$out" | tr '\n' '|' | cut -c1-140)"
+    fi
+
+    out=$(run_mode "$mode" updateStorageNodeCredentials)
+    if [[ $out == *Failed* && $out != *Done* ]]; then
+        ok "updateStorageNodeCredentials reports Failed on $label"
+    else
+        bad "updateStorageNodeCredentials did not report a failure on $label -- got: $(printf '%s' "$out" | tr '\n' '|' | cut -c1-140)"
+    fi
+
+    if [[ $out != *'<!doctype'* && $out != *'<html'* ]]; then
+        ok "updateStorageNodeCredentials keeps the reply out of the installer's output ($mode)"
+    else
+        bad "updateStorageNodeCredentials printed the endpoint's reply ($mode)"
+    fi
+done
+
+# And the good path still says Done, or the two assertions above are satisfied
+# by a function that can only ever fail.
+out=$(run_mode ok updateStorageNodeCredentials)
+if [[ $out == *Done* && $out != *Failed* ]]; then
+    ok "updateStorageNodeCredentials reports Done when the POST lands"
+else
+    bad "updateStorageNodeCredentials does not report success on a clean 200 -- got: $(printf '%s' "$out" | tr '\n' '|' | cut -c1-140)"
+fi
+
+out=$(run_mode ok registerStorageNode)
+regline=$(printf '%s\n' "$out" | grep 'Node being registered')
+if [[ $regline == *Done* && $regline != *Failed* ]]; then
+    ok "registerStorageNode reports Done when the POST lands"
+else
+    bad "registerStorageNode does not report success on a clean 200 -- got: $(printf '%s' "$out" | tr '\n' '|' | cut -c1-140)"
+fi
+
+echo
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Port of #1559 to the 1.5.x line. Fixes #575 here.

**This branch is where the reporter almost certainly was.** It carries the defect in its purest form — *both* calls printed whatever answered straight to the installer's stdout, and *both* echoed `Done` unconditionally, with no status check on either. The new test, run against this branch's pre-fix code, reproduces the reported console line verbatim:

```
 * Node being registered.......................................<!doctype
 * Ensuring node username and passwords match..................<!doctype html>|<html><head><meta http-equiv="refresh" content="0;url=https:/
```

Compare the original report:

```
Node being registered.......................................<!doctype html>
<html>
<head>
<meta http-equiv="refresh" content="0;url=https://7rx90003.ibosscloud.com/ibreports/ibp/bp.html?bu=http://10.2.218.228//fog//maintenance/create_update_node.php&bc=Failed+to+retrieve+requested+URL.&ip=10.2.218.228&er=ERR_CONNECT_FAIL%X"/>
```

An iboss filtering appliance answered in the server's place with **HTTP 200**. The installer printed the block page and said nothing was wrong, so the node silently never registered.

## Three interceptions, none of them a connection failure

curl exits 0 for all three:

| | status | body |
|---|---|---|
| inline filtering proxy | 200 | markup |
| web tier bouncing to `?node=schema` because it cannot read the master's DB | 308 | empty |
| anything else in front of the server | 200 | markup |

Hence both a status check *and* a body check — they catch different halves. `create_update_node.php` outputs nothing on success (no `echo` in it; `base.inc.php` emits headers only), so a `<` in the body is the reply of something that is not it.

## Deliberately no `-L`

curl reports `%{http_code}` for the **last** transfer it made, so following the 308 to the schema page would report that page's 200 and turn the failure straight back into a green `Done`. That is not hypothetical — it is the defect the working-1.6 fix had to undo, where a status check written for exactly this case could not see it. No legitimate redirect is lost: the URL is built from `${httpproto}` and `${webroot}`, both of which the installer set itself.

## Also

- `--noproxy '*'` on both, which working-1.6 already carried, so an `http_proxy` in the environment cannot redirect a call meant for this host.
- The doubled slash the reporter saw quoted back at them. `$webroot` always ends in one, so `${webroot}/maintenance/` built `/fog//maintenance/`.

## Not fatal, by design

The node's shares, services and FTP are already configured at this point, and both operations have a normal by-hand recovery in Storage Management. The installer now names the failure and the likely cause, then carries on.

## Verification

- `sh tests/run-all.sh` — 43 passed, 0 failed
- `tests/installer-tls-verification.test.sh` — 24 passed, 0 failed; the unverified-call allowlist and counts are unchanged
- Mutation: pre-fix `origin/dev-branch` takes the new test to **4 passed, 7 failed**

No PHP changed.