### PR TITLE
Describe the ruleset as it is now: no strict policy, a merge queue, eight checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,13 +136,23 @@ there is not a plain `git push`:
 - **merge commits only** — no squash, no rebase. This keeps the history
   linearly countable, which is what a locally generated `FOG_VERSION` is
   derived from;
-- **branches must be up to date before merging**. This is the rule that makes
-  every merge invalidate every other open PR and force a re-run of the eight
-  required checks. A merge queue is the standard fix and is the next change
-  planned here;
-- **seven `fogproject / …` checks must pass.** `regenerate / …` is deliberately
-  *not* required: it is skipped on fork PRs, and requiring it would leave those
-  unmergeable.
+- **branches need NOT be up to date** — `strict_required_status_checks_policy`
+  is `false`. It used to be true, and that was the rule that made every merge
+  invalidate every other open PR and force a re-run of every required check.
+  The **merge queue** replaced it (2026-08-30): instead of making N-1 branches
+  rebase, the queue builds one temporary `gh-readonly-queue/…` ref carrying
+  base + the entry and tests that. So the queue is not a version-bump
+  mechanism — the version left git in GH-1510/GH-1513 — it is the thing that
+  now catches a pull request whose base moved under it;
+- **eight checks must pass**: the seven `fogproject / …` contexts plus
+  `phpstan`. `regenerate / …` is deliberately *not* required: it is skipped on
+  fork PRs, and requiring it would leave those unmergeable.
+- **the price is two full suite runs per pull request.** The required contexts
+  have to be reported against the merge-group ref as well, so `tests.yml`
+  triggers on both `pull_request` and `merge_group` and there is no way to
+  report a reduced set on the queue. When pull requests are merged one at a
+  time onto a quiet base — the normal case here — the queue run tests a tree
+  byte-identical to the one the pull request already tested.
 
 No version is written into git by any of this. See **Why `FOG_VERSION` is not
 written on a branch** above.


### PR DESCRIPTION
Found as an **uncommitted edit in the shared working tree** while cleaning up after the rehearsal work. Rather than sweep it into an unrelated commit or discard it, I checked every claim against the live ruleset and it is committed here as it stood.

## Why it matters

Two statements in the committed text are now false, and both mislead someone working to them:

| Committed text says | Actually |
|---|---|
| "branches must be up to date before merging" | `strict_required_status_checks_policy` is **false** |
| "seven `fogproject / …` checks must pass" | **eight** — the seven plus `phpstan`, which reports its own context |

Verified:

```
$ gh api repos/FOGProject/fogproject/rulesets/21585641
strict_required_status_checks_policy: false
rules: pull_request, merge_queue, required_status_checks
required contexts:
  fogproject / tests (PHP 7.4)
  fogproject / tests (PHP 8.3)
  fogproject / vendor matches composer.lock
  fogproject / schema on mariadb:10.5
  fogproject / schema on mariadb:11.8
  fogproject / schema on mysql:8.0
  fogproject / release pins resolve
  phpstan
```

The old text also described the merge queue as "the next change planned here". It landed on 2026-08-30 — three PRs went through it during this session, one of which reported `The merge strategy for working-1.6 is set by the merge queue`.

## What the rewrite adds

- **What the queue actually replaces.** Instead of forcing N-1 open branches to rebase, it builds one temporary `gh-readonly-queue/…` ref carrying base + the entry and tests that. It is the thing that now catches a PR whose base moved underneath it.
- **What it is not.** Explicitly not a version-bump mechanism — the version left git in GH-1510/GH-1513. Someone reading the old text next to a live queue could reasonably assume otherwise.
- **The cost**, because it is surprising rather than wrong: required contexts must report against the merge-group ref too, so `tests.yml` triggers on both `pull_request` and `merge_group`, and there is no way to report a reduced set on the queue. Merging one PR at a time onto a quiet base means the queue run tests a tree byte-identical to the one the PR already tested.

`regenerate / …` stays deliberately not required (it is skipped on fork PRs, and requiring it would leave those unmergeable), and `fogproject / upgrade rehearsal` is not required either.

Documentation only — no code, no behavior change.