### PR TITLE
Fix the 404 Let's Encrypt link on the Certificates page

### DIFF
--- a/packages/web/src/Pages/FOGConfigurationPage.php
+++ b/packages/web/src/Pages/FOGConfigurationPage.php
@@ -829,8 +829,14 @@ class FOGConfigurationPage extends FOGPage
         $body .= '<p class="form-text">' . sprintf(
             '%s <a href="%s" target="_blank" rel="noopener">%s</a>.',
             _('A worked example of the first one, end to end:'),
+            // NO /1.6/ segment. fog-docs carries two trees and they map to
+            // two different URL shapes: docs/1.6/... publishes under
+            // /en/latest/1.6/... (pki-zones, bringing-your-own-ca), while
+            // docs/kb/... is shared across versions and publishes under
+            // /en/latest/kb/... . This how-to is in the shared tree, so the
+            // versioned form 404s -- which is what shipped first.
             \Initiator::e(
-                'https://docs.fogproject.org/en/latest/1.6/kb/how-tos/lets-encrypt-setup'
+                'https://docs.fogproject.org/en/latest/kb/how-tos/lets-encrypt-setup'
             ),
             _('Let\'s Encrypt with FOG')
         ) . '</p>';


### PR DESCRIPTION
Follow-up to #1565. One line plus a comment.

The preferences card on the Certificates page links out to the Let's Encrypt worked example — which is what #1121 asked for. The URL it shipped with **404s**.

`fog-docs` carries two trees, and they publish to two different URL shapes:

| source | URL |
|---|---|
| `docs/1.6/kb/reference/pki-zones.md` | `/en/latest/1.6/kb/reference/pki-zones` |
| `docs/kb/how-tos/lets-encrypt-setup.md` | `/en/latest/kb/how-tos/lets-encrypt-setup` |

The second tree is shared across FOG versions and carries no version segment. This how-to lives in it, so the `/1.6/` form resolves to nothing. That form is correct for every *other* PKI doc the page could have linked to (`pki-zones`, `bringing-your-own-ca`), which is exactly why it looked right.

Verified against the live site, without `-L` so a redirect can't be mistaken for the target's status:

```
404  .../en/latest/1.6/kb/how-tos/lets-encrypt-setup
302  .../en/latest/kb/how-tos/lets-encrypt-setup     -> 200
```

**No test.** This repository's shell and PHP suites are deliberately offline — "no install, no network, no root" — and the only check that could catch a dead external link is an HTTP request to `docs.fogproject.org`, which would make CI depend on a third-party site being up and would fail for reasons that have nothing to do with the change under test. The trap is recorded as a comment at the link instead, because the next person adding one will reach for the versioned form for the same reason I did.