### PR TITLE
Say in the rehearsal report which refusals are by design

### DIFF
--- a/bin/upgrade-rehearsal.php
+++ b/bin/upgrade-rehearsal.php
@@ -962,6 +962,39 @@ switch ($cmd) {
                 false === $res->error ? (int)$res->fetch()->get('n') : 'unreadable'
             );
         }
+        // WHY A MISSING CONSTRAINT HERE IS NOT AUTOMATICALLY A DEFECT, and
+        // the reason this block exists at all: the seed plants the exact
+        // conditions FOG refuses to paper over, so the refusals below are
+        // the DESIGNED outcome and reading them as a failure list sends
+        // somebody off to "fix" behavior that is already correct.
+        //
+        //   fk_nfsGroupMembers_ngmGroupID -- a storage node whose group was
+        //     deleted. Step 386 states the rule outright: a node always
+        //     belongs to a group, only the administrator knows which one,
+        //     "so nothing here guesses one", and a refused constraint named
+        //     in the log IS the correct outcome. Sweeping it would delete a
+        //     configured storage node; step 381 sweeps CASCADE junction rows
+        //     only, and says why RESTRICT rows are never touched.
+        //
+        //   fk_hostMAC_hmHostID -- refused on structure, not rows, because
+        //     section 5 of the seed widened hmHostID to bigint on purpose.
+        //
+        // Shape drift reads the same way. A clean build to FOG_SCHEMA
+        // reports ZERO differences, so every difference `shape` prints
+        // after a seeded run was planted by the seed. That the upgrade
+        // reports rather than repairs them is the decision b1348bfe1 made
+        // deliberately -- repairing any of them means narrowing a column,
+        // deleting duplicate rows or inventing a value, which is a data
+        // decision no unattended step gets to make.
+        //
+        // So the question this report answers is "did anything change",
+        // against tests/fixtures/upgrade-rehearsal-baseline.txt. A NEW
+        // refusal or a drift the seed does not explain is the finding; the
+        // ones below are the fixture working.
+        printf(
+            "  (both refusals above are seed-induced and by design --"
+            . " see the comment on this block)\n"
+        );
         exit(count($missing) ? 1 : 0);
 
     case 'dump':

--- a/tests/fixtures/upgrade-rehearsal-baseline.txt
+++ b/tests/fixtures/upgrade-rehearsal-baseline.txt
@@ -9,3 +9,4 @@
     MACs claimed by more than one host       1
     hosts with more than one primary MAC     1
     zero dates in hosts.hostLastDeploy       0
+  (both refusals above are seed-induced and by design -- see the comment on this block)


### PR DESCRIPTION
The rehearsal report lists every constraint the upgrade did not create and stops there, so the two it always names read as a defect list. **They are not**, and I misread my own tool's output because of it — I reported both to Tom as open failures and recommended adding an orphan sweep for one of them. That sweep would have deleted a configured storage node.

## What the two refusals actually are

| Refused | Why | Verdict |
|---|---|---|
| `fk_nfsGroupMembers_ngmGroupID` | Seed leaves a storage node whose group was deleted | **By design.** Step 386: a node always belongs to a group, only the admin knows which, "so nothing here guesses one", and a refused constraint named in the log *is* the correct outcome. Step 381 sweeps CASCADE junction rows only, and says why a RESTRICT orphan is never swept |
| `fk_hostMAC_hmHostID` | Seed widens `hmHostID` to `bigint(20)` in section 5 on purpose | **By design.** Structural (errno 1005/150), which is the case that section exists to plant |

## The measurement that settles the drift half

```
$ build --db=reh_clean --to=401 && shape --db=reh_clean
shape   reh_clean (schema 401)
  differences from the manifest: 0
```

A clean build to `FOG_SCHEMA` reports **zero** drift. So all six differences `shape` prints after a seeded run were planted by the seed — the upgrade is not leaving them behind on real servers. That it reports rather than repairs them is the decision `b1348bfe1` made deliberately: repairing any one of them means narrowing a column, deleting duplicate rows, or inventing a value, and no unattended schema step gets to make a data decision.

## Change

One printed line and its rationale comment, plus the baseline fixture it feeds. No behavior change to FOG — this is the harness explaining itself, so the report's question reads as *"did anything change against the baseline"* rather than *"here are eight problems"*.

`tests/run-all.sh` 260 passed, 0 failed; both PHPStan passes clean from a cold `/tmp/phpstan`.