### PR TITLE
Compare a UNIQUE index by its columns, not its name (GH-1566)

### DIFF
--- a/packages/web/src/Db/SchemaReconciler.php
+++ b/packages/web/src/Db/SchemaReconciler.php
@@ -808,11 +808,25 @@ class SchemaReconciler extends FOGBase
                 ];
         }
 
+        // COLUMN_NAME and SEQ_IN_INDEX come back with the name because an
+        // index is its columns, not its label. Reading only INDEX_NAME here
+        // meant a same-named index over a DIFFERENT column satisfied the
+        // check: on a clean database all three of hostMAC's declared UNIQUE
+        // keys could be pointed at `hmDesc`, drift still reported 0, and two
+        // hosts could then be given the same MAC -- the one thing FOG's
+        // identity model cannot tolerate. GH-1566.
+        //
+        // SUB_PART is part of the identity too. A prefix index over the
+        // first 20 characters of a column enforces uniqueness of the
+        // PREFIX, which is a weaker guarantee than the manifest's
+        // unprefixed declaration, so `col` and `col(20)` must not compare
+        // equal.
         $res = self::$DB->query(
             sprintf(
-                'SELECT `TABLE_NAME`, `INDEX_NAME` FROM'
-                . ' `information_schema`.`STATISTICS` WHERE `TABLE_SCHEMA` ='
-                . ' %s AND `NON_UNIQUE` = 0',
+                'SELECT `TABLE_NAME`, `INDEX_NAME`, `COLUMN_NAME`,'
+                . ' `SUB_PART` FROM `information_schema`.`STATISTICS`'
+                . ' WHERE `TABLE_SCHEMA` = %s AND `NON_UNIQUE` = 0'
+                . ' ORDER BY `TABLE_NAME`, `INDEX_NAME`, `SEQ_IN_INDEX`',
                 self::$DB->escape($db)
             )
         );
@@ -820,8 +834,13 @@ class SchemaReconciler extends FOGBase
         if (false === $res->error) {
             $idxRows = $res->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
             foreach ((array)$idxRows as $row) {
+                $part = $row['SUB_PART'];
                 $liveIdx[strtolower((string)$row['TABLE_NAME'])]
-                    [strtolower((string)$row['INDEX_NAME'])] = true;
+                    [strtolower((string)$row['INDEX_NAME'])][] =
+                        strtolower((string)$row['COLUMN_NAME'])
+                        . (null === $part || '' === $part
+                            ? ''
+                            : '(' . (int)$part . ')');
             }
         }
 
@@ -859,24 +878,73 @@ class SchemaReconciler extends FOGBase
                 continue;
             }
             preg_match_all(
-                '/UNIQUE KEY `([^`]+)`/',
+                '/UNIQUE KEY `([^`]+)` \(([^)]*(?:\([0-9]+\)[^)]*)*)\)/',
                 $create,
-                $m
+                $m,
+                PREG_SET_ORDER
             );
