### PR TITLE
Certificate management page, and move the PKI tree to /etc/fog/pki (GH-1121)

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -1527,6 +1527,10 @@ while [[ -z $blGo ]]; do
                     # sudoers rule is the only route the web tier has to the
                     # CA keys rather than one of two.
                     _installNodeCertSigner
+                    # Master only, for the same reason and one more: a storage
+                    # node does not serve the management UI, so the page this
+                    # helper exists for is not there to call it (GH-1121).
+                    _installPkiAdminHelper
                     # Anchors the root the two calls above have just finished
                     # settling, so this host's own curl/wget/PHP can verify
                     # this host. Reads only ${PKI_root_ca_cert} -- no key -- so it is

--- a/docs/FOGSETTINGS.md
+++ b/docs/FOGSETTINGS.md
@@ -402,9 +402,20 @@ that exists only to cover a deploy ordering the installer fixes anyway.
 | `utils/FOGBackup/FOGBackup.sh` | root | Reads `DB_*` and `STORAGE_image_share_path` |
 | `utils/reporting/report.sh` | root | Reads `DB_*`, `WEB_docroot`, `WEB_root` |
 | `Route::whoami()` | web user | Reads `.fogsettings.pub`. **The only non-root reader** |
+| `packages/pki/fog-pki-admin` | root, started by the web user over `sudo` | Reads three preference keys and rewrites them in place. Not a non-root reader: the web tier names a key from a three-entry allowlist and a value matching `^(yes|no)$`, and never sees the file (ADR 0036) |
 
 If you add a non-root reader, it reads `.fogsettings.pub` or it does not read
 this file at all.
+
+**And nothing writes it on behalf of a non-root caller except through a fixed
+key allowlist.** This file is *sourced as shell by root* on the next installer
+run, so an unvalidated value written into it executes as root. `fog-pki-admin`
+is the only such writer, it may touch exactly three keys
+(`PKI_web_cert_publicly_trusted`, `WEB_https_redirect`,
+`BOOT_rebuild_ipxe_with_my_ca`) plus `PKI_web_external_root_cert`, and its value
+pattern lives on the far side of `sudo` where the caller cannot remove it.
+`tests/pki-admin-helper.test.sh` exercises the injection cases and then sources
+the resulting file to prove nothing ran.
 
 The correct order for any new script:
 

--- a/docs/PKI_ZONES.md
+++ b/docs/PKI_ZONES.md
@@ -97,6 +97,14 @@ web/leaf/.webLeaf.{key,pem}       what the web server actually serves
 web/ca/.trustAnchor.pem           what this server anchors the web zone on: the
                                   FOG root, plus an imported root where there is
                                   one, deduped by fingerprint
+web/ca/.externalRoot.pem          a root CA imported from the Certificates page.
+                                  Absent unless one was. Self-signed CAs only --
+                                  an intermediate in the uploaded file is
+                                  dropped rather than anchored, because
+                                  anchoring one would trust it AS a root.
+                                  PKI_web_external_root_cert records THIS path,
+                                  not wherever the admin's copy came from, so
+                                  the setting still resolves a year later.
 web/dhparam.pem                   Diffie-Hellman parameters the nginx vhost
                                   names directly
 secureboot/ca/.fogSBCA.{key,pem,der}  signs the code-signing leaf; .der is

--- a/docs/PKI_ZONES.md
+++ b/docs/PKI_ZONES.md
@@ -68,9 +68,42 @@ That also has a useful consequence: because the certificate fog-client pins
 **is** the root, the Web CA sits beneath something every client already
 trusts. Trusting `ca.cert.der` now validates the web certificate too.
 
-Under `$fogprogramdir/pki/` (default `/opt/fog/pki/`), one subfolder per zone,
-each split into `ca/` (the zone's own CA material) and `leaf/` (what that CA
-issues day to day) — everything is a dotfile (`ls -a`):
+### Where the tree lives
+
+`/etc/fog/pki/`, recorded as `PKI_root_dir` in `.fogsettings`.
+
+Keys and certificates are configuration, and `/etc` is where the rest of the
+system keeps them — it is what a backup policy and a config-management run
+already capture, while `/opt/<pkg>` is for a package's own static files.
+`/etc/fog` is not new: GH-850 already makes it a real directory on every
+install, to hold `fog.conf`, so this needs no per-distro branch and no
+"Debian has no `/etc/pki`" special case.
+
+**`$fogprogramdir/pki` — `/opt/fog/pki` on a default install — keeps
+resolving**, as a symlink to the above. Every path in this document, in
+`MULTI_SERVER_CA.md` and in `EXTERNAL_CA_AND_LETSENCRYPT.md` is written against
+that name; so is an admin's renewal cron entry, and so are the canonical paths
+recorded in a `.fogsettings` written before the move. Nothing has to be
+rewritten.
+
+`_migratePkiTree()` in `lib/common/functions.sh` does the move, once, on the
+next `installfog.sh` run — and it is a **copy, then remove only if the copy
+succeeded**, never an `mv`.
+`/opt` and `/etc` are frequently separate mounts, so `mv` degrades to
+copy-then-unlink anyway; doing it in explicit steps means a failed copy leaves
+the source authoritative rather than half a tree on each side, and it is what
+makes overwriting the source key blocks possible at all (best effort via
+`shred`, which promises nothing on a journaling or copy-on-write filesystem).
+
+The migration is driven from `_pkiRootDir()`, which every zone accessor calls,
+rather than from a call placed early in `installfog.sh`. Getting that ordering
+wrong is not a visible failure: an accessor answering `/etc/fog/pki` while the
+material still sits under `/opt/fog/pki` reads as "no CA yet", mints a fresh
+root, and every fog-client in the estate stops trusting the server.
+
+Under that root, one subfolder per zone, each split into `ca/` (the zone's own
+CA material) and `leaf/` (what that CA issues day to day) — everything is a
+dotfile (`ls -a`):
 
 ```
 root/ca/.fogCA.{key,pem}          the anchor. Key never regenerated, 0400 root:root.

--- a/docs/adr/0036-the-web-tier-changes-pki-through-a-fixed-verb-set.md
+++ b/docs/adr/0036-the-web-tier-changes-pki-through-a-fixed-verb-set.md
@@ -1,0 +1,155 @@
+# The web tier changes PKI through a fixed verb set, never through a path
+
+## Status
+
+accepted, and implemented on `working-1.6` as `packages/pki/fog-pki-admin` plus
+`_installPkiAdminHelper()`.
+
+## Context
+
+`FOGConfigurationPage::certificates()` was read-only. Everything an
+administrator might want to *change* — trust a corporate root, say the web
+certificate is publicly issued, turn the HTTPS redirect on — was done by
+re-running the installer with flags or by hand-editing `.fogsettings`.
+
+Making it writable runs straight into the reason the page exists at all. Its
+headline card asks whether this web application can read a CA private key, and
+the answer is supposed to be no, because **PHP is the threat model**. The keys
+live at `0400 root:root` in `0700` directories precisely so a compromise of the
+web tier cannot reach them. So "let the page change the PKI" is, stated
+honestly, "let the thing we assume may be compromised change what this server
+trusts".
+
+Two of the four things GH-1121 asked for cannot be done by the web user at all:
+
+- `.fogsettings` is `0600 root:root`, and `docs/FOGSETTINGS.md` states the rule
+  flatly — the only non-root reader is `Route::whoami()`, reading the published
+  `.fogsettings.pub` subset.
+- `pki/root/ca`, `pki/web/ca`, `pki/web/leaf` and `pki/secureboot` are `0700
+  root:root`, so the web tier cannot read even the **public** Web CA
+  certificate, let alone hand it out.
+
+And one of them is worse than it looks. `.fogsettings` is **sourced as shell by
+root** on the next installer run. A helper that let the web tier write an
+arbitrary `key=value` into it is not a permissions nicety with a sharp edge; it
+is a root shell with extra steps. `WEB_https_redirect="no'; curl … | sh; #"`
+executes as root at install time, and nothing in between would report it.
+
+FOG already answers this shape twice — `fog-sign-kernel` and
+`fog-sign-node-cert`. Both are root-owned helpers the web user reaches through
+a narrow `sudoers` rule, and both take **no path arguments**, because that is
+what stops a compromised web server naming its own key.
+
+## Decision
+
+A third helper of the same shape, `fog-pki-admin`, and the generalization of
+the rule those two encode:
+
+**The web tier names a VERB and an allowlisted token. It never names a path, a
+key, or a value that is not drawn from a fixed set.**
+
+Five verbs, and nothing else:
+
+| verb | what the caller may say | what the helper decides |
+|---|---|---|
+| `status` | nothing | which certificates and key paths exist; emits public metadata only |
+| `export <slot> <reqid>` | one of eight slot names, a 32-hex id | which file each slot resolves to |
+| `import-root <reqid>` | a 32-hex id | whether the upload is a self-signed, in-date CA; where it lands |
+| `clear-root` | nothing | — |
+| `set-preference <key> <value>` | one of **three** keys, `yes` or `no` | — |
+
+Three consequences are the whole point:
+
+- **The `^(yes|no)$` pattern is the security boundary, not a validation
+  nicety.** It is what makes writing into a root-sourced shell file safe, so it
+  lives on the far side of `sudo` where a compromised web tier cannot remove
+  it. A duplicate check in PHP would be harmless; the helper's is load-bearing.
+- **`set-preference` refuses a key the file does not already carry.** It never
+  appends, so it cannot move a managed key past `## End of FOG Settings` into
+  the region `writeUpdateFile()`'s merge treats as the administrator's own
+  lines.
+- **`import-root` keeps only self-signed certificates.** Anchoring an
+  intermediate would trust it *as a root*, widening what the host accepts.
+  `_resolveTrustAnchor()` filters the same way, so the two halves cannot
+  disagree.
+
+**The readability check stays in PHP.** The helper reports the private keys'
+*paths*; the page tests `is_readable()` itself. The helper runs as root, so
+"root can read it" answers a different question from the one the card asks.
+
+**The gate is `system.pki`, deny by default.** No schema step seeds it, so only
+a holder of `*` has it until an administrator grants it — the way
+`system.export` and `impersonate.start` arrived. `settings.edit` was the
+alternative and is wrong for the same reason it was wrong for the database
+dump: six page nodes already map onto it, and "may edit the OUI table" is not
+"may decide what this server trusts".
+
+**Rotating FOG's own root is not offered.** The page composes the
+`installfog.sh` invocation and states the cost. It changes the certificate
+every registered fog-client pins, so every client stops authenticating until it
+is re-pinned; that is a migration with a re-pin story, and a web form should
+not be able to start one in a click.
+
+## Consequences
+
+- A third `sudoers` drop-in on a master. All three are `visudo -cqf`-validated
+  before installation and removed when their precondition stops holding —
+  here, a server that is a storage node, which does not serve the management UI
+  at all.
+- `_resolveTrustAnchor()` now reads `PKI_web_external_root_cert` directly.
+  Before, an imported root reached the anchor only through the chain file,
+  which `validateExternalCA()` writes — and that runs only when all three of
+  `--ca-cert`/`--ca-key`/`--ca-root` were supplied. "Just trust our corporate
+  root" is the narrower ask, and without this the next installer run rebuilt
+  the anchor without it and silently undid the import.
+- The imported root is copied to a canonical path inside the web zone, and
+  *that* path is what `.fogsettings` records. `--ca-root` persists the
+  administrator's **source** path, which is routinely a temp file that is gone
+  by the next run.
+- The three preferences take effect on the next installer run and not before.
+  The page says so at the point of change, because that is the difference
+  between a flag — read back before it runs — and a checkbox.
+- The helper duplicates `_splitPemBundle()` and the anchor rebuild from
+  `lib/common/functions.sh`. An installed server has `bin/` but no `lib/`, so
+  there is nothing to share; `tests/pki-admin-helper.test.sh` and
+  `tests/trust-anchor.test.sh` pin both copies against the same behavior.
+- `acmeLeaf` is not settable, because GH-1120 retired it. Whether a leaf is
+  managed elsewhere is derived from whether `PKI_web_vhost_cert` resolves
+  outside the web zone, and the page reports that derived state rather than
+  offering a flag that could disagree with the filesystem.
+
+## Alternatives rejected
+
+**A `sudoers` rule on `sed`, or on a generic settings writer.** Reduces to
+arbitrary root code execution through `.fogsettings`, as above.
+
+**Passing paths to the helper and validating them there.** The moment the
+caller names a file, the helper's job becomes proving a path is safe — symlinks,
+`..`, TOCTOU, bind mounts — instead of never being handed one. The two existing
+helpers already made this choice and it is the reason they are short enough to
+audit.
+
+**Publishing the Web CA and vhost certificates into `management/other/` so the
+web tier could read them directly.** Would have avoided a `sudo` call for the
+downloads, at the cost of a second copy of every certificate to keep in step
+and a new set of files in the document root. `status` and `export` cover it
+with no new published state.
+
+**Letting the page write `.fogsettings` through a `.fogsettings.pub`-style
+writable subset.** The public file exists so secrets can stay unreadable; a
+*writable* counterpart would have to be merged back by root anyway, which is
+this helper with a queue in front of it and a window in which the two disagree.
+
+**`BOOT_url_proto_forced` in the allowlist.** Forcing netboot to HTTPS with
+neither steering key set is GH-1116's "legal but warned" case: it breaks PXE for
+machines that cannot fix themselves. Not a thing a misclick should reach.
+
+## References
+
+- Issue: FOGProject/fogproject#1121, under FOGProject/fogproject#1116
+- [ADR 0024](0024-fogsettings-unified-key-model.md) — the key model, and why
+  `acmeLeaf` is derived rather than stored
+- [ADR 0015](0015-install-settings-are-independent-keys.md) — the three
+  preferences are independent keys
+- `docs/PKI_ZONES.md` — the zones the slots name
+- `docs/FOGSETTINGS.md` — the reader table this helper is now the second entry in

--- a/docs/adr/0037-the-pki-tree-lives-in-etc.md
+++ b/docs/adr/0037-the-pki-tree-lives-in-etc.md
@@ -1,0 +1,110 @@
+# The PKI tree lives in /etc/fog/pki, reached at its old name by a symlink
+
+## Status
+
+accepted, and implemented on `working-1.6` as `_pkiRootDir()` /
+`_migratePkiTree()` in `lib/common/functions.sh`, with `PKI_root_dir` recorded
+in `.fogsettings`.
+
+## Context
+
+FOG's four-zone PKI (ADR-adjacent, documented in `docs/PKI_ZONES.md`) sat at
+`$fogprogramdir/pki` — `/opt/fog/pki` on a default install. It holds the
+fleet's root CA key, the Web CA, the Secure Boot CA, the vhost keypair and the
+client-communication keypair every registered fog-client pins.
+
+`/opt/<pkg>` is for a package's own static files: the things that arrive with
+an install and are replaced wholesale by the next one. Keys and certificates
+are the opposite of that. They are irreplaceable per-server state, they are
+what a backup policy and a config-management run are supposed to capture, and
+every other TLS-consuming daemon on the box keeps its own under `/etc`. A site
+backing up `/etc` and not `/opt` — an entirely ordinary policy — was silently
+not backing up the one thing on this server that cannot be regenerated.
+
+## Decision
+
+The tree lives at **`/etc/fog/pki`**. `$fogprogramdir/pki` remains as a
+**symlink** to it.
+
+`/etc/fog` is not a new directory to create: GH-850 already makes it a real
+directory on every install, to hold `fog.conf` — the pointer that tells the
+next installer run where this install lives. So there is no per-distro branch
+and no "this distro has no such directory" case to handle.
+
+The location is recorded as `PKI_root_dir` in `.fogsettings`, alongside every
+other PKI location. That is what makes the tree *expressible* rather than
+hardcoded in two places: the migration has to be able to name its own source,
+the three utils scripts (`renewal-helper`, `fog-offline-ca-key`,
+`fog-mint-web-ca`) read it instead of each carrying a copy of the default, and
+the shell tests point it at a scratch directory the same way they already point
+`$fogprogramdir`.
+
+Three properties are load-bearing.
+
+**The old name keeps resolving.** `$fogprogramdir/pki` is a *published* path.
+`PKI_ZONES.md`, `MULTI_SERVER_CA.md` and `EXTERNAL_CA_AND_LETSENCRYPT.md` all
+name `/opt/fog/pki/...`; an admin's renewal cron entry names
+`/opt/fog/pki/renewal-helper`; and a `.fogsettings` written before this change
+records every canonical certificate path underneath it. A symlink means none of
+that has to be rewritten, and an admin who has memorized a path is not wrong.
+
+**The move is copy, then remove only if the copy succeeded — never `mv`.** `/opt` and `/etc` are
+frequently separate mounts, so `mv` degrades to copy-then-unlink anyway. Doing
+it in explicit steps buys two things: a failed copy leaves the *source*
+authoritative rather than half a tree on each side with no record of which
+half, and it creates the moment at which the source blocks can be overwritten
+before the unlink. That overwrite is best effort — `shred` promises nothing on
+a journaling or copy-on-write filesystem — but leaving the fleet's root CA key
+recoverable from freed blocks because the move was "just a rename" is the worse
+default.
+
+**The migration is driven from the path accessor, not from a call site.**
+`_pkiRootDir()` performs it, so no caller can reach a zone path before the tree
+is in place. Ordering this by hand in `installfog.sh` would be one line and
+would not survive: getting it wrong is not a visible failure. An accessor
+answering `/etc/fog/pki` while the material still sits under `/opt/fog/pki`
+reads as "no CA yet", mints a fresh root, and every fog-client in the estate
+stops trusting this server. The cost of the safe version is one `-L` test per
+call after the first run.
+
+## Consequences
+
+- An upgraded server relocates on its next `installfog.sh` run, once. Nothing
+  an admin has written down stops working.
+- `/etc/fog/pki` inherits `etc_t` under SELinux where the old tree was `usr_t`.
+  Both are readable by the web tier, which only needs to traverse to
+  `client/leaf`; `_migratePkiTree()` runs `restorecon -RF` on the target because
+  `cp -a` carries the *source's* labels, and a tree whose labels change the
+  first time somebody runs a relabel is worse than one that is already right.
+- `renewal-helper` is installed into the tree, so an executable now sits under
+  `/etc`. It stays there rather than moving to `$fogprogramdir/bin` beside
+  `fog-offline-ca-key`, because `/opt/fog/pki/renewal-helper` is the path in the
+  docs and in people's crontabs; the symlink keeps it working either way.
+
+## Alternatives rejected
+
+**`/etc/pki/fog`.** The first proposal, and the more obvious FHS answer. On the
+RHEL family `/etc/pki` is owned by `ca-certificates` and `openssl` and already
+holds `/etc/pki/ca-trust/`, so a distro package reorganizing under it would be
+reorganizing around FOG's private keys. It also does not exist on Debian and
+Ubuntu, which would put a per-distro branch in the one code path that must not
+have one. `/etc/fog` is FOG's own namespace and is already there on every
+install.
+
+**Leave it in `/opt/fog/pki`.** Zero work and zero risk, and it is what
+everything already points at. It also leaves the irreplaceable state in the
+directory a site is least likely to be backing up, which is the problem.
+
+**A bind mount instead of a symlink.** Survives a `readlink -f`, which a symlink
+does not — and that matters, because `_externallyManagedLeaf()` decides "is this
+certificate FOG's or the admin's" by resolving both sides and comparing. But a
+bind mount has to be re-established on every boot, so it needs an `fstab` entry
+or a systemd unit, and a server that comes up without it silently has no PKI.
+The symlink resolves identically on both sides of that comparison, so nothing
+needed the extra machinery.
+
+**Move the tree and rewrite the docs to the new path.** Cheaper to reason about
+than a compat symlink, and wrong for the one case that matters: an existing
+server whose `.fogsettings` records `/opt/fog/pki/web/leaf/.webLeaf.pem` as its
+canonical vhost certificate, and whose admin's renewal cron names the old
+helper. Both keep working through the symlink; neither survives a clean break.

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -6330,9 +6330,9 @@ _hardenPkiPermissions() {
     mkdir -p "${fogprogramdir}/bin" >>$error_log 2>&1
     install -o root -g root -m 0755 ../packages/pki/fog-offline-ca-key \
         "${fogprogramdir}/bin/fog-offline-ca-key" >>$error_log 2>&1
-    mkdir -p "${fogprogramdir}/pki" >>$error_log 2>&1
+    mkdir -p "$(_pkiRootDir)" >>$error_log 2>&1
     install -o root -g root -m 0755 ../packages/pki/renewal-helper \
-        "${fogprogramdir}/pki/renewal-helper" >>$error_log 2>&1
+        "$(_pkiRootDir)/renewal-helper" >>$error_log 2>&1
     # A storage node does not hold the fleet's root CA -- whatever CA it
     # minted (or was issued) is local to itself, so "restore it to issue a
     # certificate for a new storage node" is nonsense advice on the node
@@ -6718,6 +6718,12 @@ writeUpdateFile() {
     # ${!key}, so an unset key emits an empty line, which #1121 would read as
     # "no client cert configured".
     if [[ -n $fogprogramdir ]]; then
+        # Where the zone tree physically is. Recorded rather than left implicit
+        # so the utils scripts -- renewal-helper, fog-offline-ca-key,
+        # fog-mint-web-ca -- read it from here instead of each carrying its own
+        # copy of the default, and so an install that predates the move keeps
+        # working off its recorded (empty -> compat symlink) value.
+        PKI_root_dir="$(_pkiRootDir)"
         PKI_client_encrypt_key="$(_pkiZoneDir client)/leaf/.srvprivate.key"
         PKI_client_encrypt_cert="$(_pkiZoneDir client)/leaf/.srvpublic.crt"
     fi
@@ -6914,6 +6920,11 @@ writeUpdateFile() {
         # extra vhost/cert name(s) must carry forward on every upgrade, not just
         # the run they were set on.
         PKI_san_ip_addresses PKI_san_dns_names
+        # Where FOG's own four-zone PKI tree lives: /etc/fog/pki, reachable at
+        # its historic $fogprogramdir/pki name through a symlink. An empty value
+        # in a file written before the move means the same thing as the default,
+        # because that name still resolves.
+        PKI_root_dir
         # Where the client-communication leaf and the uploaded snapin SSL
         # material live. NOT where FOG's CAs live any more, which is the whole
         # reason the old name (sslpath) had to go.
@@ -7535,19 +7546,107 @@ _linkCanonical() {
     [[ "$(readlink -f "$real" 2>/dev/null)" == "$(readlink -f "$canon" 2>/dev/null)" ]] && return 0
     ln -sf "$real" "$canon" >>$error_log 2>&1
 }
+# Where FOG's own PKI tree physically lives: /etc/fog/pki, not $fogprogramdir/pki.
+#
+# Keys and certificates are CONFIGURATION. /etc is where the rest of the system
+# keeps them, and it is what a backup policy and a config-management run
+# already capture, while /opt/<pkg> is for a package's own static files. The
+# directory is not new and needs no per-distro branch: GH-850 already makes
+# /etc/fog a real directory on every install, to hold fog.conf.
+#
+# $fogprogramdir/pki keeps working, as a SYMLINK at the same name, because it
+# is a PUBLISHED path -- PKI_ZONES.md, MULTI_SERVER_CA.md and
+# EXTERNAL_CA_AND_LETSENCRYPT.md all name /opt/fog/pki/..., an admin's renewal
+# cron names /opt/fog/pki/renewal-helper, and a .fogsettings written before
+# this change records canonical paths underneath it.
+#
+# Overridable through PKI_root_dir, recorded in .fogsettings alongside every
+# other PKI location. That is what makes the tree EXPRESSIBLE rather than
+# hardcoded twice -- the migration below has to be able to name its own source,
+# and the shell tests point it at a scratch directory the same way they already
+# point $fogprogramdir.
+_pkiRootDir() {
+    local root="${PKI_root_dir:-/etc/fog/pki}"
+    root="${root%/}"
+    # The migration is driven from HERE, not from a call site early in the
+    # install, because getting that ordering wrong is not a visible failure: a
+    # zone accessor answering /etc/fog/pki while the real material still sits
+    # under /opt/fog/pki reads as "no CA yet", mints a fresh root, and every
+    # fog-client in the estate stops trusting this server. One -L test per call
+    # makes the ordering impossible to get wrong, and after the first run that
+    # test is all this branch costs.
+    #
+    # The other two preconditions -- no $fogprogramdir, and a tree already at
+    # the target -- are checked once, inside _migratePkiTree, rather than
+    # duplicated here. Two copies of the same guard means removing either one
+    # is invisible, which is how a guard stops being one.
+    [[ -L ${fogprogramdir}/pki ]] || _migratePkiTree "$root"
+    echo "$root"
+}
+# Move an existing $fogprogramdir/pki to $1 and leave a symlink behind.
+#
+# COPY, then remove, and only if the copy reported success on every file --
+# never mv. /opt and /etc are frequently separate mounts, so mv degrades to
+# copy-then-unlink anyway; separating the two means a failure at any point
+# leaves the SOURCE authoritative and the next run simply redoes the whole
+# move, rather than half a tree on each side with no record of which half.
+#
+# The one window that is not recoverable that way is between the removal and
+# the ln, and it recovers too: the next call finds neither a link nor a
+# directory, skips the copy, and links the already-populated target.
+#
+# Idempotent by construction. Every later run stops at the -L test in
+# _pkiRootDir and never reaches here.
+_migratePkiTree() {
+    local target="${1:-/etc/fog/pki}" legacy="${fogprogramdir}/pki"
+    [[ -z ${fogprogramdir} ]] && return 0
+    [[ $legacy == "$target" ]] && return 0
+    [[ -L $legacy ]] && return 0
+    mkdir -p "$target" >>$error_log 2>&1 || return 1
+    # The tree root is traversed by the web tier on its way to client/leaf. The
+    # zones set their own (much tighter) modes; this one only has to be enterable.
+    chmod 0755 "$target" >>$error_log 2>&1
+    if [[ -d $legacy ]]; then
+        # Nothing is removed unless the copy reported success on every file.
+        # A partial copy leaves the source authoritative, which is the whole
+        # reason this is not an mv.
+        cp -a "$legacy/." "$target/" >>$error_log 2>&1 || return 1
+        # The key material crossed a filesystem boundary, so the source blocks
+        # are still on the old device after the unlink. Overwrite what we can
+        # before dropping the tree. Best effort and NOT a guarantee -- shred
+        # promises nothing on a journaling or copy-on-write filesystem -- but
+        # leaving the fleet's root CA key recoverable from freed blocks because
+        # the move was "just a rename" is the worse default.
+        if command -v shred >/dev/null 2>&1; then
+            find "$legacy" -type f -exec shred -u {} + >>$error_log 2>&1
+        fi
+        rm -rf "$legacy" >>$error_log 2>&1
+    fi
+    mkdir -p "$(dirname "$legacy")" >>$error_log 2>&1
+    ln -s "$target" "$legacy" >>$error_log 2>&1
+    # cp -a preserves the SOURCE's SELinux labels, so the moved files would
+    # carry /opt's usr_t while sitting under /etc. Both are readable by the web
+    # tier, so nothing breaks either way -- but relabeling to the target's own
+    # default is what the next restorecon anyone runs would do, so do it now
+    # rather than ship a tree whose labels change under them later.
+    command -v restorecon >/dev/null 2>&1 && restorecon -RF "$target" >>$error_log 2>&1
+    return 0
+}
 # Single source of truth for the PKI layout, one directory per zone under
-# $fogprogramdir/pki, each split by its callers into ca/ (the zone's own CA)
-# and leaf/ (what that CA issues for this server to serve/sign with).
+# _pkiRootDir, each split by its callers into ca/ (the zone's own CA) and leaf/
+# (what that CA issues for this server to serve/sign with).
 # Independent of ${PKI_client_cert_dir} -- unlike ${PKI_client_cert_dir}, which also holds admin-uploaded
 # snapin SSL material and the client-communication leaf, this tree holds only
 # FOG's own PKI, so it can move without dragging that other content along.
+# Which is exactly what it did: the tree lives at /etc/fog/pki now, reachable
+# at its historic $fogprogramdir/pki name through a symlink.
 _pkiZoneDir() {
+    local root
     case "$1" in
-        root) echo "${fogprogramdir}/pki/root" ;;
-        web) echo "${fogprogramdir}/pki/web" ;;
-        client) echo "${fogprogramdir}/pki/client" ;;
-        secureboot) echo "${fogprogramdir}/pki/secureboot" ;;
+        root|web|client|secureboot) root="$(_pkiRootDir)" ;;
+        *) return 0 ;;
     esac
+    echo "${root}/$1"
 }
 # The shared openssl configuration both issuing zones read.
 #
@@ -7563,7 +7662,7 @@ _pkiZoneDir() {
 # certificates, so giving it the ca/+leaf/ shape the zones have would say
 # something false about it.
 _pkiConfDir() {
-    echo "${fogprogramdir}/pki/conf"
+    echo "$(_pkiRootDir)/conf"
 }
 # The client zone's leaf directory, and the compatibility links that keep the
 # canonical names working.

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -5308,6 +5308,126 @@ _installNodeCertSigner() {
     # errorStat for the same reason.
     setSELinuxContext "$stagedir" fog_share_t
 }
+# Install the PKI administration helper and the sudoers rule that lets the web
+# tier reach it.
+#
+# Master only, and for a stronger reason than _installNodeCertSigner's: a
+# storage node does not serve the management UI at all -- configureMinHttpd
+# stubs out management/index.php -- so the Certificates page that drives this
+# does not exist there. Installing the rule would grant a node's web user a
+# sudo entry nothing can call.
+#
+# Same shape as _installNodeCertSigner and _installSecureBootSigner: a
+# root-only config holding every path, a staging directory the web user owns,
+# and a validated sudoers drop-in. The web user learns nothing about where the
+# keys live and cannot rewrite these paths to point somewhere else.
+#
+# What makes this one different, and why the helper is a script rather than a
+# sudo rule on some existing tool: one of its verbs writes .fogsettings, which
+# root SOURCES AS SHELL on the next installer run. A helper that wrote
+# arbitrary key=value pairs there would be a root shell with extra steps. The
+# helper therefore takes a key from a three-entry allowlist and a value
+# matching ^(yes|no)$, and tests/pki-admin-helper.test.sh holds it to that.
+_installPkiAdminHelper() {
+    local bindir="${fogprogramdir}/bin"
+    local helper="${bindir}/fog-pki-admin"
+    local conf="${fogprogramdir}/.fog-pki-admin"
+    local stagedir="${fogprogramdir}/pkiadmin-staging"
+    local sudoersfile="/etc/sudoers.d/fog-pki-admin"
+    local webdir sbca
+
+    # Guarded here as well as at the call site, for the reason
+    # _installNodeCertSigner states: the call site is exactly the kind of thing
+    # a later refactor moves. Remove any rule a previous run installed rather
+    # than leaving a sudo entry for a helper nothing can reach -- a server
+    # converted from master to node is the case that matters.
+    if [[ ${FOG_install_type} == [Ss] ]]; then
+        rm -f "$helper" "$conf" "$sudoersfile" >>$error_log 2>&1
+        return 0
+    fi
+
+    dots "Installing the certificate management helper"
+    mkdir -p "$bindir" >>$error_log 2>&1
+    install -o root -g root -m 0755 ../packages/pki/fog-pki-admin "$helper" >>$error_log 2>&1 || {
+        echo "Failed"
+        return 0
+    }
+    # Point the helper at this install's config. It takes no path arguments on
+    # purpose -- that is what stops a compromised web server naming its own CA
+    # key or its own .fogsettings -- so the location has to be baked in here.
+    # Quoted: $fogprogramdir may contain a space, and CONF=/a/fog custom/x
+    # assigns "/a/fog" and then tries to RUN "custom/x", which bash -n does not
+    # catch.
+    sed -i "s|^CONF=.*|CONF=\"${conf}\"|" "$helper" >>$error_log 2>&1
+    if ! grep -qxF "CONF=\"${conf}\"" "$helper"; then
+        echo "Failed"
+        echo " * Could not set the config path in $helper."
+        return 0
+    fi
+
+    webdir="$(_pkiZoneDir web)"
+    sbca="$(_pkiZoneDir secureboot)/ca/.fogSBCA.pem"
+    {
+        # Every path below names a PUBLIC certificate, except the two key
+        # paths, which the helper only ever tests for EXISTENCE -- "is the
+        # root key still on this server" is the one question the Certificates
+        # page has always answered, and answering it needs the path, not the
+        # contents.
+        echo "PKI_ROOT_CERT=${PKI_root_ca_cert}"
+        echo "PKI_ROOT_KEY=${PKI_root_ca_key}"
+        echo "PKI_WEB_CA_KEY=${PKI_web_ca_key}"
+        echo "PKI_WEB_VHOST_KEY=${PKI_web_vhost_key}"
+        echo "PKI_CLIENT_KEY=${PKI_client_encrypt_key}"
+        echo "PKI_WEB_CA_CERT=${PKI_web_ca_cert}"
+        echo "PKI_WEB_CHAIN=${PKI_web_trust_chain}"
+        echo "PKI_WEB_ANCHOR=${webdir}/ca/.trustAnchor.pem"
+        echo "PKI_WEB_VHOST_CERT=${PKI_web_vhost_cert}"
+        # The zone directory, so the helper can answer "is this leaf managed
+        # outside FOG" exactly as _externallyManagedLeaf() does. GH-1120
+        # retired the acmeLeaf key precisely because a persisted flag and the
+        # filesystem could disagree; deriving it in two places from the same
+        # test keeps that property.
+        echo "PKI_WEB_ZONE_DIR=${webdir}"
+        # The canonical home for a root imported from the page. Not the
+        # admin's own path: --ca-root persists the SOURCE, which is routinely
+        # a temp file that is gone by the next run.
+        echo "PKI_EXTERNAL_ROOT=${webdir}/ca/.externalRoot.pem"
+        echo "PKI_CLIENT_CERT=${PKI_client_encrypt_cert}"
+        if [[ -f $sbca ]]; then
+            echo "PKI_SB_CA_CERT=${sbca}"
+            echo "PKI_SB_CA_KEY=$(_pkiZoneDir secureboot)/ca/.fogSBCA.key"
+        fi
+        echo "PKI_SETTINGS=${fogprogramdir}/.fogsettings"
+        echo "PKI_STAGING=${stagedir}"
+    } > "$conf"
+    chown root:root "$conf" >>$error_log 2>&1
+    chmod 0600 "$conf" >>$error_log 2>&1
+
+    # The web user owns only the staging directory: it writes an upload there
+    # and reads an exported certificate back, and can reach nothing else.
+    mkdir -p "$stagedir" >>$error_log 2>&1
+    chown "${apacheuser}":"${apacheuser}" "$stagedir" >>$error_log 2>&1
+    chmod 0750 "$stagedir" >>$error_log 2>&1
+
+    # Validate before installing: a malformed sudoers drop-in breaks sudo for
+    # the whole machine, which is far worse than a Certificates page that can
+    # only read.
+    echo "${apacheuser} ALL=(root) NOPASSWD: ${helper}" > "${sudoersfile}.tmp"
+    chmod 0440 "${sudoersfile}.tmp" >>$error_log 2>&1
+    if visudo -cqf "${sudoersfile}.tmp" >>$error_log 2>&1; then
+        mv -f "${sudoersfile}.tmp" "$sudoersfile" >>$error_log 2>&1
+        chown root:root "$sudoersfile" >>$error_log 2>&1
+        echo "Done"
+    else
+        rm -f "${sudoersfile}.tmp" >>$error_log 2>&1
+        echo "Failed"
+        echo " * Refusing to install an invalid sudoers rule; the Certificates"
+        echo "   page will show the chain but will not be able to change it."
+    fi
+    # After this function own Done/Failed, never before -- setSELinuxContext
+    # prints its own dots()/OK pair and would run into an unterminated line.
+    setSELinuxContext "$stagedir" fog_share_t
+}
 # Ask the master for a certificate, as a storage node.
 #
 # Returns non-zero on any failure, and every caller treats that as "carry on
@@ -5555,7 +5675,10 @@ _resolveTrustAnchor() {
         fp=$(openssl x509 -in "${PKI_root_ca_cert}" -noout -fingerprint -sha256 2>/dev/null)
         if [[ -n $fp ]]; then
             cat "${PKI_root_ca_cert}" >> "$out" 2>>$error_log
-            seen="$fp"
+            # Accumulates now that there are three possible sources rather than
+            # two, newline-separated so no two fingerprints can abut and
+            # manufacture a match that is in neither.
+            seen="${fp}"$'\n'
         fi
     fi
     if [[ -n ${PKI_web_trust_chain} && -f ${PKI_web_trust_chain} ]]; then
@@ -5566,10 +5689,46 @@ _resolveTrustAnchor() {
             # Fingerprint, not a path comparison: on a FOG-issued install these
             # are the same certificate reached by two different routes, and
             # comparing filenames would append it twice.
-            if [[ -n $fp && $fp != "$seen" ]]; then
+            if [[ -n $fp && $seen != *"$fp"* ]]; then
                 printf '%s\n' "$chainroot" >> "$out" 2>>$error_log
+                seen="${seen}${fp}"$'\n'
             fi
         fi
+    fi
+    # A root imported on its own, with no matching intermediate and key.
+    #
+    # ${PKI_web_external_root_cert} used to reach this bundle only via the chain
+    # file, which is written by validateExternalCA -- and that runs only when
+    # all THREE of --ca-cert/--ca-key/--ca-root were supplied. "Trust our
+    # corporate root" is the narrower ask: no certificate is issued from it,
+    # nothing chains to it, it is simply a root this box should accept. The
+    # Certificates page writes exactly that case (GH-1121), and without this
+    # the next installer run rebuilt the anchor without it and silently undid
+    # the import.
+    #
+    # Additive and idempotent everywhere else: on a full --external-ca install
+    # this certificate is already in the chain above, so the fingerprint check
+    # collapses it. The -f guard matters -- validateExternalCA persists the
+    # admin's SOURCE path, which is routinely a temp file that is gone by the
+    # next run.
+    if [[ -n ${PKI_web_external_root_cert} && -f ${PKI_web_external_root_cert} ]]; then
+        local tmpd extroot
+        tmpd=$(mktemp -d 2>>$error_log)
+        if [[ -n $tmpd ]] && _splitPemBundle "${PKI_web_external_root_cert}" "$tmpd"; then
+            for extroot in "$tmpd"/c*.pem; do
+                [[ -f $extroot ]] || continue
+                # Self-signed only. Anchoring an intermediate would trust it as
+                # a root, widening what this box accepts -- see the same rule in
+                # packages/pki/fog-pki-admin's import-root.
+                [[ $(openssl x509 -in "$extroot" -noout -subject 2>/dev/null | cut -d= -f2-) \
+                    == "$(openssl x509 -in "$extroot" -noout -issuer 2>/dev/null | cut -d= -f2-)" ]] || continue
+                fp=$(openssl x509 -in "$extroot" -noout -fingerprint -sha256 2>/dev/null)
+                [[ -n $fp && $seen != *"$fp"* ]] || continue
+                cat "$extroot" >> "$out" 2>>$error_log
+                seen="${seen}${fp}"$'\n'
+            done
+        fi
+        [[ -n $tmpd ]] && rm -rf "$tmpd" >>$error_log 2>&1
     fi
     [[ -s $out ]] || return 1
     trustAnchorPem="$out"

--- a/packages/pki/fog-mint-web-ca
+++ b/packages/pki/fog-mint-web-ca
@@ -89,11 +89,16 @@ elif [[ -r /etc/fog/fog.conf ]]; then
 fi
 : "${fogprogramdir:=/opt/fog}"
 : "${sslpath:=${fogprogramdir}/snapins/ssl}"
+# Where the four-zone tree physically lives. .fogsettings records it
+# (PKI_root_dir); a file written before the tree moved to /etc/fog/pki has no
+# such line, and the historic name is a symlink to the new one, so the fallback
+# resolves either way.
+: "${pkiroot:=${PKI_root_dir:-${fogprogramdir}/pki}}"
 
 # $rootCAKey is never persisted to .fogsettings -- installfog.sh re-derives it
 # every run -- so this falls to the canonical path, the same as fog-offline-ca-key.
 ROOT_CERT="${ROOT_CERT:-${rootCAPem:-${sslpath}/CA/.fogCA.pem}}"
-ROOT_KEY="${ROOT_KEY:-${rootCAKey:-${fogprogramdir}/pki/root/ca/.fogCA.key}}"
+ROOT_KEY="${ROOT_KEY:-${rootCAKey:-${pkiroot}/root/ca/.fogCA.key}}"
 OUTDIR="${OUTDIR:-/root/fog-web-cas}"
 
 [[ -r $ROOT_CERT ]] || { echo "Cannot read the root certificate at ${ROOT_CERT}" >&2; exit 1; }

--- a/packages/pki/fog-offline-ca-key
+++ b/packages/pki/fog-offline-ca-key
@@ -85,6 +85,11 @@ elif [[ -r /etc/fog/fog.conf ]]; then
 fi
 : "${fogprogramdir:=/opt/fog}"
 : "${sslpath:=${fogprogramdir}/snapins/ssl}"
+# Where the four-zone tree physically lives. .fogsettings records it
+# (PKI_root_dir); a file written before the tree moved to /etc/fog/pki has no
+# such line, and the historic name is a symlink to the new one, so the fallback
+# resolves either way.
+: "${pkiroot:=${PKI_root_dir:-${fogprogramdir}/pki}}"
 
 case "$zone" in
     root)
@@ -92,13 +97,13 @@ case "$zone" in
         # re-derives it fresh every run -- so this standalone script always
         # falls to the default. The certificate is deliberately not moved by
         # the pki/ split (see createSSLCA's _resolveRootCA), only the key.
-        key="${rootCAKey:-${fogprogramdir}/pki/root/ca/.fogCA.key}"
+        key="${rootCAKey:-${pkiroot}/root/ca/.fogCA.key}"
         cert="${rootCAPem:-${sslpath}/CA/.fogCA.pem}"
         label="FOG Server CA"
         ;;
     secureboot)
-        key="${fogprogramdir}/pki/secureboot/ca/.fogSBCA.key"
-        cert="${fogprogramdir}/pki/secureboot/ca/.fogSBCA.pem"
+        key="${pkiroot}/secureboot/ca/.fogSBCA.key"
+        cert="${pkiroot}/secureboot/ca/.fogSBCA.pem"
         label="FOG Secure Boot CA"
         ;;
     *)

--- a/packages/pki/fog-pki-admin
+++ b/packages/pki/fog-pki-admin
@@ -1,0 +1,579 @@
+#!/bin/bash
+#
+#  FOG is a computer imaging solution.
+#  Copyright (C) 2007  Chuck Syperski & Jian Zhang
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#    any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Read and change the parts of this server's PKI that a browser may reach.
+#
+# Invoked through sudo by the Certificates page after it has checked
+# system.pki. The split is the same one fog-sign-node-cert draws: the page
+# decides WHO may ask, this decides WHAT may be asked for and holds every
+# path. A compromise of the web application can therefore drive these five
+# verbs and nothing else -- it cannot read a private key, cannot name a file,
+# and cannot put a byte of its own choosing into .fogsettings.
+#
+# That last one is the reason this script exists at all rather than a sudo
+# rule on `sed`. .fogsettings is SOURCED AS SHELL by root on the next
+# installer run, so a helper that wrote arbitrary key=value pairs into it
+# would be a root shell with extra steps. Hence:
+#
+#  - set-preference takes a key from a three-entry allowlist and a value
+#    matching ^(yes|no)$. Nothing else reaches the file, and the key must
+#    already be present -- this never invents a line, so it cannot move the
+#    category blocks writeUpdateFile() maintains.
+#  - export takes a SLOT NAME, never a path. The slot resolves to a path from
+#    the root-only config, and every slot is a public certificate.
+#  - import-root parses what it was handed before believing any of it, keeps
+#    only the self-signed CA certificates out of it, and writes them to a
+#    canonical path of its own choosing.
+#
+# Modeled on fog-sign-node-cert throughout, including the argument patterns
+# validated before anything touches the filesystem.
+#
+# The one thing NOT here is replacing FOG's own root or its Web CA keypair.
+# That invalidates every fog-client enrollment at once and belongs on a command
+# line where it can be read back before it runs; the page composes the
+# installfog.sh invocation for it instead. See GH-1121.
+
+set -u
+
+CONF="/opt/fog/.fog-pki-admin"
+
+die() { echo "$*" >&2; exit 1; }
+
+[[ $EUID -eq 0 ]] || die "fog-pki-admin must run as root"
+[[ $# -ge 1 ]] || die "usage: fog-pki-admin <status|export|import-root|clear-root|set-preference> [args]"
+
+verb="$1"
+shift
+
+[[ -r $CONF ]] || die "missing $CONF -- re-run the FOG installer"
+# shellcheck disable=SC1090
+. "$CONF"
+
+: "${PKI_STAGING:=}"
+: "${PKI_SETTINGS:=}"
+: "${PKI_ROOT_CERT:=}"
+: "${PKI_ROOT_KEY:=}"
+: "${PKI_WEB_CA_CERT:=}"
+: "${PKI_WEB_CHAIN:=}"
+: "${PKI_WEB_ANCHOR:=}"
+: "${PKI_WEB_VHOST_CERT:=}"
+: "${PKI_WEB_ZONE_DIR:=}"
+: "${PKI_EXTERNAL_ROOT:=}"
+: "${PKI_CLIENT_CERT:=}"
+: "${PKI_SB_CA_CERT:=}"
+: "${PKI_WEB_CA_KEY:=}"
+: "${PKI_WEB_VHOST_KEY:=}"
+: "${PKI_SB_CA_KEY:=}"
+: "${PKI_CLIENT_KEY:=}"
+
+[[ -d $PKI_STAGING ]] || die "staging directory is not configured"
+
+# The three keys this may write, and the only ones it may. Every one is a
+# yes/no install preference -- nothing here names a path, holds a secret, or
+# takes effect without the installer running again.
+#
+# BOOT_url_proto_forced is deliberately absent even though it is the same
+# shape. Forcing netboot to HTTPS with neither steering key set is the case
+# GH-1116 calls "legal but warned": it breaks PXE for machines that have no
+# way to fix themselves, which is the one failure a web form must not be able
+# to cause by a misclick.
+PREF_KEYS="PKI_web_cert_publicly_trusted WEB_https_redirect BOOT_rebuild_ipxe_with_my_ca"
+
+# Where each downloadable slot lives. Public certificates only: this is the
+# whole reason export takes a slot name rather than a path, so adding a
+# private key here would defeat the mechanism rather than extend it.
+slotPath() {
+    case "$1" in
+        root)         printf '%s' "$PKI_ROOT_CERT" ;;
+        webca)        printf '%s' "$PKI_WEB_CA_CERT" ;;
+        webchain)     printf '%s' "$PKI_WEB_CHAIN" ;;
+        anchor)       printf '%s' "$PKI_WEB_ANCHOR" ;;
+        vhost)        printf '%s' "$PKI_WEB_VHOST_CERT" ;;
+        commleaf)     printf '%s' "$PKI_CLIENT_CERT" ;;
+        sbca)         printf '%s' "$PKI_SB_CA_CERT" ;;
+        externalroot) printf '%s' "$PKI_EXTERNAL_ROOT" ;;
+        *)            return 1 ;;
+    esac
+}
+
+# --- JSON emission -----------------------------------------------------------
+#
+# Hand-rolled because the helper must not depend on jq or python being
+# installed on a FOG server; nothing else here needs an interpreter either.
+# Everything escaped is openssl's own output, which is single-line by
+# construction -- the newline and tab cases below are belt and braces for a
+# subject carrying one, not an expected shape.
+jstr() {
+    local s="${1-}"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/}"
+    s="${s//$'\n'/ }"
+    printf '"%s"' "$s"
+}
+jbool() { [[ ${1:-} == 1 ]] && printf 'true' || printf 'false'; }
+
+# Field of an X.509 file, with the "subject="/"issuer=" prefix openssl prints
+# stripped off.
+certField() {
+    local file="$1" what="$2" out
+    shift 2
+    out=$(openssl x509 -in "$file" -noout "-$what" "$@" 2>/dev/null) || return 1
+    printf '%s' "${out#*=}"
+}
+
+# Is this certificate its own issuer -- i.e. a root rather than an intermediate.
+isSelfSigned() {
+    local subj issuer
+    subj=$(openssl x509 -in "$1" -noout -subject 2>/dev/null) || return 1
+    issuer=$(openssl x509 -in "$1" -noout -issuer 2>/dev/null) || return 1
+    [[ -n $subj && ${subj#subject=} == "${issuer#issuer=}" ]]
+}
+
+isCACert() {
+    openssl x509 -in "$1" -noout -text 2>/dev/null \
+        | grep -q 'CA:TRUE'
+}
+
+# Split a PEM bundle into one file per certificate.
+#
+# openssl cannot do this itself: `openssl x509 -in` reads only the FIRST
+# certificate of a bundle and discards the rest with no error and nothing in
+# any log. Same awk as _splitPemBundle() in lib/common/functions.sh, and it is
+# duplicated rather than shared because an installed server has bin/ but no
+# lib/.
+splitBundle() {
+    local src="$1" dir="$2" f found=1
+    [[ -n $src && -f $src && -d $dir ]] || return 1
+    awk -v d="$dir" '/-----BEGIN CERTIFICATE-----/{n++} n{print > (d "/c" n ".pem")}' \
+        "$src" 2>/dev/null
+    for f in "$dir"/c*.pem; do
+        [[ -f $f ]] && { found=0; break; }
+    done
+    return $found
+}
+
+# This host's system trust store, matching _caTrustLayout() in the installer.
+#
+# Re-detected here rather than baked into the config, unlike every path above.
+# The distinction is deliberate: the paths describe THIS FOG INSTALL and can
+# only come from the installer, while the trust store describes the HOST and
+# can change under a distribution upgrade without FOG being re-run. A stale
+# baked-in path would fail silently at the moment it mattered.
+caTrustLayout() {
+    if [[ -d /etc/pki/ca-trust/source/anchors ]] && command -v update-ca-trust >/dev/null 2>&1; then
+        caTrustDir="/etc/pki/ca-trust/source/anchors"
+        caTrustCmd="update-ca-trust extract"
+    elif [[ -d /etc/ca-certificates/trust-source/anchors ]] && command -v trust >/dev/null 2>&1; then
+        caTrustDir="/etc/ca-certificates/trust-source/anchors"
+        caTrustCmd="trust extract-compat"
+    elif [[ -d /usr/local/share/ca-certificates ]] && command -v update-ca-certificates >/dev/null 2>&1; then
+        caTrustDir="/usr/local/share/ca-certificates"
+        caTrustCmd="update-ca-certificates"
+    else
+        return 1
+    fi
+    return 0
+}
+
+# Rebuild pki/web/ca/.trustAnchor.pem.
+#
+# The same three inputs _resolveTrustAnchor() uses -- FOG's root, the root of
+# the web trust chain, and the imported external root -- deduplicated by
+# fingerprint so a FOG-issued install collapses to one certificate.
+#
+# Duplicated from the installer for the reason splitBundle() is: no lib/ on an
+# installed server. tests/pki-admin-helper.test.sh pins the two against each
+# other so they cannot drift into disagreeing about what this box trusts.
+#
+# This half is mandatory: the anchor file is what FOG itself verifies against,
+# so a failure here means the import did not take. Pushing it into the HOST
+# trust store is a separate, best-effort call -- see anchorInHostStore().
+rebuildAnchor() {
+    local out="$PKI_WEB_ANCHOR" tmp seen="" fp chainroot f tmpd
+    [[ -n $out ]] || return 1
+    mkdir -p "$(dirname "$out")" 2>/dev/null || return 1
+    tmp=$(mktemp) || return 1
+
+    if [[ -n $PKI_ROOT_CERT && -f $PKI_ROOT_CERT ]]; then
+        fp=$(openssl x509 -in "$PKI_ROOT_CERT" -noout -fingerprint -sha256 2>/dev/null)
+        if [[ -n $fp ]]; then
+            cat "$PKI_ROOT_CERT" >> "$tmp"
+            seen="${fp}"
+        fi
+    fi
+    # Every self-signed certificate found in the chain and in the imported
+    # root, in that order. Selected by self-signedness rather than by
+    # position, because the writers of these bundles do not agree on order --
+    # see _rootFromChain()'s comment.
+    for f in "$PKI_WEB_CHAIN" "$PKI_EXTERNAL_ROOT"; do
+        [[ -n $f && -f $f ]] || continue
+        tmpd=$(mktemp -d) || continue
+        if splitBundle "$f" "$tmpd"; then
+            for chainroot in "$tmpd"/c*.pem; do
+                [[ -f $chainroot ]] || continue
+                isSelfSigned "$chainroot" || continue
+                fp=$(openssl x509 -in "$chainroot" -noout -fingerprint -sha256 2>/dev/null)
+                [[ -n $fp ]] || continue
+                [[ $seen == *"${fp}"* ]] && continue
+                cat "$chainroot" >> "$tmp"
+                seen="${seen}${fp}"
+            done
+        fi
+        rm -rf "$tmpd"
+    done
+
+    if [[ ! -s $tmp ]]; then
+        rm -f "$tmp"
+        return 1
+    fi
+    { cat "$tmp" > "$out"; } 2>/dev/null || { rm -f "$tmp"; return 1; }
+    chmod 0644 "$out" 2>/dev/null
+    rm -f "$tmp"
+    return 0
+}
+
+# Push the rebuilt anchor into the HOST's system trust store, and say which of
+# three things happened: ok, unavailable (no store on this host), or failed.
+#
+# Reported rather than fatal, matching _installCATrustAnchor(): a server whose
+# trust store could not be updated is still a working server, and failing the
+# import would leave the admin with a certificate they can see on the page and
+# no way to tell what part went wrong.
+#
+# Re-encoded per certificate rather than copied, again as the installer does:
+# Debian's update-ca-certificates reads only *.crt in PEM, and a single-shot
+# `openssl x509 -in` over a bundle would write the first certificate and
+# silently drop the imported root -- which is the entire point of this call.
+anchorInHostStore() {
+    local out="$PKI_WEB_ANCHOR" staged tmpd f st=0
+    [[ -n $out && -s $out ]] || { printf 'trust:failed'; return 0; }
+    caTrustLayout || { printf 'trust:unavailable'; return 0; }
+    staged="${caTrustDir}/.fog-server-ca.crt.$$"
+    tmpd=$(mktemp -d) || { printf 'trust:failed'; return 0; }
+    # Braced: redirections apply left to right, so `: > f 2>/dev/null` still
+    # lets bash print its own "Permission denied" before the 2> takes effect.
+    { : > "$staged"; } 2>/dev/null || st=1
+    if [[ $st -eq 0 ]] && splitBundle "$out" "$tmpd"; then
+        for f in "$tmpd"/c*.pem; do
+            [[ -f $f ]] || continue
+            openssl x509 -in "$f" >> "$staged" 2>/dev/null || st=1
+        done
+    else
+        st=1
+    fi
+    rm -rf "$tmpd"
+    if [[ $st -eq 0 && -s $staged ]]; then
+        chmod 0644 "$staged" 2>/dev/null
+        # A fixed destination filename, so a later import overwrites the
+        # previous anchor rather than leaving a retired CA trusted alongside
+        # its replacement. mv within one directory is atomic, so a re-run
+        # cannot be caught halfway.
+        mv -f "$staged" "${caTrustDir}/fog-server-ca.crt" 2>/dev/null || st=1
+        [[ $st -eq 0 ]] && { $caTrustCmd >/dev/null 2>&1 || st=1; }
+    else
+        st=1
+    fi
+    rm -f "$staged" 2>/dev/null
+    [[ $st -eq 0 ]] && printf 'trust:ok' || printf 'trust:failed'
+    return 0
+}
+
+# Rewrite one .fogsettings key in place.
+#
+# The key must ALREADY be present, and this never appends. writeUpdateFile()
+# maintains the file as category blocks followed by a "## End of FOG Settings"
+# marker and then any lines the installer does not manage; appending a managed
+# key after that marker would put it in the carried-over region, where the next
+# in-place merge treats it as an admin's own line. A server old enough to be
+# missing the key is a server that needs the installer run, and says so.
+#
+# Value quoting matches settingLine()'s exactly, including the single-quote
+# escape, so a line written here is byte-identical in shape to one the
+# installer wrote. Both callers pass a value this script chose -- yes/no from a
+# literal pattern match, or a path out of the root-only config -- so the escape
+# is defense in depth rather than the thing holding the boundary.
+writeSetting() {
+    local key="$1" value="$2" tmp
+    [[ -n $PKI_SETTINGS && -f $PKI_SETTINGS && -w $PKI_SETTINGS ]] || return 1
+    grep -q "^${key}=" "$PKI_SETTINGS" 2>/dev/null || return 1
+    tmp=$(mktemp) || return 1
+    if ! wkey="$key" wval="$value" awk '
+        BEGIN {
+            k = ENVIRON["wkey"]
+            v = ENVIRON["wval"]
+            gsub(/\047/, "\047\\\047\047", v)
+            line = k "=\047" v "\047"
+        }
+        {
+            eq = index($0, "=")
+            if (eq && substr($0, 1, eq - 1) == k) {
+                if (!seen) { print line; seen = 1 }
+                next
+            }
+            print
+        }
+    ' "$PKI_SETTINGS" > "$tmp"; then
+        rm -f "$tmp"
+        return 1
+    fi
+    [[ -s $tmp ]] || { rm -f "$tmp"; return 1; }
+    # Written through the existing inode rather than moved over it, so the
+    # 0600 root:root mode and any ACL survive a helper that never has to
+    # remember to reapply them.
+    cat "$tmp" > "$PKI_SETTINGS" || { rm -f "$tmp"; return 1; }
+    rm -f "$tmp"
+    return 0
+}
+
+# Record (or clear) the imported external root. Separate from set-preference
+# because this is a PATH rather than one of the three yes/no preferences, and
+# because it is never caller-influenced: the only two values it is ever handed
+# are $PKI_EXTERNAL_ROOT from the root-only config, and the empty string.
+setPreferencePath() {
+    writeSetting PKI_web_external_root_cert "$1"
+}
+
+# Read one .fogsettings key without sourcing the file. Sourcing it here would
+# run whatever an admin has hand-written into it as root, in a script the web
+# user can start.
+readSetting() {
+    local key="$1" line
+    [[ -n $PKI_SETTINGS && -r $PKI_SETTINGS ]] || return 1
+    line=$(grep -m1 "^${key}=" "$PKI_SETTINGS" 2>/dev/null) || return 1
+    line="${line#*=}"
+    line="${line#\'}"
+    line="${line%\'}"
+    printf '%s' "$line"
+}
+
+case "$verb" in
+
+status)
+    [[ $# -eq 0 ]] || die "usage: fog-pki-admin status"
+
+    # Every value below is public: subjects, validity dates and fingerprints
+    # of certificates FOG either publishes already or hands to any client that
+    # connects. The two booleans say whether a private key is PRESENT, never
+    # anything about its contents.
+    printf '{\n'
+    printf '  "certificates": [\n'
+    first=1
+    for slot in root webca webchain anchor vhost commleaf sbca externalroot; do
+        path=$(slotPath "$slot") || continue
+        [[ $first -eq 1 ]] || printf ',\n'
+        first=0
+        printf '    {"slot": %s, "path": %s' "$(jstr "$slot")" "$(jstr "$path")"
+        if [[ -n $path && -f $path ]] && certField "$path" subject >/dev/null 2>&1; then
+            selfsigned=0; isSelfSigned "$path" && selfsigned=1
+            printf ', "present": true'
+            printf ', "subject": %s' "$(jstr "$(certField "$path" subject)")"
+            printf ', "issuer": %s' "$(jstr "$(certField "$path" issuer)")"
+            printf ', "not_before": %s' "$(jstr "$(certField "$path" startdate)")"
+            printf ', "not_after": %s' "$(jstr "$(certField "$path" enddate)")"
+            printf ', "sha256": %s' "$(jstr "$(certField "$path" fingerprint -sha256)")"
+            printf ', "self_signed": %s' "$(jbool $selfsigned)"
+            # A bundle is normal for webchain, anchor and externalroot, and
+            # the count is the only thing on this page that would show an
+            # imported root silently failing to land.
+            printf ', "count": %s' "$(grep -c 'BEGIN CERTIFICATE' "$path" 2>/dev/null || echo 0)"
+        else
+            printf ', "present": false'
+        fi
+        printf '}'
+    done
+    printf '\n  ],\n'
+
+    # Derived, never persisted. GH-1120 retired the acmeLeaf key precisely
+    # because a flag and the filesystem could disagree; the test is whether
+    # the canonical vhost path resolves outside the web zone.
+    managed=0
+    if [[ -n $PKI_WEB_VHOST_CERT && -n $PKI_WEB_ZONE_DIR ]]; then
+        target=$(readlink -f "$PKI_WEB_VHOST_CERT" 2>/dev/null)
+        zonedir=$(readlink -f "$PKI_WEB_ZONE_DIR" 2>/dev/null)
+        if [[ -n $target && -n $zonedir && $target != "$zonedir"/* ]]; then
+            managed=1
+        fi
+    fi
+    printf '  "externally_managed_leaf": %s,\n' "$(jbool $managed)"
+
+    rootkey=0
+    [[ -n $PKI_ROOT_KEY && -f $PKI_ROOT_KEY ]] && rootkey=1
+    printf '  "root_key_on_server": %s,\n' "$(jbool $rootkey)"
+
+    # The PATHS of the private keys, and nothing else about them.
+    #
+    # The page tests readability itself, with the web server's own
+    # credentials, because that is the only test that answers the question it
+    # is asking -- PHP is the threat model, and this helper runs as root, so
+    # "root can read it" proves nothing. All this does is say where to look,
+    # which the page used to hardcode against a layout the zone split retired.
+    #
+    # expect_readable is not a nicety. The client communication key IS meant to
+    # be readable by the web user (0640 root:$apacheuser in a 0710 directory) --
+    # FOGBase::certDecrypt() opens it on every fog-client handshake -- so a page
+    # that flagged every readable key would report the correct configuration as
+    # a breach on every install. The vhost key inherits the flag from the leaf
+    # being managed elsewhere, because _hardenPkiPermissions() deliberately
+    # leaves that one alone: an ACME renewal writes it as whatever user its
+    # hook runs as.
+    printf '  "private_keys": [\n'
+    first=1
+    while IFS='|' read -r label path expect; do
+        [[ -n $path ]] || continue
+        [[ $first -eq 1 ]] || printf ',\n'
+        first=0
+        printf '    {"label": %s, "path": %s, "expect_readable": %s}' \
+            "$(jstr "$label")" "$(jstr "$path")" "$(jbool "$expect")"
+    done <<EOF
+CA private key|${PKI_ROOT_KEY}|0
+Web CA private key|${PKI_WEB_CA_KEY}|0
+Web server private key|${PKI_WEB_VHOST_KEY}|${managed}
+Secure Boot CA private key|${PKI_SB_CA_KEY}|0
+Client communication private key|${PKI_CLIENT_KEY}|1
+EOF
+    printf '\n  ],\n'
+
+    store=0; storedir=""; anchored=0
+    if caTrustLayout; then
+        store=1
+        storedir="$caTrustDir"
+        [[ -f "${caTrustDir}/fog-server-ca.crt" ]] && anchored=1
+    fi
+    printf '  "trust_store": {"available": %s, "directory": %s, "anchored": %s},\n' \
+        "$(jbool $store)" "$(jstr "$storedir")" "$(jbool $anchored)"
+
+    printf '  "preferences": {'
+    first=1
+    for key in $PREF_KEYS; do
+        [[ $first -eq 1 ]] || printf ', '
+        first=0
+        printf '%s: %s' "$(jstr "$key")" "$(jstr "$(readSetting "$key")")"
+    done
+    printf '}\n'
+    printf '}\n'
+    ;;
+
+export)
+    [[ $# -eq 2 ]] || die "usage: fog-pki-admin export <slot> <request-id>"
+    slot="$1"
+    reqid="$2"
+    # Validated before use, not after. A request id reaching the filesystem
+    # unchecked is a path traversal into whatever the web user can write.
+    [[ $reqid =~ ^[a-f0-9]{32}$ ]] || die "malformed request id"
+    path=$(slotPath "$slot") || die "unknown certificate slot"
+    [[ -n $path && -f $path ]] || die "the ${slot} certificate is not present on this server"
+
+    out="${PKI_STAGING}/${reqid}.pem"
+    rm -f "$out"
+    # Re-emitted through openssl per certificate rather than copied, so what
+    # leaves here is certainly a certificate and certainly nothing else. A
+    # slot whose path an earlier install pointed at a bundle, or at a file
+    # with a key appended, cannot leak the extra bytes.
+    tmpd=$(mktemp -d) || die "could not create a temporary directory"
+    trap 'rm -rf "$tmpd"' EXIT
+    splitBundle "$path" "$tmpd" || die "no certificate found in the ${slot} slot"
+    { : > "$out"; } 2>/dev/null || die "could not write to the staging directory"
+    for f in "$tmpd"/c*.pem; do
+        [[ -f $f ]] || continue
+        openssl x509 -in "$f" >> "$out" 2>/dev/null || true
+    done
+    [[ -s $out ]] || { rm -f "$out"; die "the ${slot} slot did not parse as a certificate"; }
+    chmod 0644 "$out"
+    echo "OK"
+    ;;
+
+import-root)
+    [[ $# -eq 1 ]] || die "usage: fog-pki-admin import-root <request-id>"
+    reqid="$1"
+    [[ $reqid =~ ^[a-f0-9]{32}$ ]] || die "malformed request id"
+    src="${PKI_STAGING}/${reqid}.pem"
+    [[ -f $src ]] || die "no certificate at ${src}"
+    [[ -n $PKI_EXTERNAL_ROOT ]] || die "no external root path is configured -- re-run the FOG installer"
+
+    # Everything below runs before a byte is written anywhere the server
+    # reads. What arrives here came off a browser upload, so it is treated as
+    # a blob that claims to be a certificate rather than as one.
+    tmpd=$(mktemp -d) || die "could not create a temporary directory"
+    trap 'rm -rf "$tmpd"' EXIT
+    splitBundle "$src" "$tmpd" || die "that file contains no PEM certificate"
+
+    keep="${tmpd}/keep.pem"
+    : > "$keep"
+    kept=0
+    for f in "$tmpd"/c*.pem; do
+        [[ -f $f ]] || continue
+        openssl x509 -in "$f" -noout >/dev/null 2>&1 || die "that file contains something that is not a certificate"
+        # Only self-signed CA certificates are kept. An intermediate in the
+        # bundle is dropped rather than anchored: adding one to the host trust
+        # store would trust it as a root, which is a real widening of what
+        # this box accepts and is never what "import our corporate root" means.
+        isSelfSigned "$f" || continue
+        isCACert "$f" || die "a self-signed certificate in that file is not a CA (basicConstraints CA:TRUE is missing)"
+        openssl x509 -in "$f" -noout -checkend 0 >/dev/null 2>&1 \
+            || die "the CA certificate in that file has already expired"
+        cat "$f" >> "$keep"
+        kept=$((kept + 1))
+    done
+    [[ $kept -gt 0 ]] || die "that file contains no self-signed CA certificate -- a root CA is what this expects, not an intermediate or a server certificate"
+
+    install -o root -g root -m 0644 "$keep" "$PKI_EXTERNAL_ROOT" 2>/dev/null \
+        || die "could not write ${PKI_EXTERNAL_ROOT}"
+
+    # Recorded as the canonical path, not as wherever the admin's file came
+    # from. --ca-root persists the SOURCE path, which is routinely a temp file
+    # that is gone by the next installer run; the copy above is what makes the
+    # setting still mean something a year later.
+    setPreferencePath "$PKI_EXTERNAL_ROOT" || die "could not record the imported root in .fogsettings"
+
+    rebuildAnchor || die "the certificate was imported but the trust anchor could not be rebuilt"
+    # The trust-store outcome rides on the success line rather than failing the
+    # verb, so the page can say "imported, but this host's store was not
+    # updated" instead of "import failed" over a certificate that did land.
+    echo "OK ${kept} $(anchorInHostStore)"
+    ;;
+
+clear-root)
+    [[ $# -eq 0 ]] || die "usage: fog-pki-admin clear-root"
+    [[ -n $PKI_EXTERNAL_ROOT ]] || die "no external root path is configured"
+    rm -f "$PKI_EXTERNAL_ROOT"
+    setPreferencePath "" || die "could not clear the imported root in .fogsettings"
+    rebuildAnchor || die "the certificate was removed but the trust anchor could not be rebuilt"
+    echo "OK 0 $(anchorInHostStore)"
+    ;;
+
+set-preference)
+    [[ $# -eq 2 ]] || die "usage: fog-pki-admin set-preference <key> <yes|no>"
+    key="$1"
+    value="$2"
+    ok=0
+    for k in $PREF_KEYS; do [[ $k == "$key" ]] && ok=1; done
+    [[ $ok -eq 1 ]] || die "not a settable preference: ${key}"
+    # The whole security argument for this verb. .fogsettings is sourced as
+    # shell by root, so the value is matched against a literal pattern rather
+    # than quoted and hoped over.
+    [[ $value =~ ^(yes|no)$ ]] || die "value must be yes or no"
+    writeSetting "$key" "$value" || die "could not update ${key} in .fogsettings"
+    echo "OK"
+    ;;
+
+*)
+    die "unknown verb: ${verb}"
+    ;;
+esac

--- a/packages/pki/renewal-helper
+++ b/packages/pki/renewal-helper
@@ -96,14 +96,19 @@ elif [[ -r /etc/fog/fog.conf ]]; then
     [[ -r "${fogprogramdir}/.fogsettings" ]] && . "${fogprogramdir}/.fogsettings"
 fi
 : "${fogprogramdir:=/opt/fog}"
+# Where the four-zone tree physically lives. .fogsettings records it
+# (PKI_root_dir); a file written before the tree moved to /etc/fog/pki has no
+# such line, and the historic name is a symlink to the new one, so the fallback
+# resolves either way.
+: "${pkiroot:=${PKI_root_dir:-${fogprogramdir}/pki}}"
 # The shared openssl config both issuing zones read. Moved out of
 # $snapindir/ssl with the client keypair; installfog.sh's _pkiConfDir is the
 # authority on this path.
-: "${pkiconfdir:=${fogprogramdir}/pki/conf}"
+: "${pkiconfdir:=${pkiroot}/conf}"
 
 _reissueWeb() {
-    local key="${PKI_web_vhost_key:-${fogprogramdir}/pki/web/leaf/.webLeaf.key}"
-    local cert="${PKI_web_vhost_cert:-${fogprogramdir}/pki/web/leaf/.webLeaf.pem}"
+    local key="${PKI_web_vhost_key:-${pkiroot}/web/leaf/.webLeaf.key}"
+    local cert="${PKI_web_vhost_cert:-${pkiroot}/web/leaf/.webLeaf.pem}"
     local cakey="${PKI_web_ca_key:-}" capem="${PKI_web_ca_cert:-}"
     # "Is this leaf mine?" is a question for the filesystem, not a stored key.
     # GH-1120 retired acmeLeaf for exactly the reason it mattered here: it had to
@@ -111,7 +116,7 @@ _reissueWeb() {
     # resolving outside the web zone IS the signal -- the same test
     # _externallyManagedLeaf() makes in the installer.
     local zonedir target
-    zonedir="$(readlink -f "${fogprogramdir}/pki/web" 2>/dev/null)"
+    zonedir="$(readlink -f "${pkiroot}/web" 2>/dev/null)"
     target="$(readlink -f "$cert" 2>/dev/null)"
     if [[ -n $zonedir && -n $target && $target != "$zonedir"/* ]]; then
         echo "Refusing: this web certificate is managed outside FOG." >&2
@@ -164,7 +169,7 @@ _reissueWeb() {
     # writes with BOTH the FOG root and an external root where there is one --
     # so this verifies on an external-CA install too, where PKI_root_ca_cert
     # alone cannot complete the chain.
-    local anchor="${fogprogramdir}/pki/web/ca/.trustAnchor.pem"
+    local anchor="${pkiroot}/web/ca/.trustAnchor.pem"
     [[ -f $anchor ]] || anchor="${PKI_root_ca_cert:-}"
     if [[ -n ${PKI_web_trust_chain:-} && -f ${PKI_web_trust_chain} && -n $anchor ]] && \
         ! openssl verify -CAfile "$anchor" -untrusted "${PKI_web_trust_chain}" "$cert" >/dev/null 2>&1; then
@@ -186,8 +191,8 @@ _reissueWeb() {
 }
 
 _reissueSecureBoot() {
-    local cadir="${fogprogramdir}/pki/secureboot/ca"
-    local leafdir="${fogprogramdir}/pki/secureboot/leaf"
+    local cadir="${pkiroot}/secureboot/ca"
+    local leafdir="${pkiroot}/secureboot/leaf"
     if [[ ! -f "${cadir}/.fogSBCA.pem" ]]; then
         echo "No Secure Boot intermediate CA on this server (expected:" >&2
         echo "  ${cadir}/.fogSBCA.pem )." >&2

--- a/packages/web/management/js/fog/about/fog.about.certificates.js
+++ b/packages/web/management/js/fog/about/fog.about.certificates.js
@@ -1,0 +1,79 @@
+/**
+ * The Certificates page: import a root CA, remove one, set the three install
+ * preferences.
+ *
+ * Everything here posts to ?node=about&sub=certificates, which Authorization
+ * gates on system.pki for POST and settings.view for GET. A viewer without the
+ * grant is served the same page with the controls absent, so nothing below
+ * needs to reason about permissions -- the elements simply are not there.
+ *
+ * The downloads are plain links and deliberately have no JavaScript: they are
+ * ordinary GETs that stream a file, so a middle-click or a right-click-save
+ * behaves the way an administrator expects.
+ */
+(function($) {
+  var rootForm = $('#pki-root-form'),
+    importBtn = $('#pki-import-root'),
+    clearBtn = $('#pki-clear-root');
+
+  rootForm.on('submit', function(e) {
+    e.preventDefault();
+  });
+
+  importBtn.on('click', function(e) {
+    e.preventDefault();
+    // processForm builds a FormData from the form element itself, which is
+    // what carries the uploaded file and the hidden action field together.
+    rootForm.processForm(function(err) {
+      if (err) {
+        return;
+      }
+      // Reload rather than patch the card in place: an import changes the
+      // chain table, the trust-anchor bundle's certificate count and whether
+      // the Remove button exists. Re-rendering by hand would be three places
+      // to keep in step with the server's own view of the same thing.
+      location.reload();
+    });
+  });
+
+  clearBtn.on('click', function(e) {
+    e.preventDefault();
+    if (!window.confirm(
+      'Stop trusting the imported root CA on this server?'
+    )) {
+      return;
+    }
+    clearBtn.prop('disabled', true);
+    $.apiCall('post', rootForm.attr('action'), {action: 'clearRoot'},
+      function(err) {
+        clearBtn.prop('disabled', false);
+        if (err) {
+          return;
+        }
+        location.reload();
+      });
+  });
+
+  // One handler for all three switches. Each posts only its own key, so two
+  // administrators changing different preferences cannot overwrite each
+  // other's -- the helper rewrites a single line of .fogsettings per call.
+  $('.pki-pref').on('change', function() {
+    var box = $(this),
+      wanted = box.prop('checked');
+    box.prop('disabled', true);
+    $.apiCall('post', box.data('action'), {
+      action: 'setPreference',
+      key: box.data('key'),
+      value: wanted ? 1 : ''
+    }, function(err) {
+      box.prop('disabled', false);
+      if (err) {
+        // Put the control back to what the server still holds. Leaving it
+        // showing the rejected value is the worse failure here: the whole
+        // point of the card is to say what the next installer run will do,
+        // and a switch that lies about that is worse than no switch.
+        box.prop('checked', !wanted);
+      }
+    });
+  });
+})(jQuery);

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -111,6 +111,10 @@ msgid "%d architecture(s) updated."
 msgstr "Drucker aktualisiert!"
 
 #, php-format
+msgid "%d certificates in this file"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -419,6 +423,9 @@ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 msgid "A role with this name already exists!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden."
 
+msgid "A root CA uploaded on this page. Absent unless one was imported."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "Ein Gruppenname ist erforderlich!"
@@ -500,6 +507,9 @@ msgstr "Dieser Benutzername ist bereits vorhanden!"
 
 msgid "A valid database connection could not be made"
 msgstr "Eine gültige Datenbankverbindung konnte nicht hergestellt werden"
+
+msgid "A worked example of the first one, end to end:"
+msgstr ""
 
 #, fuzzy
 msgid "API"
@@ -1320,10 +1330,6 @@ msgstr "Neuen Standort erstellen"
 msgid "CA Path"
 msgstr "Pfad"
 
-#, fuzzy
-msgid "CA private key"
-msgstr "Privater Schlüssel ist fehlgeschlagen"
-
 msgid "CPU Cache"
 msgstr "CPU-Cache"
 
@@ -1539,6 +1545,10 @@ msgstr "Neueste Version"
 msgid "Catch-All Site"
 msgstr ""
 
+#, fuzzy
+msgid "Certificate"
+msgstr "Neuen Standort erstellen"
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1552,6 +1562,18 @@ msgstr "Neuen Standort erstellen"
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "Neuen Standort erstellen"
+
+#, fuzzy
+msgid "Certificate change failed"
+msgstr "Neuen Standort erstellen"
+
+#, fuzzy
+msgid "Certificate download failed"
+msgstr "Download fehlgeschlagen"
+
+#, fuzzy
+msgid "Certificate management is not configured on this server"
+msgstr "Es gibt keine Images auf diesem Server."
 
 #, fuzzy
 msgid "Certificates"
@@ -1683,6 +1705,9 @@ msgstr "Client Einstellungen"
 #, fuzzy
 msgid "Client Version"
 msgstr "Client-Version"
+
+msgid "Client communication certificate"
+msgstr ""
 
 msgid "Clients already enforcing Secure Boot cannot run this task -- they will not boot FOS in the first place. Use the manual steps below for those."
 msgstr ""
@@ -1875,9 +1900,17 @@ msgstr "Tmp-Datei konnte nicht gelesen werden."
 msgid "Could not register"
 msgstr "Konnte nicht registriert werden."
 
+#, fuzzy
+msgid "Could not remove the imported root"
+msgstr "Tmp-Datei konnte nicht gelesen werden."
+
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
+
+#, fuzzy
+msgid "Could not save that preference"
+msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 msgid "Could not seed the granted targets"
@@ -1889,6 +1922,10 @@ msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 msgid "Could not stage the upload."
+msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
+msgid "Could not stage the uploaded certificate"
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
@@ -2122,6 +2159,10 @@ msgstr "Aktuelle Datensätze"
 
 msgid "Current member-host AD state"
 msgstr ""
+
+#, fuzzy
+msgid "Currently imported"
+msgstr "Aktuelle Datensätze"
 
 msgid "DMI Field"
 msgstr ""
@@ -2488,6 +2529,9 @@ msgstr "Dauer"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgstr ""
+
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -2689,6 +2733,9 @@ msgstr "Bestehendes Objekt muss boolean sein"
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
 
+msgid "Expires"
+msgstr ""
+
 msgid "Export"
 msgstr "Export"
 
@@ -2754,6 +2801,9 @@ msgstr "Windows-Schlüssel exportieren"
 #, fuzzy
 msgid "Export the database"
 msgstr "Datenbank importieren"
+
+msgid "External root CA"
+msgstr ""
 
 msgid "FOG"
 msgstr "FOG"
@@ -4347,6 +4397,10 @@ msgid "Import known mac address makers"
 msgstr ""
 
 #, fuzzy
+msgid "Imported root"
+msgstr "Berichte importieren"
+
+#, fuzzy
 msgid "Imported successfully!"
 msgstr "iPXE-Einstellungen erfolgreich aktualisiert!"
 
@@ -4420,6 +4474,10 @@ msgstr "Plugins installieren"
 #, fuzzy
 msgid "Install plugins failed!"
 msgstr "Plugins installieren"
+
+#, fuzzy
+msgid "Install preferences"
+msgstr "Ausgewählte löschen"
 
 #, fuzzy
 msgid "Install selected"
@@ -4984,6 +5042,9 @@ msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
 msgid "Legacy BIOS (no Secure Boot)"
+msgstr ""
+
+msgid "Let's Encrypt with FOG"
 msgstr ""
 
 msgid "Level"
@@ -5726,6 +5787,10 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr "Keine Datei wurde hochgeladen"
 
+#, fuzzy
+msgid "No certificate file was uploaded"
+msgstr "Keine Datei wurde hochgeladen"
+
 msgid "No change"
 msgstr ""
 
@@ -5750,6 +5815,9 @@ msgid "No database to work off"
 msgstr "Keine Datenbank zum Arbeiten"
 
 msgid "No external data to download the file from"
+msgstr ""
+
+msgid "No external root is imported on this server."
 msgstr ""
 
 msgid "No fields passed"
@@ -6017,6 +6085,9 @@ msgstr ""
 msgid "Not allowed here"
 msgstr "Hier nicht erlaubt"
 
+msgid "Not offered here, on purpose"
+msgstr ""
+
 #, fuzzy
 msgid "Not pinged"
 msgstr "Nicht synchronisieren"
@@ -6139,6 +6210,9 @@ msgstr ""
 msgid "Off - direct membership only"
 msgstr ""
 
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgstr ""
+
 #, fuzzy
 msgid "Offered to every user on this grid."
 msgstr "Dies ist nicht die primäre Gruppe"
@@ -6207,6 +6281,9 @@ msgid "Only an administrator may grant full access."
 msgstr "Admingruppe"
 
 msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
+msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
 msgstr ""
 
 msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
@@ -6713,6 +6790,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preference saved"
+msgstr ""
+
 msgid "Preferences"
 msgstr ""
 
@@ -6832,6 +6912,9 @@ msgstr "Private Schlüssel nicht lesbar"
 
 msgid "Private key path not found"
 msgstr "Privater Schlüsselpfad nicht gefunden"
+
+msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
+msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -6993,6 +7076,9 @@ msgstr "Neustarten"
 msgid "Reboot after deploy"
 msgstr "wurde abgeschlossen"
 
+msgid "Rebuild iPXE with this server's CA embedded"
+msgstr ""
+
 msgid "Receive"
 msgstr "Erhalten"
 
@@ -7014,6 +7100,9 @@ msgstr "Datensatz wurde nicht gefunden, Fehler: %s"
 #, fuzzy
 msgid "Records"
 msgstr "Aktuelle Datensätze"
+
+msgid "Redirect HTTP to HTTPS"
+msgstr ""
 
 msgid "Redirect Login To This Provider"
 msgstr ""
@@ -7087,6 +7176,10 @@ msgid "Remove file data"
 msgstr "Entfernen fehlgeschlagen"
 
 #, fuzzy
+msgid "Remove imported root"
+msgstr "Entfernen fehlgeschlagen"
+
+#, fuzzy
 msgid "Remove selected"
 msgstr "Ausgewählte entfernen "
 
@@ -7124,6 +7217,9 @@ msgstr ""
 
 #, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
+msgstr ""
+
+msgid "Replacing the root itself -- so that FOG's anchor becomes an intermediate of yours -- is a migration rather than a setting. It changes the certificate every registered fog-client pins, so every one of them stops authenticating until it is re-pinned. That is not something a web form should be able to do in one click, so it is not on this page."
 msgstr ""
 
 #, fuzzy
@@ -7294,6 +7390,21 @@ msgstr ""
 msgid "Roles"
 msgstr ""
 
+msgid "Root"
+msgstr ""
+
+#, fuzzy
+msgid "Root CA certificate (PEM)"
+msgstr "Neuen Standort erstellen"
+
+#, fuzzy
+msgid "Root imported"
+msgstr "(empfohlen)"
+
+#, fuzzy
+msgid "Root removed"
+msgstr "Entfernt"
+
 msgid "Row"
 msgstr "Zeile"
 
@@ -7385,6 +7496,9 @@ msgid "Save the site before setting catch-all"
 msgstr ""
 
 msgid "Saved filters for one grid"
+msgstr ""
+
+msgid "Saved. It takes effect the next time the installer runs."
 msgstr ""
 
 #, fuzzy
@@ -7525,7 +7639,7 @@ msgstr ""
 msgid "Secure Boot (reported)"
 msgstr ""
 
-msgid "Secure Boot CA private key"
+msgid "Secure Boot CA"
 msgstr ""
 
 msgid "Secure Boot Enrolled"
@@ -7804,6 +7918,12 @@ msgstr ""
 #, fuzzy
 msgid "Signs In With"
 msgstr "Snapin läuft mit"
+
+msgid "Signs the FOS kernel signing certificate. Not a web certificate."
+msgstr ""
+
+msgid "Signs the web server certificate and every storage node certificate."
+msgstr ""
 
 #, fuzzy
 msgid "Single Logout"
@@ -8801,6 +8921,14 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That certificate is not available on this server."
+msgstr "Es gibt keine Gruppen auf diesem Server."
+
+#, fuzzy
+msgid "That file is too large to be a root CA certificate"
+msgstr "konnte nicht gespeichert werden"
+
+#, fuzzy
 msgid "That filter is too large to save"
 msgstr "konnte nicht gespeichert werden"
 
@@ -8944,6 +9072,17 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
+#, fuzzy
+msgid "The certificate chain"
+msgstr "Neuen Standort erstellen"
+
+msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
+msgstr ""
+
+#, fuzzy
+msgid "The certificate was refused"
+msgstr "Keine Datei wurde hochgeladen"
+
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
@@ -9023,6 +9162,9 @@ msgstr "Der einer/mehrere Speichergruppen zugeordnete Speicherknoten ist ungült
 
 msgid "The image storage group assigned is not valid"
 msgstr "Die zugewiesene Image Speichergruppe ist nicht gültig."
+
+msgid "The imported root CA has been removed."
+msgstr ""
 
 #, fuzzy
 msgid "The installers for the fog client"
@@ -9109,7 +9251,16 @@ msgstr ""
 msgid "The provider returned a configuration for a different issuer"
 msgstr ""
 
+msgid "The public half of the keypair fog-client encrypts its check-in to."
+msgstr ""
+
 msgid "The resource is not in a cancellable state."
+msgstr ""
+
+msgid "The root CA has been imported and this server now trusts it."
+msgstr ""
+
+msgid "The root CA has been imported, but this host's system trust store could not be updated -- so HTTPS calls made on this server will not accept it yet. Re-run the installer, and check the installation log."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."
@@ -9148,6 +9299,9 @@ msgstr "Der einer/mehrere Speichergruppen zugeordnete Speicherknoten ist ungült
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
+msgid "The trust anchor. Every fog-client pins this one."
+msgstr ""
+
 msgid "The upload did not arrive."
 msgstr ""
 
@@ -9167,6 +9321,9 @@ msgid "The uploaded file was only partially uploaded"
 msgstr "Die hochgeladene Datei wurde nur teilweise hochgeladen"
 
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
+msgstr ""
+
+msgid "The web certificate chains to a public CA"
 msgstr ""
 
 msgid "Theme"
@@ -9228,6 +9385,9 @@ msgstr "Dort können Sie Tools wie FOG Prep, "
 msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
 msgstr ""
 
+msgid "These decide what the NEXT installer run does. Nothing here takes effect until the installer runs again -- this page records the preference, it does not rewrite the web server configuration or reissue a certificate."
+msgstr ""
+
 #, php-format
 msgid "These plugins are still installed on disk, so forgetting them would achieve nothing: %s. Uninstall them instead."
 msgstr ""
@@ -9252,6 +9412,9 @@ msgstr ""
 msgid "This document"
 msgstr ""
 
+msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
 msgid "This endpoint only accepts POST."
 msgstr ""
 
@@ -9269,6 +9432,9 @@ msgstr ""
 
 #, php-format
 msgid "This host has finished deploying image %s."
+msgstr ""
+
+msgid "This host has no system trust store that FOG recognizes, so an imported root is recorded and re-applied but never reaches the host's own HTTPS clients."
 msgstr ""
 
 msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
@@ -9334,6 +9500,9 @@ msgstr ""
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
 msgstr ""
 
+msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9371,6 +9540,9 @@ msgid "This server's hostname, as its certificate names it."
 msgstr ""
 
 msgid "This server's own IP address. Space-separated when the interface carries more than one."
+msgstr ""
+
+msgid "This server's web certificate already resolves outside FOG's own PKI, so FOG treats it as managed elsewhere and will not reissue it or lock its key down, whatever these say. That is derived from where the certificate actually is, not from a setting, so the two cannot disagree."
 msgstr ""
 
 msgid "This servers ip(s)"
@@ -9469,6 +9641,9 @@ msgstr ""
 msgid "To get started please select an item from the menu."
 msgstr "Um zu beginnen, wählen Sie bitte ein Element aus dem Menü."
 
+msgid "To have your own CA issue FOG's web certificates, import the CA and its key by re-running the installer. That replaces the CA that signs the web server certificate and the storage node certificates -- and only that. The root fog-client pins is left alone, so no client re-enrolls."
+msgstr ""
+
 msgid "Toggle Dropdown"
 msgstr ""
 
@@ -9530,6 +9705,9 @@ msgstr ""
 msgid "Trust anchor"
 msgstr ""
 
+msgid "Trust anchor bundle"
+msgstr ""
+
 msgid "Trusted Node CIDRs"
 msgstr ""
 
@@ -9540,6 +9718,9 @@ msgstr "Versuche Snapin-Hash für"
 #, fuzzy
 msgid "Trying image size for"
 msgstr "Versuche Imagegröße für"
+
+msgid "Turn this on for a Let's Encrypt or purchased certificate. It stops FOG re-issuing the leaf, stops it locking the private key to root -- which would break the renewal that writes it -- and steers netboot to HTTPS with no iPXE rebuild, because upstream iPXE cross-certifies public CAs already."
+msgstr ""
 
 msgid "Two routes are covered in the guide linked above: a live USB with the kit above, or PXE-booting the client and choosing Enroll Secure Boot Key, which now fetches MOK.der over the network on its own, with no USB stick needed."
 msgstr ""
@@ -9697,6 +9878,10 @@ msgstr "Unbekannt"
 msgid "Unknown DB error"
 msgstr "Ein unbekannter Upload-Fehler ist aufgetreten"
 
+#, fuzzy
+msgid "Unknown action"
+msgstr "Ein unbekannter Upload-Fehler ist aufgetreten"
+
 #, php-format
 msgid "Unknown field for %s: %s"
 msgstr ""
@@ -9810,6 +9995,9 @@ msgstr "Berichte hochladen"
 
 msgid "Upload Reports"
 msgstr "Berichte hochladen"
+
+msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"
 msgstr ""
@@ -10080,10 +10268,17 @@ msgstr ""
 msgid "Using the group match function"
 msgstr "Verwenden der Gruppenübereinstimmungsfunktion,"
 
+msgid "Using your own PKI"
+msgstr ""
+
 msgid "VB Script"
 msgstr ""
 
 msgid "VNC"
+msgstr ""
+
+#, php-format
+msgid "Valid until %s."
 msgstr ""
 
 msgid "Value"
@@ -10149,13 +10344,19 @@ msgstr "Wir sind Knotenname "
 msgid "We cannot connect to LDAP server"
 msgstr "Es kann keine Verbindung zum LDAP-Server hergestellt werden."
 
-msgid "Web CA private key"
+msgid "Web CA"
+msgstr ""
+
+msgid "Web CA plus the root that anchors it -- what a client needs to verify this server."
 msgstr ""
 
 msgid "Web Server"
 msgstr "Web-Server"
 
-msgid "Web server private key"
+msgid "Web server certificate"
+msgstr ""
+
+msgid "Web trust chain"
 msgstr ""
 
 msgid "Weekly"
@@ -10170,6 +10371,12 @@ msgstr ""
 #, fuzzy
 msgid "What gets enrolled"
 msgstr "wurde abgebrochen"
+
+msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
+msgstr ""
+
+msgid "What this server itself trusts: FOG's root, plus any root imported below."
+msgstr ""
 
 msgid "What to do next"
 msgstr ""
@@ -11502,6 +11709,10 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Änderungen speichern?"
 
+#, fuzzy
+#~ msgid "CA private key"
+#~ msgstr "Privater Schlüssel ist fehlgeschlagen"
+
 #~ msgid "Can not redeclare route"
 #~ msgstr "Route kann nicht nochmal neu definiert werden"
 
@@ -11736,10 +11947,6 @@ msgstr ""
 
 #~ msgid "Import Printers"
 #~ msgstr "Drucker importieren"
-
-#, fuzzy
-#~ msgid "Import Report"
-#~ msgstr "Berichte importieren"
 
 #, fuzzy
 #~ msgid "Import Reports"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -116,6 +116,10 @@ msgid "%d architecture(s) updated."
 msgstr "Printer updated!"
 
 #, php-format
+msgid "%d certificates in this file"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -424,6 +428,9 @@ msgstr "An image already exists with this name!"
 msgid "A role with this name already exists!"
 msgstr "A hostname with that name already exists."
 
+msgid "A root CA uploaded on this page. Absent unless one was imported."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "An image name is required!"
@@ -504,6 +511,9 @@ msgid "A username already exists with this name!"
 msgstr "An image already exists with this name!"
 
 msgid "A valid database connection could not be made"
+msgstr ""
+
+msgid "A worked example of the first one, end to end:"
 msgstr ""
 
 msgid "API"
@@ -1324,10 +1334,6 @@ msgstr "Create New %s"
 msgid "CA Path"
 msgstr "Path"
 
-#, fuzzy
-msgid "CA private key"
-msgstr "Private key failed"
-
 msgid "CPU Cache"
 msgstr "CPU Cache"
 
@@ -1542,6 +1548,10 @@ msgstr "Latest Version"
 msgid "Catch-All Site"
 msgstr ""
 
+#, fuzzy
+msgid "Certificate"
+msgstr "Create New %s"
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1555,6 +1565,18 @@ msgstr "Create New %s"
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "Create New %s"
+
+#, fuzzy
+msgid "Certificate change failed"
+msgstr "Create New %s"
+
+#, fuzzy
+msgid "Certificate download failed"
+msgstr "Download Failed"
+
+#, fuzzy
+msgid "Certificate management is not configured on this server"
+msgstr "There are no images on this server."
 
 #, fuzzy
 msgid "Certificates"
@@ -1685,6 +1707,9 @@ msgstr "Settings"
 #, fuzzy
 msgid "Client Version"
 msgstr "CPU Version"
+
+msgid "Client communication certificate"
+msgstr ""
 
 msgid "Clients already enforcing Secure Boot cannot run this task -- they will not boot FOS in the first place. Use the manual steps below for those."
 msgstr ""
@@ -1877,9 +1902,17 @@ msgstr "Could not read tmp file."
 msgid "Could not register"
 msgstr "Could not create printer"
 
+#, fuzzy
+msgid "Could not remove the imported root"
+msgstr "Could not read tmp file."
+
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
+
+#, fuzzy
+msgid "Could not save that preference"
+msgstr "Could not read tmp file."
 
 #, fuzzy
 msgid "Could not seed the granted targets"
@@ -1891,6 +1924,10 @@ msgstr "Could not read tmp file."
 
 #, fuzzy
 msgid "Could not stage the upload."
+msgstr "Could not read tmp file."
+
+#, fuzzy
+msgid "Could not stage the uploaded certificate"
 msgstr "Could not read tmp file."
 
 #, fuzzy
@@ -2124,6 +2161,10 @@ msgstr "Current Records"
 
 msgid "Current member-host AD state"
 msgstr ""
+
+#, fuzzy
+msgid "Currently imported"
+msgstr "Current Records"
 
 msgid "DMI Field"
 msgstr ""
@@ -2490,6 +2531,9 @@ msgstr "Duration"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgstr ""
+
 msgid "Edit"
 msgstr "Edit"
 
@@ -2690,6 +2734,9 @@ msgstr ""
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
 
+msgid "Expires"
+msgstr ""
+
 msgid "Export"
 msgstr "Export"
 
@@ -2755,6 +2802,9 @@ msgstr "Windows 8"
 #, fuzzy
 msgid "Export the database"
 msgstr "Date"
+
+msgid "External root CA"
+msgstr ""
 
 msgid "FOG"
 msgstr "FOG"
@@ -4348,6 +4398,10 @@ msgid "Import known mac address makers"
 msgstr ""
 
 #, fuzzy
+msgid "Imported root"
+msgstr "Import Hosts"
+
+#, fuzzy
 msgid "Imported successfully!"
 msgstr "Install / Update Successful!"
 
@@ -4421,6 +4475,10 @@ msgstr "Install Plugins"
 #, fuzzy
 msgid "Install plugins failed!"
 msgstr "Install Plugins"
+
+#, fuzzy
+msgid "Install preferences"
+msgstr "Delete Selected"
 
 #, fuzzy
 msgid "Install selected"
@@ -4983,6 +5041,9 @@ msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
 msgid "Legacy BIOS (no Secure Boot)"
+msgstr ""
+
+msgid "Let's Encrypt with FOG"
 msgstr ""
 
 msgid "Level"
@@ -5724,6 +5785,10 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr "No file was uploaded"
 
+#, fuzzy
+msgid "No certificate file was uploaded"
+msgstr "No file was uploaded"
+
 msgid "No change"
 msgstr ""
 
@@ -5748,6 +5813,9 @@ msgid "No database to work off"
 msgstr "No database to work off"
 
 msgid "No external data to download the file from"
+msgstr ""
+
+msgid "No external root is imported on this server."
 msgstr ""
 
 msgid "No fields passed"
@@ -6015,6 +6083,9 @@ msgstr ""
 msgid "Not allowed here"
 msgstr "Not allowed here"
 
+msgid "Not offered here, on purpose"
+msgstr ""
+
 #, fuzzy
 msgid "Not pinged"
 msgstr "Installed Plugins"
@@ -6136,6 +6207,9 @@ msgstr ""
 msgid "Off - direct membership only"
 msgstr ""
 
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgstr ""
+
 #, fuzzy
 msgid "Offered to every user on this grid."
 msgstr " | This is not the primary group"
@@ -6204,6 +6278,9 @@ msgid "Only an administrator may grant full access."
 msgstr "Modify Group"
 
 msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
+msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
 msgstr ""
 
 msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
@@ -6710,6 +6787,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preference saved"
+msgstr ""
+
 msgid "Preferences"
 msgstr ""
 
@@ -6829,6 +6909,9 @@ msgstr "Private key not readable"
 
 msgid "Private key path not found"
 msgstr "Private key path not found"
+
+msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
+msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -6990,6 +7073,9 @@ msgstr "Reboot"
 msgid "Reboot after deploy"
 msgstr "has been destroyed"
 
+msgid "Rebuild iPXE with this server's CA embedded"
+msgstr ""
+
 msgid "Receive"
 msgstr "Receive"
 
@@ -7011,6 +7097,9 @@ msgstr "Record not found, Error: %s"
 #, fuzzy
 msgid "Records"
 msgstr "Current Records"
+
+msgid "Redirect HTTP to HTTPS"
+msgstr ""
 
 msgid "Redirect Login To This Provider"
 msgstr ""
@@ -7084,6 +7173,10 @@ msgid "Remove file data"
 msgstr "Removed"
 
 #, fuzzy
+msgid "Remove imported root"
+msgstr "Removed"
+
+#, fuzzy
 msgid "Remove selected"
 msgstr "Remove selected snapins"
 
@@ -7121,6 +7214,9 @@ msgstr ""
 
 #, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
+msgstr ""
+
+msgid "Replacing the root itself -- so that FOG's anchor becomes an intermediate of yours -- is a migration rather than a setting. It changes the certificate every registered fog-client pins, so every one of them stops authenticating until it is re-pinned. That is not something a web form should be able to do in one click, so it is not on this page."
 msgstr ""
 
 #, fuzzy
@@ -7291,6 +7387,21 @@ msgstr ""
 msgid "Roles"
 msgstr ""
 
+msgid "Root"
+msgstr ""
+
+#, fuzzy
+msgid "Root CA certificate (PEM)"
+msgstr "Create New %s"
+
+#, fuzzy
+msgid "Root imported"
+msgstr "Inventory"
+
+#, fuzzy
+msgid "Root removed"
+msgstr "Removed"
+
 msgid "Row"
 msgstr "Row"
 
@@ -7382,6 +7493,9 @@ msgid "Save the site before setting catch-all"
 msgstr ""
 
 msgid "Saved filters for one grid"
+msgstr ""
+
+msgid "Saved. It takes effect the next time the installer runs."
 msgstr ""
 
 #, fuzzy
@@ -7522,7 +7636,7 @@ msgstr ""
 msgid "Secure Boot (reported)"
 msgstr ""
 
-msgid "Secure Boot CA private key"
+msgid "Secure Boot CA"
 msgstr ""
 
 msgid "Secure Boot Enrolled"
@@ -7801,6 +7915,12 @@ msgstr ""
 #, fuzzy
 msgid "Signs In With"
 msgstr "Snapin Run With"
+
+msgid "Signs the FOS kernel signing certificate. Not a web certificate."
+msgstr ""
+
+msgid "Signs the web server certificate and every storage node certificate."
+msgstr ""
 
 #, fuzzy
 msgid "Single Logout"
@@ -8796,6 +8916,14 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That certificate is not available on this server."
+msgstr "There are no groups on this server."
+
+#, fuzzy
+msgid "That file is too large to be a root CA certificate"
+msgstr "has failed to save"
+
+#, fuzzy
 msgid "That filter is too large to save"
 msgstr "has failed to save"
 
@@ -8939,6 +9067,17 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
+#, fuzzy
+msgid "The certificate chain"
+msgstr "Create New %s"
+
+msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
+msgstr ""
+
+#, fuzzy
+msgid "The certificate was refused"
+msgstr "No file was uploaded"
+
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
@@ -9018,6 +9157,9 @@ msgstr "The storage groups associated storage node is not valid"
 
 msgid "The image storage group assigned is not valid"
 msgstr "The image storage group assigned is not valid"
+
+msgid "The imported root CA has been removed."
+msgstr ""
 
 #, fuzzy
 msgid "The installers for the fog client"
@@ -9104,7 +9246,16 @@ msgstr ""
 msgid "The provider returned a configuration for a different issuer"
 msgstr ""
 
+msgid "The public half of the keypair fog-client encrypts its check-in to."
+msgstr ""
+
 msgid "The resource is not in a cancellable state."
+msgstr ""
+
+msgid "The root CA has been imported and this server now trusts it."
+msgstr ""
+
+msgid "The root CA has been imported, but this host's system trust store could not be updated -- so HTTPS calls made on this server will not accept it yet. Re-run the installer, and check the installation log."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."
@@ -9143,6 +9294,9 @@ msgstr "The storage groups associated storage node is not valid"
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
+msgid "The trust anchor. Every fog-client pins this one."
+msgstr ""
+
 msgid "The upload did not arrive."
 msgstr ""
 
@@ -9162,6 +9316,9 @@ msgid "The uploaded file was only partially uploaded"
 msgstr "The uploaded file was only partially uploaded"
 
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
+msgstr ""
+
+msgid "The web certificate chains to a public CA"
 msgstr ""
 
 msgid "Theme"
@@ -9223,6 +9380,9 @@ msgstr ""
 msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
 msgstr ""
 
+msgid "These decide what the NEXT installer run does. Nothing here takes effect until the installer runs again -- this page records the preference, it does not rewrite the web server configuration or reissue a certificate."
+msgstr ""
+
 #, php-format
 msgid "These plugins are still installed on disk, so forgetting them would achieve nothing: %s. Uninstall them instead."
 msgstr ""
@@ -9246,6 +9406,9 @@ msgstr ""
 msgid "This document"
 msgstr ""
 
+msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
 msgid "This endpoint only accepts POST."
 msgstr ""
 
@@ -9263,6 +9426,9 @@ msgstr ""
 
 #, php-format
 msgid "This host has finished deploying image %s."
+msgstr ""
+
+msgid "This host has no system trust store that FOG recognizes, so an imported root is recorded and re-applied but never reaches the host's own HTTPS clients."
 msgstr ""
 
 msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
@@ -9328,6 +9494,9 @@ msgstr ""
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
 msgstr ""
 
+msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9365,6 +9534,9 @@ msgid "This server's hostname, as its certificate names it."
 msgstr ""
 
 msgid "This server's own IP address. Space-separated when the interface carries more than one."
+msgstr ""
+
+msgid "This server's web certificate already resolves outside FOG's own PKI, so FOG treats it as managed elsewhere and will not reissue it or lock its key down, whatever these say. That is derived from where the certificate actually is, not from a setting, so the two cannot disagree."
 msgstr ""
 
 msgid "This servers ip(s)"
@@ -9464,6 +9636,9 @@ msgstr ""
 msgid "To get started please select an item from the menu."
 msgstr ""
 
+msgid "To have your own CA issue FOG's web certificates, import the CA and its key by re-running the installer. That replaces the CA that signs the web server certificate and the storage node certificates -- and only that. The root fog-client pins is left alone, so no client re-enrolls."
+msgstr ""
+
 msgid "Toggle Dropdown"
 msgstr ""
 
@@ -9525,6 +9700,9 @@ msgstr ""
 msgid "Trust anchor"
 msgstr ""
 
+msgid "Trust anchor bundle"
+msgstr ""
+
 msgid "Trusted Node CIDRs"
 msgstr ""
 
@@ -9535,6 +9713,9 @@ msgstr "Snapin Path"
 #, fuzzy
 msgid "Trying image size for"
 msgstr "Snapin Path"
+
+msgid "Turn this on for a Let's Encrypt or purchased certificate. It stops FOG re-issuing the leaf, stops it locking the private key to root -- which would break the renewal that writes it -- and steers netboot to HTTPS with no iPXE rebuild, because upstream iPXE cross-certifies public CAs already."
+msgstr ""
 
 msgid "Two routes are covered in the guide linked above: a live USB with the kit above, or PXE-booting the client and choosing Enroll Secure Boot Key, which now fetches MOK.der over the network on its own, with no USB stick needed."
 msgstr ""
@@ -9692,6 +9873,10 @@ msgstr "Unknown"
 msgid "Unknown DB error"
 msgstr "Unknown upload error occurred.  Return code: "
 
+#, fuzzy
+msgid "Unknown action"
+msgstr "Unknown upload error occurred.  Return code: "
+
 #, php-format
 msgid "Unknown field for %s: %s"
 msgstr ""
@@ -9805,6 +9990,9 @@ msgstr "Upload Reports"
 
 msgid "Upload Reports"
 msgstr "Upload Reports"
+
+msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"
 msgstr ""
@@ -10075,10 +10263,17 @@ msgstr ""
 msgid "Using the group match function"
 msgstr ""
 
+msgid "Using your own PKI"
+msgstr ""
+
 msgid "VB Script"
 msgstr ""
 
 msgid "VNC"
+msgstr ""
+
+#, php-format
+msgid "Valid until %s."
 msgstr ""
 
 msgid "Value"
@@ -10144,13 +10339,19 @@ msgstr "Storage Node Name"
 msgid "We cannot connect to LDAP server"
 msgstr "Cannot connect to database"
 
-msgid "Web CA private key"
+msgid "Web CA"
+msgstr ""
+
+msgid "Web CA plus the root that anchors it -- what a client needs to verify this server."
 msgstr ""
 
 msgid "Web Server"
 msgstr "Web Server"
 
-msgid "Web server private key"
+msgid "Web server certificate"
+msgstr ""
+
+msgid "Web trust chain"
 msgstr ""
 
 msgid "Weekly"
@@ -10165,6 +10366,12 @@ msgstr ""
 #, fuzzy
 msgid "What gets enrolled"
 msgstr "has been successfully updated"
+
+msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
+msgstr ""
+
+msgid "What this server itself trusts: FOG's root, plus any root imported below."
+msgstr ""
 
 msgid "What to do next"
 msgstr ""
@@ -11489,6 +11696,10 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Save Changes"
 
+#, fuzzy
+#~ msgid "CA private key"
+#~ msgstr "Private key failed"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Check that database is running"
 
@@ -11710,10 +11921,6 @@ msgstr ""
 
 #~ msgid "Import Printers"
 #~ msgstr "Import Printers"
-
-#, fuzzy
-#~ msgid "Import Report"
-#~ msgstr "Import Hosts"
 
 #, fuzzy
 #~ msgid "Import Reports"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -114,6 +114,10 @@ msgid "%d architecture(s) updated."
 msgstr "Impresora actualiza!"
 
 #, php-format
+msgid "%d certificates in this file"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -422,6 +426,9 @@ msgstr "Una imagen ya existe con este nombre!"
 msgid "A role with this name already exists!"
 msgstr "Sesión con ese nombre ya existe"
 
+msgid "A root CA uploaded on this page. Absent unless one was imported."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "Se requiere un nombre de imagen!"
@@ -502,6 +509,9 @@ msgid "A username already exists with this name!"
 msgstr "Una imagen ya existe con este nombre!"
 
 msgid "A valid database connection could not be made"
+msgstr ""
+
+msgid "A worked example of the first one, end to end:"
 msgstr ""
 
 msgid "API"
@@ -1341,10 +1351,6 @@ msgstr "Crear nuevo grupo"
 msgid "CA Path"
 msgstr "Camino"
 
-#, fuzzy
-msgid "CA private key"
-msgstr "clave privada fracasó"
-
 msgid "CPU Cache"
 msgstr "caché de la CPU"
 
@@ -1559,6 +1565,10 @@ msgstr "Versión del sistema"
 msgid "Catch-All Site"
 msgstr ""
 
+#, fuzzy
+msgid "Certificate"
+msgstr "Crear nuevo grupo"
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1572,6 +1582,18 @@ msgstr "Crear nuevo grupo"
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "Crear nuevo grupo"
+
+#, fuzzy
+msgid "Certificate change failed"
+msgstr "Crear nuevo grupo"
+
+#, fuzzy
+msgid "Certificate download failed"
+msgstr "Descarga fracasó"
+
+#, fuzzy
+msgid "Certificate management is not configured on this server"
+msgstr "No hay grupos en este servidor."
 
 #, fuzzy
 msgid "Certificates"
@@ -1705,6 +1727,9 @@ msgstr "Configuración Tecla"
 #, fuzzy
 msgid "Client Version"
 msgstr "Versión de la CPU"
+
+msgid "Client communication certificate"
+msgstr ""
 
 msgid "Clients already enforcing Secure Boot cannot run this task -- they will not boot FOS in the first place. Use the manual steps below for those."
 msgstr ""
@@ -1897,9 +1922,17 @@ msgstr "No se pudo leer el archivo tmp."
 msgid "Could not register"
 msgstr "No se pudo crear la impresora"
 
+#, fuzzy
+msgid "Could not remove the imported root"
+msgstr "No se pudo leer el archivo tmp."
+
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
+
+#, fuzzy
+msgid "Could not save that preference"
+msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
 msgid "Could not seed the granted targets"
@@ -1911,6 +1944,10 @@ msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
 msgid "Could not stage the upload."
+msgstr "No se pudo leer el archivo tmp."
+
+#, fuzzy
+msgid "Could not stage the uploaded certificate"
 msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
@@ -2145,6 +2182,10 @@ msgstr "Registros actuales"
 
 msgid "Current member-host AD state"
 msgstr ""
+
+#, fuzzy
+msgid "Currently imported"
+msgstr "Registros actuales"
 
 msgid "DMI Field"
 msgstr ""
@@ -2523,6 +2564,9 @@ msgstr "Configuración"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgstr ""
+
 msgid "Edit"
 msgstr "Editar"
 
@@ -2725,6 +2769,9 @@ msgstr ""
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
 
+msgid "Expires"
+msgstr ""
+
 msgid "Export"
 msgstr "Exportar"
 
@@ -2791,6 +2838,9 @@ msgstr "impresora iPrint"
 #, fuzzy
 msgid "Export the database"
 msgstr "Fecha"
+
+msgid "External root CA"
+msgstr ""
 
 #, fuzzy
 msgid "FOG"
@@ -4426,6 +4476,10 @@ msgid "Import known mac address makers"
 msgstr ""
 
 #, fuzzy
+msgid "Imported root"
+msgstr "Importar"
+
+#, fuzzy
 msgid "Imported successfully!"
 msgstr "actualización de servicio no pudo"
 
@@ -4499,6 +4553,10 @@ msgstr "Añadir fallidos SNAPin!"
 #, fuzzy
 msgid "Install plugins failed!"
 msgstr "Añadir fallidos SNAPin!"
+
+#, fuzzy
+msgid "Install preferences"
+msgstr "Eliminar seleccionado"
 
 #, fuzzy
 msgid "Install selected"
@@ -5081,6 +5139,9 @@ msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
 msgid "Legacy BIOS (no Secure Boot)"
+msgstr ""
+
+msgid "Let's Encrypt with FOG"
 msgstr ""
 
 msgid "Level"
@@ -5844,6 +5905,10 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr "Ningún archivo fue subido"
 
+#, fuzzy
+msgid "No certificate file was uploaded"
+msgstr "Ningún archivo fue subido"
+
 msgid "No change"
 msgstr ""
 
@@ -5871,6 +5936,9 @@ msgid "No database to work off"
 msgstr "No se obtuvieron datos"
 
 msgid "No external data to download the file from"
+msgstr ""
+
+msgid "No external root is imported on this server."
 msgstr ""
 
 msgid "No fields passed"
@@ -6142,6 +6210,9 @@ msgstr ""
 msgid "Not allowed here"
 msgstr ""
 
+msgid "Not offered here, on purpose"
+msgstr ""
+
 #, fuzzy
 msgid "Not pinged"
 msgstr "Instalador inteligente (recomendado)"
@@ -6263,6 +6334,9 @@ msgstr ""
 msgid "Off - direct membership only"
 msgstr ""
 
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgstr ""
+
 msgid "Offered to every user on this grid."
 msgstr ""
 
@@ -6330,6 +6404,9 @@ msgid "Only an administrator may grant full access."
 msgstr "modificar Grupo"
 
 msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
+msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
 msgstr ""
 
 msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
@@ -6844,6 +6921,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preference saved"
+msgstr ""
+
 msgid "Preferences"
 msgstr ""
 
@@ -6968,6 +7048,9 @@ msgstr "clave privada no se puede leer"
 
 msgid "Private key path not found"
 msgstr "ruta de la clave privada no encontrado"
+
+msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
+msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -7130,6 +7213,9 @@ msgstr "Reiniciar"
 msgid "Reboot after deploy"
 msgstr "Deben estar cifrados"
 
+msgid "Rebuild iPXE with this server's CA embedded"
+msgstr ""
+
 #, fuzzy
 msgid "Receive"
 msgstr "retirar"
@@ -7152,6 +7238,9 @@ msgstr "Registro no encontrado, error: %s"
 #, fuzzy
 msgid "Records"
 msgstr "Registros actuales"
+
+msgid "Redirect HTTP to HTTPS"
+msgstr ""
 
 msgid "Redirect Login To This Provider"
 msgstr ""
@@ -7226,6 +7315,10 @@ msgid "Remove file data"
 msgstr "Remoto"
 
 #, fuzzy
+msgid "Remove imported root"
+msgstr "Remoto"
+
+#, fuzzy
 msgid "Remove selected"
 msgstr "Remoto"
 
@@ -7264,6 +7357,9 @@ msgstr ""
 
 #, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
+msgstr ""
+
+msgid "Replacing the root itself -- so that FOG's anchor becomes an intermediate of yours -- is a migration rather than a setting. It changes the certificate every registered fog-client pins, so every one of them stops authenticating until it is re-pinned. That is not something a web form should be able to do in one click, so it is not on this page."
 msgstr ""
 
 #, fuzzy
@@ -7436,6 +7532,21 @@ msgstr ""
 msgid "Roles"
 msgstr ""
 
+msgid "Root"
+msgstr ""
+
+#, fuzzy
+msgid "Root CA certificate (PEM)"
+msgstr "Crear nuevo grupo"
+
+#, fuzzy
+msgid "Root imported"
+msgstr "ID de inventario"
+
+#, fuzzy
+msgid "Root removed"
+msgstr "retirar"
+
 msgid "Row"
 msgstr "Fila"
 
@@ -7528,6 +7639,9 @@ msgid "Save the site before setting catch-all"
 msgstr ""
 
 msgid "Saved filters for one grid"
+msgstr ""
+
+msgid "Saved. It takes effect the next time the installer runs."
 msgstr ""
 
 #, fuzzy
@@ -7669,7 +7783,7 @@ msgstr ""
 msgid "Secure Boot (reported)"
 msgstr ""
 
-msgid "Secure Boot CA private key"
+msgid "Secure Boot CA"
 msgstr ""
 
 msgid "Secure Boot Enrolled"
@@ -7951,6 +8065,12 @@ msgstr ""
 #, fuzzy
 msgid "Signs In With"
 msgstr "snapin replicador"
+
+msgid "Signs the FOS kernel signing certificate. Not a web certificate."
+msgstr ""
+
+msgid "Signs the web server certificate and every storage node certificate."
+msgstr ""
 
 #, fuzzy
 msgid "Single Logout"
@@ -8979,6 +9099,14 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That certificate is not available on this server."
+msgstr "No hay grupos en este servidor."
+
+#, fuzzy
+msgid "That file is too large to be a root CA certificate"
+msgstr "no ha logrado ahorrar"
+
+#, fuzzy
 msgid "That filter is too large to save"
 msgstr "no ha logrado ahorrar"
 
@@ -9120,6 +9248,17 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
+#, fuzzy
+msgid "The certificate chain"
+msgstr "Crear nuevo grupo"
+
+msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
+msgstr ""
+
+#, fuzzy
+msgid "The certificate was refused"
+msgstr "Ningún archivo fue subido"
+
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
@@ -9200,6 +9339,9 @@ msgstr "Marque aquí para ver los grupos no asignado esta imagen"
 #, fuzzy
 msgid "The image storage group assigned is not valid"
 msgstr "Marque aquí para ver los grupos no asignado esta imagen"
+
+msgid "The imported root CA has been removed."
+msgstr ""
 
 #, fuzzy
 msgid "The installers for the fog client"
@@ -9287,7 +9429,16 @@ msgstr ""
 msgid "The provider returned a configuration for a different issuer"
 msgstr ""
 
+msgid "The public half of the keypair fog-client encrypts its check-in to."
+msgstr ""
+
 msgid "The resource is not in a cancellable state."
+msgstr ""
+
+msgid "The root CA has been imported and this server now trusts it."
+msgstr ""
+
+msgid "The root CA has been imported, but this host's system trust store could not be updated -- so HTTPS calls made on this server will not accept it yet. Re-run the installer, and check the installation log."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."
@@ -9325,6 +9476,9 @@ msgstr ""
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
+msgid "The trust anchor. Every fog-client pins this one."
+msgstr ""
+
 msgid "The upload did not arrive."
 msgstr ""
 
@@ -9344,6 +9498,9 @@ msgid "The uploaded file was only partially uploaded"
 msgstr "El archivo subido se ha subido sólo parcialmente"
 
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
+msgstr ""
+
+msgid "The web certificate chains to a public CA"
 msgstr ""
 
 msgid "Theme"
@@ -9407,6 +9564,9 @@ msgstr ""
 msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
 msgstr ""
 
+msgid "These decide what the NEXT installer run does. Nothing here takes effect until the installer runs again -- this page records the preference, it does not rewrite the web server configuration or reissue a certificate."
+msgstr ""
+
 #, php-format
 msgid "These plugins are still installed on disk, so forgetting them would achieve nothing: %s. Uninstall them instead."
 msgstr ""
@@ -9430,6 +9590,9 @@ msgstr ""
 msgid "This document"
 msgstr ""
 
+msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
 msgid "This endpoint only accepts POST."
 msgstr ""
 
@@ -9447,6 +9610,9 @@ msgstr ""
 
 #, php-format
 msgid "This host has finished deploying image %s."
+msgstr ""
+
+msgid "This host has no system trust store that FOG recognizes, so an imported root is recorded and re-applied but never reaches the host's own HTTPS clients."
 msgstr ""
 
 msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
@@ -9510,6 +9676,9 @@ msgstr ""
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
 msgstr ""
 
+msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9547,6 +9716,9 @@ msgid "This server's hostname, as its certificate names it."
 msgstr ""
 
 msgid "This server's own IP address. Space-separated when the interface carries more than one."
+msgstr ""
+
+msgid "This server's web certificate already resolves outside FOG's own PKI, so FOG treats it as managed elsewhere and will not reissue it or lock its key down, whatever these say. That is derived from where the certificate actually is, not from a setting, so the two cannot disagree."
 msgstr ""
 
 msgid "This servers ip(s)"
@@ -9642,6 +9814,9 @@ msgstr ""
 msgid "To get started please select an item from the menu."
 msgstr ""
 
+msgid "To have your own CA issue FOG's web certificates, import the CA and its key by re-running the installer. That replaces the CA that signs the web server certificate and the storage node certificates -- and only that. The root fog-client pins is left alone, so no client re-enrolls."
+msgstr ""
+
 msgid "Toggle Dropdown"
 msgstr ""
 
@@ -9701,6 +9876,9 @@ msgstr ""
 msgid "Trust anchor"
 msgstr ""
 
+msgid "Trust anchor bundle"
+msgstr ""
+
 msgid "Trusted Node CIDRs"
 msgstr ""
 
@@ -9709,6 +9887,9 @@ msgid "Trying Snapin hash for"
 msgstr "Camino snapin"
 
 msgid "Trying image size for"
+msgstr ""
+
+msgid "Turn this on for a Let's Encrypt or purchased certificate. It stops FOG re-issuing the leaf, stops it locking the private key to root -- which would break the renewal that writes it -- and steers netboot to HTTPS with no iPXE rebuild, because upstream iPXE cross-certifies public CAs already."
 msgstr ""
 
 msgid "Two routes are covered in the guide linked above: a live USB with the kit above, or PXE-booting the client and choosing Enroll Secure Boot Key, which now fetches MOK.der over the network on its own, with no USB stick needed."
@@ -9868,6 +10049,10 @@ msgstr "Desconocido"
 msgid "Unknown DB error"
 msgstr "Se produjo un error de carga desconocida. Código de retorno: "
 
+#, fuzzy
+msgid "Unknown action"
+msgstr "Se produjo un error de carga desconocida. Código de retorno: "
+
 #, php-format
 msgid "Unknown field for %s: %s"
 msgstr ""
@@ -9982,6 +10167,9 @@ msgstr "Subir archivo"
 #, fuzzy
 msgid "Upload Reports"
 msgstr "Subir archivo"
+
+msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"
 msgstr ""
@@ -10257,10 +10445,17 @@ msgstr ""
 msgid "Using the group match function"
 msgstr ""
 
+msgid "Using your own PKI"
+msgstr ""
+
 msgid "VB Script"
 msgstr ""
 
 msgid "VNC"
+msgstr ""
+
+#, php-format
+msgid "Valid until %s."
 msgstr ""
 
 msgid "Value"
@@ -10325,13 +10520,19 @@ msgstr ""
 msgid "We cannot connect to LDAP server"
 msgstr "Error: No se pudo descargar kernel"
 
-msgid "Web CA private key"
+msgid "Web CA"
+msgstr ""
+
+msgid "Web CA plus the root that anchors it -- what a client needs to verify this server."
 msgstr ""
 
 msgid "Web Server"
 msgstr "Servidor web"
 
-msgid "Web server private key"
+msgid "Web server certificate"
+msgstr ""
+
+msgid "Web trust chain"
 msgstr ""
 
 msgid "Weekly"
@@ -10346,6 +10547,12 @@ msgstr ""
 #, fuzzy
 msgid "What gets enrolled"
 msgstr "se ha actualizado correctamente"
+
+msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
+msgstr ""
+
+msgid "What this server itself trusts: FOG's root, plus any root imported below."
+msgstr ""
 
 msgid "What to do next"
 msgstr ""
@@ -11664,6 +11871,10 @@ msgstr ""
 #~ msgstr "Guardar cambios"
 
 #, fuzzy
+#~ msgid "CA private key"
+#~ msgstr "clave privada fracasó"
+
+#, fuzzy
 #~ msgid "Check that database is running"
 #~ msgstr "Compruebe que la base de datos se está ejecutando"
 
@@ -11897,10 +12108,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Import Printers"
 #~ msgstr "Impresora TCP / IP Port"
-
-#, fuzzy
-#~ msgid "Import Report"
-#~ msgstr "Importar"
 
 #, fuzzy
 #~ msgid "Import Reports"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -111,6 +111,10 @@ msgid "%d architecture(s) updated."
 msgstr "Drucker aktualisiert!"
 
 #, php-format
+msgid "%d certificates in this file"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -419,6 +423,9 @@ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 msgid "A role with this name already exists!"
 msgstr "Ein Host mit diesem Namen ist bereits vorhanden."
 
+msgid "A root CA uploaded on this page. Absent unless one was imported."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "Ein Gruppenname ist erforderlich!"
@@ -500,6 +507,9 @@ msgstr "Dieser Benutzername ist bereits vorhanden!"
 
 msgid "A valid database connection could not be made"
 msgstr "Eine gültige Datenbankverbindung konnte nicht hergestellt werden"
+
+msgid "A worked example of the first one, end to end:"
+msgstr ""
 
 #, fuzzy
 msgid "API"
@@ -1320,10 +1330,6 @@ msgstr "Neuen Standort erstellen"
 msgid "CA Path"
 msgstr "Pfad"
 
-#, fuzzy
-msgid "CA private key"
-msgstr "Privater Schlüssel ist fehlgeschlagen"
-
 msgid "CPU Cache"
 msgstr "CPU-Cache"
 
@@ -1539,6 +1545,10 @@ msgstr "Neueste Version"
 msgid "Catch-All Site"
 msgstr ""
 
+#, fuzzy
+msgid "Certificate"
+msgstr "Neuen Standort erstellen"
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1552,6 +1562,18 @@ msgstr "Neuen Standort erstellen"
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "Neuen Standort erstellen"
+
+#, fuzzy
+msgid "Certificate change failed"
+msgstr "Neuen Standort erstellen"
+
+#, fuzzy
+msgid "Certificate download failed"
+msgstr "Download fehlgeschlagen"
+
+#, fuzzy
+msgid "Certificate management is not configured on this server"
+msgstr "Es gibt keine Images auf diesem Server."
 
 #, fuzzy
 msgid "Certificates"
@@ -1683,6 +1705,9 @@ msgstr "Client Einstellungen"
 #, fuzzy
 msgid "Client Version"
 msgstr "Client-Version"
+
+msgid "Client communication certificate"
+msgstr ""
 
 msgid "Clients already enforcing Secure Boot cannot run this task -- they will not boot FOS in the first place. Use the manual steps below for those."
 msgstr ""
@@ -1875,9 +1900,17 @@ msgstr "Tmp-Datei konnte nicht gelesen werden."
 msgid "Could not register"
 msgstr "Konnte nicht registriert werden."
 
+#, fuzzy
+msgid "Could not remove the imported root"
+msgstr "Tmp-Datei konnte nicht gelesen werden."
+
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
+
+#, fuzzy
+msgid "Could not save that preference"
+msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 msgid "Could not seed the granted targets"
@@ -1889,6 +1922,10 @@ msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 msgid "Could not stage the upload."
+msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
+msgid "Could not stage the uploaded certificate"
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
@@ -2122,6 +2159,10 @@ msgstr "Aktuelle Datensätze"
 
 msgid "Current member-host AD state"
 msgstr ""
+
+#, fuzzy
+msgid "Currently imported"
+msgstr "Aktuelle Datensätze"
 
 msgid "DMI Field"
 msgstr ""
@@ -2488,6 +2529,9 @@ msgstr "Dauer"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgstr ""
+
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -2689,6 +2733,9 @@ msgstr "Bestehendes Objekt muss boolean sein"
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
 
+msgid "Expires"
+msgstr ""
+
 msgid "Export"
 msgstr "Export"
 
@@ -2754,6 +2801,9 @@ msgstr "Windows-Schlüssel exportieren"
 #, fuzzy
 msgid "Export the database"
 msgstr "Datenbank importieren"
+
+msgid "External root CA"
+msgstr ""
 
 msgid "FOG"
 msgstr "FOG"
@@ -4347,6 +4397,10 @@ msgid "Import known mac address makers"
 msgstr ""
 
 #, fuzzy
+msgid "Imported root"
+msgstr "Berichte importieren"
+
+#, fuzzy
 msgid "Imported successfully!"
 msgstr "iPXE-Einstellungen erfolgreich aktualisiert!"
 
@@ -4420,6 +4474,10 @@ msgstr "Plugins installieren"
 #, fuzzy
 msgid "Install plugins failed!"
 msgstr "Plugins installieren"
+
+#, fuzzy
+msgid "Install preferences"
+msgstr "Ausgewählte löschen"
 
 #, fuzzy
 msgid "Install selected"
@@ -4985,6 +5043,9 @@ msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
 msgid "Legacy BIOS (no Secure Boot)"
+msgstr ""
+
+msgid "Let's Encrypt with FOG"
 msgstr ""
 
 msgid "Level"
@@ -5727,6 +5788,10 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr "Keine Datei wurde hochgeladen"
 
+#, fuzzy
+msgid "No certificate file was uploaded"
+msgstr "Keine Datei wurde hochgeladen"
+
 msgid "No change"
 msgstr ""
 
@@ -5751,6 +5816,9 @@ msgid "No database to work off"
 msgstr "Keine Datenbank zum Arbeiten"
 
 msgid "No external data to download the file from"
+msgstr ""
+
+msgid "No external root is imported on this server."
 msgstr ""
 
 msgid "No fields passed"
@@ -6018,6 +6086,9 @@ msgstr ""
 msgid "Not allowed here"
 msgstr "Hier nicht erlaubt"
 
+msgid "Not offered here, on purpose"
+msgstr ""
+
 #, fuzzy
 msgid "Not pinged"
 msgstr "Nicht synchronisieren"
@@ -6140,6 +6211,9 @@ msgstr ""
 msgid "Off - direct membership only"
 msgstr ""
 
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgstr ""
+
 #, fuzzy
 msgid "Offered to every user on this grid."
 msgstr "Dies ist nicht die primäre Gruppe"
@@ -6208,6 +6282,9 @@ msgid "Only an administrator may grant full access."
 msgstr "Admingruppe"
 
 msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
+msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
 msgstr ""
 
 msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
@@ -6714,6 +6791,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preference saved"
+msgstr ""
+
 msgid "Preferences"
 msgstr ""
 
@@ -6833,6 +6913,9 @@ msgstr "Private Schlüssel nicht lesbar"
 
 msgid "Private key path not found"
 msgstr "Privater Schlüsselpfad nicht gefunden"
+
+msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
+msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -6994,6 +7077,9 @@ msgstr "Neustarten"
 msgid "Reboot after deploy"
 msgstr "wurde abgeschlossen"
 
+msgid "Rebuild iPXE with this server's CA embedded"
+msgstr ""
+
 msgid "Receive"
 msgstr "Erhalten"
 
@@ -7015,6 +7101,9 @@ msgstr "Datensatz wurde nicht gefunden, Fehler: %s"
 #, fuzzy
 msgid "Records"
 msgstr "Aktuelle Datensätze"
+
+msgid "Redirect HTTP to HTTPS"
+msgstr ""
 
 msgid "Redirect Login To This Provider"
 msgstr ""
@@ -7088,6 +7177,10 @@ msgid "Remove file data"
 msgstr "Entfernen fehlgeschlagen"
 
 #, fuzzy
+msgid "Remove imported root"
+msgstr "Entfernen fehlgeschlagen"
+
+#, fuzzy
 msgid "Remove selected"
 msgstr "Ausgewählte entfernen "
 
@@ -7125,6 +7218,9 @@ msgstr ""
 
 #, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
+msgstr ""
+
+msgid "Replacing the root itself -- so that FOG's anchor becomes an intermediate of yours -- is a migration rather than a setting. It changes the certificate every registered fog-client pins, so every one of them stops authenticating until it is re-pinned. That is not something a web form should be able to do in one click, so it is not on this page."
 msgstr ""
 
 #, fuzzy
@@ -7295,6 +7391,21 @@ msgstr ""
 msgid "Roles"
 msgstr ""
 
+msgid "Root"
+msgstr ""
+
+#, fuzzy
+msgid "Root CA certificate (PEM)"
+msgstr "Neuen Standort erstellen"
+
+#, fuzzy
+msgid "Root imported"
+msgstr "(empfohlen)"
+
+#, fuzzy
+msgid "Root removed"
+msgstr "Entfernt"
+
 msgid "Row"
 msgstr "Zeile"
 
@@ -7386,6 +7497,9 @@ msgid "Save the site before setting catch-all"
 msgstr ""
 
 msgid "Saved filters for one grid"
+msgstr ""
+
+msgid "Saved. It takes effect the next time the installer runs."
 msgstr ""
 
 #, fuzzy
@@ -7526,7 +7640,7 @@ msgstr ""
 msgid "Secure Boot (reported)"
 msgstr ""
 
-msgid "Secure Boot CA private key"
+msgid "Secure Boot CA"
 msgstr ""
 
 msgid "Secure Boot Enrolled"
@@ -7805,6 +7919,12 @@ msgstr ""
 #, fuzzy
 msgid "Signs In With"
 msgstr "Snapin läuft mit"
+
+msgid "Signs the FOS kernel signing certificate. Not a web certificate."
+msgstr ""
+
+msgid "Signs the web server certificate and every storage node certificate."
+msgstr ""
 
 #, fuzzy
 msgid "Single Logout"
@@ -8802,6 +8922,14 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That certificate is not available on this server."
+msgstr "Es gibt keine Gruppen auf diesem Server."
+
+#, fuzzy
+msgid "That file is too large to be a root CA certificate"
+msgstr "konnte nicht gespeichert werden"
+
+#, fuzzy
 msgid "That filter is too large to save"
 msgstr "konnte nicht gespeichert werden"
 
@@ -8945,6 +9073,17 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
+#, fuzzy
+msgid "The certificate chain"
+msgstr "Neuen Standort erstellen"
+
+msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
+msgstr ""
+
+#, fuzzy
+msgid "The certificate was refused"
+msgstr "Keine Datei wurde hochgeladen"
+
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
@@ -9024,6 +9163,9 @@ msgstr "Der einer/mehrere Speichergruppen zugeordnete Speicherknoten ist ungült
 
 msgid "The image storage group assigned is not valid"
 msgstr "Die zugewiesene Image Speichergruppe ist nicht gültig."
+
+msgid "The imported root CA has been removed."
+msgstr ""
 
 #, fuzzy
 msgid "The installers for the fog client"
@@ -9110,7 +9252,16 @@ msgstr ""
 msgid "The provider returned a configuration for a different issuer"
 msgstr ""
 
+msgid "The public half of the keypair fog-client encrypts its check-in to."
+msgstr ""
+
 msgid "The resource is not in a cancellable state."
+msgstr ""
+
+msgid "The root CA has been imported and this server now trusts it."
+msgstr ""
+
+msgid "The root CA has been imported, but this host's system trust store could not be updated -- so HTTPS calls made on this server will not accept it yet. Re-run the installer, and check the installation log."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."
@@ -9149,6 +9300,9 @@ msgstr "Der einer/mehrere Speichergruppen zugeordnete Speicherknoten ist ungült
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
+msgid "The trust anchor. Every fog-client pins this one."
+msgstr ""
+
 msgid "The upload did not arrive."
 msgstr ""
 
@@ -9168,6 +9322,9 @@ msgid "The uploaded file was only partially uploaded"
 msgstr "Die hochgeladene Datei wurde nur teilweise hochgeladen"
 
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
+msgstr ""
+
+msgid "The web certificate chains to a public CA"
 msgstr ""
 
 msgid "Theme"
@@ -9229,6 +9386,9 @@ msgstr "Dort können Sie Tools wie FOG Prep, "
 msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
 msgstr ""
 
+msgid "These decide what the NEXT installer run does. Nothing here takes effect until the installer runs again -- this page records the preference, it does not rewrite the web server configuration or reissue a certificate."
+msgstr ""
+
 #, php-format
 msgid "These plugins are still installed on disk, so forgetting them would achieve nothing: %s. Uninstall them instead."
 msgstr ""
@@ -9253,6 +9413,9 @@ msgstr ""
 msgid "This document"
 msgstr ""
 
+msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
 msgid "This endpoint only accepts POST."
 msgstr ""
 
@@ -9270,6 +9433,9 @@ msgstr ""
 
 #, php-format
 msgid "This host has finished deploying image %s."
+msgstr ""
+
+msgid "This host has no system trust store that FOG recognizes, so an imported root is recorded and re-applied but never reaches the host's own HTTPS clients."
 msgstr ""
 
 msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
@@ -9335,6 +9501,9 @@ msgstr ""
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
 msgstr ""
 
+msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9372,6 +9541,9 @@ msgid "This server's hostname, as its certificate names it."
 msgstr ""
 
 msgid "This server's own IP address. Space-separated when the interface carries more than one."
+msgstr ""
+
+msgid "This server's web certificate already resolves outside FOG's own PKI, so FOG treats it as managed elsewhere and will not reissue it or lock its key down, whatever these say. That is derived from where the certificate actually is, not from a setting, so the two cannot disagree."
 msgstr ""
 
 msgid "This servers ip(s)"
@@ -9470,6 +9642,9 @@ msgstr ""
 msgid "To get started please select an item from the menu."
 msgstr "Um zu beginnen, wählen Sie bitte ein Element aus dem Menü."
 
+msgid "To have your own CA issue FOG's web certificates, import the CA and its key by re-running the installer. That replaces the CA that signs the web server certificate and the storage node certificates -- and only that. The root fog-client pins is left alone, so no client re-enrolls."
+msgstr ""
+
 msgid "Toggle Dropdown"
 msgstr ""
 
@@ -9531,6 +9706,9 @@ msgstr ""
 msgid "Trust anchor"
 msgstr ""
 
+msgid "Trust anchor bundle"
+msgstr ""
+
 msgid "Trusted Node CIDRs"
 msgstr ""
 
@@ -9541,6 +9719,9 @@ msgstr "Versuche Snapin-Hash für"
 #, fuzzy
 msgid "Trying image size for"
 msgstr "Versuche Imagegröße für"
+
+msgid "Turn this on for a Let's Encrypt or purchased certificate. It stops FOG re-issuing the leaf, stops it locking the private key to root -- which would break the renewal that writes it -- and steers netboot to HTTPS with no iPXE rebuild, because upstream iPXE cross-certifies public CAs already."
+msgstr ""
 
 msgid "Two routes are covered in the guide linked above: a live USB with the kit above, or PXE-booting the client and choosing Enroll Secure Boot Key, which now fetches MOK.der over the network on its own, with no USB stick needed."
 msgstr ""
@@ -9698,6 +9879,10 @@ msgstr "Unbekannt"
 msgid "Unknown DB error"
 msgstr "Ein unbekannter Upload-Fehler ist aufgetreten"
 
+#, fuzzy
+msgid "Unknown action"
+msgstr "Ein unbekannter Upload-Fehler ist aufgetreten"
+
 #, php-format
 msgid "Unknown field for %s: %s"
 msgstr ""
@@ -9811,6 +9996,9 @@ msgstr "Berichte hochladen"
 
 msgid "Upload Reports"
 msgstr "Berichte hochladen"
+
+msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"
 msgstr ""
@@ -10081,10 +10269,17 @@ msgstr ""
 msgid "Using the group match function"
 msgstr "Verwenden der Gruppenübereinstimmungsfunktion,"
 
+msgid "Using your own PKI"
+msgstr ""
+
 msgid "VB Script"
 msgstr ""
 
 msgid "VNC"
+msgstr ""
+
+#, php-format
+msgid "Valid until %s."
 msgstr ""
 
 msgid "Value"
@@ -10150,13 +10345,19 @@ msgstr "Wir sind Knotenname "
 msgid "We cannot connect to LDAP server"
 msgstr "Es kann keine Verbindung zum LDAP-Server hergestellt werden."
 
-msgid "Web CA private key"
+msgid "Web CA"
+msgstr ""
+
+msgid "Web CA plus the root that anchors it -- what a client needs to verify this server."
 msgstr ""
 
 msgid "Web Server"
 msgstr "Web-Server"
 
-msgid "Web server private key"
+msgid "Web server certificate"
+msgstr ""
+
+msgid "Web trust chain"
 msgstr ""
 
 msgid "Weekly"
@@ -10171,6 +10372,12 @@ msgstr ""
 #, fuzzy
 msgid "What gets enrolled"
 msgstr "wurde abgebrochen"
+
+msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
+msgstr ""
+
+msgid "What this server itself trusts: FOG's root, plus any root imported below."
+msgstr ""
 
 msgid "What to do next"
 msgstr ""
@@ -11503,6 +11710,10 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Änderungen speichern?"
 
+#, fuzzy
+#~ msgid "CA private key"
+#~ msgstr "Privater Schlüssel ist fehlgeschlagen"
+
 #~ msgid "Can not redeclare route"
 #~ msgstr "Route kann nicht nochmal neu definiert werden"
 
@@ -11737,10 +11948,6 @@ msgstr ""
 
 #~ msgid "Import Printers"
 #~ msgstr "Drucker importieren"
-
-#, fuzzy
-#~ msgid "Import Report"
-#~ msgstr "Berichte importieren"
 
 #, fuzzy
 #~ msgid "Import Reports"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -117,6 +117,10 @@ msgid "%d architecture(s) updated."
 msgstr "Imprimante mis à jour!"
 
 #, php-format
+msgid "%d certificates in this file"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -425,6 +429,9 @@ msgstr "Une image existe déjà avec ce nom!"
 msgid "A role with this name already exists!"
 msgstr "Un nom d'hôte avec ce nom existe déjà."
 
+msgid "A root CA uploaded on this page. Absent unless one was imported."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "Un nom de l'image est nécessaire!"
@@ -505,6 +512,9 @@ msgid "A username already exists with this name!"
 msgstr "Une image existe déjà avec ce nom!"
 
 msgid "A valid database connection could not be made"
+msgstr ""
+
+msgid "A worked example of the first one, end to end:"
 msgstr ""
 
 msgid "API"
@@ -1325,10 +1335,6 @@ msgstr "Créer un nouveau %s"
 msgid "CA Path"
 msgstr "Chemin"
 
-#, fuzzy
-msgid "CA private key"
-msgstr "La clé privée a échoué"
-
 msgid "CPU Cache"
 msgstr "Cache du CPU"
 
@@ -1543,6 +1549,10 @@ msgstr "Dernière version"
 msgid "Catch-All Site"
 msgstr ""
 
+#, fuzzy
+msgid "Certificate"
+msgstr "Créer un nouveau %s"
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1556,6 +1566,18 @@ msgstr "Créer un nouveau %s"
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "Créer un nouveau %s"
+
+#, fuzzy
+msgid "Certificate change failed"
+msgstr "Créer un nouveau %s"
+
+#, fuzzy
+msgid "Certificate download failed"
+msgstr "Échec du téléchargement"
+
+#, fuzzy
+msgid "Certificate management is not configured on this server"
+msgstr "Il n'y a pas d'images sur ce serveur."
 
 #, fuzzy
 msgid "Certificates"
@@ -1687,6 +1709,9 @@ msgstr "Paramètres"
 #, fuzzy
 msgid "Client Version"
 msgstr "CPU Version"
+
+msgid "Client communication certificate"
+msgstr ""
 
 msgid "Clients already enforcing Secure Boot cannot run this task -- they will not boot FOS in the first place. Use the manual steps below for those."
 msgstr ""
@@ -1879,9 +1904,17 @@ msgstr "Impossible de lire le fichier tmp."
 msgid "Could not register"
 msgstr "Impossible de créer l'imprimante"
 
+#, fuzzy
+msgid "Could not remove the imported root"
+msgstr "Impossible de lire le fichier tmp."
+
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
+
+#, fuzzy
+msgid "Could not save that preference"
+msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
 msgid "Could not seed the granted targets"
@@ -1893,6 +1926,10 @@ msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
 msgid "Could not stage the upload."
+msgstr "Impossible de lire le fichier tmp."
+
+#, fuzzy
+msgid "Could not stage the uploaded certificate"
 msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
@@ -2126,6 +2163,10 @@ msgstr "Enregistrements courants"
 
 msgid "Current member-host AD state"
 msgstr ""
+
+#, fuzzy
+msgid "Currently imported"
+msgstr "Enregistrements courants"
 
 msgid "DMI Field"
 msgstr ""
@@ -2492,6 +2533,9 @@ msgstr "Durée"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgstr ""
+
 msgid "Edit"
 msgstr "modifier"
 
@@ -2692,6 +2736,9 @@ msgstr ""
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
 
+msgid "Expires"
+msgstr ""
+
 msgid "Export"
 msgstr "Exportation"
 
@@ -2757,6 +2804,9 @@ msgstr "Windows 8"
 #, fuzzy
 msgid "Export the database"
 msgstr "date"
+
+msgid "External root CA"
+msgstr ""
 
 msgid "FOG"
 msgstr "BROUILLARD"
@@ -4350,6 +4400,10 @@ msgid "Import known mac address makers"
 msgstr ""
 
 #, fuzzy
+msgid "Imported root"
+msgstr "Hôtes d'importation"
+
+#, fuzzy
 msgid "Imported successfully!"
 msgstr "Installation / Mise à jour réussie!"
 
@@ -4423,6 +4477,10 @@ msgstr "Installer Plugins"
 #, fuzzy
 msgid "Install plugins failed!"
 msgstr "Installer Plugins"
+
+#, fuzzy
+msgid "Install preferences"
+msgstr "Supprimer sélectionnée"
 
 #, fuzzy
 msgid "Install selected"
@@ -4985,6 +5043,9 @@ msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
 msgid "Legacy BIOS (no Secure Boot)"
+msgstr ""
+
+msgid "Let's Encrypt with FOG"
 msgstr ""
 
 msgid "Level"
@@ -5726,6 +5787,10 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr "Aucun fichier a été téléchargé"
 
+#, fuzzy
+msgid "No certificate file was uploaded"
+msgstr "Aucun fichier a été téléchargé"
+
 msgid "No change"
 msgstr ""
 
@@ -5750,6 +5815,9 @@ msgid "No database to work off"
 msgstr "Aucune base de données de travailler hors"
 
 msgid "No external data to download the file from"
+msgstr ""
+
+msgid "No external root is imported on this server."
 msgstr ""
 
 msgid "No fields passed"
@@ -6017,6 +6085,9 @@ msgstr ""
 msgid "Not allowed here"
 msgstr "Non autorisé ici"
 
+msgid "Not offered here, on purpose"
+msgstr ""
+
 #, fuzzy
 msgid "Not pinged"
 msgstr "Plugins installés"
@@ -6138,6 +6209,9 @@ msgstr ""
 msgid "Off - direct membership only"
 msgstr ""
 
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgstr ""
+
 #, fuzzy
 msgid "Offered to every user on this grid."
 msgstr " | Cela ne veut pas le groupe principal"
@@ -6206,6 +6280,9 @@ msgid "Only an administrator may grant full access."
 msgstr "Modifier Groupe"
 
 msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
+msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
 msgstr ""
 
 msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
@@ -6712,6 +6789,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preference saved"
+msgstr ""
+
 msgid "Preferences"
 msgstr ""
 
@@ -6831,6 +6911,9 @@ msgstr "La clé privée pas lisible"
 
 msgid "Private key path not found"
 msgstr "chemin de la clé privée non trouvée"
+
+msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
+msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -6992,6 +7075,9 @@ msgstr "Réinitialiser"
 msgid "Reboot after deploy"
 msgstr "a été détruit"
 
+msgid "Rebuild iPXE with this server's CA embedded"
+msgstr ""
+
 msgid "Receive"
 msgstr "Recevoir"
 
@@ -7013,6 +7099,9 @@ msgstr "Enregistrement non trouvé, Erreur: %s"
 #, fuzzy
 msgid "Records"
 msgstr "Enregistrements courants"
+
+msgid "Redirect HTTP to HTTPS"
+msgstr ""
 
 msgid "Redirect Login To This Provider"
 msgstr ""
@@ -7086,6 +7175,10 @@ msgid "Remove file data"
 msgstr "supprimé"
 
 #, fuzzy
+msgid "Remove imported root"
+msgstr "supprimé"
+
+#, fuzzy
 msgid "Remove selected"
 msgstr "Retirer snapins sélectionnés"
 
@@ -7123,6 +7216,9 @@ msgstr ""
 
 #, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
+msgstr ""
+
+msgid "Replacing the root itself -- so that FOG's anchor becomes an intermediate of yours -- is a migration rather than a setting. It changes the certificate every registered fog-client pins, so every one of them stops authenticating until it is re-pinned. That is not something a web form should be able to do in one click, so it is not on this page."
 msgstr ""
 
 #, fuzzy
@@ -7293,6 +7389,21 @@ msgstr ""
 msgid "Roles"
 msgstr ""
 
+msgid "Root"
+msgstr ""
+
+#, fuzzy
+msgid "Root CA certificate (PEM)"
+msgstr "Créer un nouveau %s"
+
+#, fuzzy
+msgid "Root imported"
+msgstr "Inventaire"
+
+#, fuzzy
+msgid "Root removed"
+msgstr "supprimé"
+
 msgid "Row"
 msgstr "Rangée"
 
@@ -7384,6 +7495,9 @@ msgid "Save the site before setting catch-all"
 msgstr ""
 
 msgid "Saved filters for one grid"
+msgstr ""
+
+msgid "Saved. It takes effect the next time the installer runs."
 msgstr ""
 
 #, fuzzy
@@ -7524,7 +7638,7 @@ msgstr ""
 msgid "Secure Boot (reported)"
 msgstr ""
 
-msgid "Secure Boot CA private key"
+msgid "Secure Boot CA"
 msgstr ""
 
 msgid "Secure Boot Enrolled"
@@ -7803,6 +7917,12 @@ msgstr ""
 #, fuzzy
 msgid "Signs In With"
 msgstr "Snapin Run With"
+
+msgid "Signs the FOS kernel signing certificate. Not a web certificate."
+msgstr ""
+
+msgid "Signs the web server certificate and every storage node certificate."
+msgstr ""
 
 #, fuzzy
 msgid "Single Logout"
@@ -8798,6 +8918,14 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That certificate is not available on this server."
+msgstr "Il n'y a pas de groupes sur ce serveur."
+
+#, fuzzy
+msgid "That file is too large to be a root CA certificate"
+msgstr "n'a pas réussi à sauver"
+
+#, fuzzy
 msgid "That filter is too large to save"
 msgstr "n'a pas réussi à sauver"
 
@@ -8941,6 +9069,17 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
+#, fuzzy
+msgid "The certificate chain"
+msgstr "Créer un nouveau %s"
+
+msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
+msgstr ""
+
+#, fuzzy
+msgid "The certificate was refused"
+msgstr "Aucun fichier a été téléchargé"
+
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
@@ -9020,6 +9159,9 @@ msgstr "Le nœud de stockage des groupes de stockage associé est pas valide"
 
 msgid "The image storage group assigned is not valid"
 msgstr "Le groupe de stockage d'images attribuée est non valable"
+
+msgid "The imported root CA has been removed."
+msgstr ""
 
 #, fuzzy
 msgid "The installers for the fog client"
@@ -9106,7 +9248,16 @@ msgstr ""
 msgid "The provider returned a configuration for a different issuer"
 msgstr ""
 
+msgid "The public half of the keypair fog-client encrypts its check-in to."
+msgstr ""
+
 msgid "The resource is not in a cancellable state."
+msgstr ""
+
+msgid "The root CA has been imported and this server now trusts it."
+msgstr ""
+
+msgid "The root CA has been imported, but this host's system trust store could not be updated -- so HTTPS calls made on this server will not accept it yet. Re-run the installer, and check the installation log."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."
@@ -9145,6 +9296,9 @@ msgstr "Le nœud de stockage des groupes de stockage associé est pas valide"
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
+msgid "The trust anchor. Every fog-client pins this one."
+msgstr ""
+
 msgid "The upload did not arrive."
 msgstr ""
 
@@ -9164,6 +9318,9 @@ msgid "The uploaded file was only partially uploaded"
 msgstr "Le fichier n'a été que partiellement téléchargé"
 
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
+msgstr ""
+
+msgid "The web certificate chains to a public CA"
 msgstr ""
 
 msgid "Theme"
@@ -9225,6 +9382,9 @@ msgstr ""
 msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
 msgstr ""
 
+msgid "These decide what the NEXT installer run does. Nothing here takes effect until the installer runs again -- this page records the preference, it does not rewrite the web server configuration or reissue a certificate."
+msgstr ""
+
 #, php-format
 msgid "These plugins are still installed on disk, so forgetting them would achieve nothing: %s. Uninstall them instead."
 msgstr ""
@@ -9248,6 +9408,9 @@ msgstr ""
 msgid "This document"
 msgstr ""
 
+msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
 msgid "This endpoint only accepts POST."
 msgstr ""
 
@@ -9265,6 +9428,9 @@ msgstr ""
 
 #, php-format
 msgid "This host has finished deploying image %s."
+msgstr ""
+
+msgid "This host has no system trust store that FOG recognizes, so an imported root is recorded and re-applied but never reaches the host's own HTTPS clients."
 msgstr ""
 
 msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
@@ -9330,6 +9496,9 @@ msgstr ""
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
 msgstr ""
 
+msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9367,6 +9536,9 @@ msgid "This server's hostname, as its certificate names it."
 msgstr ""
 
 msgid "This server's own IP address. Space-separated when the interface carries more than one."
+msgstr ""
+
+msgid "This server's web certificate already resolves outside FOG's own PKI, so FOG treats it as managed elsewhere and will not reissue it or lock its key down, whatever these say. That is derived from where the certificate actually is, not from a setting, so the two cannot disagree."
 msgstr ""
 
 msgid "This servers ip(s)"
@@ -9466,6 +9638,9 @@ msgstr ""
 msgid "To get started please select an item from the menu."
 msgstr ""
 
+msgid "To have your own CA issue FOG's web certificates, import the CA and its key by re-running the installer. That replaces the CA that signs the web server certificate and the storage node certificates -- and only that. The root fog-client pins is left alone, so no client re-enrolls."
+msgstr ""
+
 msgid "Toggle Dropdown"
 msgstr ""
 
@@ -9527,6 +9702,9 @@ msgstr ""
 msgid "Trust anchor"
 msgstr ""
 
+msgid "Trust anchor bundle"
+msgstr ""
+
 msgid "Trusted Node CIDRs"
 msgstr ""
 
@@ -9537,6 +9715,9 @@ msgstr "snapin Chemin"
 #, fuzzy
 msgid "Trying image size for"
 msgstr "snapin Chemin"
+
+msgid "Turn this on for a Let's Encrypt or purchased certificate. It stops FOG re-issuing the leaf, stops it locking the private key to root -- which would break the renewal that writes it -- and steers netboot to HTTPS with no iPXE rebuild, because upstream iPXE cross-certifies public CAs already."
+msgstr ""
 
 msgid "Two routes are covered in the guide linked above: a live USB with the kit above, or PXE-booting the client and choosing Enroll Secure Boot Key, which now fetches MOK.der over the network on its own, with no USB stick needed."
 msgstr ""
@@ -9694,6 +9875,10 @@ msgstr "Inconnu"
 msgid "Unknown DB error"
 msgstr "Erreur inconnue de téléchargement a eu lieu. Code de retour: "
 
+#, fuzzy
+msgid "Unknown action"
+msgstr "Erreur inconnue de téléchargement a eu lieu. Code de retour: "
+
 #, php-format
 msgid "Unknown field for %s: %s"
 msgstr ""
@@ -9807,6 +9992,9 @@ msgstr "Télécharger Rapports"
 
 msgid "Upload Reports"
 msgstr "Télécharger Rapports"
+
+msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"
 msgstr ""
@@ -10077,10 +10265,17 @@ msgstr ""
 msgid "Using the group match function"
 msgstr ""
 
+msgid "Using your own PKI"
+msgstr ""
+
 msgid "VB Script"
 msgstr ""
 
 msgid "VNC"
+msgstr ""
+
+#, php-format
+msgid "Valid until %s."
 msgstr ""
 
 msgid "Value"
@@ -10146,13 +10341,19 @@ msgstr "Nom du nœud de stockage"
 msgid "We cannot connect to LDAP server"
 msgstr "Impossible de se connecter à la base de données"
 
-msgid "Web CA private key"
+msgid "Web CA"
+msgstr ""
+
+msgid "Web CA plus the root that anchors it -- what a client needs to verify this server."
 msgstr ""
 
 msgid "Web Server"
 msgstr "Serveur Web"
 
-msgid "Web server private key"
+msgid "Web server certificate"
+msgstr ""
+
+msgid "Web trust chain"
 msgstr ""
 
 msgid "Weekly"
@@ -10167,6 +10368,12 @@ msgstr ""
 #, fuzzy
 msgid "What gets enrolled"
 msgstr "a été mis à jour avec succès"
+
+msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
+msgstr ""
+
+msgid "What this server itself trusts: FOG's root, plus any root imported below."
+msgstr ""
 
 msgid "What to do next"
 msgstr ""
@@ -11491,6 +11698,10 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Sauvegarder les modifications"
 
+#, fuzzy
+#~ msgid "CA private key"
+#~ msgstr "La clé privée a échoué"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Vérifiez que la base de données est en cours d'exécution"
 
@@ -11716,10 +11927,6 @@ msgstr ""
 
 #~ msgid "Import Printers"
 #~ msgstr "Imprimantes d'importation"
-
-#, fuzzy
-#~ msgid "Import Report"
-#~ msgstr "Hôtes d'importation"
 
 #, fuzzy
 #~ msgid "Import Reports"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -116,6 +116,10 @@ msgid "%d architecture(s) updated."
 msgstr "aggiornato stampante!"
 
 #, php-format
+msgid "%d certificates in this file"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -415,6 +419,9 @@ msgstr "Esiste già un ruolo con questo nome!"
 msgid "A role with this name already exists!"
 msgstr "Un nome host con questo nome esiste già"
 
+msgid "A root CA uploaded on this page. Absent unless one was imported."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "È richiesto un nome di gruppo!"
@@ -491,6 +498,9 @@ msgstr "Esiste già un nome utente con questo nome!"
 
 msgid "A valid database connection could not be made"
 msgstr "Non è possibile effettuare una connessione di database valida"
+
+msgid "A worked example of the first one, end to end:"
+msgstr ""
 
 #, fuzzy
 msgid "API"
@@ -1285,10 +1295,6 @@ msgstr "Crea nuova posizione"
 msgid "CA Path"
 msgstr "Percorso"
 
-#, fuzzy
-msgid "CA private key"
-msgstr "Chiave privata non è riuscita"
-
 msgid "CPU Cache"
 msgstr "cache della CPU"
 
@@ -1499,6 +1505,10 @@ msgstr "Ultima versione"
 msgid "Catch-All Site"
 msgstr ""
 
+#, fuzzy
+msgid "Certificate"
+msgstr "Crea nuova posizione"
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1512,6 +1522,18 @@ msgstr "Crea nuova posizione"
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "Crea nuova posizione"
+
+#, fuzzy
+msgid "Certificate change failed"
+msgstr "Crea nuova posizione"
+
+#, fuzzy
+msgid "Certificate download failed"
+msgstr "Scaricamento fallito"
+
+#, fuzzy
+msgid "Certificate management is not configured on this server"
+msgstr "Non ci sono immagini su questo server"
 
 #, fuzzy
 msgid "Certificates"
@@ -1638,6 +1660,9 @@ msgstr "Impostazioni Client"
 
 msgid "Client Version"
 msgstr "Versione client"
+
+msgid "Client communication certificate"
+msgstr ""
 
 msgid "Clients already enforcing Secure Boot cannot run this task -- they will not boot FOS in the first place. Use the manual steps below for those."
 msgstr ""
@@ -1819,9 +1844,17 @@ msgstr "Impossibile leggere il file tmp."
 msgid "Could not register"
 msgstr "Non posso registrare"
 
+#, fuzzy
+msgid "Could not remove the imported root"
+msgstr "Impossibile leggere il file tmp."
+
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
+
+#, fuzzy
+msgid "Could not save that preference"
+msgstr "Impossibile leggere il file tmp."
 
 #, fuzzy
 msgid "Could not seed the granted targets"
@@ -1833,6 +1866,10 @@ msgstr "Impossibile leggere il file tmp."
 
 #, fuzzy
 msgid "Could not stage the upload."
+msgstr "Impossibile leggere il file tmp."
+
+#, fuzzy
+msgid "Could not stage the uploaded certificate"
 msgstr "Impossibile leggere il file tmp."
 
 #, fuzzy
@@ -2065,6 +2102,10 @@ msgstr "Current Records"
 
 msgid "Current member-host AD state"
 msgstr ""
+
+#, fuzzy
+msgid "Currently imported"
+msgstr "Current Records"
 
 msgid "DMI Field"
 msgstr ""
@@ -2424,6 +2465,9 @@ msgstr "Durata"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgstr ""
+
 msgid "Edit"
 msgstr "Modifica"
 
@@ -2623,6 +2667,9 @@ msgstr "Exists deve essere boolean"
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
 
+msgid "Expires"
+msgstr ""
+
 msgid "Export"
 msgstr "Esportare"
 
@@ -2683,6 +2730,9 @@ msgstr "Esporta chiavi Windows"
 #, fuzzy
 msgid "Export the database"
 msgstr "Importa database"
+
+msgid "External root CA"
+msgstr ""
 
 msgid "FOG"
 msgstr "NEBBIA"
@@ -4226,6 +4276,10 @@ msgid "Import known mac address makers"
 msgstr ""
 
 #, fuzzy
+msgid "Imported root"
+msgstr "Importa Report"
+
+#, fuzzy
 msgid "Imported successfully!"
 msgstr "Impostazioni iPXE aggiornate correttamente!"
 
@@ -4296,6 +4350,10 @@ msgstr "installare plugin"
 #, fuzzy
 msgid "Install plugins failed!"
 msgstr "installare plugin"
+
+#, fuzzy
+msgid "Install preferences"
+msgstr "Cancella selezionato"
 
 #, fuzzy
 msgid "Install selected"
@@ -4834,6 +4892,9 @@ msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
 msgid "Legacy BIOS (no Secure Boot)"
+msgstr ""
+
+msgid "Let's Encrypt with FOG"
 msgstr ""
 
 msgid "Level"
@@ -5553,6 +5614,10 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr "Nessun file è stato caricato"
 
+#, fuzzy
+msgid "No certificate file was uploaded"
+msgstr "Nessun file è stato caricato"
+
 msgid "No change"
 msgstr ""
 
@@ -5576,6 +5641,9 @@ msgid "No database to work off"
 msgstr "Nessun database di lavorare off"
 
 msgid "No external data to download the file from"
+msgstr ""
+
+msgid "No external root is imported on this server."
 msgstr ""
 
 msgid "No fields passed"
@@ -5831,6 +5899,9 @@ msgstr ""
 msgid "Not allowed here"
 msgstr "Non ammessi qui"
 
+msgid "Not offered here, on purpose"
+msgstr ""
+
 #, fuzzy
 msgid "Not pinged"
 msgstr "Non sincronizzo"
@@ -5952,6 +6023,9 @@ msgstr ""
 msgid "Off - direct membership only"
 msgstr ""
 
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgstr ""
+
 #, fuzzy
 msgid "Offered to every user on this grid."
 msgstr "Questo non è il gruppo primario"
@@ -6017,6 +6091,9 @@ msgid "Only an administrator may grant full access."
 msgstr "Gruppo amministrativo"
 
 msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
+msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
 msgstr ""
 
 msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
@@ -6510,6 +6587,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preference saved"
+msgstr ""
+
 msgid "Preferences"
 msgstr ""
 
@@ -6623,6 +6703,9 @@ msgstr "chiave privata non leggibile"
 
 msgid "Private key path not found"
 msgstr "Percorso chiave privata non trovata"
+
+msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
+msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -6784,6 +6867,9 @@ msgstr "Riavvio"
 msgid "Reboot after deploy"
 msgstr "è stato completato"
 
+msgid "Rebuild iPXE with this server's CA embedded"
+msgstr ""
+
 msgid "Receive"
 msgstr "Ricevere"
 
@@ -6804,6 +6890,9 @@ msgstr "Record non trovato"
 #, fuzzy
 msgid "Records"
 msgstr "Current Records"
+
+msgid "Redirect HTTP to HTTPS"
+msgstr ""
 
 msgid "Redirect Login To This Provider"
 msgstr ""
@@ -6876,6 +6965,10 @@ msgid "Remove file data"
 msgstr "Rimozione fallita"
 
 #, fuzzy
+msgid "Remove imported root"
+msgstr "Rimozione fallita"
+
+#, fuzzy
 msgid "Remove selected"
 msgstr "Rimuovi i selezionati"
 
@@ -6912,6 +7005,9 @@ msgstr ""
 
 #, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
+msgstr ""
+
+msgid "Replacing the root itself -- so that FOG's anchor becomes an intermediate of yours -- is a migration rather than a setting. It changes the certificate every registered fog-client pins, so every one of them stops authenticating until it is re-pinned. That is not something a web form should be able to do in one click, so it is not on this page."
 msgstr ""
 
 #, fuzzy
@@ -7076,6 +7172,21 @@ msgstr ""
 msgid "Roles"
 msgstr ""
 
+msgid "Root"
+msgstr ""
+
+#, fuzzy
+msgid "Root CA certificate (PEM)"
+msgstr "Crea nuova posizione"
+
+#, fuzzy
+msgid "Root imported"
+msgstr "Consigliato"
+
+#, fuzzy
+msgid "Root removed"
+msgstr "Rimosso"
+
 msgid "Row"
 msgstr "Riga"
 
@@ -7165,6 +7276,9 @@ msgid "Save the site before setting catch-all"
 msgstr ""
 
 msgid "Saved filters for one grid"
+msgstr ""
+
+msgid "Saved. It takes effect the next time the installer runs."
 msgstr ""
 
 msgid "Saving data for"
@@ -7299,7 +7413,7 @@ msgstr ""
 msgid "Secure Boot (reported)"
 msgstr ""
 
-msgid "Secure Boot CA private key"
+msgid "Secure Boot CA"
 msgstr ""
 
 msgid "Secure Boot Enrolled"
@@ -7573,6 +7687,12 @@ msgstr ""
 #, fuzzy
 msgid "Signs In With"
 msgstr "Snapin Avvia con"
+
+msgid "Signs the FOS kernel signing certificate. Not a web certificate."
+msgstr ""
+
+msgid "Signs the web server certificate and every storage node certificate."
+msgstr ""
 
 #, fuzzy
 msgid "Single Logout"
@@ -8517,6 +8637,14 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That certificate is not available on this server."
+msgstr "Non ci sono gruppi su questo server"
+
+#, fuzzy
+msgid "That file is too large to be a root CA certificate"
+msgstr "fallito il salvataggio"
+
+#, fuzzy
 msgid "That filter is too large to save"
 msgstr "fallito il salvataggio"
 
@@ -8659,6 +8787,17 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
+#, fuzzy
+msgid "The certificate chain"
+msgstr "Crea nuova posizione"
+
+msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
+msgstr ""
+
+#, fuzzy
+msgid "The certificate was refused"
+msgstr "Nessun file è stato caricato"
+
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
@@ -8738,6 +8877,9 @@ msgstr "Il nodo di archiviazione gruppi di archiviazione associato non è valido
 
 msgid "The image storage group assigned is not valid"
 msgstr "Il gruppo di archiviazione immagine assegnato non è valido"
+
+msgid "The imported root CA has been removed."
+msgstr ""
 
 msgid "The installers for the fog client"
 msgstr "Installatori per fog client"
@@ -8823,7 +8965,16 @@ msgstr ""
 msgid "The provider returned a configuration for a different issuer"
 msgstr ""
 
+msgid "The public half of the keypair fog-client encrypts its check-in to."
+msgstr ""
+
 msgid "The resource is not in a cancellable state."
+msgstr ""
+
+msgid "The root CA has been imported and this server now trusts it."
+msgstr ""
+
+msgid "The root CA has been imported, but this host's system trust store could not be updated -- so HTTPS calls made on this server will not accept it yet. Re-run the installer, and check the installation log."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."
@@ -8862,6 +9013,9 @@ msgstr "Il nodo di archiviazione gruppi di archiviazione associato non è valido
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
+msgid "The trust anchor. Every fog-client pins this one."
+msgstr ""
+
 msgid "The upload did not arrive."
 msgstr ""
 
@@ -8879,6 +9033,9 @@ msgid "The uploaded file was only partially uploaded"
 msgstr "Il file caricato è stato solo parzialmente caricato"
 
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
+msgstr ""
+
+msgid "The web certificate chains to a public CA"
 msgstr ""
 
 msgid "Theme"
@@ -8938,6 +9095,9 @@ msgstr "Qui è possibile scaricare programmi di utilità come FOG Prep"
 msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
 msgstr ""
 
+msgid "These decide what the NEXT installer run does. Nothing here takes effect until the installer runs again -- this page records the preference, it does not rewrite the web server configuration or reissue a certificate."
+msgstr ""
+
 #, php-format
 msgid "These plugins are still installed on disk, so forgetting them would achieve nothing: %s. Uninstall them instead."
 msgstr ""
@@ -8962,6 +9122,9 @@ msgstr ""
 msgid "This document"
 msgstr ""
 
+msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
 msgid "This endpoint only accepts POST."
 msgstr ""
 
@@ -8978,6 +9141,9 @@ msgstr ""
 
 #, php-format
 msgid "This host has finished deploying image %s."
+msgstr ""
+
+msgid "This host has no system trust store that FOG recognizes, so an imported root is recorded and re-applied but never reaches the host's own HTTPS clients."
 msgstr ""
 
 msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
@@ -9042,6 +9208,9 @@ msgstr ""
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
 msgstr ""
 
+msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9079,6 +9248,9 @@ msgid "This server's hostname, as its certificate names it."
 msgstr ""
 
 msgid "This server's own IP address. Space-separated when the interface carries more than one."
+msgstr ""
+
+msgid "This server's web certificate already resolves outside FOG's own PKI, so FOG treats it as managed elsewhere and will not reissue it or lock its key down, whatever these say. That is derived from where the certificate actually is, not from a setting, so the two cannot disagree."
 msgstr ""
 
 msgid "This servers ip(s)"
@@ -9174,6 +9346,9 @@ msgstr ""
 msgid "To get started please select an item from the menu."
 msgstr "Per iniziare, seleziona un elemento dal menu."
 
+msgid "To have your own CA issue FOG's web certificates, import the CA and its key by re-running the installer. That replaces the CA that signs the web server certificate and the storage node certificates -- and only that. The root fog-client pins is left alone, so no client re-enrolls."
+msgstr ""
+
 msgid "Toggle Dropdown"
 msgstr ""
 
@@ -9234,6 +9409,9 @@ msgstr ""
 msgid "Trust anchor"
 msgstr ""
 
+msgid "Trust anchor bundle"
+msgstr ""
+
 msgid "Trusted Node CIDRs"
 msgstr ""
 
@@ -9242,6 +9420,9 @@ msgstr "Cercando hash di Snapin per"
 
 msgid "Trying image size for"
 msgstr "Prova della dimensione dell'immagine per"
+
+msgid "Turn this on for a Let's Encrypt or purchased certificate. It stops FOG re-issuing the leaf, stops it locking the private key to root -- which would break the renewal that writes it -- and steers netboot to HTTPS with no iPXE rebuild, because upstream iPXE cross-certifies public CAs already."
+msgstr ""
 
 msgid "Two routes are covered in the guide linked above: a live USB with the kit above, or PXE-booting the client and choosing Enroll Secure Boot Key, which now fetches MOK.der over the network on its own, with no USB stick needed."
 msgstr ""
@@ -9395,6 +9576,10 @@ msgstr "Sconosciuto"
 msgid "Unknown DB error"
 msgstr "Si è verificato errore di caricamento sconosciuto"
 
+#, fuzzy
+msgid "Unknown action"
+msgstr "Si è verificato errore di caricamento sconosciuto"
+
 #, php-format
 msgid "Unknown field for %s: %s"
 msgstr ""
@@ -9507,6 +9692,9 @@ msgstr "Carica Report"
 
 msgid "Upload Reports"
 msgstr "Carica Report"
+
+msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"
 msgstr ""
@@ -9766,10 +9954,17 @@ msgstr ""
 msgid "Using the group match function"
 msgstr "Utilizzo della funzione di corrispondenza gruppo"
 
+msgid "Using your own PKI"
+msgstr ""
+
 msgid "VB Script"
 msgstr ""
 
 msgid "VNC"
+msgstr ""
+
+#, php-format
+msgid "Valid until %s."
 msgstr ""
 
 msgid "Value"
@@ -9829,13 +10024,19 @@ msgstr "Siamo il nome del nodo"
 msgid "We cannot connect to LDAP server"
 msgstr "Non è possibile connettersi al server LDAP"
 
-msgid "Web CA private key"
+msgid "Web CA"
+msgstr ""
+
+msgid "Web CA plus the root that anchors it -- what a client needs to verify this server."
 msgstr ""
 
 msgid "Web Server"
 msgstr "Server web"
 
-msgid "Web server private key"
+msgid "Web server certificate"
+msgstr ""
+
+msgid "Web trust chain"
 msgstr ""
 
 msgid "Weekly"
@@ -9850,6 +10051,12 @@ msgstr ""
 #, fuzzy
 msgid "What gets enrolled"
 msgstr "è stato cancellato"
+
+msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
+msgstr ""
+
+msgid "What this server itself trusts: FOG's root, plus any root imported below."
+msgstr ""
 
 msgid "What to do next"
 msgstr ""
@@ -11125,6 +11332,10 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Applicare cambiamenti?"
 
+#, fuzzy
+#~ msgid "CA private key"
+#~ msgstr "Chiave privata non è riuscita"
+
 #~ msgid "Can not redeclare route"
 #~ msgstr "Impossibile ridichiarare il percorso"
 
@@ -11355,10 +11566,6 @@ msgstr ""
 
 #~ msgid "Import Printers"
 #~ msgstr "Stampanti di importazione"
-
-#, fuzzy
-#~ msgid "Import Report"
-#~ msgstr "Importa Report"
 
 #~ msgid "Import Reports"
 #~ msgstr "Importa Report"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -107,6 +107,10 @@ msgid "%d architecture(s) updated."
 msgstr "プリンターを更新しました！"
 
 #, php-format
+msgid "%d certificates in this file"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -404,6 +408,9 @@ msgstr "この名前のロールは既に存在します！"
 msgid "A role with this name already exists!"
 msgstr "その名前のホストは既に存在します"
 
+msgid "A root CA uploaded on this page. Absent unless one was imported."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "名前は必須です！"
@@ -477,6 +484,9 @@ msgstr "このユーザー名は既に存在します！"
 
 msgid "A valid database connection could not be made"
 msgstr "有効なデータベース接続を確立できませんでした"
+
+msgid "A worked example of the first one, end to end:"
+msgstr ""
 
 #, fuzzy
 msgid "API"
@@ -1269,10 +1279,6 @@ msgstr "新しいロケーションを作成"
 msgid "CA Path"
 msgstr "パス"
 
-#, fuzzy
-msgid "CA private key"
-msgstr "秘密鍵の処理に失敗しました"
-
 msgid "CPU Cache"
 msgstr "CPU キャッシュ"
 
@@ -1483,6 +1489,10 @@ msgstr "シャーシバージョン"
 msgid "Catch-All Site"
 msgstr "サイトを作成"
 
+#, fuzzy
+msgid "Certificate"
+msgstr "新しいロケーションを作成"
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1496,6 +1506,18 @@ msgstr "新しいロケーションを作成"
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "新しいロケーションを作成"
+
+#, fuzzy
+msgid "Certificate change failed"
+msgstr "新しいロケーションを作成"
+
+#, fuzzy
+msgid "Certificate download failed"
+msgstr "ダウンロードに失敗しました"
+
+#, fuzzy
+msgid "Certificate management is not configured on this server"
+msgstr "このサーバーにはグループがありません"
 
 #, fuzzy
 msgid "Certificates"
@@ -1622,6 +1644,9 @@ msgstr "クライアント設定"
 
 msgid "Client Version"
 msgstr "クライアントバージョン"
+
+msgid "Client communication certificate"
+msgstr ""
 
 msgid "Clients already enforcing Secure Boot cannot run this task -- they will not boot FOS in the first place. Use the manual steps below for those."
 msgstr ""
@@ -1803,9 +1828,17 @@ msgstr "一時ファイルを読み取れませんでした。"
 msgid "Could not register"
 msgstr "登録できませんでした"
 
+#, fuzzy
+msgid "Could not remove the imported root"
+msgstr "一時ファイルを読み取れませんでした。"
+
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
+
+#, fuzzy
+msgid "Could not save that preference"
+msgstr "一時ファイルを読み取れませんでした。"
 
 #, fuzzy
 msgid "Could not seed the granted targets"
@@ -1817,6 +1850,10 @@ msgstr "一時ファイルを読み取れませんでした。"
 
 #, fuzzy
 msgid "Could not stage the upload."
+msgstr "一時ファイルを読み取れませんでした。"
+
+#, fuzzy
+msgid "Could not stage the uploaded certificate"
 msgstr "一時ファイルを読み取れませんでした。"
 
 #, fuzzy
@@ -2049,6 +2086,10 @@ msgstr "現在のレコード"
 
 msgid "Current member-host AD state"
 msgstr ""
+
+#, fuzzy
+msgid "Currently imported"
+msgstr "現在のレコード"
 
 msgid "DMI Field"
 msgstr "DMI フィールド"
@@ -2407,6 +2448,9 @@ msgstr "期間"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgstr ""
+
 msgid "Edit"
 msgstr "編集"
 
@@ -2606,6 +2650,9 @@ msgstr "Exists 項目はブール値である必要があります"
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
 
+msgid "Expires"
+msgstr ""
+
 msgid "Export"
 msgstr "エクスポート"
 
@@ -2666,6 +2713,9 @@ msgstr "Windows キーをエクスポート"
 #, fuzzy
 msgid "Export the database"
 msgstr "データベースをエクスポート"
+
+msgid "External root CA"
+msgstr ""
 
 msgid "FOG"
 msgstr "FOG"
@@ -4190,6 +4240,10 @@ msgid "Import known mac address makers"
 msgstr ""
 
 #, fuzzy
+msgid "Imported root"
+msgstr "ホストをインポート"
+
+#, fuzzy
 msgid "Imported successfully!"
 msgstr "インポートに成功しました"
 
@@ -4259,6 +4313,10 @@ msgstr "プラグインをインストール"
 #, fuzzy
 msgid "Install plugins failed!"
 msgstr "プラグインをインストール"
+
+#, fuzzy
+msgid "Install preferences"
+msgstr "カーネルをインストール"
 
 #, fuzzy
 msgid "Install selected"
@@ -4797,6 +4855,9 @@ msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
 msgid "Legacy BIOS (no Secure Boot)"
+msgstr ""
+
+msgid "Let's Encrypt with FOG"
 msgstr ""
 
 msgid "Level"
@@ -5514,6 +5575,10 @@ msgid "No archive was uploaded."
 msgstr "ファイルはアップロードされませんでした"
 
 #, fuzzy
+msgid "No certificate file was uploaded"
+msgstr "ファイルはアップロードされませんでした"
+
+#, fuzzy
 msgid "No change"
 msgstr "変更を適用しますか？"
 
@@ -5536,6 +5601,9 @@ msgid "No database to work off"
 msgstr "使用するデータベースがありません"
 
 msgid "No external data to download the file from"
+msgstr ""
+
+msgid "No external root is imported on this server."
 msgstr ""
 
 msgid "No fields passed"
@@ -5793,6 +5861,9 @@ msgstr ""
 msgid "Not allowed here"
 msgstr "ここでは許可されていません"
 
+msgid "Not offered here, on purpose"
+msgstr ""
+
 #, fuzzy
 msgid "Not pinged"
 msgstr "同期していません"
@@ -5915,6 +5986,9 @@ msgstr ""
 msgid "Off - direct membership only"
 msgstr ""
 
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgstr ""
+
 #, fuzzy
 msgid "Offered to every user on this grid."
 msgstr "このグループ内のすべてのホストでこの項目をクリアします。"
@@ -5979,6 +6053,9 @@ msgid "Only an administrator may grant full access."
 msgstr ""
 
 msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
+msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
 msgstr ""
 
 msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
@@ -6479,6 +6556,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preference saved"
+msgstr ""
+
 msgid "Preferences"
 msgstr ""
 
@@ -6591,6 +6671,9 @@ msgstr "秘密鍵を読み取れません"
 
 msgid "Private key path not found"
 msgstr "秘密鍵のパスが見つかりません"
+
+msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
+msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -6751,6 +6834,9 @@ msgstr "再起動"
 msgid "Reboot after deploy"
 msgstr "展開後に再起動"
 
+msgid "Rebuild iPXE with this server's CA embedded"
+msgstr ""
+
 msgid "Receive"
 msgstr "受信"
 
@@ -6771,6 +6857,9 @@ msgstr "レコードが見つかりません"
 #, fuzzy
 msgid "Records"
 msgstr "現在のレコード"
+
+msgid "Redirect HTTP to HTTPS"
+msgstr ""
 
 msgid "Redirect Login To This Provider"
 msgstr ""
@@ -6843,6 +6932,10 @@ msgid "Remove file data"
 msgstr "削除に失敗しました"
 
 #, fuzzy
+msgid "Remove imported root"
+msgstr "選択したホストを削除"
+
+#, fuzzy
 msgid "Remove selected"
 msgstr "選択した項目を削除"
 
@@ -6878,6 +6971,9 @@ msgstr ""
 
 #, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
+msgstr ""
+
+msgid "Replacing the root itself -- so that FOG's anchor becomes an intermediate of yours -- is a migration rather than a setting. It changes the certificate every registered fog-client pins, so every one of them stops authenticating until it is re-pinned. That is not something a web form should be able to do in one click, so it is not on this page."
 msgstr ""
 
 #, fuzzy
@@ -7035,6 +7131,21 @@ msgstr ""
 msgid "Roles"
 msgstr "ロール"
 
+msgid "Root"
+msgstr ""
+
+#, fuzzy
+msgid "Root CA certificate (PEM)"
+msgstr "新しいロケーションを作成"
+
+#, fuzzy
+msgid "Root imported"
+msgstr "保護されていません"
+
+#, fuzzy
+msgid "Root removed"
+msgstr "削除済み"
+
 msgid "Row"
 msgstr "行"
 
@@ -7125,6 +7236,9 @@ msgid "Save the site before setting catch-all"
 msgstr ""
 
 msgid "Saved filters for one grid"
+msgstr ""
+
+msgid "Saved. It takes effect the next time the installer runs."
 msgstr ""
 
 msgid "Saving data for"
@@ -7260,7 +7374,7 @@ msgstr ""
 msgid "Secure Boot (reported)"
 msgstr ""
 
-msgid "Secure Boot CA private key"
+msgid "Secure Boot CA"
 msgstr ""
 
 msgid "Secure Boot Enrolled"
@@ -7531,6 +7645,12 @@ msgstr ""
 #, fuzzy
 msgid "Signs In With"
 msgstr "スナップイン実行ユーザー"
+
+msgid "Signs the FOS kernel signing certificate. Not a web certificate."
+msgstr ""
+
+msgid "Signs the web server certificate and every storage node certificate."
+msgstr ""
 
 #, fuzzy
 msgid "Single Logout"
@@ -8459,6 +8579,14 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That certificate is not available on this server."
+msgstr "このサーバーにはグループがありません"
+
+#, fuzzy
+msgid "That file is too large to be a root CA certificate"
+msgstr "保存に失敗しました"
+
+#, fuzzy
 msgid "That filter is too large to save"
 msgstr "保存に失敗しました"
 
@@ -8601,6 +8729,17 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
+#, fuzzy
+msgid "The certificate chain"
+msgstr "新しいロケーションを作成"
+
+msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
+msgstr ""
+
+#, fuzzy
+msgid "The certificate was refused"
+msgstr "ファイルはアップロードされませんでした"
+
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
@@ -8679,6 +8818,9 @@ msgstr "ストレージグループに関連付けられたストレージノー
 
 msgid "The image storage group assigned is not valid"
 msgstr "割り当てられたイメージのストレージグループが無効です"
+
+msgid "The imported root CA has been removed."
+msgstr ""
 
 msgid "The installers for the fog client"
 msgstr "FOG クライアント用インストーラー"
@@ -8766,7 +8908,16 @@ msgstr ""
 msgid "The provider returned a configuration for a different issuer"
 msgstr ""
 
+msgid "The public half of the keypair fog-client encrypts its check-in to."
+msgstr ""
+
 msgid "The resource is not in a cancellable state."
+msgstr ""
+
+msgid "The root CA has been imported and this server now trusts it."
+msgstr ""
+
+msgid "The root CA has been imported, but this host's system trust store could not be updated -- so HTTPS calls made on this server will not accept it yet. Re-run the installer, and check the installation log."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."
@@ -8806,6 +8957,9 @@ msgstr "ストレージグループに関連付けられたストレージノー
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
+msgid "The trust anchor. Every fog-client pins this one."
+msgstr ""
+
 msgid "The upload did not arrive."
 msgstr ""
 
@@ -8823,6 +8977,9 @@ msgid "The uploaded file was only partially uploaded"
 msgstr "アップロードしたファイルは一部しかアップロードされませんでした"
 
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
+msgstr ""
+
+msgid "The web certificate chains to a public CA"
 msgstr ""
 
 msgid "Theme"
@@ -8882,6 +9039,9 @@ msgstr "そこから FOG Prep などのユーティリティをダウンロー�
 msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
 msgstr ""
 
+msgid "These decide what the NEXT installer run does. Nothing here takes effect until the installer runs again -- this page records the preference, it does not rewrite the web server configuration or reissue a certificate."
+msgstr ""
+
 #, php-format
 msgid "These plugins are still installed on disk, so forgetting them would achieve nothing: %s. Uninstall them instead."
 msgstr ""
@@ -8906,6 +9066,9 @@ msgstr ""
 msgid "This document"
 msgstr ""
 
+msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
 msgid "This endpoint only accepts POST."
 msgstr ""
 
@@ -8922,6 +9085,9 @@ msgstr ""
 
 #, php-format
 msgid "This host has finished deploying image %s."
+msgstr ""
+
+msgid "This host has no system trust store that FOG recognizes, so an imported root is recorded and re-applied but never reaches the host's own HTTPS clients."
 msgstr ""
 
 msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
@@ -8985,6 +9151,9 @@ msgstr ""
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
 msgstr ""
 
+msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9022,6 +9191,9 @@ msgid "This server's hostname, as its certificate names it."
 msgstr ""
 
 msgid "This server's own IP address. Space-separated when the interface carries more than one."
+msgstr ""
+
+msgid "This server's web certificate already resolves outside FOG's own PKI, so FOG treats it as managed elsewhere and will not reissue it or lock its key down, whatever these say. That is derived from where the certificate actually is, not from a setting, so the two cannot disagree."
 msgstr ""
 
 msgid "This servers ip(s)"
@@ -9118,6 +9290,9 @@ msgstr ""
 msgid "To get started please select an item from the menu."
 msgstr "開始するにはメニューから項目を選択してください。"
 
+msgid "To have your own CA issue FOG's web certificates, import the CA and its key by re-running the installer. That replaces the CA that signs the web server certificate and the storage node certificates -- and only that. The root fog-client pins is left alone, so no client re-enrolls."
+msgstr ""
+
 msgid "Toggle Dropdown"
 msgstr ""
 
@@ -9178,6 +9353,9 @@ msgstr ""
 msgid "Trust anchor"
 msgstr ""
 
+msgid "Trust anchor bundle"
+msgstr ""
+
 msgid "Trusted Node CIDRs"
 msgstr ""
 
@@ -9186,6 +9364,9 @@ msgstr "次のスナップインのハッシュを取得しています:"
 
 msgid "Trying image size for"
 msgstr "次のイメージサイズを取得しています:"
+
+msgid "Turn this on for a Let's Encrypt or purchased certificate. It stops FOG re-issuing the leaf, stops it locking the private key to root -- which would break the renewal that writes it -- and steers netboot to HTTPS with no iPXE rebuild, because upstream iPXE cross-certifies public CAs already."
+msgstr ""
 
 msgid "Two routes are covered in the guide linked above: a live USB with the kit above, or PXE-booting the client and choosing Enroll Secure Boot Key, which now fetches MOK.der over the network on its own, with no USB stick needed."
 msgstr ""
@@ -9337,6 +9518,10 @@ msgstr "不明"
 msgid "Unknown DB error"
 msgstr "不明なデータベースエラー"
 
+#, fuzzy
+msgid "Unknown action"
+msgstr "不明なデータベースエラー"
+
 #, php-format
 msgid "Unknown field for %s: %s"
 msgstr ""
@@ -9449,6 +9634,9 @@ msgstr "レポートをアップロード"
 
 msgid "Upload Reports"
 msgstr "レポートをアップロード"
+
+msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"
 msgstr "アップロードできるファイルの拡張子は jpg、jpeg、png のいずれかです"
@@ -9712,11 +9900,18 @@ msgstr ""
 msgid "Using the group match function"
 msgstr "グループ照合機能を使用しています"
 
+msgid "Using your own PKI"
+msgstr ""
+
 msgid "VB Script"
 msgstr ""
 
 msgid "VNC"
 msgstr "VNC"
+
+#, php-format
+msgid "Valid until %s."
+msgstr ""
 
 msgid "Value"
 msgstr "値"
@@ -9774,13 +9969,19 @@ msgstr "現在のノード名"
 msgid "We cannot connect to LDAP server"
 msgstr "LDAP サーバーに接続できません"
 
-msgid "Web CA private key"
+msgid "Web CA"
+msgstr ""
+
+msgid "Web CA plus the root that anchors it -- what a client needs to verify this server."
 msgstr ""
 
 msgid "Web Server"
 msgstr "サーバー"
 
-msgid "Web server private key"
+msgid "Web server certificate"
+msgstr ""
+
+msgid "Web trust chain"
 msgstr ""
 
 msgid "Weekly"
@@ -9795,6 +9996,12 @@ msgstr ""
 #, fuzzy
 msgid "What gets enrolled"
 msgstr "強制終了されました"
+
+msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
+msgstr ""
+
+msgid "What this server itself trusts: FOG's root, plus any root imported below."
+msgstr ""
 
 msgid "What to do next"
 msgstr ""
@@ -11168,6 +11375,10 @@ msgstr ""
 #~ msgid "Boot Exit settings"
 #~ msgstr "ブート終了設定"
 
+#, fuzzy
+#~ msgid "CA private key"
+#~ msgstr "秘密鍵の処理に失敗しました"
+
 #~ msgid "Can not redeclare route"
 #~ msgstr "ルートを再定義できません"
 
@@ -11869,9 +12080,6 @@ msgstr ""
 #~ msgid "Import Groups"
 #~ msgstr "グループをインポート"
 
-#~ msgid "Import Hosts"
-#~ msgstr "ホストをインポート"
-
 #~ msgid "Import Images"
 #~ msgstr "イメージをインポート"
 
@@ -11906,9 +12114,6 @@ msgstr ""
 
 #~ msgid "Install / Update Successful!"
 #~ msgstr "インストール/更新に成功しました！"
-
-#~ msgid "Install Kernel"
-#~ msgstr "カーネルをインストール"
 
 #~ msgid "Invalid Host Colors"
 #~ msgstr "無効なホストカラー"
@@ -12510,9 +12715,6 @@ msgstr ""
 
 #~ msgid "Remove selected groups"
 #~ msgstr "選択したグループを削除"
-
-#~ msgid "Remove selected hosts"
-#~ msgstr "選択したホストを削除"
 
 #~ msgid "Remove selected printers"
 #~ msgstr "選択したプリンターを削除"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -92,6 +92,10 @@ msgid "%d architecture(s) updated."
 msgstr ""
 
 #, php-format
+msgid "%d certificates in this file"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -371,6 +375,9 @@ msgstr ""
 msgid "A role with this name already exists!"
 msgstr ""
 
+msgid "A root CA uploaded on this page. Absent unless one was imported."
+msgstr ""
+
 msgid "A scheduled time is required"
 msgstr ""
 
@@ -435,6 +442,9 @@ msgid "A username already exists with this name!"
 msgstr ""
 
 msgid "A valid database connection could not be made"
+msgstr ""
+
+msgid "A worked example of the first one, end to end:"
 msgstr ""
 
 msgid "API"
@@ -1136,9 +1146,6 @@ msgstr ""
 msgid "CA Path"
 msgstr ""
 
-msgid "CA private key"
-msgstr ""
-
 msgid "CPU Cache"
 msgstr ""
 
@@ -1320,6 +1327,9 @@ msgstr ""
 msgid "Catch-All Site"
 msgstr ""
 
+msgid "Certificate"
+msgstr ""
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1330,6 +1340,15 @@ msgid "Certificate Status"
 msgstr ""
 
 msgid "Certificate Verification"
+msgstr ""
+
+msgid "Certificate change failed"
+msgstr ""
+
+msgid "Certificate download failed"
+msgstr ""
+
+msgid "Certificate management is not configured on this server"
 msgstr ""
 
 msgid "Certificates"
@@ -1448,6 +1467,9 @@ msgid "Client Settings"
 msgstr ""
 
 msgid "Client Version"
+msgstr ""
+
+msgid "Client communication certificate"
 msgstr ""
 
 msgid "Clients already enforcing Secure Boot cannot run this task -- they will not boot FOS in the first place. Use the manual steps below for those."
@@ -1609,8 +1631,14 @@ msgstr ""
 msgid "Could not register"
 msgstr ""
 
+msgid "Could not remove the imported root"
+msgstr ""
+
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
+msgstr ""
+
+msgid "Could not save that preference"
 msgstr ""
 
 msgid "Could not seed the granted targets"
@@ -1620,6 +1648,9 @@ msgid "Could not send data from file"
 msgstr ""
 
 msgid "Could not stage the upload."
+msgstr ""
+
+msgid "Could not stage the uploaded certificate"
 msgstr ""
 
 msgid "Could not update host"
@@ -1810,6 +1841,9 @@ msgid "Current Records"
 msgstr ""
 
 msgid "Current member-host AD state"
+msgstr ""
+
+msgid "Currently imported"
 msgstr ""
 
 msgid "DMI Field"
@@ -2123,6 +2157,9 @@ msgstr ""
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgstr ""
+
 msgid "Edit"
 msgstr ""
 
@@ -2304,6 +2341,9 @@ msgstr ""
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
 
+msgid "Expires"
+msgstr ""
+
 msgid "Export"
 msgstr ""
 
@@ -2354,6 +2394,9 @@ msgid "Export Windows Keys"
 msgstr ""
 
 msgid "Export the database"
+msgstr ""
+
+msgid "External root CA"
 msgstr ""
 
 msgid "FOG"
@@ -3696,6 +3739,9 @@ msgstr ""
 msgid "Import known mac address makers"
 msgstr ""
 
+msgid "Imported root"
+msgstr ""
+
 msgid "Imported successfully!"
 msgstr ""
 
@@ -3756,6 +3802,9 @@ msgid "Install a plugin"
 msgstr ""
 
 msgid "Install plugins failed!"
+msgstr ""
+
+msgid "Install preferences"
 msgstr ""
 
 msgid "Install selected"
@@ -4233,6 +4282,9 @@ msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
 msgid "Legacy BIOS (no Secure Boot)"
+msgstr ""
+
+msgid "Let's Encrypt with FOG"
 msgstr ""
 
 msgid "Level"
@@ -4861,6 +4913,9 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr ""
 
+msgid "No certificate file was uploaded"
+msgstr ""
+
 msgid "No change"
 msgstr ""
 
@@ -4883,6 +4938,9 @@ msgid "No database to work off"
 msgstr ""
 
 msgid "No external data to download the file from"
+msgstr ""
+
+msgid "No external root is imported on this server."
 msgstr ""
 
 msgid "No fields passed"
@@ -5113,6 +5171,9 @@ msgstr ""
 msgid "Not allowed here"
 msgstr ""
 
+msgid "Not offered here, on purpose"
+msgstr ""
+
 msgid "Not pinged"
 msgstr ""
 
@@ -5215,6 +5276,9 @@ msgstr ""
 msgid "Off - direct membership only"
 msgstr ""
 
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgstr ""
+
 msgid "Offered to every user on this grid."
 msgstr ""
 
@@ -5276,6 +5340,9 @@ msgid "Only an administrator may grant full access."
 msgstr ""
 
 msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
+msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
 msgstr ""
 
 msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
@@ -5707,6 +5774,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preference saved"
+msgstr ""
+
 msgid "Preferences"
 msgstr ""
 
@@ -5813,6 +5883,9 @@ msgid "Private key not readable"
 msgstr ""
 
 msgid "Private key path not found"
+msgstr ""
+
+msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
 msgstr ""
 
 msgid "Private keys are readable by the web server"
@@ -5948,6 +6021,9 @@ msgstr ""
 msgid "Reboot after deploy"
 msgstr ""
 
+msgid "Rebuild iPXE with this server's CA embedded"
+msgstr ""
+
 msgid "Receive"
 msgstr ""
 
@@ -5964,6 +6040,9 @@ msgid "Recorded in range"
 msgstr ""
 
 msgid "Records"
+msgstr ""
+
+msgid "Redirect HTTP to HTTPS"
 msgstr ""
 
 msgid "Redirect Login To This Provider"
@@ -6028,6 +6107,9 @@ msgstr ""
 msgid "Remove file data"
 msgstr ""
 
+msgid "Remove imported root"
+msgstr ""
+
 msgid "Remove selected"
 msgstr ""
 
@@ -6063,6 +6145,9 @@ msgstr ""
 
 #, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
+msgstr ""
+
+msgid "Replacing the root itself -- so that FOG's anchor becomes an intermediate of yours -- is a migration rather than a setting. It changes the certificate every registered fog-client pins, so every one of them stops authenticating until it is re-pinned. That is not something a web form should be able to do in one click, so it is not on this page."
 msgstr ""
 
 msgid "Replicates"
@@ -6207,6 +6292,18 @@ msgstr ""
 msgid "Roles"
 msgstr ""
 
+msgid "Root"
+msgstr ""
+
+msgid "Root CA certificate (PEM)"
+msgstr ""
+
+msgid "Root imported"
+msgstr ""
+
+msgid "Root removed"
+msgstr ""
+
 msgid "Row"
 msgstr ""
 
@@ -6289,6 +6386,9 @@ msgid "Save the site before setting catch-all"
 msgstr ""
 
 msgid "Saved filters for one grid"
+msgstr ""
+
+msgid "Saved. It takes effect the next time the installer runs."
 msgstr ""
 
 msgid "Saving data for"
@@ -6409,7 +6509,7 @@ msgstr ""
 msgid "Secure Boot (reported)"
 msgstr ""
 
-msgid "Secure Boot CA private key"
+msgid "Secure Boot CA"
 msgstr ""
 
 msgid "Secure Boot Enrolled"
@@ -6646,6 +6746,12 @@ msgid "Signing is already done on this server. The remaining work is per-client 
 msgstr ""
 
 msgid "Signs In With"
+msgstr ""
+
+msgid "Signs the FOS kernel signing certificate. Not a web certificate."
+msgstr ""
+
+msgid "Signs the web server certificate and every storage node certificate."
 msgstr ""
 
 msgid "Single Logout"
@@ -7468,6 +7574,12 @@ msgstr ""
 msgid "Text to match against the id and name. A few classes match more: host also on MAC, storagenode on node hostname, setting on value."
 msgstr ""
 
+msgid "That certificate is not available on this server."
+msgstr ""
+
+msgid "That file is too large to be a root CA certificate"
+msgstr ""
+
 msgid "That filter is too large to save"
 msgstr ""
 
@@ -7598,6 +7710,15 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
+msgid "The certificate chain"
+msgstr ""
+
+msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
+msgstr ""
+
+msgid "The certificate was refused"
+msgstr ""
+
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
@@ -7668,6 +7789,9 @@ msgid "The image associated does not have a valid OS!"
 msgstr ""
 
 msgid "The image storage group assigned is not valid"
+msgstr ""
+
+msgid "The imported root CA has been removed."
 msgstr ""
 
 msgid "The installers for the fog client"
@@ -7750,7 +7874,16 @@ msgstr ""
 msgid "The provider returned a configuration for a different issuer"
 msgstr ""
 
+msgid "The public half of the keypair fog-client encrypts its check-in to."
+msgstr ""
+
 msgid "The resource is not in a cancellable state."
+msgstr ""
+
+msgid "The root CA has been imported and this server now trusts it."
+msgstr ""
+
+msgid "The root CA has been imported, but this host's system trust store could not be updated -- so HTTPS calls made on this server will not accept it yet. Re-run the installer, and check the installation log."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."
@@ -7786,6 +7919,9 @@ msgstr ""
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
+msgid "The trust anchor. Every fog-client pins this one."
+msgstr ""
+
 msgid "The upload did not arrive."
 msgstr ""
 
@@ -7803,6 +7939,9 @@ msgid "The uploaded file was only partially uploaded"
 msgstr ""
 
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
+msgstr ""
+
+msgid "The web certificate chains to a public CA"
 msgstr ""
 
 msgid "Theme"
@@ -7857,6 +7996,9 @@ msgstr ""
 msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
 msgstr ""
 
+msgid "These decide what the NEXT installer run does. Nothing here takes effect until the installer runs again -- this page records the preference, it does not rewrite the web server configuration or reissue a certificate."
+msgstr ""
+
 #, php-format
 msgid "These plugins are still installed on disk, so forgetting them would achieve nothing: %s. Uninstall them instead."
 msgstr ""
@@ -7880,6 +8022,9 @@ msgstr ""
 msgid "This document"
 msgstr ""
 
+msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
 msgid "This endpoint only accepts POST."
 msgstr ""
 
@@ -7896,6 +8041,9 @@ msgstr ""
 
 #, php-format
 msgid "This host has finished deploying image %s."
+msgstr ""
+
+msgid "This host has no system trust store that FOG recognizes, so an imported root is recorded and re-applied but never reaches the host's own HTTPS clients."
 msgstr ""
 
 msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
@@ -7959,6 +8107,9 @@ msgstr ""
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
 msgstr ""
 
+msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -7994,6 +8145,9 @@ msgid "This server's hostname, as its certificate names it."
 msgstr ""
 
 msgid "This server's own IP address. Space-separated when the interface carries more than one."
+msgstr ""
+
+msgid "This server's web certificate already resolves outside FOG's own PKI, so FOG treats it as managed elsewhere and will not reissue it or lock its key down, whatever these say. That is derived from where the certificate actually is, not from a setting, so the two cannot disagree."
 msgstr ""
 
 msgid "This servers ip(s)"
@@ -8086,6 +8240,9 @@ msgstr ""
 msgid "To get started please select an item from the menu."
 msgstr ""
 
+msgid "To have your own CA issue FOG's web certificates, import the CA and its key by re-running the installer. That replaces the CA that signs the web server certificate and the storage node certificates -- and only that. The root fog-client pins is left alone, so no client re-enrolls."
+msgstr ""
+
 msgid "Toggle Dropdown"
 msgstr ""
 
@@ -8140,6 +8297,9 @@ msgstr ""
 msgid "Trust anchor"
 msgstr ""
 
+msgid "Trust anchor bundle"
+msgstr ""
+
 msgid "Trusted Node CIDRs"
 msgstr ""
 
@@ -8147,6 +8307,9 @@ msgid "Trying Snapin hash for"
 msgstr ""
 
 msgid "Trying image size for"
+msgstr ""
+
+msgid "Turn this on for a Let's Encrypt or purchased certificate. It stops FOG re-issuing the leaf, stops it locking the private key to root -- which would break the renewal that writes it -- and steers netboot to HTTPS with no iPXE rebuild, because upstream iPXE cross-certifies public CAs already."
 msgstr ""
 
 msgid "Two routes are covered in the guide linked above: a live USB with the kit above, or PXE-booting the client and choosing Enroll Secure Boot Key, which now fetches MOK.der over the network on its own, with no USB stick needed."
@@ -8275,6 +8438,9 @@ msgstr ""
 msgid "Unknown DB error"
 msgstr ""
 
+msgid "Unknown action"
+msgstr ""
+
 #, php-format
 msgid "Unknown field for %s: %s"
 msgstr ""
@@ -8370,6 +8536,9 @@ msgid "Upload"
 msgstr ""
 
 msgid "Upload Reports"
+msgstr ""
+
+msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
 msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"
@@ -8600,10 +8769,17 @@ msgstr ""
 msgid "Using the group match function"
 msgstr ""
 
+msgid "Using your own PKI"
+msgstr ""
+
 msgid "VB Script"
 msgstr ""
 
 msgid "VNC"
+msgstr ""
+
+#, php-format
+msgid "Valid until %s."
 msgstr ""
 
 msgid "Value"
@@ -8660,13 +8836,19 @@ msgstr ""
 msgid "We cannot connect to LDAP server"
 msgstr ""
 
-msgid "Web CA private key"
+msgid "Web CA"
+msgstr ""
+
+msgid "Web CA plus the root that anchors it -- what a client needs to verify this server."
 msgstr ""
 
 msgid "Web Server"
 msgstr ""
 
-msgid "Web server private key"
+msgid "Web server certificate"
+msgstr ""
+
+msgid "Web trust chain"
 msgstr ""
 
 msgid "Weekly"
@@ -8679,6 +8861,12 @@ msgid "What Setup Mode means (firmware usually calls it \"Custom\")"
 msgstr ""
 
 msgid "What gets enrolled"
+msgstr ""
+
+msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
+msgstr ""
+
+msgid "What this server itself trusts: FOG's root, plus any root imported below."
 msgstr ""
 
 msgid "What to do next"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -116,6 +116,10 @@ msgid "%d architecture(s) updated."
 msgstr "Impressora atualizado!"
 
 #, php-format
+msgid "%d certificates in this file"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -424,6 +428,9 @@ msgstr "Uma imagem já existe com este nome!"
 msgid "A role with this name already exists!"
 msgstr "Um nome de host com esse nome já existe."
 
+msgid "A root CA uploaded on this page. Absent unless one was imported."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "Um nome de imagem é necessário!"
@@ -504,6 +511,9 @@ msgid "A username already exists with this name!"
 msgstr "Uma imagem já existe com este nome!"
 
 msgid "A valid database connection could not be made"
+msgstr ""
+
+msgid "A worked example of the first one, end to end:"
 msgstr ""
 
 msgid "API"
@@ -1324,10 +1334,6 @@ msgstr "Criar novo %s"
 msgid "CA Path"
 msgstr "Caminho"
 
-#, fuzzy
-msgid "CA private key"
-msgstr "chave privada falhou"
-
 msgid "CPU Cache"
 msgstr "cache CPU"
 
@@ -1542,6 +1548,10 @@ msgstr "Última versão"
 msgid "Catch-All Site"
 msgstr ""
 
+#, fuzzy
+msgid "Certificate"
+msgstr "Criar novo %s"
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1555,6 +1565,18 @@ msgstr "Criar novo %s"
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "Criar novo %s"
+
+#, fuzzy
+msgid "Certificate change failed"
+msgstr "Criar novo %s"
+
+#, fuzzy
+msgid "Certificate download failed"
+msgstr "Falha no download"
+
+#, fuzzy
+msgid "Certificate management is not configured on this server"
+msgstr "Não há imagens neste servidor."
 
 #, fuzzy
 msgid "Certificates"
@@ -1686,6 +1708,9 @@ msgstr "Configurações"
 #, fuzzy
 msgid "Client Version"
 msgstr "Versão CPU"
+
+msgid "Client communication certificate"
+msgstr ""
 
 msgid "Clients already enforcing Secure Boot cannot run this task -- they will not boot FOS in the first place. Use the manual steps below for those."
 msgstr ""
@@ -1878,9 +1903,17 @@ msgstr "Não foi possível ler o arquivo tmp."
 msgid "Could not register"
 msgstr "Não foi possível criar impressora"
 
+#, fuzzy
+msgid "Could not remove the imported root"
+msgstr "Não foi possível ler o arquivo tmp."
+
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
+
+#, fuzzy
+msgid "Could not save that preference"
+msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
 msgid "Could not seed the granted targets"
@@ -1892,6 +1925,10 @@ msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
 msgid "Could not stage the upload."
+msgstr "Não foi possível ler o arquivo tmp."
+
+#, fuzzy
+msgid "Could not stage the uploaded certificate"
 msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
@@ -2125,6 +2162,10 @@ msgstr "Registros atuais"
 
 msgid "Current member-host AD state"
 msgstr ""
+
+#, fuzzy
+msgid "Currently imported"
+msgstr "Registros atuais"
 
 msgid "DMI Field"
 msgstr ""
@@ -2491,6 +2532,9 @@ msgstr "Duração"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgstr ""
+
 msgid "Edit"
 msgstr "Editar"
 
@@ -2691,6 +2735,9 @@ msgstr ""
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
 
+msgid "Expires"
+msgstr ""
+
 msgid "Export"
 msgstr "Exportar"
 
@@ -2756,6 +2803,9 @@ msgstr "Windows 8"
 #, fuzzy
 msgid "Export the database"
 msgstr "Encontro"
+
+msgid "External root CA"
+msgstr ""
 
 msgid "FOG"
 msgstr "NÉVOA"
@@ -4349,6 +4399,10 @@ msgid "Import known mac address makers"
 msgstr ""
 
 #, fuzzy
+msgid "Imported root"
+msgstr "Hosts de importação"
+
+#, fuzzy
 msgid "Imported successfully!"
 msgstr "Instalar / Atualizar sucesso!"
 
@@ -4422,6 +4476,10 @@ msgstr "instalar Plugins"
 #, fuzzy
 msgid "Install plugins failed!"
 msgstr "instalar Plugins"
+
+#, fuzzy
+msgid "Install preferences"
+msgstr "Delete Selected"
 
 #, fuzzy
 msgid "Install selected"
@@ -4984,6 +5042,9 @@ msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
 msgid "Legacy BIOS (no Secure Boot)"
+msgstr ""
+
+msgid "Let's Encrypt with FOG"
 msgstr ""
 
 msgid "Level"
@@ -5725,6 +5786,10 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr "Nenhum arquivo foi transferido"
 
+#, fuzzy
+msgid "No certificate file was uploaded"
+msgstr "Nenhum arquivo foi transferido"
+
 msgid "No change"
 msgstr ""
 
@@ -5749,6 +5814,9 @@ msgid "No database to work off"
 msgstr "Nenhum banco de dados para trabalhar fora"
 
 msgid "No external data to download the file from"
+msgstr ""
+
+msgid "No external root is imported on this server."
 msgstr ""
 
 msgid "No fields passed"
@@ -6016,6 +6084,9 @@ msgstr ""
 msgid "Not allowed here"
 msgstr "Não permitido aqui"
 
+msgid "Not offered here, on purpose"
+msgstr ""
+
 #, fuzzy
 msgid "Not pinged"
 msgstr "Plugins instalados"
@@ -6137,6 +6208,9 @@ msgstr ""
 msgid "Off - direct membership only"
 msgstr ""
 
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgstr ""
+
 #, fuzzy
 msgid "Offered to every user on this grid."
 msgstr " | Este não é o grupo primário"
@@ -6205,6 +6279,9 @@ msgid "Only an administrator may grant full access."
 msgstr "modificar Grupo"
 
 msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
+msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
 msgstr ""
 
 msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
@@ -6711,6 +6788,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preference saved"
+msgstr ""
+
 msgid "Preferences"
 msgstr ""
 
@@ -6830,6 +6910,9 @@ msgstr "chave privada não pode ser lido"
 
 msgid "Private key path not found"
 msgstr "caminho da chave privada não encontrados"
+
+msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
+msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -6991,6 +7074,9 @@ msgstr "reinicialização"
 msgid "Reboot after deploy"
 msgstr "foi destruído"
 
+msgid "Rebuild iPXE with this server's CA embedded"
+msgstr ""
+
 msgid "Receive"
 msgstr "Receber"
 
@@ -7012,6 +7098,9 @@ msgstr "Registro não encontrado, erro: %s"
 #, fuzzy
 msgid "Records"
 msgstr "Registros atuais"
+
+msgid "Redirect HTTP to HTTPS"
+msgstr ""
 
 msgid "Redirect Login To This Provider"
 msgstr ""
@@ -7085,6 +7174,10 @@ msgid "Remove file data"
 msgstr "Removido"
 
 #, fuzzy
+msgid "Remove imported root"
+msgstr "Removido"
+
+#, fuzzy
 msgid "Remove selected"
 msgstr "Remover snapins selecionados"
 
@@ -7122,6 +7215,9 @@ msgstr ""
 
 #, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
+msgstr ""
+
+msgid "Replacing the root itself -- so that FOG's anchor becomes an intermediate of yours -- is a migration rather than a setting. It changes the certificate every registered fog-client pins, so every one of them stops authenticating until it is re-pinned. That is not something a web form should be able to do in one click, so it is not on this page."
 msgstr ""
 
 #, fuzzy
@@ -7292,6 +7388,21 @@ msgstr ""
 msgid "Roles"
 msgstr ""
 
+msgid "Root"
+msgstr ""
+
+#, fuzzy
+msgid "Root CA certificate (PEM)"
+msgstr "Criar novo %s"
+
+#, fuzzy
+msgid "Root imported"
+msgstr "Inventário"
+
+#, fuzzy
+msgid "Root removed"
+msgstr "Removido"
+
 msgid "Row"
 msgstr "Linha"
 
@@ -7383,6 +7494,9 @@ msgid "Save the site before setting catch-all"
 msgstr ""
 
 msgid "Saved filters for one grid"
+msgstr ""
+
+msgid "Saved. It takes effect the next time the installer runs."
 msgstr ""
 
 #, fuzzy
@@ -7523,7 +7637,7 @@ msgstr ""
 msgid "Secure Boot (reported)"
 msgstr ""
 
-msgid "Secure Boot CA private key"
+msgid "Secure Boot CA"
 msgstr ""
 
 msgid "Secure Boot Enrolled"
@@ -7802,6 +7916,12 @@ msgstr ""
 #, fuzzy
 msgid "Signs In With"
 msgstr "Snapin Run Com"
+
+msgid "Signs the FOS kernel signing certificate. Not a web certificate."
+msgstr ""
+
+msgid "Signs the web server certificate and every storage node certificate."
+msgstr ""
 
 #, fuzzy
 msgid "Single Logout"
@@ -8797,6 +8917,14 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That certificate is not available on this server."
+msgstr "Não existem grupos neste servidor."
+
+#, fuzzy
+msgid "That file is too large to be a root CA certificate"
+msgstr "não foi capaz de salvar"
+
+#, fuzzy
 msgid "That filter is too large to save"
 msgstr "não foi capaz de salvar"
 
@@ -8940,6 +9068,17 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
+#, fuzzy
+msgid "The certificate chain"
+msgstr "Criar novo %s"
+
+msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
+msgstr ""
+
+#, fuzzy
+msgid "The certificate was refused"
+msgstr "Nenhum arquivo foi transferido"
+
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
@@ -9019,6 +9158,9 @@ msgstr "O nó de armazenamento grupos de armazenamento associado não é válido
 
 msgid "The image storage group assigned is not valid"
 msgstr "O grupo de armazenamento de imagens atribuído não é válido"
+
+msgid "The imported root CA has been removed."
+msgstr ""
 
 #, fuzzy
 msgid "The installers for the fog client"
@@ -9105,7 +9247,16 @@ msgstr ""
 msgid "The provider returned a configuration for a different issuer"
 msgstr ""
 
+msgid "The public half of the keypair fog-client encrypts its check-in to."
+msgstr ""
+
 msgid "The resource is not in a cancellable state."
+msgstr ""
+
+msgid "The root CA has been imported and this server now trusts it."
+msgstr ""
+
+msgid "The root CA has been imported, but this host's system trust store could not be updated -- so HTTPS calls made on this server will not accept it yet. Re-run the installer, and check the installation log."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."
@@ -9144,6 +9295,9 @@ msgstr "O nó de armazenamento grupos de armazenamento associado não é válido
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
+msgid "The trust anchor. Every fog-client pins this one."
+msgstr ""
+
 msgid "The upload did not arrive."
 msgstr ""
 
@@ -9163,6 +9317,9 @@ msgid "The uploaded file was only partially uploaded"
 msgstr "O arquivo enviado foi apenas parcialmente carregado"
 
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
+msgstr ""
+
+msgid "The web certificate chains to a public CA"
 msgstr ""
 
 msgid "Theme"
@@ -9224,6 +9381,9 @@ msgstr ""
 msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
 msgstr ""
 
+msgid "These decide what the NEXT installer run does. Nothing here takes effect until the installer runs again -- this page records the preference, it does not rewrite the web server configuration or reissue a certificate."
+msgstr ""
+
 #, php-format
 msgid "These plugins are still installed on disk, so forgetting them would achieve nothing: %s. Uninstall them instead."
 msgstr ""
@@ -9247,6 +9407,9 @@ msgstr ""
 msgid "This document"
 msgstr ""
 
+msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
 msgid "This endpoint only accepts POST."
 msgstr ""
 
@@ -9264,6 +9427,9 @@ msgstr ""
 
 #, php-format
 msgid "This host has finished deploying image %s."
+msgstr ""
+
+msgid "This host has no system trust store that FOG recognizes, so an imported root is recorded and re-applied but never reaches the host's own HTTPS clients."
 msgstr ""
 
 msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
@@ -9329,6 +9495,9 @@ msgstr ""
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
 msgstr ""
 
+msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9366,6 +9535,9 @@ msgid "This server's hostname, as its certificate names it."
 msgstr ""
 
 msgid "This server's own IP address. Space-separated when the interface carries more than one."
+msgstr ""
+
+msgid "This server's web certificate already resolves outside FOG's own PKI, so FOG treats it as managed elsewhere and will not reissue it or lock its key down, whatever these say. That is derived from where the certificate actually is, not from a setting, so the two cannot disagree."
 msgstr ""
 
 msgid "This servers ip(s)"
@@ -9465,6 +9637,9 @@ msgstr ""
 msgid "To get started please select an item from the menu."
 msgstr ""
 
+msgid "To have your own CA issue FOG's web certificates, import the CA and its key by re-running the installer. That replaces the CA that signs the web server certificate and the storage node certificates -- and only that. The root fog-client pins is left alone, so no client re-enrolls."
+msgstr ""
+
 msgid "Toggle Dropdown"
 msgstr ""
 
@@ -9526,6 +9701,9 @@ msgstr ""
 msgid "Trust anchor"
 msgstr ""
 
+msgid "Trust anchor bundle"
+msgstr ""
+
 msgid "Trusted Node CIDRs"
 msgstr ""
 
@@ -9536,6 +9714,9 @@ msgstr "Caminho Snapin"
 #, fuzzy
 msgid "Trying image size for"
 msgstr "Caminho Snapin"
+
+msgid "Turn this on for a Let's Encrypt or purchased certificate. It stops FOG re-issuing the leaf, stops it locking the private key to root -- which would break the renewal that writes it -- and steers netboot to HTTPS with no iPXE rebuild, because upstream iPXE cross-certifies public CAs already."
+msgstr ""
 
 msgid "Two routes are covered in the guide linked above: a live USB with the kit above, or PXE-booting the client and choosing Enroll Secure Boot Key, which now fetches MOK.der over the network on its own, with no USB stick needed."
 msgstr ""
@@ -9693,6 +9874,10 @@ msgstr "Desconhecido"
 msgid "Unknown DB error"
 msgstr "Ocorreu um erro de upload desconhecido. Código de retorno: "
 
+#, fuzzy
+msgid "Unknown action"
+msgstr "Ocorreu um erro de upload desconhecido. Código de retorno: "
+
 #, php-format
 msgid "Unknown field for %s: %s"
 msgstr ""
@@ -9806,6 +9991,9 @@ msgstr "carregar relatórios"
 
 msgid "Upload Reports"
 msgstr "carregar relatórios"
+
+msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"
 msgstr ""
@@ -10076,10 +10264,17 @@ msgstr ""
 msgid "Using the group match function"
 msgstr ""
 
+msgid "Using your own PKI"
+msgstr ""
+
 msgid "VB Script"
 msgstr ""
 
 msgid "VNC"
+msgstr ""
+
+#, php-format
+msgid "Valid until %s."
 msgstr ""
 
 msgid "Value"
@@ -10145,13 +10340,19 @@ msgstr "Nome Storage Node"
 msgid "We cannot connect to LDAP server"
 msgstr "Não é possível conectar ao banco de dados"
 
-msgid "Web CA private key"
+msgid "Web CA"
+msgstr ""
+
+msgid "Web CA plus the root that anchors it -- what a client needs to verify this server."
 msgstr ""
 
 msgid "Web Server"
 msgstr "Servidor web"
 
-msgid "Web server private key"
+msgid "Web server certificate"
+msgstr ""
+
+msgid "Web trust chain"
 msgstr ""
 
 msgid "Weekly"
@@ -10166,6 +10367,12 @@ msgstr ""
 #, fuzzy
 msgid "What gets enrolled"
 msgstr "foi atualizado com sucesso"
+
+msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
+msgstr ""
+
+msgid "What this server itself trusts: FOG's root, plus any root imported below."
+msgstr ""
 
 msgid "What to do next"
 msgstr ""
@@ -11490,6 +11697,10 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "Salvar alterações"
 
+#, fuzzy
+#~ msgid "CA private key"
+#~ msgstr "chave privada falhou"
+
 #~ msgid "Check that database is running"
 #~ msgstr "Verifique o banco de dados está em execução"
 
@@ -11715,10 +11926,6 @@ msgstr ""
 
 #~ msgid "Import Printers"
 #~ msgstr "importação Impressoras"
-
-#, fuzzy
-#~ msgid "Import Report"
-#~ msgstr "Hosts de importação"
 
 #, fuzzy
 #~ msgid "Import Reports"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -116,6 +116,10 @@ msgid "%d architecture(s) updated."
 msgstr "打印机更新！"
 
 #, php-format
+msgid "%d certificates in this file"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -424,6 +428,9 @@ msgstr "图像已经存在具有此名称！"
 msgid "A role with this name already exists!"
 msgstr "使用此名称的主机名已经存在。"
 
+msgid "A root CA uploaded on this page. Absent unless one was imported."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "图像名是必需的！"
@@ -504,6 +511,9 @@ msgid "A username already exists with this name!"
 msgstr "图像已经存在具有此名称！"
 
 msgid "A valid database connection could not be made"
+msgstr ""
+
+msgid "A worked example of the first one, end to end:"
 msgstr ""
 
 msgid "API"
@@ -1324,10 +1334,6 @@ msgstr "新建%s"
 msgid "CA Path"
 msgstr "路径"
 
-#, fuzzy
-msgid "CA private key"
-msgstr "私钥失败"
-
 msgid "CPU Cache"
 msgstr "CPU缓存"
 
@@ -1542,6 +1548,10 @@ msgstr "最新版本"
 msgid "Catch-All Site"
 msgstr ""
 
+#, fuzzy
+msgid "Certificate"
+msgstr "新建%s"
+
 msgid "Certificate SHA-1"
 msgstr ""
 
@@ -1555,6 +1565,18 @@ msgstr "新建%s"
 #, fuzzy
 msgid "Certificate Verification"
 msgstr "新建%s"
+
+#, fuzzy
+msgid "Certificate change failed"
+msgstr "新建%s"
+
+#, fuzzy
+msgid "Certificate download failed"
+msgstr "下载失败"
+
+#, fuzzy
+msgid "Certificate management is not configured on this server"
+msgstr "有此服务器上没有图像。"
 
 #, fuzzy
 msgid "Certificates"
@@ -1686,6 +1708,9 @@ msgstr "设置"
 #, fuzzy
 msgid "Client Version"
 msgstr "CPU版本"
+
+msgid "Client communication certificate"
+msgstr ""
 
 msgid "Clients already enforcing Secure Boot cannot run this task -- they will not boot FOS in the first place. Use the manual steps below for those."
 msgstr ""
@@ -1878,9 +1903,17 @@ msgstr "无法读取tmp文件。"
 msgid "Could not register"
 msgstr "无法创建打印机"
 
+#, fuzzy
+msgid "Could not remove the imported root"
+msgstr "无法读取tmp文件。"
+
 #, php-format
 msgid "Could not replace the existing %s. Is %s writable?"
 msgstr ""
+
+#, fuzzy
+msgid "Could not save that preference"
+msgstr "无法读取tmp文件。"
 
 #, fuzzy
 msgid "Could not seed the granted targets"
@@ -1892,6 +1925,10 @@ msgstr "无法读取tmp文件。"
 
 #, fuzzy
 msgid "Could not stage the upload."
+msgstr "无法读取tmp文件。"
+
+#, fuzzy
+msgid "Could not stage the uploaded certificate"
 msgstr "无法读取tmp文件。"
 
 #, fuzzy
@@ -2125,6 +2162,10 @@ msgstr "当前记录"
 
 msgid "Current member-host AD state"
 msgstr ""
+
+#, fuzzy
+msgid "Currently imported"
+msgstr "当前记录"
 
 msgid "DMI Field"
 msgstr ""
@@ -2491,6 +2532,9 @@ msgstr "为期"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgstr ""
+
 msgid "Edit"
 msgstr "编辑"
 
@@ -2691,6 +2735,9 @@ msgstr ""
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
 
+msgid "Expires"
+msgstr ""
+
 msgid "Export"
 msgstr "出口"
 
@@ -2756,6 +2803,9 @@ msgstr "Windows 8的"
 #, fuzzy
 msgid "Export the database"
 msgstr "日期"
+
+msgid "External root CA"
+msgstr ""
 
 msgid "FOG"
 msgstr "雾"
@@ -4349,6 +4399,10 @@ msgid "Import known mac address makers"
 msgstr ""
 
 #, fuzzy
+msgid "Imported root"
+msgstr "进口主机"
+
+#, fuzzy
 msgid "Imported successfully!"
 msgstr "安装/升级成功！"
 
@@ -4422,6 +4476,10 @@ msgstr "安装插件"
 #, fuzzy
 msgid "Install plugins failed!"
 msgstr "安装插件"
+
+#, fuzzy
+msgid "Install preferences"
+msgstr "删除所选"
 
 #, fuzzy
 msgid "Install selected"
@@ -4984,6 +5042,9 @@ msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
 msgid "Legacy BIOS (no Secure Boot)"
+msgstr ""
+
+msgid "Let's Encrypt with FOG"
 msgstr ""
 
 msgid "Level"
@@ -5725,6 +5786,10 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr "没有文件被上传"
 
+#, fuzzy
+msgid "No certificate file was uploaded"
+msgstr "没有文件被上传"
+
 msgid "No change"
 msgstr ""
 
@@ -5749,6 +5814,9 @@ msgid "No database to work off"
 msgstr "没有数据库工作关闭"
 
 msgid "No external data to download the file from"
+msgstr ""
+
+msgid "No external root is imported on this server."
 msgstr ""
 
 msgid "No fields passed"
@@ -6016,6 +6084,9 @@ msgstr ""
 msgid "Not allowed here"
 msgstr "这里不允许"
 
+msgid "Not offered here, on purpose"
+msgstr ""
+
 #, fuzzy
 msgid "Not pinged"
 msgstr "已安装的插件"
@@ -6137,6 +6208,9 @@ msgstr ""
 msgid "Off - direct membership only"
 msgstr ""
 
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgstr ""
+
 #, fuzzy
 msgid "Offered to every user on this grid."
 msgstr "|这不是主要组"
@@ -6205,6 +6279,9 @@ msgid "Only an administrator may grant full access."
 msgstr "修改组"
 
 msgid "Only for a peer running its own FOG database. On that peer run bin/fog-node-key.php --set with this same value, or it cannot verify requests this server signs."
+msgstr ""
+
+msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
 msgstr ""
 
 msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
@@ -6711,6 +6788,9 @@ msgstr ""
 msgid "Preference key or value is not storable"
 msgstr ""
 
+msgid "Preference saved"
+msgstr ""
+
 msgid "Preferences"
 msgstr ""
 
@@ -6830,6 +6910,9 @@ msgstr "私钥不可读"
 
 msgid "Private key path not found"
 msgstr "私钥未找到路径"
+
+msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
+msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -6991,6 +7074,9 @@ msgstr "重启"
 msgid "Reboot after deploy"
 msgstr "已被破坏"
 
+msgid "Rebuild iPXE with this server's CA embedded"
+msgstr ""
+
 msgid "Receive"
 msgstr "接收"
 
@@ -7012,6 +7098,9 @@ msgstr "未发现记录，错误： %s"
 #, fuzzy
 msgid "Records"
 msgstr "当前记录"
+
+msgid "Redirect HTTP to HTTPS"
+msgstr ""
 
 msgid "Redirect Login To This Provider"
 msgstr ""
@@ -7085,6 +7174,10 @@ msgid "Remove file data"
 msgstr "去除"
 
 #, fuzzy
+msgid "Remove imported root"
+msgstr "去除"
+
+#, fuzzy
 msgid "Remove selected"
 msgstr "删除选定snapins"
 
@@ -7122,6 +7215,9 @@ msgstr ""
 
 #, php-format
 msgid "Repaired %1$d orphaned work row(s) across %2$d column(s)"
+msgstr ""
+
+msgid "Replacing the root itself -- so that FOG's anchor becomes an intermediate of yours -- is a migration rather than a setting. It changes the certificate every registered fog-client pins, so every one of them stops authenticating until it is re-pinned. That is not something a web form should be able to do in one click, so it is not on this page."
 msgstr ""
 
 #, fuzzy
@@ -7292,6 +7388,21 @@ msgstr ""
 msgid "Roles"
 msgstr ""
 
+msgid "Root"
+msgstr ""
+
+#, fuzzy
+msgid "Root CA certificate (PEM)"
+msgstr "新建%s"
+
+#, fuzzy
+msgid "Root imported"
+msgstr "库存"
+
+#, fuzzy
+msgid "Root removed"
+msgstr "去除"
+
 msgid "Row"
 msgstr "行"
 
@@ -7383,6 +7494,9 @@ msgid "Save the site before setting catch-all"
 msgstr ""
 
 msgid "Saved filters for one grid"
+msgstr ""
+
+msgid "Saved. It takes effect the next time the installer runs."
 msgstr ""
 
 #, fuzzy
@@ -7523,7 +7637,7 @@ msgstr ""
 msgid "Secure Boot (reported)"
 msgstr ""
 
-msgid "Secure Boot CA private key"
+msgid "Secure Boot CA"
 msgstr ""
 
 msgid "Secure Boot Enrolled"
@@ -7802,6 +7916,12 @@ msgstr ""
 #, fuzzy
 msgid "Signs In With"
 msgstr "管理单元运行方式"
+
+msgid "Signs the FOS kernel signing certificate. Not a web certificate."
+msgstr ""
+
+msgid "Signs the web server certificate and every storage node certificate."
+msgstr ""
 
 #, fuzzy
 msgid "Single Logout"
@@ -8797,6 +8917,14 @@ msgid "Text to match against the id and name. A few classes match more: host als
 msgstr ""
 
 #, fuzzy
+msgid "That certificate is not available on this server."
+msgstr "有此服务器上没有组。"
+
+#, fuzzy
+msgid "That file is too large to be a root CA certificate"
+msgstr "未能保存"
+
+#, fuzzy
 msgid "That filter is too large to save"
 msgstr "未能保存"
 
@@ -8940,6 +9068,17 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
+#, fuzzy
+msgid "The certificate chain"
+msgstr "新建%s"
+
+msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
+msgstr ""
+
+#, fuzzy
+msgid "The certificate was refused"
+msgstr "没有文件被上传"
+
 msgid "The configured LDAPS CA path cannot be read by the web server, so it is being ignored and the system trust store used instead; verification against a private CA will fail until the path is readable"
 msgstr ""
 
@@ -9019,6 +9158,9 @@ msgstr "存储组相关联的存储节点无效"
 
 msgid "The image storage group assigned is not valid"
 msgstr "分配图像存储组无效"
+
+msgid "The imported root CA has been removed."
+msgstr ""
 
 #, fuzzy
 msgid "The installers for the fog client"
@@ -9105,7 +9247,16 @@ msgstr ""
 msgid "The provider returned a configuration for a different issuer"
 msgstr ""
 
+msgid "The public half of the keypair fog-client encrypts its check-in to."
+msgstr ""
+
 msgid "The resource is not in a cancellable state."
+msgstr ""
+
+msgid "The root CA has been imported and this server now trusts it."
+msgstr ""
+
+msgid "The root CA has been imported, but this host's system trust store could not be updated -- so HTTPS calls made on this server will not accept it yet. Re-run the installer, and check the installation log."
 msgstr ""
 
 msgid "The same rules in prose, for a client reading this at runtime."
@@ -9144,6 +9295,9 @@ msgstr "存储组相关联的存储节点无效"
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
+msgid "The trust anchor. Every fog-client pins this one."
+msgstr ""
+
 msgid "The upload did not arrive."
 msgstr ""
 
@@ -9163,6 +9317,9 @@ msgid "The uploaded file was only partially uploaded"
 msgstr "上传的文件只有部分被上传"
 
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
+msgstr ""
+
+msgid "The web certificate chains to a public CA"
 msgstr ""
 
 msgid "Theme"
@@ -9224,6 +9381,9 @@ msgstr ""
 msgid "These binaries are staged on every install, HTTPS included. An HTTPS web interface has no bearing on netboot, which has its own protocol setting. HTTPS netboot only needs a rebuilt iPXE when the certificate comes from a private CA -- a publicly-issued one on an FQDN needs no rebuild and keeps the signed shim."
 msgstr ""
 
+msgid "These decide what the NEXT installer run does. Nothing here takes effect until the installer runs again -- this page records the preference, it does not rewrite the web server configuration or reissue a certificate."
+msgstr ""
+
 #, php-format
 msgid "These plugins are still installed on disk, so forgetting them would achieve nothing: %s. Uninstall them instead."
 msgstr ""
@@ -9247,6 +9407,9 @@ msgstr ""
 msgid "This document"
 msgstr ""
 
+msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
 msgid "This endpoint only accepts POST."
 msgstr ""
 
@@ -9264,6 +9427,9 @@ msgstr ""
 
 #, php-format
 msgid "This host has finished deploying image %s."
+msgstr ""
+
+msgid "This host has no system trust store that FOG recognizes, so an imported root is recorded and re-applied but never reaches the host's own HTTPS clients."
 msgstr ""
 
 msgid "This host last booted in legacy BIOS mode, where Secure Boot does not exist. There is nothing for this task to enroll into."
@@ -9329,6 +9495,9 @@ msgstr ""
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
 msgstr ""
 
+msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
+msgstr ""
+
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9366,6 +9535,9 @@ msgid "This server's hostname, as its certificate names it."
 msgstr ""
 
 msgid "This server's own IP address. Space-separated when the interface carries more than one."
+msgstr ""
+
+msgid "This server's web certificate already resolves outside FOG's own PKI, so FOG treats it as managed elsewhere and will not reissue it or lock its key down, whatever these say. That is derived from where the certificate actually is, not from a setting, so the two cannot disagree."
 msgstr ""
 
 msgid "This servers ip(s)"
@@ -9465,6 +9637,9 @@ msgstr ""
 msgid "To get started please select an item from the menu."
 msgstr ""
 
+msgid "To have your own CA issue FOG's web certificates, import the CA and its key by re-running the installer. That replaces the CA that signs the web server certificate and the storage node certificates -- and only that. The root fog-client pins is left alone, so no client re-enrolls."
+msgstr ""
+
 msgid "Toggle Dropdown"
 msgstr ""
 
@@ -9526,6 +9701,9 @@ msgstr ""
 msgid "Trust anchor"
 msgstr ""
 
+msgid "Trust anchor bundle"
+msgstr ""
+
 msgid "Trusted Node CIDRs"
 msgstr ""
 
@@ -9536,6 +9714,9 @@ msgstr "管理单元路径"
 #, fuzzy
 msgid "Trying image size for"
 msgstr "管理单元路径"
+
+msgid "Turn this on for a Let's Encrypt or purchased certificate. It stops FOG re-issuing the leaf, stops it locking the private key to root -- which would break the renewal that writes it -- and steers netboot to HTTPS with no iPXE rebuild, because upstream iPXE cross-certifies public CAs already."
+msgstr ""
 
 msgid "Two routes are covered in the guide linked above: a live USB with the kit above, or PXE-booting the client and choosing Enroll Secure Boot Key, which now fetches MOK.der over the network on its own, with no USB stick needed."
 msgstr ""
@@ -9693,6 +9874,10 @@ msgstr "未知"
 msgid "Unknown DB error"
 msgstr "发生未知上传错误。返回代码："
 
+#, fuzzy
+msgid "Unknown action"
+msgstr "发生未知上传错误。返回代码："
+
 #, php-format
 msgid "Unknown field for %s: %s"
 msgstr ""
@@ -9806,6 +9991,9 @@ msgstr "上传报告"
 
 msgid "Upload Reports"
 msgstr "上传报告"
+
+msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"
 msgstr ""
@@ -10076,10 +10264,17 @@ msgstr ""
 msgid "Using the group match function"
 msgstr ""
 
+msgid "Using your own PKI"
+msgstr ""
+
 msgid "VB Script"
 msgstr ""
 
 msgid "VNC"
+msgstr ""
+
+#, php-format
+msgid "Valid until %s."
 msgstr ""
 
 msgid "Value"
@@ -10145,13 +10340,19 @@ msgstr "存储节点名称"
 msgid "We cannot connect to LDAP server"
 msgstr "无法连接到数据库"
 
-msgid "Web CA private key"
+msgid "Web CA"
+msgstr ""
+
+msgid "Web CA plus the root that anchors it -- what a client needs to verify this server."
 msgstr ""
 
 msgid "Web Server"
 msgstr "网络服务器"
 
-msgid "Web server private key"
+msgid "Web server certificate"
+msgstr ""
+
+msgid "Web trust chain"
 msgstr ""
 
 msgid "Weekly"
@@ -10166,6 +10367,12 @@ msgstr ""
 #, fuzzy
 msgid "What gets enrolled"
 msgstr "已成功更新"
+
+msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
+msgstr ""
+
+msgid "What this server itself trusts: FOG's root, plus any root imported below."
+msgstr ""
 
 msgid "What to do next"
 msgstr ""
@@ -11490,6 +11697,10 @@ msgstr ""
 #~ msgid "Bulk Changes"
 #~ msgstr "保存更改"
 
+#, fuzzy
+#~ msgid "CA private key"
+#~ msgstr "私钥失败"
+
 #~ msgid "Check that database is running"
 #~ msgstr "检查数据库运行"
 
@@ -11715,10 +11926,6 @@ msgstr ""
 
 #~ msgid "Import Printers"
 #~ msgstr "进口打印机"
-
-#, fuzzy
-#~ msgid "Import Report"
-#~ msgstr "进口主机"
 
 #, fuzzy
 #~ msgid "Import Reports"

--- a/packages/web/src/Auth/Authorization.php
+++ b/packages/web/src/Auth/Authorization.php
@@ -186,6 +186,18 @@ class Authorization extends FOGBase
         // these, _subToAction() reads the sub's prefix and lands them on
         // user.view/user.edit, so anyone who could open the page could
         // revoke the tokens on it.
+        // Keyed by the ALIASED node, so these are the FOG Configuration page's
+        // subs -- `about` resolves to `settings` above.
+        'settings' => [
+            // Reading the certificate hierarchy is reading server
+            // configuration, so the GET stays where the rest of the page is.
+            // The POST is not: it imports a root CA into this host's trust
+            // store and writes preferences into a file root SOURCES AS SHELL
+            // on the next installer run. "May change a setting" is not
+            // self-evidently "may decide what this server trusts", and SIX
+            // page nodes already map onto settings.edit (GH-1121).
+            'certificates' => ['GET' => 'settings.view', 'POST' => 'system.pki']
+        ],
         'user' => [
             'userapitokenlist' => 'apitoken.view',
             'userapitokenenable' => 'apitoken.edit',
@@ -617,7 +629,18 @@ class Authorization extends FOGBase
             // It also fixes the audit trail as a side effect: _auditGate()
             // records the permission string, so the row now says the whole
             // database left the server instead of saying settings.edit.
-            'system' => ['export'],
+            //
+            // `pki` joins it for the same reason and arrives the same way.
+            // It decides what certificate authorities this host trusts --
+            // an imported root reaches the OS trust store, so every
+            // server-side HTTPS call on the box accepts anything it signs --
+            // and it writes the three install preferences that decide
+            // whether FOG re-issues the admin's web certificate. Deny by
+            // default: no schema step seeds it, so until an administrator
+            // grants it only a holder of '*' has it, and a role holding
+            // settings.edit and nothing else LOSES nothing it ever had,
+            // because the page could not do any of this before.
+            'system' => ['export', 'pki'],
             // Impersonation (ADR 0033). ONE action, and it is `start` --
             // there is deliberately no `impersonate.end`, because ending is
             // never checked against anything. A user holding no roles is a

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -131,7 +131,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 401);
-        define('FOG_BCACHE_VER', 353);
+        define('FOG_BCACHE_VER', 354);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/src/Pages/FOGConfigurationPage.php
+++ b/packages/web/src/Pages/FOGConfigurationPage.php
@@ -313,28 +313,99 @@ class FOGConfigurationPage extends FOGPage
         $this->_downloadPost('initrd');
     }
     /**
-     * Where this server keeps its certificate material.
+     * Ask the PKI helper a question, as root, through sudo.
      *
-     * Read from the storage node record rather than from .fogsettings, which
-     * is root-only and deliberately unreadable here. This is the same lookup
-     * FOGBase::certDecrypt() uses to find the communication key, so the two
-     * can never disagree about where the PKI lives.
+     * The helper is the privilege boundary: it holds every path, takes no path
+     * from here, and implements five verbs and nothing else. This side decides
+     * WHO may ask -- Authorization gates the sub on system.pki -- and the
+     * helper decides what may be asked for. Same split as
+     * service/nodecert.php and FOGPage::secureBootSign().
      *
-     * @return string Path with no trailing separator, or '' if unknown.
+     * @param array $args the verb and its arguments, each escaped separately.
+     *
+     * @return array{ok:bool,out:string} the helper's combined output.
      */
-    private static function _sslPath()
+    private static function _pkiRun(array $args)
     {
-        $paths = Route::getIds('storagenode', [], 'sslpath');
-        foreach ((array) $paths as $path) {
-            if (!$path) {
-                continue;
-            }
-            return rtrim(str_replace(['\\', '/'], [DS, DS], $path), DS);
+        $helper = FOG_BASE_DIR . DS . 'bin' . DS . 'fog-pki-admin';
+        if (!is_executable($helper)) {
+            return ['ok' => false, 'out' => ''];
         }
-        return '';
+        // escapeshellarg on every piece, including values this method chose
+        // rather than received. $reqid is hex from random_bytes and the slot
+        // names are literals, so nothing here is caller-influenced today --
+        // quoting anyway costs nothing and means a later change that lets one
+        // become caller-influenced does not silently become a shell injection.
+        // FOG_BASE_DIR is installer-written and may contain a space, which
+        // would split into two arguments and no longer match the sudoers rule.
+        $cmd = 'sudo -n ' . escapeshellarg($helper);
+        foreach ($args as $arg) {
+            $cmd .= ' ' . escapeshellarg((string) $arg);
+        }
+        $out = [];
+        $ret = 1;
+        exec($cmd . ' 2>&1', $out, $ret);
+        return ['ok' => 0 === $ret, 'out' => trim(implode("\n", $out))];
     }
     /**
-     * Show this server's certificate hierarchy and the state of its keys.
+     * This server's PKI as the helper reports it, or null when the helper is
+     * not installed.
+     *
+     * Cached for the request: certificates() asks several questions of it and
+     * a sudo round trip per card would be four processes to answer one page.
+     *
+     * @return array|null
+     */
+    private static function _pkiStatus()
+    {
+        static $status = false;
+        if (false !== $status) {
+            return $status;
+        }
+        $status = null;
+        $res = self::_pkiRun(['status']);
+        if ($res['ok']) {
+            $decoded = json_decode($res['out'], true);
+            // An empty answer decodes to null rather than throwing, so it has
+            // to be tested for explicitly -- a null here would otherwise kill
+            // the render on first property access and leave the page blank
+            // with nothing to say why.
+            if (is_array($decoded)) {
+                $status = $decoded;
+            }
+        }
+        return $status;
+    }
+    /**
+     * The staging directory the helper and the web tier exchange files in.
+     *
+     * @return string '' when PKI administration is not configured here.
+     */
+    private static function _pkiStagingDir()
+    {
+        $dir = FOG_BASE_DIR . DS . 'pkiadmin-staging';
+        return (is_dir($dir) && is_writable($dir)) ? $dir : '';
+    }
+    /**
+     * One row of the certificate table, by slot.
+     *
+     * @param array|null $status the helper's report.
+     * @param string     $slot   the slot name.
+     *
+     * @return array|null
+     */
+    private static function _pkiCert($status, $slot)
+    {
+        foreach ((array) ($status['certificates'] ?? []) as $cert) {
+            if (($cert['slot'] ?? '') === $slot) {
+                return $cert;
+            }
+        }
+        return null;
+    }
+    /**
+     * Show this server's certificate hierarchy, and change the parts of it a
+     * browser may safely change.
      *
      * The reason this page runs the private key check in PHP rather than
      * simply reporting what the installer did: PHP *is* the threat model. The
@@ -345,105 +416,478 @@ class FOGConfigurationPage extends FOGPage
      * set 0400 and a web tier that can nonetheless open the file is precisely
      * the failure worth surfacing, and it is invisible from anywhere else.
      *
-     * That failure is not hypothetical. $sslpath lives under $snapindir, and
-     * configureSnapins() used to chown the whole tree to the web user at 775
-     * -- after the certificates were created, so it silently undid them.
+     * That failure is not hypothetical. The client zone lives under
+     * $snapindir, and configureSnapins() used to chown the whole tree to the
+     * web user at 775 -- after the certificates were created, so it silently
+     * undid them.
+     *
+     * The key PATHS now come from the helper. They used to be built here from
+     * the storage-node record as $sslpath/CA/.fogCA.key, and the zoned PKI
+     * moved every one of them: only .fogCA.pem, .fogWebCA.pem and the client
+     * keypair kept compat symlinks at the old names, and .fogCA.key was not
+     * among them. So the check that this whole card exists for had been
+     * testing paths that no longer exist, and passing every time (GH-1121).
      *
      * @return void
      */
     public function certificates()
     {
-        $sslpath = self::_sslPath();
-        $capem = BASEPATH . 'management' . DS . 'other' . DS . 'ca.cert.pem';
+        $this->title = _('Certificates');
+        $status = self::_pkiStatus();
+        $mayEdit = Authorization::can('system.pki');
 
-        // What every fog-client pins, and now also the anchor the web
-        // certificate chains to. Its fingerprint is the one value worth
-        // showing: it is what an admin compares against a client's trust store
-        // when working out why a client stopped authenticating.
+        // --- what the certificates are for, and what fog-client pins --------
         $body = '<p>' . _(
             'FOG uses certificates for three unrelated jobs: the web server, '
             . 'the encrypted fog-client check-in, and the signature on the FOS '
             . 'kernels. They are issued by separate CAs beneath one anchor, so '
             . 'replacing any one of them leaves the other two alone.'
         ) . '</p>';
-        if (file_exists($capem)) {
-            $der = openssl_x509_read(file_get_contents($capem));
-            $subject = '';
-            if ($der !== false) {
-                $parsed = openssl_x509_parse($der);
-                $subject = isset($parsed['subject']['CN'])
-                    ? $parsed['subject']['CN']
-                    : '';
-            }
+        $root = self::_pkiCert($status, 'root');
+        if ($root && !empty($root['present'])) {
             $body .= '<p><strong>' . _('Trust anchor') . '</strong> &mdash; '
                 . _('published as ca.cert.der and pinned by every fog-client')
                 . '</p>';
-            if ($subject) {
-                $body .= '<pre>' . \Initiator::e($subject) . '</pre>';
-            }
+            $body .= '<pre>' . \Initiator::e($root['subject']) . '</pre>';
             $body .= '<p><strong>' . _('SHA-256') . '</strong></p>';
-            $body .= '<pre>' . \Initiator::e(
-                strtoupper(
-                    implode(':', str_split(hash_file('sha256', $capem), 2))
-                )
-            ) . '</pre>';
+            $body .= '<pre>' . \Initiator::e($root['sha256']) . '</pre>';
+            $body .= '<p>' . _(
+                'This is the value to compare against a client\'s trust store '
+                . 'when working out why a client stopped authenticating.'
+            ) . '</p>';
         }
+        if (null === $status) {
+            // Says which of the two it is. A page that simply showed less
+            // would leave an administrator comparing it against the
+            // documentation and finding nothing to explain the difference.
+            $body .= '<p class="text-warning">' . _(
+                'The certificate management helper is not installed on this '
+                . 'server, so this page can only show what it can read for '
+                . 'itself. Re-run the installer to enable it. On a storage '
+                . 'node this is expected: a node has no CA of its own.'
+            ) . '</p>';
+        }
+        echo $this->_box(_('Certificates'), $body, ['color' => 'info']);
 
-        // The check that matters. Every path here is one a compromised web
-        // application would go looking for first.
-        $keys = [];
-        if ($sslpath) {
-            $keys[_('CA private key')] = $sslpath . DS . 'CA' . DS . '.fogCA.key';
-            $keys[_('Web CA private key')] = $sslpath . DS . 'CA' . DS . 'web'
-                . DS . '.fogWebCA.key';
-            $keys[_('Web server private key')] = $sslpath . DS . 'CA' . DS . 'web'
-                . DS . '.webLeaf.key';
+        $this->_certificateKeyExposure($status);
+        $this->_certificateChain($status);
+        $this->_certificateExternalRoot($status, $mayEdit);
+        $this->_certificatePreferences($status, $mayEdit);
+        $this->_certificateOwnPki($status);
+    }
+    /**
+     * The check that matters: can this web application read a private key it
+     * must not be able to read.
+     *
+     * @param array|null $status the helper's report.
+     *
+     * @return void
+     */
+    private function _certificateKeyExposure($status)
+    {
+        $keys = (array) ($status['private_keys'] ?? []);
+        if (!$keys) {
+            return;
         }
-        $keys[_('Secure Boot CA private key')] = FOG_BASE_DIR . DS . 'secureboot'
-            . DS . 'ca' . DS . '.fogSBCA.key';
         $exposed = [];
-        foreach ($keys as $label => $path) {
-            if (file_exists($path) && is_readable($path)) {
-                $exposed[$label] = $path;
+        foreach ($keys as $key) {
+            $path = (string) ($key['path'] ?? '');
+            // The client communication key is MEANT to be readable here --
+            // FOGBase::certDecrypt() opens it on every fog-client handshake --
+            // so flagging every readable key would report a correct install as
+            // a breach. Same for the vhost key once the leaf is managed
+            // outside FOG, which _hardenPkiPermissions() deliberately leaves
+            // alone because an ACME renewal writes it as its hook's user.
+            if (!empty($key['expect_readable'])) {
+                continue;
+            }
+            if ($path && file_exists($path) && is_readable($path)) {
+                $exposed[(string) ($key['label'] ?? $path)] = $path;
             }
         }
-        if (count($exposed) > 0) {
-            $warn = '<p>' . _(
-                'The web application can read the following private keys. It '
-                . 'should not be able to read any of them, and anything able to '
-                . 'run code in this web application can copy them.'
-            ) . '</p><ul>';
-            foreach ($exposed as $label => $path) {
-                $warn .= '<li><strong>' . \Initiator::e($label) . '</strong> &mdash; <code>'
-                    . \Initiator::e($path) . '</code></li>';
-            }
-            $warn .= '</ul><p>' . _(
-                'Re-run the installer, which restricts them to root. If this '
-                . 'persists, check that nothing else is widening permissions on '
-                . 'the snapins directory afterward.'
-            ) . '</p>';
-            echo $this->_box(_('Private keys are readable by the web server'), $warn, ['color' => 'danger']);
+        if (!$exposed) {
+            return;
         }
-
-        // Pseudo-offline is the shipped default and a deliberate starting
-        // point, not the recommended end state. Saying so here is the only
-        // place an admin who never reads the install output will see it.
-        $rootkey = $sslpath ? $sslpath . DS . 'CA' . DS . '.fogCA.key' : '';
-        if ($rootkey && file_exists($rootkey)) {
-            $body .= '<p><strong>' . _('The CA private key is on this server')
-                . '</strong></p>';
-            $body .= '<p>' . _(
-                'It is restricted to root, which protects it from a compromise '
-                . 'of this web application but not from a compromise of the '
-                . 'machine. Moving it to a vault is a separate step:'
+        $warn = '<p>' . _(
+            'The web application can read the following private keys. It '
+            . 'should not be able to read any of them, and anything able to '
+            . 'run code in this web application can copy them.'
+        ) . '</p><ul>';
+        foreach ($exposed as $label => $path) {
+            $warn .= '<li><strong>' . \Initiator::e(_($label))
+                . '</strong> &mdash; <code>' . \Initiator::e($path)
+                . '</code></li>';
+        }
+        $warn .= '</ul><p>' . _(
+            'Re-run the installer, which restricts them to root. If this '
+            . 'persists, check that nothing else is widening permissions on '
+            . 'the snapins directory afterward.'
+        ) . '</p>';
+        echo $this->_box(
+            _('Private keys are readable by the web server'),
+            $warn,
+            ['color' => 'danger']
+        );
+    }
+    /**
+     * The chain, and a download for each public certificate in it.
+     *
+     * Every file here is public: the root is already published as
+     * ca.cert.der, the vhost certificate is handed to anyone who connects,
+     * and the rest are what a client needs to build a chain. They are behind
+     * settings.view rather than a plain link only because the page is, and
+     * because the web tier cannot read most of them off disk -- pki/web/ca
+     * and pki/web/leaf are 0700 root:root, so the helper fetches them.
+     *
+     * @param array|null $status the helper's report.
+     *
+     * @return void
+     */
+    private function _certificateChain($status)
+    {
+        if (null === $status) {
+            return;
+        }
+        $labels = [
+            'root' => [
+                _('Root'),
+                _('The trust anchor. Every fog-client pins this one.')
+            ],
+            'webca' => [
+                _('Web CA'),
+                _('Signs the web server certificate and every storage node certificate.')
+            ],
+            'webchain' => [
+                _('Web trust chain'),
+                _('Web CA plus the root that anchors it -- what a client needs to verify this server.')
+            ],
+            'anchor' => [
+                _('Trust anchor bundle'),
+                _('What this server itself trusts: FOG\'s root, plus any root imported below.')
+            ],
+            'vhost' => [
+                _('Web server certificate'),
+                _('What the browser is shown. Replaced by an ACME renewal where one is configured.')
+            ],
+            'commleaf' => [
+                _('Client communication certificate'),
+                _('The public half of the keypair fog-client encrypts its check-in to.')
+            ],
+            'sbca' => [
+                _('Secure Boot CA'),
+                _('Signs the FOS kernel signing certificate. Not a web certificate.')
+            ],
+            'externalroot' => [
+                _('Imported root'),
+                _('A root CA uploaded on this page. Absent unless one was imported.')
+            ]
+        ];
+        $rows = '';
+        foreach ($labels as $slot => $meta) {
+            $cert = self::_pkiCert($status, $slot);
+            if (!$cert || empty($cert['present'])) {
+                continue;
+            }
+            $count = (int) ($cert['count'] ?? 1);
+            $rows .= '<tr><td><strong>' . \Initiator::e($meta[0]) . '</strong>'
+                . '<br><small class="text-muted">' . \Initiator::e($meta[1])
+                . '</small></td>'
+                . '<td><code>' . \Initiator::e($cert['subject']) . '</code>'
+                . ($count > 1
+                    ? '<br><small class="text-muted">' . sprintf(
+                        _('%d certificates in this file'),
+                        $count
+                    ) . '</small>'
+                    : '')
+                . '</td>'
+                . '<td class="text-nowrap"><small>'
+                . \Initiator::e($cert['not_after']) . '</small></td>'
+                . '<td class="text-nowrap"><a class="btn btn-sm btn-secondary" href="'
+                . \Initiator::e(
+                    '?node=about&sub=certificatedownload&slot=' . $slot
+                ) . '">' . _('Download') . '</a></td></tr>';
+        }
+        if ('' === $rows) {
+            return;
+        }
+        $body = '<p>' . _(
+            'Each of these is a public certificate. Downloading one is how you '
+            . 'add this server to another machine\'s trust store, hand an '
+            . 'auditor the chain, or check what a client is actually being '
+            . 'offered.'
+        ) . '</p>';
+        $body .= '<div class="table-responsive"><table class="table table-sm align-middle">';
+        $body .= '<thead><tr><th>' . _('Certificate') . '</th><th>' . _('Subject')
+            . '</th><th>' . _('Expires') . '</th><th></th></tr></thead>';
+        $body .= '<tbody>' . $rows . '</tbody></table></div>';
+        $body .= '<p class="form-text">' . _(
+            'Private keys are deliberately absent. Nothing on this page can '
+            . 'read one, and nothing on it can hand one out.'
+        ) . '</p>';
+        echo $this->_box(_('The certificate chain'), $body, ['color' => 'info']);
+    }
+    /**
+     * Import, show and remove an external root CA.
+     *
+     * The narrow case that --ca-root cannot express on its own: a corporate
+     * or step-ca root that FOG issues nothing from and nothing chains to, but
+     * which this server must accept. validateExternalCA() only runs when all
+     * THREE of --ca-cert/--ca-key/--ca-root were given, so before this there
+     * was no way to say "just trust this" short of editing the host trust
+     * store by hand -- which the next installer run would not know about.
+     *
+     * @param array|null $status  the helper's report.
+     * @param bool       $mayEdit does the caller hold system.pki.
+     *
+     * @return void
+     */
+    private function _certificateExternalRoot($status, $mayEdit)
+    {
+        if (null === $status) {
+            return;
+        }
+        $cert = self::_pkiCert($status, 'externalroot');
+        $have = $cert && !empty($cert['present']);
+        $body = '<p>' . _(
+            'Upload a root CA certificate to have this server trust it. It is '
+            . 'added to the host\'s own trust store, so every HTTPS call this '
+            . 'server makes will accept a certificate issued beneath it, and '
+            . 'it is re-applied on every later installer run.'
+        ) . '</p>';
+        $body .= '<p>' . _(
+            'This does not change what FOG issues, and it does not change what '
+            . 'fog-client pins. Only a self-signed CA certificate is accepted: '
+            . 'an intermediate in the same file is dropped rather than trusted, '
+            . 'because anchoring an intermediate would trust it as a root.'
+        ) . '</p>';
+        if ($have) {
+            $body .= '<p><strong>' . _('Currently imported') . '</strong></p>';
+            $body .= '<pre>' . \Initiator::e($cert['subject']) . '</pre>';
+            $body .= '<p><strong>' . _('SHA-256') . '</strong></p>';
+            $body .= '<pre>' . \Initiator::e($cert['sha256']) . '</pre>';
+            $body .= '<p class="form-text">' . sprintf(
+                _('Valid until %s.'),
+                \Initiator::e($cert['not_after'])
             ) . '</p>';
-            $body .= '<pre>' . \Initiator::e(FOG_BASE_DIR . '/bin/fog-offline-ca-key /mnt/vault')
-                . '</pre>';
-            $body .= '<p>' . _(
-                'Nothing needs it day to day. Restore it only to issue a new '
-                . 'intermediate, or a certificate for a new storage node.'
+        } else {
+            $body .= '<p class="form-text">' . _(
+                'No external root is imported on this server.'
             ) . '</p>';
-        } elseif ($rootkey) {
+        }
+        $store = (array) ($status['trust_store'] ?? []);
+        if (empty($store['available'])) {
+            $body .= '<p class="text-warning">' . _(
+                'This host has no system trust store that FOG recognizes, so '
+                . 'an imported root is recorded and re-applied but never '
+                . 'reaches the host\'s own HTTPS clients.'
+            ) . '</p>';
+        }
+        if (!$mayEdit) {
+            echo $this->_box(_('External root CA'), $body, ['color' => 'info']);
+            return;
+        }
+        $body .= '<label class="form-label" for="pki-root-file">'
+            . _('Root CA certificate (PEM)') . '</label>';
+        $body .= self::makeInput(
+            'form-control',
+            'rootca',
+            '',
+            'file',
+            'pki-root-file',
+            '',
+            true,
+            false,
+            -1,
+            -1,
+            'accept=".pem,.crt,.cer"'
+        );
+        // The action rides in the form rather than in the button, so
+        // processForm's FormData carries it with the file in one POST --
+        // certificatesPost() serves three actions and has to be told which.
+        $body .= self::makeInput('', 'action', '', 'hidden', 'pki-action', 'importRoot');
+        $buttons = self::makeButton(
+            'pki-import-root',
+            _('Import'),
+            'btn btn-primary float-end'
+        );
+        if ($have) {
+            // Destructive, so left, per the button convention. Removing an
+            // imported root is genuinely undoable -- the file is the admin's
+            // and can be uploaded again -- but it stops this server trusting
+            // whatever that CA issued, which is worth the deliberate travel.
+            $buttons .= self::makeButton(
+                'pki-clear-root',
+                _('Remove imported root'),
+                'btn btn-danger float-start'
+            );
+        }
+        // Wrapped in its own form: the upload needs multipart, and this card
+        // is the only thing on the page that posts a file.
+        echo self::makeFormTag(
+            '',
+            'pki-root-form',
+            $this->formAction,
+            'post',
+            'multipart/form-data',
+            true
+        );
+        echo $this->_box(
+            _('External root CA'),
+            $body,
+            ['color' => 'info', 'footer' => $buttons]
+        );
+        echo '</form>';
+    }
+    /**
+     * The three install preferences that decide what FOG does to the web
+     * certificate on its next run.
+     *
+     * Each one states its consequence beside the control, because that is the
+     * whole difference between setting this here and setting it on a command
+     * line: an installer flag is read back before it runs, and a checkbox is
+     * not.
+     *
+     * They are PREFERENCES, not switches -- nothing on this page rewrites the
+     * vhost or rebuilds iPXE. Saying so at the point of change is the only
+     * place an administrator will see it before wondering why nothing
+     * happened.
+     *
+     * @param array|null $status  the helper's report.
+     * @param bool       $mayEdit does the caller hold system.pki.
+     *
+     * @return void
+     */
+    private function _certificatePreferences($status, $mayEdit)
+    {
+        if (null === $status) {
+            return;
+        }
+        $prefs = (array) ($status['preferences'] ?? []);
+        $meta = [
+            'PKI_web_cert_publicly_trusted' => [
+                _('The web certificate chains to a public CA'),
+                _(
+                    'Turn this on for a Let\'s Encrypt or purchased '
+                    . 'certificate. It stops FOG re-issuing the leaf, stops it '
+                    . 'locking the private key to root -- which would break the '
+                    . 'renewal that writes it -- and steers netboot to HTTPS '
+                    . 'with no iPXE rebuild, because upstream iPXE '
+                    . 'cross-certifies public CAs already.'
+                )
+            ],
+            'WEB_https_redirect' => [
+                _('Redirect HTTP to HTTPS'),
+                _(
+                    'Off by default on purpose. Trust in FOG\'s CA reaches a '
+                    . 'client when fog-client installs it there, so on a server '
+                    . 'whose clients are not enrolled yet a forced redirect '
+                    . 'breaks exactly the machines that cannot fix themselves. '
+                    . 'Turn it on once trust is in place.'
+                )
+            ],
+            'BOOT_rebuild_ipxe_with_my_ca' => [
+                _('Rebuild iPXE with this server\'s CA embedded'),
+                _(
+                    'Only needed for HTTPS netboot behind a PRIVATE CA, and it '
+                    . 'costs a 10-25 minute build on every install. It also '
+                    . 'makes Secure Boot harder, not easier: a binary carrying '
+                    . 'a private CA is not upstream\'s signed one, so the chain '
+                    . 'has to hand off to a MOK-signed FOG build and the MOK '
+                    . 'must be enrolled first.'
+                )
+            ]
+        ];
+        $rows = '';
+        foreach ($meta as $key => $text) {
+            $on = 'yes' === (string) ($prefs[$key] ?? 'no');
+            $rows .= '<div class="form-check form-switch mb-3">';
+            // data-action rather than reading it off the upload form: that
+            // form is only rendered when an external root can be imported, so
+            // the switches would have lost their POST target on a server where
+            // it is absent.
+            $rows .= '<input class="form-check-input pki-pref" type="checkbox"'
+                . ' id="' . \Initiator::e($key) . '"'
+                . ' data-key="' . \Initiator::e($key) . '"'
+                . ' data-action="' . \Initiator::e($this->formAction) . '"'
+                . ($on ? ' checked' : '')
+                . ($mayEdit ? '' : ' disabled')
+                . '>';
+            $rows .= '<label class="form-check-label" for="'
+                . \Initiator::e($key) . '"><strong>'
+                . \Initiator::e($text[0]) . '</strong>'
+                . '<br><span class="text-muted">' . \Initiator::e($text[1])
+                . '</span><br><code>' . \Initiator::e($key) . '</code></label>';
+            $rows .= '</div>';
+        }
+        $body = '<p>' . _(
+            'These decide what the NEXT installer run does. Nothing here takes '
+            . 'effect until the installer runs again -- this page records the '
+            . 'preference, it does not rewrite the web server configuration or '
+            . 'reissue a certificate.'
+        ) . '</p>';
+        $body .= $rows;
+        $body .= '<p class="form-text">' . sprintf(
+            '%s <a href="%s" target="_blank" rel="noopener">%s</a>.',
+            _('A worked example of the first one, end to end:'),
+            \Initiator::e(
+                'https://docs.fogproject.org/en/latest/1.6/kb/how-tos/lets-encrypt-setup'
+            ),
+            _('Let\'s Encrypt with FOG')
+        ) . '</p>';
+        if (!empty($status['externally_managed_leaf'])) {
+            $body .= '<p class="text-info">' . _(
+                'This server\'s web certificate already resolves outside FOG\'s '
+                . 'own PKI, so FOG treats it as managed elsewhere and will not '
+                . 'reissue it or lock its key down, whatever these say. That is '
+                . 'derived from where the certificate actually is, not from a '
+                . 'setting, so the two cannot disagree.'
+            ) . '</p>';
+        }
+        echo $this->_box(
+            _('Install preferences'),
+            $body,
+            ['color' => 'info']
+        );
+    }
+    /**
+     * Replacing FOG's own PKI: what it costs, and the command that does it.
+     *
+     * Deliberately NOT a button. Rotating the root invalidates every
+     * fog-client enrollment on the estate at once, and the recovery is to
+     * re-pin every client -- so it belongs somewhere it can be read back
+     * before it runs. The page composes the invocation; the administrator
+     * runs it (GH-1121).
+     *
+     * @param array|null $status the helper's report.
+     *
+     * @return void
+     */
+    private function _certificateOwnPki($status)
+    {
+        $body = '<p>' . _(
+            'To have your own CA issue FOG\'s web certificates, import the CA '
+            . 'and its key by re-running the installer. That replaces the CA '
+            . 'that signs the web server certificate and the storage node '
+            . 'certificates -- and only that. The root fog-client pins is left '
+            . 'alone, so no client re-enrolls.'
+        ) . '</p>';
+        $body .= '<pre>' . \Initiator::e(
+            './installfog.sh --external-ca \\
+    --web-ca-cert /path/to/intermediate.pem \\
+    --web-ca-key  /path/to/intermediate.key \\
+    --web-ca-root /path/to/root.pem'
+        ) . '</pre>';
+        $body .= '<p><strong>' . _('Not offered here, on purpose')
+            . '</strong></p>';
+        $body .= '<p>' . _(
+            'Replacing the root itself -- so that FOG\'s anchor becomes an '
+            . 'intermediate of yours -- is a migration rather than a setting. '
+            . 'It changes the certificate every registered fog-client pins, so '
+            . 'every one of them stops authenticating until it is re-pinned. '
+            . 'That is not something a web form should be able to do in one '
+            . 'click, so it is not on this page.'
+        ) . '</p>';
+        if ($status && empty($status['root_key_on_server'])) {
             $body .= '<p><strong>' . _('The CA private key is not on this server')
                 . '</strong></p>';
             $body .= '<p>' . _(
@@ -451,8 +895,239 @@ class FOGConfigurationPage extends FOGPage
                 . 'intermediate or a certificate for a new storage node, then '
                 . 'move it back.'
             ) . '</p>';
+        } elseif ($status) {
+            $body .= '<p><strong>' . _('The CA private key is on this server')
+                . '</strong></p>';
+            $body .= '<p>' . _(
+                'It is restricted to root, which protects it from a compromise '
+                . 'of this web application but not from a compromise of the '
+                . 'machine. Moving it to a vault is a separate step:'
+            ) . '</p>';
+            $body .= '<pre>' . \Initiator::e(
+                FOG_BASE_DIR . '/bin/fog-offline-ca-key /mnt/vault'
+            ) . '</pre>';
+            $body .= '<p>' . _(
+                'Nothing needs it day to day. Restore it only to issue a new '
+                . 'intermediate, or a certificate for a new storage node.'
+            ) . '</p>';
         }
-        echo $this->_box(_('Certificates'), $body, ['color' => 'info']);
+        echo $this->_box(
+            _('Using your own PKI'),
+            $body,
+            ['color' => 'warning']
+        );
+    }
+    /**
+     * Hand back one public certificate as a file.
+     *
+     * The slot name is passed straight through to the helper, which holds the
+     * allowlist -- so this method never learns a path and a slot it does not
+     * recognize is refused on the far side of sudo rather than here. Gated on
+     * settings.view: the page is, and every one of these is public.
+     *
+     * @return void
+     */
+    public function certificatedownload()
+    {
+        $slot = (string) filter_input(INPUT_GET, 'slot');
+        $staging = self::_pkiStagingDir();
+        // Generated here rather than accepted, and in the exact shape the
+        // helper validates.
+        $reqid = bin2hex(random_bytes(16));
+        $out = $staging . DS . $reqid . '.pem';
+        $res = $staging ? self::_pkiRun(['export', $slot, $reqid]) : ['ok' => false];
+        $pem = ($res['ok'] && file_exists($out)) ? file_get_contents($out) : '';
+        if (file_exists($out)) {
+            unlink($out);
+        }
+        if ('' === $pem) {
+            $this->title = _('Certificates');
+            echo $this->_box(
+                _('Certificate download failed'),
+                '<p>' . _('That certificate is not available on this server.')
+                . '</p>',
+                ['color' => 'danger']
+            );
+            return;
+        }
+        // basename() on a value the helper already constrained to its own
+        // allowlist. Belt and braces: this string lands in a header, and a
+        // newline in a filename splits the response.
+        $name = 'fog-' . preg_replace('/[^a-z0-9]/', '', strtolower($slot))
+            . '.pem';
+        header('Content-Type: application/x-pem-file');
+        header('Content-Disposition: attachment; filename="' . $name . '"');
+        header('Content-Length: ' . strlen($pem));
+        // The output buffer collapses whitespace (Initiator::sanitizeOutput),
+        // which would corrupt PEM's line structure and produce a file openssl
+        // cannot read. Discard it rather than flushing it.
+        while (ob_get_level() > 0) {
+            ob_end_clean();
+        }
+        echo $pem;
+        exit;
+    }
+    /**
+     * Import a root CA, remove one, or set an install preference.
+     *
+     * Gated on system.pki by Authorization::SUB_OVERRIDES, not on
+     * settings.edit: an imported root reaches this host's trust store, and the
+     * preferences are written into a file root sources as shell.
+     *
+     * @return void
+     */
+    public function certificatesPost()
+    {
+        self::checkAuthAndCSRF();
+        $action = (string) filter_input(INPUT_POST, 'action');
+        try {
+            switch ($action) {
+                case 'importRoot':
+                    $this->_pkiImportRoot();
+                    break;
+                case 'clearRoot':
+                    $this->_pkiClearRoot();
+                    break;
+                case 'setPreference':
+                    $this->_pkiSetPreference();
+                    break;
+                default:
+                    throw new \Exception(_('Unknown action'));
+            }
+        } catch (\Exception $e) {
+            $this->_jsonExit(
+                HTTPResponseCodes::HTTP_BAD_REQUEST,
+                [
+                    'error' => $e->getMessage(),
+                    'title' => _('Certificate change failed')
+                ]
+            );
+        }
+    }
+    /**
+     * Stage an uploaded root CA and hand it to the helper.
+     *
+     * Nothing is validated here beyond the upload itself. The helper parses
+     * it, requires a self-signed CA that has not expired, keeps only the
+     * self-signed certificates out of a bundle, and chooses where it lands --
+     * because this side is the side that might be compromised.
+     *
+     * @return void
+     */
+    private function _pkiImportRoot()
+    {
+        $staging = self::_pkiStagingDir();
+        if (!$staging) {
+            throw new \Exception(
+                _('Certificate management is not configured on this server')
+            );
+        }
+        if (!isset($_FILES['rootca']) || !is_uploaded_file($_FILES['rootca']['tmp_name'] ?? '')) {
+            throw new \Exception(_('No certificate file was uploaded'));
+        }
+        if (UPLOAD_ERR_OK !== ($_FILES['rootca']['error'] ?? UPLOAD_ERR_NO_FILE)) {
+            throw new UploadException($_FILES['rootca']['error']);
+        }
+        // A root CA certificate is a couple of kilobytes; a bundle of them is
+        // a few more. The cap is here so a multi-megabyte upload is refused
+        // before it is written into the staging directory rather than after.
+        if (($_FILES['rootca']['size'] ?? 0) > 128 * 1024) {
+            throw new \Exception(
+                _('That file is too large to be a root CA certificate')
+            );
+        }
+        $reqid = bin2hex(random_bytes(16));
+        $dest = $staging . DS . $reqid . '.pem';
+        if (!move_uploaded_file($_FILES['rootca']['tmp_name'], $dest)) {
+            throw new \Exception(_('Could not stage the uploaded certificate'));
+        }
+        $res = self::_pkiRun(['import-root', $reqid]);
+        if (file_exists($dest)) {
+            unlink($dest);
+        }
+        if (!$res['ok']) {
+            throw new \Exception(
+                $res['out'] ?: _('The certificate was refused')
+            );
+        }
+        // The helper answers "OK <kept> trust:<ok|failed|unavailable>". A
+        // trust-store failure is reported rather than fatal, matching
+        // _installCATrustAnchor(): the certificate did land and is re-applied
+        // on every later run, so calling this a failure would be wrong and
+        // saying nothing would be worse.
+        $parts = explode(' ', $res['out']);
+        $trust = $parts[2] ?? '';
+        $msg = _('The root CA has been imported and this server now trusts it.');
+        if ('trust:ok' !== $trust) {
+            $msg = _(
+                'The root CA has been imported, but this host\'s system trust '
+                . 'store could not be updated -- so HTTPS calls made on this '
+                . 'server will not accept it yet. Re-run the installer, and '
+                . 'check the installation log.'
+            );
+        }
+        $this->_jsonExit(
+            HTTPResponseCodes::HTTP_SUCCESS,
+            ['msg' => $msg, 'title' => _('Root imported')]
+        );
+    }
+    /**
+     * Stop trusting a previously imported root CA.
+     *
+     * The helper removes the file, clears the recorded path and rebuilds the
+     * anchor, so the removal survives the next installer run the same way the
+     * import did. Offered at all because an import nobody can undo from the
+     * same screen is the destructive-web-form problem this page is otherwise
+     * careful to avoid.
+     *
+     * @return void
+     */
+    private function _pkiClearRoot()
+    {
+        $res = self::_pkiRun(['clear-root']);
+        if (!$res['ok']) {
+            throw new \Exception(
+                $res['out'] ?: _('Could not remove the imported root')
+            );
+        }
+        $this->_jsonExit(
+            HTTPResponseCodes::HTTP_SUCCESS,
+            [
+                'msg' => _('The imported root CA has been removed.'),
+                'title' => _('Root removed')
+            ]
+        );
+    }
+    /**
+     * Set one install preference.
+     *
+     * Both the key and the value are passed through unexamined. The helper
+     * holds the three-entry key allowlist and the ^(yes|no)$ value pattern,
+     * and it has to: .fogsettings is sourced as shell by root on the next
+     * installer run, so validating here -- on the side that might be
+     * compromised -- would be validating in the wrong place.
+     *
+     * @return void
+     */
+    private function _pkiSetPreference()
+    {
+        $key = (string) filter_input(INPUT_POST, 'key');
+        $value = filter_input(INPUT_POST, 'value') ? 'yes' : 'no';
+        $res = self::_pkiRun(['set-preference', $key, $value]);
+        if (!$res['ok']) {
+            throw new \Exception(
+                $res['out'] ?: _('Could not save that preference')
+            );
+        }
+        $this->_jsonExit(
+            HTTPResponseCodes::HTTP_SUCCESS,
+            [
+                'msg' => _(
+                    'Saved. It takes effect the next time the installer runs.'
+                ),
+                'title' => _('Preference saved')
+            ]
+        );
     }
     /**
      * Show the Secure Boot enrollment page.

--- a/tests/certificate-management-permission.test.php
+++ b/tests/certificate-management-permission.test.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Changing this server's PKI from the Certificates page takes its own
+ * permission, and the helper is the only thing that can act on it.
+ *
+ * The page can now import a root CA into this host's system trust store and
+ * write three install preferences into .fogsettings. Both are a larger
+ * authority than the page's other cards:
+ *
+ *  - an imported root reaches /etc/pki/ca-trust (or the distro equivalent), so
+ *    every server-side HTTPS call on the box accepts anything issued beneath
+ *    it, for as long as it stays there;
+ *  - .fogsettings is SOURCED AS SHELL by root on the next installer run, so a
+ *    value written into it unvalidated executes as root.
+ *
+ * settings.edit is what SIX page nodes already map onto. "May edit the OUI
+ * table" and "may decide what this server trusts" are not the same grant, so
+ * this arrives the way system.export and impersonate.start did: a new action
+ * on the system node, seeded by no schema step, held by nobody but '*' until
+ * an administrator grants it (GH-1121).
+ *
+ * The permission half is EXECUTED -- resolvePagePermission() is the same call
+ * the router makes, so a map entry edited back, or a registry node dropped,
+ * fails here. A grep for the string would pass on a page rewired around it.
+ *
+ * The second half is about the OTHER side of sudo. The web tier is the side
+ * that might be compromised, so the validation that matters cannot live in
+ * PHP: the key allowlist and the ^(yes|no)$ value pattern have to be in the
+ * root helper. Asserted here as the absence of a PHP-side decision that would
+ * make the helper's version redundant and therefore removable.
+ *
+ * Refs https://github.com/FOGProject/fogproject/issues/1121
+ *
+ * Boots through FogTestHarness with a fake DB, the way
+ * impersonation-read-only-gate.test.php does: resolvePagePermission() fires
+ * PERMISSION_REGISTRY_DATA so plugins can add nodes, so it needs a hook
+ * manager to exist. Nothing here touches a real database.
+ *
+ * Usage: php tests/certificate-management-permission.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('certificate-management-permission');
+FogTestHarness::fakeDb();
+
+$root = dirname(__DIR__);
+$webroot = $root . '/packages/web';
+
+$results = [];
+
+/**
+ * Record one assertion and echo its result.
+ *
+ * Named uniquely rather than check(): tests/ is analyzed as one program by
+ * phpstan-tests.neon, and a global check() collides with the dozens of other
+ * files that declare their own.
+ *
+ * @param string $label what is being asserted
+ * @param bool   $ok    whether it held
+ * @param string $extra detail printed on failure
+ *
+ * @return bool the value of $ok, for the caller to collect
+ */
+function pkiPermCheck($label, $ok, $extra = '')
+{
+    $suffix = ('' !== $extra ? " ($extra)" : '');
+    echo ($ok ? 'ok   - ' : 'FAIL - ') . $label . ($ok ? '' : $suffix) . "\n";
+    return $ok;
+}
+
+/*
+ * 1. The two verbs resolve differently, executed through the router's own
+ *    resolver. Reading the chain is reading server configuration; changing it
+ *    is not.
+ */
+$get = FOG\Auth\Authorization::resolvePagePermission('about', 'certificates', false);
+$post = FOG\Auth\Authorization::resolvePagePermission('about', 'certificates', true);
+$results[] = pkiPermCheck(
+    'GET ?node=about&sub=certificates stays on settings.view',
+    'settings.view' === $get,
+    'got ' . var_export($get, true)
+);
+/*
+ * This is also what pins the override to the ALIASED node. `about` resolves to
+ * `settings` through NODE_ALIASES before SUB_OVERRIDES is consulted, so an
+ * override written under 'about' is never read and this POST falls through to
+ * settings.edit -- silently, and with the page still working for an
+ * administrator, who holds both. Asserted by executing the resolver rather
+ * than by inspecting the constant, which phpstan folds to a literal.
+ */
+$results[] = pkiPermCheck(
+    'POST to the same sub resolves to system.pki',
+    'system.pki' === $post,
+    'got ' . var_export($post, true)
+);
+$results[] = pkiPermCheck(
+    'it is not settings.edit, which six page nodes share',
+    'settings.edit' !== $post,
+    'got ' . var_export($post, true)
+);
+/*
+ * 2. Downloading a public certificate is not a change. Every slot the helper
+ *    will export is a certificate FOG either publishes already or hands to
+ *    anyone who connects, so it belongs with the page rather than behind the
+ *    write grant -- otherwise an operator who may look at the chain cannot
+ *    save a copy of the root they are looking at.
+ */
+$dl = FOG\Auth\Authorization::resolvePagePermission('about', 'certificatedownload', false);
+$results[] = pkiPermCheck(
+    'the certificate download is gated on settings.view',
+    'settings.view' === $dl,
+    'got ' . var_export($dl, true)
+);
+
+/*
+ * 3. The permission has to be grantable, or the only holder is '*' forever and
+ *    assertCanGrant() refuses to delegate it.
+ */
+$registry = FOG\Auth\Authorization::coreRegistry();
+$results[] = pkiPermCheck(
+    "the registry declares a 'system' node",
+    array_key_exists('system', $registry),
+    'nodes: ' . implode(',', array_keys($registry))
+);
+$results[] = pkiPermCheck(
+    "'system' offers the pki action",
+    in_array('pki', (array) ($registry['system'] ?? []), true),
+    'actions: ' . implode(',', (array) ($registry['system'] ?? []))
+);
+
+/*
+ * 4. Deny by default. Nothing may seed system.pki into a role, so an upgrade
+ *    hands it to nobody and an install that never wants it gets that by doing
+ *    nothing. Matched against the schema source because seeding is what a
+ *    schema step would do.
+ */
+$schema = (string) file_get_contents($webroot . '/commons/schema.php');
+$results[] = pkiPermCheck(
+    'no schema step seeds system.pki into a role',
+    false === strpos($schema, 'system.pki'),
+    'commons/schema.php mentions system.pki'
+);
+
+/*
+ * 5. The validation lives on the far side of sudo, and has to.
+ *
+ * PHP is the side that might be compromised, so a key allowlist or a value
+ * pattern written HERE decides nothing -- an attacker running code in the web
+ * tier simply calls the helper directly, which is exactly what the sudoers
+ * rule permits. Both therefore live in packages/pki/fog-pki-admin.
+ *
+ * Asserted as their PRESENCE in the helper rather than their absence from the
+ * page: a duplicate check in PHP is harmless defense in depth, while a missing
+ * one in the helper is the whole boundary gone.
+ */
+$helper = (string) file_get_contents($root . '/packages/pki/fog-pki-admin');
+$results[] = pkiPermCheck(
+    'the helper constrains the preference value to yes or no',
+    1 === preg_match('#\[\[ \$value =~ \^\(yes\|no\)\$ \]\]#', $helper),
+    'the ^(yes|no)$ pattern is not in fog-pki-admin'
+);
+$results[] = pkiPermCheck(
+    'the helper carries a key allowlist, and it is the three preferences',
+    1 === preg_match(
+        '#PREF_KEYS="PKI_web_cert_publicly_trusted WEB_https_redirect '
+        . 'BOOT_rebuild_ipxe_with_my_ca"#',
+        $helper
+    ),
+    'PREF_KEYS is missing or has gained an entry'
+);
+/*
+ * Neither secret in .fogsettings may be reachable, whatever else changes.
+ * SVC_password is the FTP account image replication logs in with fleet-wide.
+ */
+foreach (['SVC_password', 'DB_password', 'FOG_program_dir'] as $forbidden) {
+    $results[] = pkiPermCheck(
+        "the allowlist does not carry $forbidden",
+        1 !== preg_match('#PREF_KEYS="[^"]*' . preg_quote($forbidden, '#') . '#', $helper),
+        'PREF_KEYS reaches ' . $forbidden
+    );
+}
+/*
+ * The helper must never accept a path. Every path it uses comes from a
+ * root-only config written at install time, which is what stops a compromised
+ * web server naming its own CA key or its own .fogsettings.
+ */
+$results[] = pkiPermCheck(
+    'the helper reads its paths from a root-only config, not from arguments',
+    1 === preg_match('#^CONF="/opt/fog/\.fog-pki-admin"$#m', $helper),
+    'the CONF assignment is missing or is no longer a literal'
+);
+
+/*
+ * 6. The page hands the helper escaped arguments. exec() gives its string to a
+ *    shell, and FOG_BASE_DIR is installer-written and may contain a space --
+ *    which would split into two arguments and stop matching the sudoers rule.
+ */
+$page = (string) file_get_contents($webroot . '/src/Pages/FOGConfigurationPage.php');
+$results[] = pkiPermCheck(
+    'every argument passed to the helper goes through escapeshellarg',
+    1 === preg_match(
+        "#\\\$cmd = 'sudo -n ' \\. escapeshellarg\\(\\\$helper\\);.*?"
+        . "foreach \\(\\\$args as \\\$arg\\) \\{.*?"
+        . "escapeshellarg\\(\\(string\\) \\\$arg\\)#s",
+        $page
+    ),
+    'the sudo invocation no longer escapes both the helper and its arguments'
+);
+/*
+ * The download streams PEM, whose line structure the output buffer would
+ * destroy: Initiator::sanitizeOutput collapses whitespace, and a PEM body run
+ * together on one line is a file openssl cannot read. The buffer has to be
+ * discarded before the bytes go out.
+ */
+$results[] = pkiPermCheck(
+    'the certificate download discards the output buffer before sending PEM',
+    1 === preg_match(
+        '#while \(ob_get_level\(\) > 0\) \{\s*ob_end_clean\(\);\s*\}\s*echo \$pem;#',
+        $page
+    ),
+    'the buffer is not discarded, so the PEM would be whitespace-collapsed'
+);
+
+$failed = count(array_filter($results, static function ($r) {
+    return !$r;
+}));
+printf(
+    "\n%d check(s), %d failed\n",
+    count($results),
+    $failed
+);
+exit($failed > 0 ? 1 : 0);

--- a/tests/client-repin-warning.test.sh
+++ b/tests/client-repin-warning.test.sh
@@ -60,6 +60,10 @@ setSELinuxContext() { :; }
 
 # --- a self-contained install tree -------------------------------------------
 fogprogramdir="$WORK/opt/fog"
+# The tree lives at /etc/fog/pki on a real install. Point it inside the scratch
+# $fogprogramdir instead, or this would reach for the host's own /etc/fog --
+# and _migratePkiTree would try to CREATE it.
+PKI_root_dir="$fogprogramdir/pki"
 snapindir="$WORK/opt/fog/snapins"
 PKI_client_cert_dir="$snapindir/ssl"
 webdirdest="$WORK/var/www/fog"

--- a/tests/client-zone-migration.test.sh
+++ b/tests/client-zone-migration.test.sh
@@ -66,6 +66,10 @@ apacheuser="$(id -un)"
 # A fresh tree per scenario, so one case cannot leak into the next.
 newtree() {
     fogprogramdir="$WORK/$1/opt/fog"
+    # The tree lives at /etc/fog/pki on a real install. Point it inside the
+    # scratch $fogprogramdir instead, or every case below would reach for the
+    # host's own /etc/fog -- and _migratePkiTree would try to CREATE it.
+    PKI_root_dir="$fogprogramdir/pki"
     snapindir="$fogprogramdir/snapins"
     PKI_client_cert_dir="$snapindir/ssl"
     PKI_client_encrypt_key=""

--- a/tests/external-cert-detection.test.sh
+++ b/tests/external-cert-detection.test.sh
@@ -125,6 +125,10 @@ echo "== _externallyManagedLeaf: the symlink test that replaced \$acmeLeaf =="
 # _pkiZoneDir derives from it, and unset it resolves to /pki/web.
 eml_env() {
     fogprogramdir="$WORK/eml/opt/fog"
+    # The tree lives at /etc/fog/pki on a real install. Point it inside the
+    # scratch $fogprogramdir instead, or every case below would reach for the
+    # host's own /etc/fog -- and _migratePkiTree would try to CREATE it.
+    PKI_root_dir="$fogprogramdir/pki"
     EMLZONE="$fogprogramdir/pki/web"
     EMLLEAF="$EMLZONE/leaf"
     mkdir -p "$EMLLEAF" "$WORK/eml/etc/letsencrypt/live/fog"

--- a/tests/install-settings-resolution.test.sh
+++ b/tests/install-settings-resolution.test.sh
@@ -296,7 +296,7 @@ for key in WEB_https_redirect PKI_web_cert_publicly_trusted \
     fi
 done
 
-# All 68 keys of the model are managed, and NOTHING ELSE is: adding a key to
+# All 69 keys of the model are managed, and NOTHING ELSE is: adding a key to
 # this array turns a hand-set key into a managed one, and the admin's value
 # starts being overwritten. That is a behavior change even though it looks
 # like documentation, so the count is asserted as well as the membership.
@@ -311,7 +311,8 @@ modelKeys="
     FOG_packages FOG_program_dir FOG_send_reports FOG_update_channel
     NET_fog_server_ip NET_hostname NET_interface NET_subnet_mask
     PKI_allowed_domain_names PKI_client_cert_dir PKI_client_encrypt_cert PKI_client_encrypt_key
-    PKI_internal_subnets PKI_root_ca_cert PKI_root_ca_key PKI_san_dns_names
+    PKI_internal_subnets PKI_root_ca_cert PKI_root_ca_key PKI_root_dir
+    PKI_san_dns_names
     PKI_san_ip_addresses PKI_sb_ca_cert PKI_sb_codesign_cert PKI_sb_codesign_key
     PKI_sb_enabled PKI_web_ca_cert PKI_web_ca_key PKI_web_cert_publicly_trusted
     PKI_web_external_root_cert PKI_web_trust_chain PKI_web_vhost_cert PKI_web_vhost_key

--- a/tests/installer-tls-verification.test.sh
+++ b/tests/installer-tls-verification.test.sh
@@ -254,6 +254,10 @@ tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 error_log="$tmp/error.log"
 fogprogramdir="$tmp/opt-fog"
+# The tree lives at /etc/fog/pki on a real install. Point it inside the scratch
+# $fogprogramdir instead, or this would reach for the host's own /etc/fog --
+# and _migratePkiTree would try to CREATE it.
+PKI_root_dir="$fogprogramdir/pki"
 mkdir -p "$fogprogramdir"
 
 # shellcheck source=/dev/null

--- a/tests/pki-admin-helper.test.sh
+++ b/tests/pki-admin-helper.test.sh
@@ -1,0 +1,440 @@
+#!/bin/bash
+#
+# Guards fog-pki-admin, the root helper the Certificates page drives over sudo.
+#
+#   tests/pki-admin-helper.test.sh
+#
+# This script is a privilege boundary: the web user can start it, and on the
+# other side of it are a CA, the host trust store, and a file that root SOURCES
+# AS SHELL on the next installer run. Everything below is a refusal that has to
+# hold, or a value that has to survive intact.
+#
+# The .fogsettings half is the one worth stating plainly. Writing an
+# unvalidated value into a file root later sources is a root shell with extra
+# steps, so set-preference matches its value against ^(yes|no)$ and its key
+# against a three-entry allowlist. Both refusals are exercised here, and both
+# are checked by "did the file change", not merely by "did the command exit
+# non-zero" -- a helper that rejected the argument after writing would pass the
+# weaker test.
+#
+# Runs the REAL script with its REAL hardcoded config path, as a REAL uid 0, by
+# putting a tmpfs over /opt inside an unprivileged user namespace. No fixture
+# copy of the helper, no sed-rewritten path, nothing that can drift from what
+# ships.
+#
+# Needs openssl and either unshare(1) with unprivileged user namespaces, or to
+# be run as root already (which CI is).
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+HELPER="$REPO/packages/pki/fog-pki-admin"
+
+[[ -f $HELPER ]] || { echo "ERROR: $HELPER not found" >&2; exit 1; }
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl is not installed"; exit 0; }
+
+# Re-exec inside a user namespace unless we are already root. The namespace
+# gives uid 0 and a private mount table, so the helper's own `[[ $EUID -eq 0 ]]`
+# and its hardcoded CONF="/opt/fog/.fog-pki-admin" are both exercised as
+# shipped.
+if [[ ${FOG_PKI_TEST_INNER:-0} -ne 1 ]]; then
+    if [[ $EUID -ne 0 ]]; then
+        command -v unshare >/dev/null 2>&1 \
+            || { echo "SKIP: not root and unshare(1) is unavailable"; exit 0; }
+        unshare -rm true >/dev/null 2>&1 \
+            || { echo "SKIP: unprivileged user namespaces are unavailable"; exit 0; }
+        exec unshare -rm env FOG_PKI_TEST_INNER=1 bash "${BASH_SOURCE[0]}" "$@"
+    fi
+    export FOG_PKI_TEST_INNER=1
+    # Already root: still take a private mount namespace so the tmpfs below
+    # cannot be seen by, or outlive, this test.
+    if command -v unshare >/dev/null 2>&1; then
+        exec unshare -m bash "${BASH_SOURCE[0]}" "$@"
+    fi
+fi
+
+mount -t tmpfs none /opt >/dev/null 2>&1 \
+    || { echo "SKIP: could not place a tmpfs over /opt"; exit 0; }
+
+FOGDIR=/opt/fog
+CONF="$FOGDIR/.fog-pki-admin"
+SETTINGS="$FOGDIR/.fogsettings"
+STAGING="$FOGDIR/pkiadmin-staging"
+ZONE="$FOGDIR/pki/web"
+mkdir -p "$FOGDIR" "$STAGING" "$ZONE/ca" "$ZONE/leaf" "$FOGDIR/pki/root/ca" "$FOGDIR/pki/client/leaf"
+
+WORK="$(mktemp -d)"
+PASS=0; FAIL=0
+ok()    { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad()   { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+check() { [[ $1 == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+# openssl 3.x prints "CN = FOG Server CA" where older releases print "CN=FOG
+# Server CA". Neither spelling is the thing under test, so normalize both away.
+subjectOf() { openssl x509 -in "$1" -noout -subject 2>/dev/null | sed 's/ *= */=/g'; }
+
+# --- fixtures ---------------------------------------------------------------
+# A FOG root and its web intermediate; a separate corporate root with its own
+# intermediate; a plain server certificate; an already-expired root.
+mkroot() { # name subject days -> $WORK/<name>.{key,pem}
+    openssl req -x509 -newkey rsa:2048 -nodes -days "$3" -subj "/CN=$2" \
+        -addext "basicConstraints=critical,CA:TRUE" \
+        -keyout "$WORK/$1.key" -out "$WORK/$1.pem" >/dev/null 2>&1
+}
+mkint() { # name subject signer -> $WORK/<name>.pem
+    openssl req -newkey rsa:2048 -nodes -subj "/CN=$2" \
+        -keyout "$WORK/$1.key" -out "$WORK/$1.csr" >/dev/null 2>&1
+    printf 'basicConstraints=critical,CA:TRUE,pathlen:0\n' > "$WORK/$1.ext"
+    openssl x509 -req -in "$WORK/$1.csr" -CA "$WORK/$3.pem" -CAkey "$WORK/$3.key" \
+        -CAcreateserial -days 3650 -extfile "$WORK/$1.ext" \
+        -out "$WORK/$1.pem" >/dev/null 2>&1
+}
+mkleaf() { # name subject signer -> $WORK/<name>.pem
+    openssl req -newkey rsa:2048 -nodes -subj "/CN=$2" \
+        -keyout "$WORK/$1.key" -out "$WORK/$1.csr" >/dev/null 2>&1
+    printf 'basicConstraints=critical,CA:FALSE\n' > "$WORK/$1.ext"
+    openssl x509 -req -in "$WORK/$1.csr" -CA "$WORK/$3.pem" -CAkey "$WORK/$3.key" \
+        -CAcreateserial -days 3650 -extfile "$WORK/$1.ext" \
+        -out "$WORK/$1.pem" >/dev/null 2>&1
+}
+
+mkroot fogroot "FOG Server CA" 3650
+mkint  webca   "FOG Web CA"    fogroot
+mkleaf vhost   "fog.example.org" webca
+mkroot corp    "Corp Root CA"  3650
+# Self-signed AND CA:FALSE. The server certificate below is signed by corp, so
+# it is filtered by self-signedness before basicConstraints is ever consulted --
+# which left the CA:TRUE check untested until this fixture existed.
+openssl req -x509 -newkey rsa:2048 -nodes -days 3650 -subj "/CN=selfsigned.example.org" \
+    -addext "basicConstraints=critical,CA:FALSE" \
+    -keyout "$WORK/selfleaf.key" -out "$WORK/selfleaf.pem" >/dev/null 2>&1
+mkint  corpint "Corp Issuing CA" corp
+mkleaf plain   "www.example.org" corp
+
+# An expired root has to be MINTED expired: openssl req -days cannot go
+# negative, so back-date with -not_before/-not_after via a CA-signed self
+# issuance is fussier than simply using faketime. Use a 1-day root and
+# -checkend far enough out that the helper's own -checkend 0 still passes,
+# then build the expired case with openssl x509 -req against itself.
+openssl req -newkey rsa:2048 -nodes -subj "/CN=Expired Root CA" \
+    -keyout "$WORK/expired.key" -out "$WORK/expired.csr" >/dev/null 2>&1
+printf 'basicConstraints=critical,CA:TRUE\n' > "$WORK/expired.ext"
+openssl x509 -req -in "$WORK/expired.csr" -signkey "$WORK/expired.key" \
+    -extfile "$WORK/expired.ext" -not_before 20200101000000Z \
+    -not_after 20200102000000Z -out "$WORK/expired.pem" >/dev/null 2>&1
+if ! openssl x509 -in "$WORK/expired.pem" -noout >/dev/null 2>&1; then
+    # -not_before/-not_after landed in OpenSSL 3.4; older releases need -days
+    # counted from now, which cannot express the past. Skip just that case.
+    rm -f "$WORK/expired.pem"
+fi
+
+install -m 0644 "$WORK/fogroot.pem" "$FOGDIR/pki/root/ca/.fogCA.pem"
+install -m 0400 "$WORK/fogroot.key" "$FOGDIR/pki/root/ca/.fogCA.key"
+install -m 0644 "$WORK/webca.pem"   "$ZONE/ca/.fogWebCA.pem"
+cat "$WORK/webca.pem" "$WORK/fogroot.pem" > "$ZONE/ca/.fogWebCAchain.pem"
+install -m 0644 "$WORK/vhost.pem"   "$ZONE/leaf/.webLeaf.pem"
+install -m 0644 "$WORK/fogroot.pem" "$FOGDIR/pki/client/leaf/.srvpublic.crt"
+
+cat > "$CONF" <<EOF
+PKI_ROOT_CERT=$FOGDIR/pki/root/ca/.fogCA.pem
+PKI_ROOT_KEY=$FOGDIR/pki/root/ca/.fogCA.key
+PKI_WEB_CA_CERT=$ZONE/ca/.fogWebCA.pem
+PKI_WEB_CHAIN=$ZONE/ca/.fogWebCAchain.pem
+PKI_WEB_ANCHOR=$ZONE/ca/.trustAnchor.pem
+PKI_WEB_VHOST_CERT=$ZONE/leaf/.webLeaf.pem
+PKI_WEB_ZONE_DIR=$ZONE
+PKI_EXTERNAL_ROOT=$ZONE/ca/.externalRoot.pem
+PKI_CLIENT_CERT=$FOGDIR/pki/client/leaf/.srvpublic.crt
+PKI_SB_CA_CERT=$FOGDIR/pki/secureboot/ca/.fogSBCA.pem
+PKI_WEB_CA_KEY=$ZONE/ca/.fogWebCA.key
+PKI_WEB_VHOST_KEY=$ZONE/leaf/.webLeaf.key
+PKI_SB_CA_KEY=$FOGDIR/pki/secureboot/ca/.fogSBCA.key
+PKI_CLIENT_KEY=$FOGDIR/pki/client/leaf/.srvprivate.key
+PKI_SETTINGS=$SETTINGS
+PKI_STAGING=$STAGING
+EOF
+chmod 0600 "$CONF"
+
+writeSettingsFixture() {
+    cat > "$SETTINGS" <<'EOF'
+## Start of FOG Settings
+## Version: 1.6.0
+
+## PKI -- certificate authorities and trust
+PKI_sb_enabled='yes'
+PKI_web_cert_publicly_trusted='no'
+PKI_web_external_root_cert=''
+
+## WEB
+WEB_https_redirect='no'
+
+## BOOT
+BOOT_rebuild_ipxe_with_my_ca='no'
+BOOT_url_proto_forced='no'
+
+## The two cleartext secrets, and a path key. Present in the fixture ON
+## PURPOSE: without them the allowlist below would be tested by a file that
+## does not carry the key, so writeSetting's "must already exist" guard would
+## refuse them whatever the allowlist said, and deleting the allowlist would
+## not turn a single assertion red.
+SVC_password='correct-horse'
+DB_password='battery-staple'
+FOG_program_dir='/opt/fog'
+## End of FOG Settings
+
+## Carried over from the previous file.
+inetConnectTimeout=20
+EOF
+    chmod 0600 "$SETTINGS"
+}
+writeSettingsFixture
+
+stage() { # <file> -> echoes the request id it was staged under
+    local id
+    id=$(openssl rand -hex 16)
+    cp "$1" "$STAGING/$id.pem"
+    printf '%s' "$id"
+}
+settingOf() { # read a key back the way the installer does: by sourcing
+    ( set +u; . "$SETTINGS" >/dev/null 2>&1; printf '%s' "${!1}" )
+}
+
+echo "== status: reports the chain as public metadata =="
+out=$("$HELPER" status 2>&1); st=$?
+check "$st" "0" "status exits 0"
+if command -v php >/dev/null 2>&1; then
+    php -r '$j=json_decode(file_get_contents("php://stdin"),true); exit($j===null?1:0);' <<< "$out"
+    check "$?" "0" "status emits valid JSON"
+    subj=$(php -r '$j=json_decode(file_get_contents("php://stdin"),true);
+        foreach($j["certificates"] as $c){ if($c["slot"]==="root"){ echo $c["subject"]; } }' <<< "$out")
+    check "${subj// = /=}" "CN=FOG Server CA" "status names the subject of the root"
+    php -r '$j=json_decode(file_get_contents("php://stdin"),true);
+        exit($j["root_key_on_server"]===true?0:1);' <<< "$out"
+    check "$?" "0" "status sees the root key on disk"
+    php -r '$j=json_decode(file_get_contents("php://stdin"),true);
+        exit($j["externally_managed_leaf"]===false?0:1);' <<< "$out"
+    check "$?" "0" "a leaf inside the web zone is not externally managed"
+    php -r '$j=json_decode(file_get_contents("php://stdin"),true);
+        exit($j["preferences"]["WEB_https_redirect"]==="no"?0:1);' <<< "$out"
+    check "$?" "0" "status reads the preferences out of .fogsettings"
+else
+    echo "  SKIP  JSON assertions (php is not installed)"
+fi
+# status DOES name the private key paths, deliberately: the page tests
+# readability itself, with the web server's own credentials, because that is
+# the only test that answers the question it asks. What must never appear is a
+# key's CONTENTS -- this helper runs as root and can read every one of them.
+case "$out" in
+    *BEGIN*PRIVATE*) bad "status leaked private key material" ;;
+    *)               ok "status carries no private key material" ;;
+esac
+if command -v php >/dev/null 2>&1; then
+    php -r '$j=json_decode(file_get_contents("php://stdin"),true);
+        $k=[]; foreach($j["private_keys"] as $p){ $k[$p["label"]]=$p["expect_readable"]; }
+        exit(($k["CA private key"]===false
+              && $k["Client communication private key"]===true) ? 0 : 1);' <<< "$out"
+    check "$?" "0" "status marks the client key as legitimately web-readable and the CA key as not"
+    php -r '$j=json_decode(file_get_contents("php://stdin"),true);
+        foreach($j["private_keys"] as $p){ if($p["label"]==="CA private key"){ echo $p["path"]; } }' <<< "$out"         | grep -qxF "$FOGDIR/pki/root/ca/.fogCA.key"
+    check "$?" "0" "status names the real key path, not a retired layout"
+fi
+
+echo
+echo "== export: a slot name, never a path =="
+id=$(stage "$WORK/fogroot.pem"); rm -f "$STAGING/$id.pem"
+"$HELPER" export root "$id" >/dev/null 2>&1
+check "$?" "0" "export root succeeds"
+check "$(subjectOf "$STAGING/$id.pem")" \
+      "subject=CN=FOG Server CA" "export root writes the root certificate"
+rm -f "$STAGING/$id.pem"
+
+# A real, readable, perfectly valid certificate that is simply not one of the
+# slots. Handing it a private key instead proved nothing: that is refused for
+# containing no certificate, so the allowlist could be deleted with every
+# assertion still green.
+"$HELPER" export "$WORK/corp.pem" "$id" >/dev/null 2>&1
+check "$?" "1" "export refuses a path in place of a slot name"
+"$HELPER" export "$FOGDIR/pki/root/ca/.fogCA.key" "$id" >/dev/null 2>&1
+check "$?" "1" "export refuses a path to a private key"
+# Aimed at a directory the helper CAN write. Pointed at /etc it was refused by
+# the filesystem rather than by the pattern, so deleting the pattern turned
+# nothing red.
+"$HELPER" export root "../canary" >/dev/null 2>&1
+check "$?" "1" "export refuses a traversing request id"
+[[ -e /opt/fog/canary.pem ]] && bad "the traversing export escaped the staging directory" \
+    || ok "nothing was written outside the staging directory"
+"$HELPER" export privatekey "$id" >/dev/null 2>&1
+check "$?" "1" "export refuses an unknown slot"
+[[ -e "$STAGING/$id.pem" ]] && bad "a refused export still wrote to staging" \
+    || ok "a refused export writes nothing"
+
+echo
+echo "== import-root: only a self-signed CA, and only the self-signed part =="
+id=$(stage "$WORK/corp.pem")
+out=$("$HELPER" import-root "$id" 2>&1); st=$?
+check "$st" "0" "a corporate root imports"
+# Rebuilding the anchor FILE is mandatory; pushing it into the host trust store
+# is best-effort and reported, matching _installCATrustAnchor(). The test
+# namespace cannot write the real store, so the token is what is pinned here --
+# not which of the three it is.
+case "$out" in
+    "OK 1 trust:ok"|"OK 1 trust:failed"|"OK 1 trust:unavailable")
+        ok "import-root reports how many roots it kept and what the host store did" ;;
+    *)  bad "import-root's success line is '$out'" ;;
+esac
+check "$(subjectOf "$ZONE/ca/.externalRoot.pem")" \
+      "subject=CN=Corp Root CA" "the imported root lands at the canonical path"
+check "$(settingOf PKI_web_external_root_cert)" "$ZONE/ca/.externalRoot.pem" \
+      "the canonical path is recorded in .fogsettings, not the upload's own path"
+check "$(grep -c 'BEGIN CERTIFICATE' "$ZONE/ca/.trustAnchor.pem" 2>/dev/null)" "2" \
+      "the trust anchor carries FOG's root and the imported one"
+rm -f "$STAGING/$id.pem"
+
+# A bundle: the anchor must gain the root and NOT the intermediate. Anchoring
+# an intermediate would trust it as a root, which widens what this box accepts.
+cat "$WORK/corpint.pem" "$WORK/corp.pem" > "$WORK/bundle.pem"
+id=$(stage "$WORK/bundle.pem")
+"$HELPER" import-root "$id" >/dev/null 2>&1
+check "$?" "0" "a root+intermediate bundle imports"
+check "$(grep -c 'BEGIN CERTIFICATE' "$ZONE/ca/.externalRoot.pem" 2>/dev/null)" "1" \
+      "only the self-signed certificate is kept out of a bundle"
+rm -f "$STAGING/$id.pem"
+
+for case_ in "corpint:an intermediate" "plain:a server certificate" \
+             "selfleaf:a self-signed certificate that is not a CA"; do
+    f="${case_%%:*}"; label="${case_#*:}"
+    before=$(sha256sum "$ZONE/ca/.externalRoot.pem" | cut -d' ' -f1)
+    id=$(stage "$WORK/$f.pem")
+    "$HELPER" import-root "$id" >/dev/null 2>&1
+    check "$?" "1" "import-root refuses $label"
+    check "$(sha256sum "$ZONE/ca/.externalRoot.pem" | cut -d' ' -f1)" "$before" \
+          "a refused import ($label) left the previous root in place"
+    rm -f "$STAGING/$id.pem"
+done
+
+if [[ -f $WORK/expired.pem ]]; then
+    id=$(stage "$WORK/expired.pem")
+    "$HELPER" import-root "$id" >/dev/null 2>&1
+    check "$?" "1" "import-root refuses an expired root"
+    rm -f "$STAGING/$id.pem"
+else
+    echo "  SKIP  expired-root case (this openssl cannot mint one)"
+fi
+
+# The request id is what keeps import-root reading inside the staging
+# directory. A perfectly valid root placed just outside it must still be
+# unreachable.
+cp "$WORK/corp.pem" "$FOGDIR/outside.pem"
+before=$(sha256sum "$ZONE/ca/.externalRoot.pem" | cut -d' ' -f1)
+"$HELPER" import-root "../outside" >/dev/null 2>&1
+check "$?" "1" "import-root refuses a traversing request id"
+check "$(sha256sum "$ZONE/ca/.externalRoot.pem" | cut -d' ' -f1)" "$before" \
+      "and imported nothing from outside the staging directory"
+
+printf 'not a certificate at all\n' > "$WORK/junk.pem"
+id=$(stage "$WORK/junk.pem")
+"$HELPER" import-root "$id" >/dev/null 2>&1
+check "$?" "1" "import-root refuses a file that is not PEM"
+rm -f "$STAGING/$id.pem"
+
+# A private key wearing a certificate's clothes: PEM, parses as something,
+# and must never be stored or echoed back.
+id=$(openssl rand -hex 16)
+cat "$WORK/corp.key" > "$STAGING/$id.pem"
+out=$("$HELPER" import-root "$id" 2>&1); st=$?
+check "$st" "1" "import-root refuses a private key"
+case "$out" in
+    *PRIVATE*) bad "the refusal echoed the key back" ;;
+    *)         ok "the refusal does not echo the key back" ;;
+esac
+rm -f "$STAGING/$id.pem"
+
+echo
+echo "== clear-root: the import is undoable from the same screen =="
+"$HELPER" clear-root >/dev/null 2>&1
+check "$?" "0" "clear-root succeeds"
+[[ -e "$ZONE/ca/.externalRoot.pem" ]] && bad "clear-root left the file behind" \
+    || ok "clear-root removes the imported root"
+check "$(settingOf PKI_web_external_root_cert)" "" "clear-root clears the setting"
+check "$(grep -c 'BEGIN CERTIFICATE' "$ZONE/ca/.trustAnchor.pem" 2>/dev/null)" "1" \
+      "the trust anchor drops back to FOG's root alone"
+
+echo
+echo "== set-preference: .fogsettings is sourced as shell by root =="
+writeSettingsFixture
+before=$(sha256sum "$SETTINGS" | cut -d' ' -f1)
+
+"$HELPER" set-preference WEB_https_redirect yes >/dev/null 2>&1
+check "$?" "0" "an allowlisted key with an allowed value is accepted"
+check "$(settingOf WEB_https_redirect)" "yes" "the value is what the file sources to"
+check "$(grep -c '^WEB_https_redirect=' "$SETTINGS")" "1" "the key is rewritten, not duplicated"
+check "$(settingOf inetConnectTimeout)" "20" "an unmanaged carried-over line survives"
+check "$(grep -c '^## End of FOG Settings' "$SETTINGS")" "1" "the file structure is intact"
+
+# Every value here is "yes", which the value pattern accepts. Using a value
+# the pattern rejects (a password, a path) would have let the KEY allowlist be
+# deleted with every assertion still green -- the refusal would have come from
+# the other gate.
+for key in SVC_password DB_password FOG_program_dir BOOT_url_proto_forced PKI_root_ca_cert; do
+    before=$(sha256sum "$SETTINGS" | cut -d' ' -f1)
+    "$HELPER" set-preference "$key" yes >/dev/null 2>&1
+    check "$?" "1" "set-preference refuses the key $key"
+    check "$(sha256sum "$SETTINGS" | cut -d' ' -f1)" "$before" \
+          "refusing $key changed nothing in the file"
+done
+
+# The injection cases. Each of these, written verbatim into a file root later
+# sources, executes as root.
+CANARY=/opt/fog/canary
+for payload in "no'; touch ${CANARY}; #" \
+               "\$(touch ${CANARY})" \
+               "\`touch ${CANARY}\`" \
+               "yes"$'\n'"touch ${CANARY}" \
+               "YES" "1" "true" ""; do
+    before=$(sha256sum "$SETTINGS" | cut -d' ' -f1)
+    "$HELPER" set-preference WEB_https_redirect "$payload" >/dev/null 2>&1
+    st=$?
+    label=$(printf '%s' "$payload" | tr '\n' ' ')
+    check "$st" "1" "set-preference refuses the value '${label:-<empty>}'"
+    check "$(sha256sum "$SETTINGS" | cut -d' ' -f1)" "$before" \
+          "refusing '${label:-<empty>}' changed nothing in the file"
+done
+# Source the file the way installfog.sh does and see whether anything ran.
+( set +u; . "$SETTINGS" >/dev/null 2>&1 )
+[[ -e $CANARY ]] && bad "sourcing .fogsettings executed an injected payload" \
+    || ok "sourcing .fogsettings after every refusal executes nothing"
+
+# A key the allowlist permits but the file does not carry. Appending it would
+# land it after "## End of FOG Settings", in the region the installer's merge
+# treats as the admin's own lines.
+grep -v '^BOOT_rebuild_ipxe_with_my_ca=' "$SETTINGS" > "$SETTINGS.x" && mv "$SETTINGS.x" "$SETTINGS"
+"$HELPER" set-preference BOOT_rebuild_ipxe_with_my_ca yes >/dev/null 2>&1
+check "$?" "1" "set-preference refuses a key the file does not already carry"
+check "$(grep -c '^BOOT_rebuild_ipxe_with_my_ca=' "$SETTINGS")" "0" "and appends nothing"
+
+echo
+echo "== the helper refuses to run without its config =="
+mv "$CONF" "$CONF.away"
+out=$("$HELPER" status 2>&1)
+check "$?" "1" "no config means no verbs"
+# On the MESSAGE, not just the exit status. Without the config the staging
+# check below it also fails, so a bare exit-code assertion stays green even if
+# the config requirement is deleted -- and the admin would then be told the
+# staging directory is misconfigured for a server that simply has not been
+# installed.
+case "$out" in
+    *"re-run the FOG installer"*) ok "and says which of the two it is" ;;
+    *)                            bad "the refusal blamed something else: $out" ;;
+esac
+mv "$CONF.away" "$CONF"
+
+# The root check cannot be turned red from here: this test IS root, which is
+# the only way to exercise the rest of the script at all. It is one line and
+# the sudoers rule is what actually places the boundary; noted rather than
+# faked with an assertion that proves nothing.
+
+echo
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+rm -rf "$WORK"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/tests/pki-idempotence.test.sh
+++ b/tests/pki-idempotence.test.sh
@@ -74,6 +74,10 @@ setSELinuxContext() { :; }
 
 # --- a self-contained install tree -------------------------------------------
 fogprogramdir="$WORK/opt/fog"
+# The tree lives at /etc/fog/pki on a real install. Point it inside the
+# scratch $fogprogramdir instead, or every case below would reach for the
+# host's own /etc/fog -- and _migratePkiTree would try to CREATE it.
+PKI_root_dir="$fogprogramdir/pki"
 snapindir="$WORK/opt/fog/snapins"
 PKI_client_cert_dir="$snapindir/ssl"
 webdirdest="$WORK/var/www/fog"

--- a/tests/pki-tree-relocation.test.sh
+++ b/tests/pki-tree-relocation.test.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+#
+# The PKI tree lives at /etc/fog/pki, and the move to it is safe to interrupt.
+#
+#   tests/pki-tree-relocation.test.sh
+#
+# FOG's four-zone PKI used to sit at $fogprogramdir/pki -- /opt/fog/pki on a
+# default install. Keys and certificates are configuration, so they belong in
+# /etc, which is what a backup policy and a config-management run already
+# capture; /opt/<pkg> is for a package's own static files. /etc/fog is not new
+# (GH-850 makes it a real directory on every install, for fog.conf), so the
+# move needs no per-distro branch.
+#
+# Two properties have to hold, and both are load-bearing:
+#
+#   (a) $fogprogramdir/pki KEEPS RESOLVING, as a symlink. It is a published
+#       path -- PKI_ZONES.md, MULTI_SERVER_CA.md and
+#       EXTERNAL_CA_AND_LETSENCRYPT.md name /opt/fog/pki/..., an admin's
+#       renewal cron names /opt/fog/pki/renewal-helper, and a .fogsettings
+#       written before this change records canonical paths underneath it.
+#
+#   (b) The move is COPY, then remove only if the copy succeeded -- never mv. /opt and /etc are
+#       frequently separate mounts, so mv degrades to copy-then-unlink anyway.
+#       Doing it in explicit steps means a failed copy leaves the SOURCE
+#       authoritative rather than half a tree on each side, and it is what
+#       makes overwriting the source key blocks possible at all.
+#
+# The stake on getting this wrong is the whole estate: a zone accessor that
+# answers /etc/fog/pki while the material still sits under /opt/fog/pki reads
+# as "no CA yet", mints a fresh root, and every fog-client stops trusting the
+# server. That is why _pkiRootDir() drives the migration itself rather than
+# relying on a call placed early enough in installfog.sh.
+#
+# MUTATION-VERIFIED -- every guard below was removed in turn and this file
+# went red for it:
+#
+#   dropped the trailing `ln -s`                     -> 5 red (the compat path)
+#   `cp -a` -> `cp -r`                               -> 1 red (timestamps)
+#   dropped `cp ... || return 1`                     -> 2 red (case E)
+#   dropped `[[ -L $legacy ]] && return 0`           -> 1 red (case C)
+#   dropped `[[ $legacy == "$target" ]] && return 0` -> 1 red (case F)
+#   dropped `[[ -z ${fogprogramdir} ]] && return 0`  -> 1 red (case G)
+#   _pkiZoneDir echoes ${fogprogramdir}/pki/$1 again -> 5 red (case B)
+#   _pkiConfDir likewise                             -> 1 red (case B)
+#   the default reverts to ${fogprogramdir}/pki      -> 1 red (case G)
+#
+# The first cut of this file could not see four of those: three guards were
+# duplicated between _pkiRootDir and _migratePkiTree, so removing either copy
+# was invisible, and the mode assertions could not tell `cp -a` from `cp -r`
+# because an ordinary umask strips nothing off 0600 or 0700. The duplication is
+# gone and the timestamp check is what separates the two copies.
+#
+# Runs on generated fixtures -- no install, no network, no root, and never
+# touches the host's own /etc/fog.
+#
+# Exit status 0 = pass, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'chmod -R u+rwX "$WORK" 2>/dev/null; rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+error_log="$WORK/error.log"
+: > "$error_log"
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+dots() { :; }
+errorStat() { :; }
+
+# Every case gets its own $fogprogramdir and its own target, so nothing here
+# can reach the host's /etc/fog -- which _migratePkiTree would otherwise CREATE.
+newcase() {
+    CASE="$WORK/$1"
+    fogprogramdir="$CASE/opt/fog"
+    TARGET="$CASE/etc/fog/pki"
+    PKI_root_dir="$TARGET"
+    mkdir -p "$fogprogramdir"
+}
+
+# A stand-in for the four zones, with a private key whose mode has to survive.
+seedLegacyTree() {
+    mkdir -p "$fogprogramdir/pki/root/ca" "$fogprogramdir/pki/web/leaf" \
+        "$fogprogramdir/pki/secureboot/ca" "$fogprogramdir/pki/conf"
+    echo "root-ca-key" > "$fogprogramdir/pki/root/ca/.fogCA.key"
+    chmod 0600 "$fogprogramdir/pki/root/ca/.fogCA.key"
+    chmod 0700 "$fogprogramdir/pki/root/ca"
+    echo "web-leaf" > "$fogprogramdir/pki/web/leaf/.webLeaf.pem"
+    echo "sb-ca" > "$fogprogramdir/pki/secureboot/ca/.fogSBCA.pem"
+    # A distinctive mtime. Modes survive a plain `cp -r` under an ordinary
+    # umask, so they cannot tell -a from -r on their own; timestamps can, and
+    # -a is what also carries ownership, which an unprivileged test cannot see.
+    touch -d '2020-01-02 03:04:05' "$fogprogramdir/pki/secureboot/ca/.fogSBCA.pem"
+    printf 'basicConstraints=CA:FALSE\n' > "$fogprogramdir/pki/conf/ca.cnf"
+    echo "#!/bin/sh" > "$fogprogramdir/pki/renewal-helper"
+    chmod 0755 "$fogprogramdir/pki/renewal-helper"
+}
+
+echo "== an existing tree is moved, and the old name keeps resolving =="
+newcase moved
+seedLegacyTree
+_migratePkiTree "$TARGET"
+
+is "$(cat "$TARGET/root/ca/.fogCA.key" 2>/dev/null)" "root-ca-key" \
+    "A: the root CA key arrived at the new tree"
+is "$(cat "$TARGET/web/leaf/.webLeaf.pem" 2>/dev/null)" "web-leaf" \
+    "A: the web leaf arrived"
+is "$(cat "$TARGET/conf/ca.cnf" 2>/dev/null)" "basicConstraints=CA:FALSE" \
+    "A: the shared openssl config arrived"
+# cp -a, not cp: a 0600 key that lands 0644 under /etc is the move handing the
+# key to every local account, and nothing would report it.
+is "$(stat -c %a "$TARGET/root/ca/.fogCA.key" 2>/dev/null)" "600" \
+    "A: the private key kept its mode"
+is "$(stat -c %a "$TARGET/root/ca" 2>/dev/null)" "700" \
+    "A: the root CA directory kept its mode"
+is "$(stat -c %a "$TARGET/renewal-helper" 2>/dev/null)" "755" \
+    "A: the renewal helper is still executable"
+is "$(stat -c %y "$TARGET/secureboot/ca/.fogSBCA.pem" 2>/dev/null | cut -d. -f1)" \
+    "2020-01-02 03:04:05" \
+    "A: the copy is an archive copy, so timestamps came too"
+
+# (a) the compat contract. Every published path is written against this name.
+[[ -L "$fogprogramdir/pki" ]] \
+    && ok "A: the historic name is now a symlink" \
+    || bad "A: the historic name is now a symlink"
+is "$(readlink "$fogprogramdir/pki")" "$TARGET" \
+    "A: it points at the new tree"
+is "$(cat "$fogprogramdir/pki/web/leaf/.webLeaf.pem" 2>/dev/null)" "web-leaf" \
+    "A: a documented /opt/fog/pki/... path still reads the file"
+
+# The source tree is gone rather than left as a second, diverging copy. This is
+# the half that matters for key material: two authoritative roots is worse than
+# either location on its own.
+# find -type d does not follow the symlink, so this asks the question the [[ -d ]]
+# test cannot: is there still a REAL directory at the old name?
+[[ -z "$(find "$fogprogramdir" -maxdepth 1 -name pki -type d 2>/dev/null)" ]] \
+    && ok "A: no real directory is left behind at the old path" \
+    || bad "A: no real directory is left behind at the old path"
+
+echo "== the accessors answer under the new tree =="
+is "$(_pkiZoneDir root)" "$TARGET/root" "B: _pkiZoneDir root"
+is "$(_pkiZoneDir web)" "$TARGET/web" "B: _pkiZoneDir web"
+is "$(_pkiZoneDir client)" "$TARGET/client" "B: _pkiZoneDir client"
+is "$(_pkiZoneDir secureboot)" "$TARGET/secureboot" "B: _pkiZoneDir secureboot"
+is "$(_pkiConfDir)" "$TARGET/conf" "B: _pkiConfDir"
+is "$(_pkiZoneDir nosuchzone)" "" "B: an unknown zone token still answers nothing"
+
+echo "== running again changes nothing =="
+before="$(stat -c %Y "$TARGET/root/ca/.fogCA.key" 2>/dev/null)"
+echo "post-move-edit" > "$TARGET/web/leaf/.webLeaf.pem"
+_migratePkiTree "$TARGET"
+_migratePkiTree "$TARGET"
+is "$(cat "$TARGET/web/leaf/.webLeaf.pem" 2>/dev/null)" "post-move-edit" \
+    "C: a second run does not re-copy over live files"
+is "$(stat -c %Y "$TARGET/root/ca/.fogCA.key" 2>/dev/null)" "$before" \
+    "C: and does not rewrite what it already moved"
+[[ -L "$fogprogramdir/pki" ]] \
+    && ok "C: the compat symlink survives" \
+    || bad "C: the compat symlink survives"
+# Called directly, so the -L guard is the only thing between here and cp
+# copying the target over itself. It has to be a clean no-op, not a failure
+# that merely happens to change nothing.
+_migratePkiTree "$TARGET"
+is "$?" "0" "C: a migration with nothing to do succeeds"
+
+echo "== a fresh install has nothing to move =="
+newcase fresh
+_migratePkiTree "$TARGET"
+[[ -d "$TARGET" ]] \
+    && ok "D: the tree is created" \
+    || bad "D: the tree is created"
+[[ -L "$fogprogramdir/pki" ]] \
+    && ok "D: the compat symlink is created with it" \
+    || bad "D: the compat symlink is created with it"
+is "$(_pkiZoneDir web)" "$TARGET/web" "D: the accessors work straight away"
+
+echo "== a failed copy leaves the source authoritative =="
+# The reason this is not an mv. cp reports the failure, nothing is removed, and
+# the next run simply redoes the whole move -- rather than leaving half the
+# tree on each side with no record of which half.
+newcase partial
+seedLegacyTree
+chmod 000 "$fogprogramdir/pki/root/ca/.fogCA.key"
+_migratePkiTree "$TARGET"
+rc=$?
+chmod 0600 "$fogprogramdir/pki/root/ca/.fogCA.key"
+if [[ $EUID -eq 0 ]]; then
+    echo "  skip  E: running as root, an unreadable file is still readable"
+else
+    is "$rc" "1" "E: the migration reports failure"
+    [[ -d "$fogprogramdir/pki" && ! -L "$fogprogramdir/pki" ]] \
+        && ok "E: the source tree is still a real directory" \
+        || bad "E: the source tree is still a real directory"
+    is "$(cat "$fogprogramdir/pki/web/leaf/.webLeaf.pem" 2>/dev/null)" "web-leaf" \
+        "E: the source content is intact"
+fi
+
+echo "== the tree is expressible, so a scratch or custom location works =="
+# PKI_root_dir is what lets the tests above exist at all, and what an admin
+# with a reason to keep the tree elsewhere sets. When it names the historic
+# path, _pkiRootDir must NOT try to migrate a directory onto itself.
+newcase samepath
+PKI_root_dir="$fogprogramdir/pki"
+mkdir -p "$fogprogramdir/pki/web"
+is "$(_pkiRootDir)" "$fogprogramdir/pki" \
+    "F: an override naming the old path is honored"
+[[ ! -L "$fogprogramdir/pki" ]] \
+    && ok "F: and nothing is moved onto itself" \
+    || bad "F: and nothing is moved onto itself"
+_migratePkiTree "$fogprogramdir/pki"
+is "$?" "0" "F: and a direct call is a clean no-op rather than a failure"
+
+echo "== the default, when nothing overrides it =="
+newcase default
+PKI_root_dir=""
+fogprogramdir=""
+is "$(_pkiRootDir)" "/etc/fog/pki" \
+    "G: the tree defaults to /etc/fog/pki"
+# No $fogprogramdir means functions.sh was sourced by a utils script outside an
+# install -- bin/updatefog.sh, renewal-helper. Answering the default is right;
+# creating anything is not, and the guard for that is the only reason the check
+# above can safely name the host's real /etc/fog. Aimed at a scratch target so
+# a regression fails here instead of writing to /etc.
+PKI_root_dir="$TARGET"
+_pkiRootDir >/dev/null
+[[ ! -e "$TARGET" ]] \
+    && ok "G: with no install location, nothing is created" \
+    || bad "G: with no install location, nothing is created"
+
+echo
+echo "  passed: $PASS  failed: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/tests/selfcall-verification.test.sh
+++ b/tests/selfcall-verification.test.sh
@@ -66,6 +66,10 @@ mkleaf "fogown.example.org" fogown
 # elsewhere. _externallyManagedLeaf reads $fogprogramdir through _pkiZoneDir, so
 # the sandbox needs both the dir and a leaf inside it to exercise either answer.
 fogprogramdir="$WORK/fogprog"
+# The tree lives at /etc/fog/pki on a real install. Point it inside the
+# scratch $fogprogramdir instead, or every case below would reach for the
+# host's own /etc/fog -- and _migratePkiTree would try to CREATE it.
+PKI_root_dir="$fogprogramdir/pki"
 mkdir -p "$fogprogramdir/pki/web/leaf"
 cp "$WORK/fogown.pem" "$fogprogramdir/pki/web/leaf/.webLeaf.pem"
 

--- a/tests/trust-anchor.test.sh
+++ b/tests/trust-anchor.test.sh
@@ -110,6 +110,7 @@ newcase() {
     mkdir -p "$fogprogramdir"
     PKI_root_ca_cert=""
     PKI_web_trust_chain=""
+    PKI_web_external_root_cert=""
     trustAnchorPem=""
     FOG_install_type=""
 }
@@ -208,6 +209,89 @@ if _resolveTrustAnchor; then
     bad "F: returned success with no root and no chain"
 else
     ok "F: returns non-zero when there is nothing to anchor"
+fi
+
+# --- an imported root with no intermediate behind it (GH-1121) ---------------
+#
+# The Certificates page can import a corporate root on its own: nothing is
+# issued from it and nothing chains to it, it is simply a root this box should
+# accept. That never reaches the chain file, because validateExternalCA only
+# runs when all three of --ca-cert/--ca-key/--ca-root were supplied -- so
+# before GH-1121 the next installer run rebuilt the anchor without it and
+# silently undid the import.
+
+# Case G -- the case above, on an otherwise ordinary FOG-issued install.
+newcase G
+PKI_root_ca_cert="$WORK/fog/root.pem"
+PKI_web_trust_chain="$WORK/g-chain.pem"
+cat "$WORK/fog/int.pem" "$WORK/fog/root.pem" > "${PKI_web_trust_chain}"
+PKI_web_external_root_cert="$WORK/ext/root.pem"
+if _resolveTrustAnchor; then
+    check "$(count_certs "$trustAnchorPem")" "2" "G: an imported root is anchored alongside FOG's"
+    has_fp "$trustAnchorPem" "$EXTROOT_FP" \
+        && ok "G: the imported root survives a rebuild" \
+        || bad "G: the imported root was dropped -- the next installer run undoes the import"
+    has_fp "$trustAnchorPem" "$FOGROOT_FP" \
+        && ok "G: FOG's own root is still anchored" || bad "G: FOG's own root was dropped"
+else
+    bad "G: _resolveTrustAnchor returned non-zero"
+fi
+
+# Case H -- an intermediate must not ride in on the import. Anchoring one
+# trusts it AS a root, which widens what this box accepts; fog-pki-admin
+# filters the same way at import time and this is the second half of that.
+newcase H
+PKI_root_ca_cert="$WORK/fog/root.pem"
+PKI_web_external_root_cert="$WORK/h-import.pem"
+cat "$WORK/ext/int.pem" "$WORK/ext/root.pem" > "${PKI_web_external_root_cert}"
+if _resolveTrustAnchor; then
+    has_fp "$trustAnchorPem" "$EXTROOT_FP" \
+        && ok "H: the root out of an imported bundle is anchored" \
+        || bad "H: the root out of an imported bundle is missing"
+    has_fp "$trustAnchorPem" "$EXTINT_FP" \
+        && bad "H: an intermediate was anchored as a root" \
+        || ok "H: the intermediate in the bundle is not anchored"
+else
+    bad "H: _resolveTrustAnchor returned non-zero"
+fi
+
+# Case I -- the full --external-ca install, where the same certificate arrives
+# by both routes. It must collapse, not appear twice: a duplicated anchor is
+# not a verification failure, so nothing would ever report it.
+newcase I
+PKI_root_ca_cert="$WORK/fog/root.pem"
+PKI_web_trust_chain="$WORK/i-chain.pem"
+cat "$WORK/ext/root.pem" "$WORK/ext/int.pem" > "${PKI_web_trust_chain}"
+PKI_web_external_root_cert="$WORK/ext/root.pem"
+if _resolveTrustAnchor; then
+    check "$(count_certs "$trustAnchorPem")" "2" \
+        "I: a root reached by both routes is anchored once"
+else
+    bad "I: _resolveTrustAnchor returned non-zero"
+fi
+
+# Case J -- validateExternalCA persists the admin's SOURCE path, which is
+# routinely a temp file that is gone by the next run. That must be a no-op,
+# not a failure.
+newcase J
+PKI_root_ca_cert="$WORK/fog/root.pem"
+PKI_web_external_root_cert="$WORK/this-file-was-deleted.pem"
+if _resolveTrustAnchor; then
+    check "$(count_certs "$trustAnchorPem")" "1" "J: a vanished imported root is simply skipped"
+else
+    bad "J: _resolveTrustAnchor returned non-zero"
+fi
+
+# Case K -- an imported root and NOTHING else. A server whose own root has not
+# been minted yet still has something to anchor.
+newcase K
+PKI_web_external_root_cert="$WORK/ext/root.pem"
+if _resolveTrustAnchor; then
+    check "$(count_certs "$trustAnchorPem")" "1" "K: an imported root alone is enough to anchor"
+    has_fp "$trustAnchorPem" "$EXTROOT_FP" \
+        && ok "K: it is the imported root" || bad "K: the wrong certificate was anchored"
+else
+    bad "K: _resolveTrustAnchor returned non-zero with an imported root present"
 fi
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"

--- a/tests/trust-anchor.test.sh
+++ b/tests/trust-anchor.test.sh
@@ -107,6 +107,10 @@ error_log=/dev/null
 # indistinguishable from a pass.
 newcase() {
     fogprogramdir="$WORK/case$1"
+    # The tree lives at /etc/fog/pki on a real install. Point it inside the
+    # scratch $fogprogramdir instead, or every case below would reach for the
+    # host's own /etc/fog -- and _migratePkiTree would try to CREATE it.
+    PKI_root_dir="$fogprogramdir/pki"
     mkdir -p "$fogprogramdir"
     PKI_root_ca_cert=""
     PKI_web_trust_chain=""

--- a/tests/web-chain-feedback.test.sh
+++ b/tests/web-chain-feedback.test.sh
@@ -61,6 +61,10 @@ errorStat() { :; }
 
 # --- fixture: root -> intermediate -> leaf, the shape FOG issues -------------
 fogprogramdir="$WORK/opt/fog"
+# The tree lives at /etc/fog/pki on a real install. Point it inside the
+# scratch $fogprogramdir instead, or every case below would reach for the
+# host's own /etc/fog -- and _migratePkiTree would try to CREATE it.
+PKI_root_dir="$fogprogramdir/pki"
 PKI_client_cert_dir="$WORK/opt/fog/snapins/ssl"
 webdirdest="$WORK/var/www/fog"
 leafdir="$fogprogramdir/pki/web/leaf"


### PR DESCRIPTION
Closes #1121. Last phase of #1116.

Two commits: the certificate management page, then the PKI tree relocation. Both touch `lib/common/functions.sh`, which is why they are one PR — the `working-1.6` ruleset makes every merge invalidate every other open PR against it, so splitting them would guarantee a rebase for no benefit.

## 1. Build out the certificate management page

`FOGConfigurationPage::certificates()` was read-only. #1121 asked for four things it could not do, and two of them the web user **cannot** do at all: `.fogsettings` is `0600 root:root`, and `pki/root/ca`, `pki/web/ca`, `pki/web/leaf` and `pki/secureboot` are `0700 root:root` — so the page cannot read even the *public* Web CA certificate, let alone hand it out.

Writing `.fogsettings` from the web tier is worse than it looks: the installer **sources it as shell, as root**, on its next run. An unvalidated value there is a root shell with extra steps.

So the page reaches PKI through the house sudo-helper pattern already used by `fog-sign-kernel` and `fog-sign-node-cert`: a root `0755` helper behind a `visudo -cqf`-validated sudoers drop-in, taking **no path arguments** — every path lives in a root-only `0600` config written at install time. `packages/pki/fog-pki-admin` has five verbs and nothing else:

| verb | does |
|---|---|
| `status` | JSON: the chain, key readability, trust-store state, the three preferences |
| `export <slot> <reqid>` | one PEM, slot from an eight-entry allowlist, reqid `^[a-f0-9]{32}$` |
| `import-root <reqid>` | keeps **only** self-signed, in-date CA certs; installs and re-anchors |
| `clear-root` | |
| `set-preference <key> <value>` | key from a fixed three-key list, value `^(yes\|no)$` |

The allowlist and the value pattern live **on the far side of sudo**, so a compromised web tier cannot remove them. `SVC_password`, `DB_password` and `FOG_program_dir` are refused by the helper itself, and the resulting `.fogsettings` is sourced in the test to prove no injected payload ran.

Writes take a new **`system.pki`** permission, deny-by-default — no schema seed, so only `*` holders have it until it is granted. Same shape as `system.export` and `impersonate.start`. GET stays on `settings.view`.

Also fixed along the way, both live bugs:

- The page's headline "can PHP read a CA private key" card was testing **retired paths**, so it had been passing unconditionally. It now uses the helper-reported real paths, and skips the two keys the web tier is *supposed* to read (the client comm key, and the vhost key when the leaf is externally managed).
- `_resolveTrustAnchor()` could not see a root imported through anything but the full three-file `--ca-*` import, so a UI import would have been silently undone by the next installer run.

Not offered, deliberately: **root CA rotation** (the page composes the `installfog.sh --external-ca …` command instead — rotating the root un-trusts every fog-client in the estate, and that is not a button), and **sub-CA delegation** (an unsettled design question, not a scoped-out one).

Reasoning and four rejected alternatives: `docs/adr/0036-the-web-tier-changes-pki-through-a-fixed-verb-set.md`.

### Verification

`tests/pki-admin-helper.test.sh` — 76 assertions. It re-execs itself under `unshare -rm` and mounts a tmpfs over `/opt`, so the helper's real `[[ $EUID -eq 0 ]]` and its real hardcoded `CONF=/opt/fog/.fog-pki-admin` are exercised **as shipped**, unprivileged, with no fixture copy that could drift.

Mutation testing found **six fake gates** in the first cut — each was passing for a reason unrelated to the check it claimed to make. Two examples: the key-allowlist test's refused keys were absent from the fixture *and* failed the value pattern anyway, and the `isCACert` test's fixture was filtered out by `isSelfSigned` first, so a deliberately self-signed `CA:FALSE` certificate had to be minted to reach it. All six are fixed and the header records what each mutation turned red.

`tests/certificate-management-permission.test.php` — 15 checks, executing the router's own `resolvePagePermission()` rather than grepping for the string.

## 2. Move the PKI tree to /etc/fog/pki

`/opt/<pkg>` is for a package's own static files. Keys and certificates are the opposite — irreplaceable per-server state, and what a backup policy and a config-management run are supposed to capture. A site backing up `/etc` and not `/opt`, an entirely ordinary policy, was silently not backing up the one thing on the server that cannot be regenerated.

`/etc/fog` is not a new directory: GH-850 already makes it a real one on every install, for `fog.conf`. So no per-distro branch, and none of the "Debian has no `/etc/pki`" problem the first proposal had.

**`$fogprogramdir/pki` keeps resolving, as a symlink.** It is a published path — `PKI_ZONES.md`, `MULTI_SERVER_CA.md` and `EXTERNAL_CA_AND_LETSENCRYPT.md` all name `/opt/fog/pki/...`, an admin's renewal cron names `/opt/fog/pki/renewal-helper`, and a `.fogsettings` written before this change records every canonical certificate path underneath it. `readlink -f` resolves identically on both sides of `_externallyManagedLeaf()`'s comparison, so "is this certificate FOG's or the admin's" answers the same as before.

The move is a **copy, then a remove only if the copy reported success** — never `mv`. `/opt` and `/etc` are frequently separate mounts, so `mv` degrades to copy-then-unlink anyway; separating them means a failure leaves the *source* authoritative rather than half a tree on each side, and it creates the moment at which the source key blocks can be overwritten before the unlink (best effort — `shred` promises nothing on a journaling or CoW filesystem).

`_pkiRootDir()` drives the migration rather than a call placed early in `installfog.sh`. Ordering it by hand would be one line and would not survive: an accessor answering `/etc/fog/pki` while the material still sits under `/opt/fog/pki` reads as "no CA yet", mints a fresh root, and **every fog-client in the estate stops trusting the server**. The safe version costs one `-L` test per call after the first run.

New `.fogsettings` key `PKI_root_dir`. An empty value — a file written before this change — means the same as the default, because that name still resolves.

Reasoning and four rejected alternatives (`/etc/pki/fog`, a bind mount, leaving it, a clean break): `docs/adr/0037-the-pki-tree-lives-in-etc.md`.

### Verification

`tests/pki-tree-relocation.test.sh` — 32 assertions, mutation-verified: each of the nine guards removed in turn, and the file went red for each.

The first cut could not see four of them. Three preconditions were duplicated between `_pkiRootDir` and `_migratePkiTree`, so removing either copy was invisible — the duplication is gone and each is now checked in exactly one place. The mode assertions could not tell `cp -a` from `cp -r`, because an ordinary umask strips nothing off `0600` or `0700`; a timestamp check is what separates them.

Nine existing shell tests now set `PKI_root_dir` to a scratch path. Without it they reach for the host's own `/etc/fog` — and under root, `_migratePkiTree` would **create** it.

## Status

263 shell + PHP tests pass, both PHPStan passes clean, branch merged up to `working-1.6` at 728fe9eaf.

**Not yet exercised against a live server.** The helper needs an installer run to place its sudoers drop-in and its root-only config, and the tree relocation happens on that same run — neither can be proven from a checkout. What that run should show: `/etc/fog/pki` populated with `/opt/fog/pki` a symlink to it, `sudo -n -u <apacheuser> /opt/fog/bin/fog-pki-admin status` returning JSON, and the Certificates page rendering five cards with the key-exposure card reporting **no** readable CA private keys.

## Downstream

None. No route class was added or removed, so FogApi's hardcoded 1.6 class list is unaffected.

## Notes for review

- `regenerate / …` will correct the gettext catalog. The pre-commit hook skipped `updateLanguage()` on both commits because `packages/web/lib/plugins` is empty in this worktree — a pre-existing guard (it refuses to drop every plugin string from the catalog), not something these commits introduced.
- A user-facing docs page for the Certificates page belongs in `FOGProject/fog-docs` and is not in this PR.