-            foreach ($m[1] as $idx) {
-                if (isset($liveIdx[$lt][strtolower($idx)])) {
-                    continue;
+            foreach ($m as $decl) {
+                $idx = $decl[1];
+                $want = self::_indexColumns((string)$decl[2]);
+                // The GUARANTEE is what matters, and the guarantee belongs
+                // to the columns. So an index over exactly these columns
+                // satisfies the declaration whatever it is called -- a
+                // server that acquired one under a different name through a
+                // restore or a hand-run ALTER is not missing anything, and
+                // reporting it would be a false positive on a database that
+                // is entirely correct.
+                foreach ((array)($liveIdx[$lt] ?? []) as $cols) {
+                    if ($cols === $want) {
+                        continue 2;
+                    }
                 }
+                // Nothing covers those columns. The declared NAME existing
+                // over different ones is reported separately and on
+                // purpose: it is the more alarming of the two states,
+                // because it looks correct in every listing that prints
+                // index names and enforces something else entirely.
+                $have = $liveIdx[$lt][strtolower($idx)] ?? null;
                 $drift[] = [
                     'table' => $table,
                     'kind' => 'unique',
                     'name' => $idx,
-                    'expected' => 'UNIQUE',
-                    'actual' => 'absent',
+                    'expected' => 'UNIQUE(' . implode(',', $want) . ')',
+                    'actual' => null === $have
+                        ? 'absent'
+                        : 'UNIQUE(' . implode(',', $have) . ')',
                 ];
             }
         }
         return $drift;
+    }
+
+    /**
+     * The ordered column list inside a manifest index declaration.
+     *
+     * Takes what sits between the parentheses of a
+     * ``UNIQUE KEY `x` (`a`,`b`(20))`` and returns
+     * ``['a', 'b(20)']`` -- lowercased, prefix lengths kept, order
+     * preserved. All three of those matter to whether two indexes enforce
+     * the same guarantee: an index on (a,b) is not an index on (b,a), and
+     * a prefix index constrains only the prefix.
+     *
+     * Compared against the same shape built from information_schema's
+     * STATISTICS rows, so both sides are normalized here rather than at
+     * each call site.
+     *
+     * @param string $cols the text between the index's parentheses
+     *
+     * @return array ordered, lowercased column identifiers
+     */
+    private static function _indexColumns($cols)
+    {
+        preg_match_all('/`([^`]+)`(?:\s*\(([0-9]+)\))?/', (string)$cols, $m, PREG_SET_ORDER);
+        $out = [];
+        foreach ($m as $col) {
+            $out[] = strtolower($col[1])
+                . (isset($col[2]) ? '(' . (int)$col[2] . ')' : '');
+        }
+        return $out;
     }
 
     /**

--- a/tests/schema-shape-drift.test.php
+++ b/tests/schema-shape-drift.test.php
@@ -78,11 +78,13 @@ $serve = static function (array $cols, array $indexes) {
         if (false !== strpos($sql, 'STATISTICS')) {
             $uniqueOnly = false !== strpos($sql, 'NON_UNIQUE` = 0');
             $out = [];
-            foreach ($indexes as $idx) {
-                if ($uniqueOnly && (int)$idx['NON_UNIQUE'] !== 0) {
-                    continue;
+            foreach ($indexes as $rows) {
+                foreach ((array)$rows as $idx) {
+                    if ($uniqueOnly && (int)$idx['NON_UNIQUE'] !== 0) {
+                        continue;
+                    }
+                    $out[] = $idx;
                 }
-                $out[] = $idx;
             }
             return $out;
         }
@@ -94,12 +96,23 @@ $serve = static function (array $cols, array $indexes) {
     return $db;
 };
 
-$idx = static function ($name, $nonUnique = 0) {
-    return [
-        'TABLE_NAME' => 'hostMAC',
-        'INDEX_NAME' => $name,
-        'NON_UNIQUE' => $nonUnique,
-    ];
+// An index is its COLUMNS, not its name, so the fixture has to carry them --
+// and $cols defaults to hmMAC rather than to $name because both indexes the
+// manifest declares here cover that one column under two different names,
+// which is precisely the shape GH-1566 was about.
+$idx = static function ($name, $nonUnique = 0, $cols = ['hmMAC'], $sub = null) {
+    $rows = [];
+    foreach ((array)$cols as $i => $c) {
+        $rows[] = [
+            'TABLE_NAME' => 'hostMAC',
+            'INDEX_NAME' => $name,
+            'COLUMN_NAME' => $c,
+            'SEQ_IN_INDEX' => $i + 1,
+            'SUB_PART' => $sub,
+            'NON_UNIQUE' => $nonUnique,
+        ];
+    }
+    return $rows;
 };
 
 $col = static function ($name, $type, $null = 'NO') {
@@ -198,6 +211,55 @@ $serve($matching, [$idx('hmMAC')]);
 $t->check(
     'a plain KEY that is absent is not reported as drift',
     SchemaReconciler::shapeDrift($manifest) === []
+);
+
+// --- GH-1566: the same name over a DIFFERENT column is not a pass ----------
+// The false NEGATIVE, and the reason this was filed. Reading only
+// INDEX_NAME, a unique index called `hmMAC` sitting on `hmDesc` satisfied
+// the declaration: drift reported clean while nothing whatsoever enforced
+// uniqueness of a MAC. Proven against a real database before the fix --
+// all three of hostMAC's declared UNIQUE keys were repointed at `hmDesc`,
+// `shape` printed 0 differences, and two hosts were then given one MAC.
+$serve($matching, [$idx('hmMAC', 0, ['hmDesc']), $idx('idxMac', 1)]);
+$drift = SchemaReconciler::shapeDrift($manifest);
+$t->check(
+    'a UNIQUE index with the right name over the wrong column is reported',
+    count($drift) === 1
+        && ($drift[0]['kind'] ?? '') === 'unique'
+        && ($drift[0]['name'] ?? '') === 'hmMAC'
+);
+// Reported as what it IS, not as "absent". An index that exists over the
+// wrong columns is the more alarming state of the two -- it looks correct
+// in every listing that prints names -- so the line has to say so or the
+// admin goes looking for a missing index that is right there.
+$t->check(
+    'the report names the columns on both sides',
+    false !== strpos((string)($drift[0]['expected'] ?? ''), 'hmmac')
+        && false !== strpos((string)($drift[0]['actual'] ?? ''), 'hmdesc')
+);
+
+// --- GH-1566: the guarantee under a different NAME is not drift ------------
+// The false POSITIVE, and the one a real server hits without anybody doing
+// anything odd: a restore or a hand-run `ADD UNIQUE uniq_mac (hmMAC)`
+// leaves the guarantee intact under another label. The manifest describes
+// an end state, and that end state is satisfied -- saying otherwise sends
+// an admin to fix a database that is already correct.
+$serve($matching, [$idx('uniq_mac', 0, ['hmMAC']), $idx('idxMac', 1)]);
+$t->check(
+    'the declared UNIQUE under a different name is not reported',
+    SchemaReconciler::shapeDrift($manifest) === []
+);
+
+// --- GH-1566: a PREFIX index is a weaker guarantee -------------------------
+// `hmMAC(10)` constrains the first ten characters, not the value, so two
+// different MACs sharing a prefix still collide. Compared exactly for that
+// reason: treating `col` and `col(10)` as equal would accept a weaker
+// index as though it satisfied the declaration.
+$serve($matching, [$idx('hmMAC', 0, ['hmMAC'], 10), $idx('idxMac', 1)]);
+$drift = SchemaReconciler::shapeDrift($manifest);
+$t->check(
+    'a prefix index does not satisfy an unprefixed UNIQUE declaration',
+    count($drift) === 1 && ($drift[0]['kind'] ?? '') === 'unique'
 );
 
 // --- an ABSENT column is not drift -----------------------------------------


### PR DESCRIPTION
Closes #1566.

`SchemaReconciler::shapeDrift()` decided whether a manifest-declared UNIQUE index was present by comparing index **names**, and never looked at the columns the index covered.

## The two failures, both reproduced on a real database

**False negative.** On a clean build to `FOG_SCHEMA`, all three of `hostMAC`'s declared UNIQUE keys dropped and recreated under their own names over `hmDesc`:

```
$ shape --db=reh_gh1566
  differences from the manifest: 0          # before the fix

INSERT INTO hosts (hostID,hostName) VALUES (1,'h1'),(2,'h2');
INSERT INTO hostMAC (hmHostID,hmMAC,hmDesc,hmPrimary)
  VALUES (1,'de:ad:be:ef:00:01','a',1),(2,'de:ad:be:ef:00:01','b',1);   -- accepted
SELECT COUNT(*) FROM hostMAC WHERE hmMAC='de:ad:be:ef:00:01';           -- 2
```

A host is identified by its MAC, so those two hosts check in as each other — and the report said the database matched the manifest.

**False positive**, and the half a real server hits without anyone doing anything strange: a unique index on `hmMAC` under any other name (a restore, a hand-run `ADD UNIQUE uniq_mac (hmMAC)`) was reported as three missing indexes on a database that is entirely correct. That is how a drift report stops being read.

## The fix

`information_schema.STATISTICS` already returned the answer — the query asked for `TABLE_NAME` and `INDEX_NAME` and threw the rest of the row away. It now reads `COLUMN_NAME`, `SEQ_IN_INDEX` and `SUB_PART`, and the manifest side parses the column list out of the declaration instead of just the name.

| Server state | Before | After |
|---|---|---|
| index over exactly the declared columns, different name | 3 spurious `UNIQUE -> absent` | clean |
| declared name, wrong column | **clean** | `UNIQUE(hmmac) -> UNIQUE(hmdesc(20))` |
| prefix index `hmMAC(10)` | clean | reported — a prefix constrains the prefix, not the value |
| genuinely absent | `UNIQUE -> absent` | `UNIQUE(hmmac) -> absent` |

A name over the wrong columns is reported as *what it is* rather than as "absent", because it is the more alarming of the two states: it looks correct in every listing that prints index names.

Side effect worth naming: `hostMAC` declares three UNIQUE keys over the same single column, so one real index now satisfies all three and a correct server reports nothing where it previously reported two phantom absences. That redundancy is still worth collapsing, but it needs a schema change plus a manifest regeneration and is not bundled here.

## Proven by mutation

Reverting the comparison to name-only turns **exactly** the four new checks red and moves nothing else:

```
FAIL (4 of 17):
  - a UNIQUE index with the right name over the wrong column is reported
  - the report names the columns on both sides
  - the declared UNIQUE under a different name is not reported
  - a prefix index does not satisfy an unprefixed UNIQUE declaration
```

The regex change was also checked against the whole manifest: all **68** `UNIQUE KEY` declarations still parse, so no table silently stopped being checked.

`tests/run-all.sh` 261 passed, 0 failed. Both PHPStan passes clean from a cold `/tmp/phpstan`.