### PR TITLE
Make the node sub-menu labels whole translatable phrases (GH-435)

### DIFF
--- a/bin/migrate-menu-translations.php
+++ b/bin/migrate-menu-translations.php
@@ -1,0 +1,558 @@
+<?php
+/**
+ * Seeds the per-node menu msgids added by GH-435 from what each catalog
+ * already renders, so no language regresses to English.
+ *
+ * PHP version 7.4+
+ *
+ * WHY THIS EXISTS
+ *
+ * FOGPage::_buildSubMenuItems() used to build every "List All X" / "Create
+ * New X" label by sprintf()ing a translated noun into a translated format
+ * string. GH-435 replaced that with whole phrases, because a single format
+ * string cannot inflect for gender or pluralize correctly in any language
+ * that does either.
+ *
+ * The catch is that whole phrases are NEW msgids. Nine catalogs carry
+ * translations for the old format strings and the nouns, and none of them
+ * carries one for "List All Storage Nodes". Left alone, every non-English
+ * menu entry that works today would fall back to English -- a visible
+ * regression shipped in order to fix one.
+ *
+ * So this composes each new msgstr the way the RUNTIME composed it, out of
+ * that catalog's own strings:
+ *
+ *     msgstr("List All Users") := sprintf(msgstr("List All %s"), msgstr("User") . 's')
+ *     msgstr("Create New User") := sprintf(msgstr("Create New %s"), msgstr("User"))
+ *
+ * Every language therefore renders exactly what it rendered before the code
+ * change, and the entries are now individually correctable -- which is the
+ * whole point, and what French and Spanish then get by hand.
+ *
+ * Deliberately conservative. An entry is skipped, leaving the msgid
+ * untranslated, when:
+ *
+ *   - the catalog has no translation for the format string or for the noun.
+ *     Composing from an English fallback would write English INTO the
+ *     catalog, which msgmerge could never later distinguish from a real
+ *     translation;
+ *   - the format string lost its %s (es_ES ships `Crear nuevo grupo`).
+ *     Seeding that would stamp "group" onto all eleven entities permanently;
+ *   - the msgid already has a non-empty msgstr. This script never overwrites
+ *     a human translation, so it is safe to re-run.
+ *
+ * The `s` appended for the plural is the old behavior being preserved, not
+ * endorsed -- it is one of the two bugs GH-435 exists to end. It is
+ * reproduced here only so the seeded value equals today's rendering; the
+ * point of seeding is that a translator can now fix each one.
+ *
+ * Usage, from the repository root:
+ *
+ *     php bin/migrate-menu-translations.php            # report only
+ *     php bin/migrate-menu-translations.php --write    # edit the .po files
+ *
+ * @category Tools
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$write = in_array('--write', array_slice($argv, 1), true);
+$root = dirname(__DIR__);
+$langDir = $root . '/packages/web/management/languages';
+
+// node => [singular noun msgid, list msgid, add msgid]. The nouns are the
+// msgids _buildSubMenuItems() fed to sprintf -- ucfirst() of the node name --
+// so composing with them reproduces the old label exactly.
+$nodes = [
+    'group'        => ['Group',        'List All Groups',         'Create New Group'],
+    'host'         => ['Host',         'List All Hosts',          'Create New Host'],
+    'image'        => ['Image',        'List All Images',         'Create New Image'],
+    'ipxe'         => ['Ipxe',         'List All Ipxe Menus',     'Create New Ipxe Menu'],
+    'module'       => ['Module',       'List All Modules',        'Create New Module'],
+    'printer'      => ['Printer',      'List All Printers',       'Create New Printer'],
+    'role'         => ['Role',         'List All Roles',          'Create New Role'],
+    'site'         => ['Site',         'List All Sites',          'Create New Site'],
+    'snapin'       => ['Snapin',       'List All Snapins',        'Create New Snapin'],
+    'storagegroup' => ['Storagegroup', 'List All Storage Groups', 'Create New Storage Group'],
+    'storagenode'  => ['Storagenode',  'List All Storage Nodes',  'Create New Storage Node'],
+    'user'         => ['User',         'List All Users',          'Create New User'],
+    'usergroup'    => ['Usergroup',    'List All User Groups',    'Create New User Group'],
+];
+
+/**
+ * Every msgid => msgstr in a .po, single- and multi-line forms both.
+ *
+ * Not a general gettext parser and does not need to be: it reads the two
+ * shapes msgcat emits and ignores obsolete (#~) entries, which is the whole
+ * of what these files contain.
+ *
+ * @param string $path .po file
+ *
+ * @return array
+ */
+function poRead($path)
+{
+    $out = [];
+    $lines = file($path, FILE_IGNORE_NEW_LINES);
+    if (false === $lines) {
+        return $out;
+    }
+    $id = '';
+    $buf = '';
+    $in = '';
+    // Written as a flat loop rather than with a flush closure. A closure
+    // capturing $id/$in by reference is correct at runtime but opaque to
+    // static analysis -- phpstan types the captured variables from their
+    // INITIALIZERS, so every comparison inside reads as always-false and the
+    // build fails on five findings that are not bugs. Inlining the two-line
+    // flush costs a repetition and keeps the file analyzable.
+    foreach ($lines as $line) {
+        $t = trim($line);
+        if ('' === $t || '#' === substr($t, 0, 1)) {
+            // Comments and obsolete (#~) entries alike: an obsolete entry is
+            // not compiled and is not shown to anyone, so it is not a value
+            // this script may read a translation out of.
+            continue;
+        }
+        $start = '';
+        if (0 === strpos($t, 'msgid ')) {
+            $start = 'msgid';
+            $frag = substr($t, 6);
+        } elseif (0 === strpos($t, 'msgstr ')) {
+            $start = 'msgstr';
+            $frag = substr($t, 7);
+        }
+        if ('' !== $start) {
+            if ('msgstr' === $in && '' !== $id) {
+                $out[$id] = $buf;
+            } elseif ('msgid' === $in) {
+                $id = $buf;
+            }
+            $in = $start;
+            $buf = poUnquote((string)$frag);
+            continue;
+        }
+        if ('"' === substr($t, 0, 1) && '' !== $in) {
+            $buf .= poUnquote($t);
+        }
+    }
+    if ('msgstr' === $in && '' !== $id) {
+        $out[$id] = $buf;
+    }
+    return $out;
+}
+
+
+/**
+ * The msgids in a .po whose entry is flagged `#, fuzzy`.
+ *
+ * A fuzzy entry is msgmerge's GUESS, carried over from a similar msgid and
+ * never confirmed by a person. msgfmt excludes fuzzy entries from the compiled
+ * .mo, so nothing in one has ever been shown to a user -- which is exactly why
+ * they are so wrong here. At HEAD every single `Create New X` entry in every
+ * catalog is fuzzy, and de_DE's guesses include "Neuen Drucker erstellen"
+ * (Create New PRINTER) under msgid `Create New Storage Node` and "Neuen
+ * Schlüssel erstellen" (Create New KEY) under `Create New Group`.
+ *
+ * That matters because this change makes those msgids live for the first time:
+ * the labels used to be composed at runtime and never looked these up. Treating
+ * a fuzzy msgstr as a real translation would therefore not preserve anything --
+ * it would PROMOTE nine catalogs' worth of unreviewed guesses into text users
+ * finally see. So the seeder treats fuzzy as untranslated and composes over it.
+ *
+ * @param string $path .po file
+ *
+ * @return array msgid => true
+ */
+function poFuzzy($path)
+{
+    $out = [];
+    $lines = file($path, FILE_IGNORE_NEW_LINES);
+    if (false === $lines) {
+        return $out;
+    }
+    $fuzzy = false;
+    foreach ($lines as $line) {
+        $t = trim($line);
+        if (0 === strpos($t, '#,')) {
+            $fuzzy = (false !== strpos($t, 'fuzzy'));
+            continue;
+        }
+        if (preg_match('/^msgid "(.*)"$/', $t, $m)) {
+            if ($fuzzy) {
+                $out[poUnquote('"' . $m[1] . '"')] = true;
+            }
+            $fuzzy = false;
+            continue;
+        }
+        if ('' === $t) {
+            $fuzzy = false;
+        }
+    }
+    return $out;
+}
+
+/**
+ * The value of one quoted .po string fragment.
+ *
+ * @param string $s fragment including its surrounding quotes
+ *
+ * @return string
+ */
+function poUnquote($s)
+{
+    $s = trim($s);
+    if ('"' !== substr($s, 0, 1)) {
+        return '';
+    }
+    $s = substr($s, 1, -1);
+    return str_replace(
+        ['\\\\n', '\\\\t', '\\\\"', '\\\\\\\\'],
+        ["\n", "\t", '"', '\\\\'],
+        $s
+    );
+}
+
+/**
+ * A .po-safe quoted literal.
+ *
+ * @param string $s raw value
+ *
+ * @return string
+ */
+function poQuote($s)
+{
+    return '"' . str_replace(
+        ['\\\\', '"', "\n", "\t"],
+        ['\\\\\\\\', '\\\\"', '\\\\n', '\\\\t'],
+        $s
+    ) . '"';
+}
+
+/**
+ * sprintf that reports failure instead of throwing or warning.
+ *
+ * PHP 8 throws on a bad specifier, 7.4 warns and returns false. Both mean
+ * "this catalog's format string is unusable", and both must skip.
+ *
+ * @param string $fmt format string
+ * @param string $val substitution
+ *
+ * @return string|null null when the format is unusable
+ */
+function safeFormat($fmt, $val)
+{
+    if (false === strpos($fmt, '%s')) {
+        return null;
+    }
+    try {
+        $r = @sprintf($fmt, $val);
+    } catch (\Throwable $e) {
+        return null;
+    }
+    return '' === (string)$r ? null : (string)$r;
+}
+
+
+/**
+ * Sets each msgid's msgstr in a .po, in place.
+ *
+ * Appending instead of rewriting is what the first cut of this script did,
+ * and msgfmt rejected all nine catalogs with `duplicate message definition`.
+ * Two reasons a msgid that "needs seeding" is already in the file:
+ *
+ *   - an entry with an EMPTY msgstr is still an entry;
+ *   - a msgid that fell out of the sources is kept as an OBSOLETE entry,
+ *     commented with #~. That is exactly what gettext keeps them for -- so a
+ *     returning string can be revived rather than retyped -- and these
+ *     strings are returning. fr_FR carries `#~ msgid "List All Roles"`.
+ *
+ * So: rewrite a live entry where one exists, revive an obsolete one where it
+ * does not, and only append when the msgid is genuinely absent. A `#, fuzzy`
+ * marker immediately above is dropped in both cases -- the value being
+ * written is derived deliberately, and leaving it flagged fuzzy invites
+ * msgmerge to discard it again.
+ *
+ * @param string $path .po file
+ * @param array  $set  msgid => msgstr
+ *
+ * @return void
+ */
+function poWrite($path, array $set)
+{
+    $lines = explode("\n", file_get_contents($path));
+    $out = [];
+    $seen = [];
+    $n = count($lines);
+    for ($i = 0; $i < $n; $i++) {
+        $line = $lines[$i];
+        // Order matters: preg_match EMPTIES $m when it fails, so testing for
+        // an obsolete entry after a live one has already matched would throw
+        // the live capture away and send every live msgid down the append
+        // path instead -- which is how the first cut of this produced nine
+        // catalogs full of duplicate definitions.
+        $live = preg_match('/^msgid "(.*)"$/', $line, $m);
+        $dead = $live ? 0 : preg_match('/^#~[ \t]*msgid "(.*)"$/', $line, $m);
+        if ((!$live && !$dead) || !array_key_exists($m[1], $set)) {
+            $out[] = $line;
+            continue;
+        }
+        $prefix = $dead ? '/^#~[ \t]*/' : null;
+        $j = $i + 1;
+        // Skip to the end of this entry's msgstr, continuation lines included.
+        while ($j < $n
+            && !preg_match($dead ? '/^#~[ \t]*msgstr/' : '/^msgstr/', $lines[$j])
+        ) {
+            $j++;
+        }
+        if ($j < $n) {
+            $j++;
+            while ($j < $n
+                && preg_match(
+                    $dead ? '/^#~[ \t]*"/' : '/^"/',
+                    $lines[$j]
+                )
+            ) {
+                $j++;
+            }
+        }
+        while (count($out)
+            && 0 === strpos(end($out), '#,')
+            && false !== strpos(end($out), 'fuzzy')
+        ) {
+            array_pop($out);
+        }
+        $out[] = 'msgid ' . poQuote($m[1]);
+        $out[] = 'msgstr ' . poQuote($set[$m[1]]);
+        $seen[$m[1]] = true;
+        $i = $j - 1;
+        unset($prefix);
+    }
+    $text = rtrim(implode("\n", $out), "\n") . "\n";
+    $missing = array_diff_key($set, $seen);
+    if (count($missing)) {
+        $text .= "\n#. GH-435: seeded from this catalog's own \"List All %s\" /\n"
+            . "#. \"Create New %s\" and noun, so the label renders exactly as it\n"
+            . "#. did before those format strings became whole phrases.\n";
+        ksort($missing);
+        foreach ($missing as $msgid => $msgstr) {
+            $text .= "\nmsgid " . poQuote($msgid) . "\nmsgstr " . poQuote($msgstr) . "\n";
+        }
+    }
+    file_put_contents($path, $text);
+}
+
+
+// Correct French for every per-node label. Written out rather than derived:
+// agreement is the entire point of GH-435, and no rule generates it from the
+// English. `machine` and `image` are feminine (toutes les / une nouvelle),
+// `utilisateur` is masculine but vowel-initial (nouvel, not nouveau) -- the
+// three cases the reporter cited, in that order.
+$hand = [];
+$hand['fr_FR'] = [
+    'List All Groups'          => 'Lister tous les groupes',
+    'Create New Group'         => 'Créer un nouveau groupe',
+    'List All Hosts'           => 'Lister toutes les machines',
+    'Create New Host'          => 'Créer une nouvelle machine',
+    'List All Images'          => 'Lister toutes les images',
+    'Create New Image'         => 'Créer une nouvelle image',
+    'List All Ipxe Menus'      => 'Lister tous les menus iPXE',
+    'Create New Ipxe Menu'     => 'Créer un nouveau menu iPXE',
+    'List All Modules'         => 'Lister tous les modules',
+    'Create New Module'        => 'Créer un nouveau module',
+    'List All Printers'        => 'Lister toutes les imprimantes',
+    'Create New Printer'       => 'Créer une nouvelle imprimante',
+    'List All Roles'           => 'Lister tous les rôles',
+    'Create New Role'          => 'Créer un nouveau rôle',
+    'List All Sites'           => 'Lister tous les sites',
+    'Create New Site'          => 'Créer un nouveau site',
+    'List All Snapins'         => 'Lister tous les snapins',
+    'Create New Snapin'        => 'Créer un nouveau snapin',
+    'List All Storage Groups'  => 'Lister tous les groupes de stockage',
+    'Create New Storage Group' => 'Créer un nouveau groupe de stockage',
+    'List All Storage Nodes'   => 'Lister tous les nœuds de stockage',
+    'Create New Storage Node'  => 'Créer un nouveau nœud de stockage',
+    'List All Users'           => 'Lister tous les utilisateurs',
+    'Create New User'          => 'Créer un nouvel utilisateur',
+    'List All User Groups'     => "Lister tous les groupes d'utilisateurs",
+    'Create New User Group'    => "Créer un nouveau groupe d'utilisateurs",
+    // Not menu labels, but the same catalog damage and the same one-line fix.
+    // `Site` read "minutes" and `Role` read "Nom du module" -- which is how
+    // "Lister tous les minutess" was being generated at runtime while this
+    // was still composed. Corrected here because the composed form is what
+    // made them invisible; they are wrong wherever else they are used too.
+    'Site'                     => 'Site',
+    'Role'                     => 'Rôle',
+    'Module'                   => 'Module',
+];
+
+// Correct Spanish, for the same reason and with the same damage: every single
+// "Create New X" in this catalog reads "Crear nuevo grupo" -- Create New
+// *Group* -- because a fuzzy match against `Create New %s` was accepted
+// wholesale. A Spanish user on the host page is told they are creating a
+// group. `imagen` and `impresora` are feminine (todas las / nueva); the rest
+// are masculine.
+$hand['es_ES'] = [
+    'List All Groups'          => 'Listar todos los grupos',
+    'Create New Group'         => 'Crear nuevo grupo',
+    'List All Hosts'           => 'Listar todos los anfitriones',
+    'Create New Host'          => 'Crear nuevo anfitrión',
+    'List All Images'          => 'Listar todas las imágenes',
+    'Create New Image'         => 'Crear nueva imagen',
+    'List All Ipxe Menus'      => 'Listar todos los menús iPXE',
+    'Create New Ipxe Menu'     => 'Crear nuevo menú iPXE',
+    'List All Modules'         => 'Listar todos los módulos',
+    'Create New Module'        => 'Crear nuevo módulo',
+    'List All Printers'        => 'Listar todas las impresoras',
+    'Create New Printer'       => 'Crear nueva impresora',
+    'List All Roles'           => 'Listar todos los roles',
+    'Create New Role'          => 'Crear nuevo rol',
+    'List All Sites'           => 'Listar todos los sitios',
+    'Create New Site'          => 'Crear nuevo sitio',
+    'List All Snapins'         => 'Listar todos los snapins',
+    'Create New Snapin'        => 'Crear nuevo snapin',
+    'List All Storage Groups'  => 'Listar todos los grupos de almacenamiento',
+    'Create New Storage Group' => 'Crear nuevo grupo de almacenamiento',
+    'List All Storage Nodes'   => 'Listar todos los nodos de almacenamiento',
+    'Create New Storage Node'  => 'Crear nuevo nodo de almacenamiento',
+    'List All Users'           => 'Listar todos los usuarios',
+    'Create New User'          => 'Crear nuevo usuario',
+    'List All User Groups'     => 'Listar todos los grupos de usuarios',
+    'Create New User Group'    => 'Crear nuevo grupo de usuarios',
+    // Same class of damage in the bare nouns, which the composed labels were
+    // reading from: `Site` said "minutos", `Role` and `Module` both said
+    // "Nombre del módulo", `iPXE Menu` held a whole sentence about gpxe.
+    'Site'                     => 'Sitio',
+    'Role'                     => 'Rol',
+    'Module'                   => 'Módulo',
+    'Printer'                  => 'Impresora',
+    'iPXE Menu'                => 'Menú iPXE',
+    'User Group'               => 'Grupo de usuarios',
+];
+
+
+$locales = glob($langDir . '/*.UTF-8/LC_MESSAGES/messages.po');
+sort($locales);
+$grandAdded = 0;
+$grandSkipped = 0;
+
+foreach ($locales as $po) {
+    preg_match('#/([^/]+)\.UTF-8/#', $po, $lm);
+    $locale = $lm[1] ?? $po;
+    // The msgid IS the English, so seeding en_US would add nothing and would
+    // make every entry look translated. It still gets the stray-%s sweep
+    // below: an en_US msgstr reading "Create New %s" under msgid "Create New
+    // Group" shows that %s to an English user, and blanking it falls back to
+    // the msgid, which is already the right words.
+    $seed = ('en_US' !== $locale);
+    $tr = poRead($po);
+    $fz = poFuzzy($po);
+    $listFmt = $tr['List All %s'] ?? '';
+    $addFmt = $tr['Create New %s'] ?? '';
+
+    $added = [];
+    $skipped = [];
+    foreach ($seed ? $nodes : [] as $node => $spec) {
+        list($noun, $listId, $addId) = $spec;
+        // Where the catalog never translated the noun, compose with the
+        // English one rather than skipping. Skipping drops the whole label to
+        // English; composing keeps the locale's own verb, which is what these
+        // catalogs actually rendered before. It is also strictly better than
+        // before: the old code passed _(ucfirst($node)), so an untranslated
+        // German storage group read "Alle Storagegroups auflisten" -- a word
+        // that exists in no language. The properly spaced English noun is
+        // carried by the msgid itself, so it needs no second table.
+        $nounTr = $tr[$noun] ?? '';
+        $listArg = '' !== $nounTr
+            ? $nounTr . 's'
+            : substr($listId, strlen('List All '));
+        $addArg = '' !== $nounTr
+            ? $nounTr
+            : substr($addId, strlen('Create New '));
+        foreach ([[$listFmt, $listId, $listArg], [$addFmt, $addId, $addArg]] as $job) {
+            list($fmt, $msgid, $arg) = $job;
+            // Never overwrite a real translation -- but a msgstr carrying a
+            // literal %s is not one. Those came from a fuzzy match against
+            // `Create New %s` that somebody accepted, so the catalog claims
+            // `Create New Host` is translated and renders "Neue %s erstellen"
+            // on screen. Composing over it is strictly better, and it is what
+            // keeps this migration lossless: blanking such an entry instead
+            // would drop that locale to English for a label it can express.
+            $cur = (string)($tr[$msgid] ?? '');
+            if (isset($fz[$msgid]) || false !== strpos($cur, '%s')) {
+                $cur = '';
+            }
+            if ('' !== $cur) {
+                continue;
+            }
+            if ('' === $fmt) {
+                $skipped[] = $msgid . ' (no format string in this catalog)';
+                continue;
+            }
+            $val = safeFormat($fmt, $arg);
+            if (null === $val) {
+                $skipped[] = $msgid . ' (format has no usable %s)';
+                continue;
+            }
+            $added[$msgid] = $val;
+        }
+    }
+
+    printf(
+        "%-8s %2d seeded, %2d skipped\n",
+        $locale,
+        count($added),
+        count($skipped)
+    );
+    foreach ($skipped as $s) {
+        printf("           skip %s\n", $s);
+    }
+    $grandAdded += count($added);
+    $grandSkipped += count($skipped);
+
+    if (!$write) {
+        continue;
+    }
+
+    // A msgstr that still carries a literal %s is SHOWING that %s to users:
+    // it came from a fuzzy match against `Create New %s` that somebody
+    // accepted, and these msgids already existed because the codebase writes
+    // _('Create New User') and friends as page titles. Blanking makes gettext
+    // fall back to the English msgid, which is the wrong language but a real
+    // phrase; writing German or Chinese here would be guessing.
+    $blank = [];
+    foreach ($nodes as $spec) {
+        foreach ([$spec[1], $spec[2]] as $msgid) {
+            if (isset($added[$msgid])) {
+                continue;
+            }
+            if (false !== strpos((string)($tr[$msgid] ?? ''), '%s')) {
+                $blank[$msgid] = '';
+            }
+        }
+    }
+    if (count($blank)) {
+        printf("%-8s %2d msgstr(s) carrying a literal %%s blanked\n", $locale, count($blank));
+        $added += $blank;
+    }
+
+    if (isset($hand[$locale])) {
+        // Overwrites the seeds and the blanks above on purpose: seeding
+        // reproduces what the catalog rendered before, and for these two
+        // locales what it rendered before is precisely the bug.
+        $added = $hand[$locale] + $added;
+        printf(
+            "%-8s %2d hand-written entries applied\n",
+            $locale,
+            count($hand[$locale])
+        );
+    }
+
+    if (count($added)) {
+        poWrite($po, $added);
+    }
+}
+
+printf("\n%d entries seeded, %d skipped\n", $grandAdded, $grandSkipped);

--- a/bin/migrate-menu-translations.php
+++ b/bin/migrate-menu-translations.php
@@ -550,6 +550,23 @@ foreach ($locales as $po) {
         );
     }
 
+    // Last word: a CONFIRMED translation is never overwritten, by any pass.
+    // Confirmed means a live, non-empty, non-fuzzy msgstr that does not carry
+    // a stray %s -- a person wrote it and reviewed it. Everything above is
+    // reconstruction, and reconstruction does not get to overrule that, not
+    // even the hand-written tables. On this branch only ja_JP's `Create New
+    // Printer` and `Create New Snapin` qualify, and neither is in a hand
+    // table, so this changes nothing here; it is the same rule dev-branch
+    // needs, where five catalogs hold confirmed entries and the French table
+    // would otherwise have rewritten one of them.
+    foreach (array_keys($added) as $msgid) {
+        $cur = (string)($tr[$msgid] ?? '');
+        if ('' === $cur || isset($fz[$msgid]) || false !== strpos($cur, '%s')) {
+            continue;
+        }
+        unset($added[$msgid]);
+    }
+
     if (count($added)) {
         poWrite($po, $added);
     }

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1970,29 +1970,25 @@ msgstr "Neue %s erstellen"
 msgid "Create New Capone"
 msgstr "Neues Snapin erstellen"
 
-#, fuzzy
 msgid "Create New Group"
-msgstr "Neuen Schlüssel erstellen"
+msgstr "Neue Gruppe erstellen"
 
 #, fuzzy
 msgid "Create New Hello World"
 msgstr "Neue %s erstellen"
 
-#, fuzzy
 msgid "Create New Host"
-msgstr "Neue %s erstellen"
+msgstr "Neue Host erstellen"
 
-#, fuzzy
 msgid "Create New Image"
-msgstr "Neuen Schlüssel erstellen"
+msgstr "Neue Image erstellen"
 
 #, fuzzy
 msgid "Create New Immediate"
 msgstr "Neuen Schlüssel erstellen"
 
-#, fuzzy
 msgid "Create New Ipxe Menu"
-msgstr "Neuen Schlüssel erstellen"
+msgstr "Neue Ipxe Menu erstellen"
 
 #, fuzzy
 msgid "Create New LDAP Group"
@@ -2006,9 +2002,8 @@ msgstr "Neuen Drucker erstellen"
 msgid "Create New Location"
 msgstr "Neuen Standort erstellen"
 
-#, fuzzy
 msgid "Create New Module"
-msgstr "Neuen Schlüssel erstellen"
+msgstr "Neue Modulname erstellen"
 
 #, fuzzy
 msgid "Create New OU"
@@ -2018,37 +2013,31 @@ msgstr "Neue %s erstellen"
 msgid "Create New OpenID Connect Provider"
 msgstr "Neuen Drucker erstellen"
 
-#, fuzzy
 msgid "Create New Printer"
-msgstr "Neuen Drucker erstellen"
+msgstr "Neue Drucker erstellen"
 
 #, fuzzy
 msgid "Create New Provider Group"
 msgstr "Neuen Schlüssel erstellen"
 
-#, fuzzy
 msgid "Create New Role"
-msgstr "Neuen Schlüssel erstellen"
+msgstr "Neue Rollenname erstellen"
 
 #, fuzzy
 msgid "Create New Scheduled"
 msgstr "Neuen Schlüssel erstellen"
 
-#, fuzzy
 msgid "Create New Site"
-msgstr "Neuen Drucker erstellen"
+msgstr "Neue Sites erstellen"
 
-#, fuzzy
 msgid "Create New Snapin"
-msgstr "Neues Snapin erstellen"
+msgstr "Neue Snapin erstellen"
 
-#, fuzzy
 msgid "Create New Storage Group"
-msgstr "Speichergruppe"
+msgstr "Neue Storage Group erstellen"
 
-#, fuzzy
 msgid "Create New Storage Node"
-msgstr "Neuen Drucker erstellen"
+msgstr "Neue Storage Node erstellen"
 
 #, fuzzy
 msgid "Create New Subnet Group"
@@ -2062,13 +2051,11 @@ msgstr "Neuen Drucker erstellen"
 msgid "Create New Task Type"
 msgstr "Neue %s erstellen"
 
-#, fuzzy
 msgid "Create New User"
-msgstr "Neue %s erstellen"
+msgstr "Neue Benutzer erstellen"
 
-#, fuzzy
 msgid "Create New User Group"
-msgstr "Neuen Schlüssel erstellen"
+msgstr "Neue User Group erstellen"
 
 #, fuzzy
 msgid "Create New Windows Key"
@@ -12002,9 +11989,8 @@ msgstr ""
 #~ msgid "Latest SVN Version"
 #~ msgstr "Neueste SVN-Version"
 
-#, fuzzy
-#~ msgid "List All Roles"
-#~ msgstr "Alle %s auflisten"
+msgid "List All Roles"
+msgstr "Alle Rollennames auflisten"
 
 #, fuzzy
 #~ msgid "List All Rules"
@@ -12339,3 +12325,43 @@ msgstr ""
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Version"
+
+#. GH-435: seeded from this catalog's own "List All %s" /
+#. "Create New %s" and noun, so the label renders exactly as it
+#. did before those format strings became whole phrases.
+
+msgid "List All Groups"
+msgstr "Alle Gruppes auflisten"
+
+msgid "List All Hosts"
+msgstr "Alle Hosts auflisten"
+
+msgid "List All Images"
+msgstr "Alle Images auflisten"
+
+msgid "List All Ipxe Menus"
+msgstr "Alle Ipxe Menus auflisten"
+
+msgid "List All Modules"
+msgstr "Alle Modulnames auflisten"
+
+msgid "List All Printers"
+msgstr "Alle Druckers auflisten"
+
+msgid "List All Sites"
+msgstr "Alle Sitess auflisten"
+
+msgid "List All Snapins"
+msgstr "Alle Snapins auflisten"
+
+msgid "List All Storage Groups"
+msgstr "Alle Storage Groups auflisten"
+
+msgid "List All Storage Nodes"
+msgstr "Alle Storage Nodes auflisten"
+
+msgid "List All User Groups"
+msgstr "Alle User Groups auflisten"
+
+msgid "List All Users"
+msgstr "Alle Benutzers auflisten"

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -5101,9 +5101,42 @@ msgstr "Alle %s auflisten"
 msgid "List All %s"
 msgstr "Alle %s auflisten"
 
+msgid "List All Groups"
+msgstr "Alle Gruppes auflisten"
+
+msgid "List All Hosts"
+msgstr "Alle Hosts auflisten"
+
+msgid "List All Images"
+msgstr "Alle Images auflisten"
+
+msgid "List All Ipxe Menus"
+msgstr "Alle Ipxe Menus auflisten"
+
+msgid "List All Modules"
+msgstr "Alle Modulnames auflisten"
+
 #, fuzzy
 msgid "List All Plugins"
 msgstr "Plugins installieren"
+
+msgid "List All Printers"
+msgstr "Alle Druckers auflisten"
+
+msgid "List All Roles"
+msgstr "Alle Rollennames auflisten"
+
+msgid "List All Sites"
+msgstr "Alle Sitess auflisten"
+
+msgid "List All Snapins"
+msgstr "Alle Snapins auflisten"
+
+msgid "List All Storage Groups"
+msgstr "Alle Storage Groups auflisten"
+
+msgid "List All Storage Nodes"
+msgstr "Alle Storage Nodes auflisten"
 
 #, fuzzy
 msgid "List All Task States"
@@ -5112,6 +5145,12 @@ msgstr "Task Status"
 #, fuzzy
 msgid "List All Task Types"
 msgstr "Task-Typen"
+
+msgid "List All User Groups"
+msgstr "Alle User Groups auflisten"
+
+msgid "List All Users"
+msgstr "Alle Benutzers auflisten"
 
 #, fuzzy
 msgid "List Available Plugins"
@@ -11989,9 +12028,6 @@ msgstr ""
 #~ msgid "Latest SVN Version"
 #~ msgstr "Neueste SVN-Version"
 
-msgid "List All Roles"
-msgstr "Alle Rollennames auflisten"
-
 #, fuzzy
 #~ msgid "List All Rules"
 #~ msgstr "Alle %s auflisten"
@@ -12325,43 +12361,3 @@ msgstr "Alle Rollennames auflisten"
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Version"
-
-#. GH-435: seeded from this catalog's own "List All %s" /
-#. "Create New %s" and noun, so the label renders exactly as it
-#. did before those format strings became whole phrases.
-
-msgid "List All Groups"
-msgstr "Alle Gruppes auflisten"
-
-msgid "List All Hosts"
-msgstr "Alle Hosts auflisten"
-
-msgid "List All Images"
-msgstr "Alle Images auflisten"
-
-msgid "List All Ipxe Menus"
-msgstr "Alle Ipxe Menus auflisten"
-
-msgid "List All Modules"
-msgstr "Alle Modulnames auflisten"
-
-msgid "List All Printers"
-msgstr "Alle Druckers auflisten"
-
-msgid "List All Sites"
-msgstr "Alle Sitess auflisten"
-
-msgid "List All Snapins"
-msgstr "Alle Snapins auflisten"
-
-msgid "List All Storage Groups"
-msgstr "Alle Storage Groups auflisten"
-
-msgid "List All Storage Nodes"
-msgstr "Alle Storage Nodes auflisten"
-
-msgid "List All User Groups"
-msgstr "Alle User Groups auflisten"
-
-msgid "List All Users"
-msgstr "Alle Benutzers auflisten"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -5102,8 +5102,52 @@ msgid "List All %s"
 msgstr "List All %s"
 
 #, fuzzy
+msgid "List All Groups"
+msgstr "List All %s"
+
+#, fuzzy
+msgid "List All Hosts"
+msgstr "List All %s"
+
+#, fuzzy
+msgid "List All Images"
+msgstr "List All %s"
+
+#, fuzzy
+msgid "List All Ipxe Menus"
+msgstr "List All %s"
+
+#, fuzzy
+msgid "List All Modules"
+msgstr "List All %s"
+
+#, fuzzy
 msgid "List All Plugins"
 msgstr "Install Plugins"
+
+#, fuzzy
+msgid "List All Printers"
+msgstr "Printers"
+
+#, fuzzy
+msgid "List All Roles"
+msgstr "List All %s"
+
+#, fuzzy
+msgid "List All Sites"
+msgstr "List All %s"
+
+#, fuzzy
+msgid "List All Snapins"
+msgstr "Install Plugins"
+
+#, fuzzy
+msgid "List All Storage Groups"
+msgstr "All Storage Groups"
+
+#, fuzzy
+msgid "List All Storage Nodes"
+msgstr "All Storage Nodes"
 
 #, fuzzy
 msgid "List All Task States"
@@ -5112,6 +5156,14 @@ msgstr "Task States"
 #, fuzzy
 msgid "List All Task Types"
 msgstr "Task Types"
+
+#, fuzzy
+msgid "List All User Groups"
+msgstr "Groups"
+
+#, fuzzy
+msgid "List All Users"
+msgstr "List All %s"
 
 #, fuzzy
 msgid "List Available Plugins"
@@ -11963,14 +12015,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Latest SVN Version"
 #~ msgstr "Latest Version"
-
-#, fuzzy
-#~ msgid "List All Roles"
-#~ msgstr "List All %s"
-
-#, fuzzy
-#~ msgid "List All Rules"
-#~ msgstr "List All %s"
 
 #, fuzzy
 #~ msgid "Login accepted"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1972,29 +1972,25 @@ msgstr "Create New %s"
 msgid "Create New Capone"
 msgstr "Create New %s"
 
-#, fuzzy
 msgid "Create New Group"
-msgstr "Create New %s"
+msgstr ""
 
 #, fuzzy
 msgid "Create New Hello World"
 msgstr "Create New %s"
 
-#, fuzzy
 msgid "Create New Host"
-msgstr "Create New %s"
+msgstr ""
 
-#, fuzzy
 msgid "Create New Image"
-msgstr "Create New %s"
+msgstr ""
 
 #, fuzzy
 msgid "Create New Immediate"
 msgstr "Create New %s"
 
-#, fuzzy
 msgid "Create New Ipxe Menu"
-msgstr "Create New %s"
+msgstr ""
 
 #, fuzzy
 msgid "Create New LDAP Group"
@@ -2008,9 +2004,8 @@ msgstr "Create New %s"
 msgid "Create New Location"
 msgstr "Create New %s"
 
-#, fuzzy
 msgid "Create New Module"
-msgstr "Create New %s"
+msgstr ""
 
 #, fuzzy
 msgid "Create New OU"
@@ -2020,37 +2015,32 @@ msgstr "Create New %s"
 msgid "Create New OpenID Connect Provider"
 msgstr "Create New %s"
 
-#, fuzzy
 msgid "Create New Printer"
-msgstr "Create New %s"
+msgstr ""
 
 #, fuzzy
 msgid "Create New Provider Group"
 msgstr "Create New %s"
 
-#, fuzzy
 msgid "Create New Role"
-msgstr "Create New %s"
+msgstr ""
 
 #, fuzzy
 msgid "Create New Scheduled"
 msgstr "Create New %s"
 
-#, fuzzy
 msgid "Create New Site"
-msgstr "Create New %s"
+msgstr ""
 
-#, fuzzy
 msgid "Create New Snapin"
-msgstr "Create New %s"
+msgstr ""
 
 #, fuzzy
 msgid "Create New Storage Group"
 msgstr "Storage Group"
 
-#, fuzzy
 msgid "Create New Storage Node"
-msgstr "Create New %s"
+msgstr ""
 
 #, fuzzy
 msgid "Create New Subnet Group"
@@ -2064,13 +2054,11 @@ msgstr "Create New %s"
 msgid "Create New Task Type"
 msgstr "Create New %s"
 
-#, fuzzy
 msgid "Create New User"
-msgstr "Create New %s"
+msgstr ""
 
-#, fuzzy
 msgid "Create New User Group"
-msgstr "Create New %s"
+msgstr ""
 
 #, fuzzy
 msgid "Create New Windows Key"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1992,7 +1992,6 @@ msgstr "Crear nuevo grupo"
 msgid "Create New Capone"
 msgstr "Crear nuevo grupo"
 
-#, fuzzy
 msgid "Create New Group"
 msgstr "Crear nuevo grupo"
 
@@ -2000,21 +1999,18 @@ msgstr "Crear nuevo grupo"
 msgid "Create New Hello World"
 msgstr "Crear nuevo grupo"
 
-#, fuzzy
 msgid "Create New Host"
-msgstr "Crear nuevo grupo"
+msgstr "Crear nuevo anfitrión"
 
-#, fuzzy
 msgid "Create New Image"
-msgstr "Crear nuevo grupo"
+msgstr "Crear nueva imagen"
 
 #, fuzzy
 msgid "Create New Immediate"
 msgstr "Crear nuevo grupo"
 
-#, fuzzy
 msgid "Create New Ipxe Menu"
-msgstr "Crear nuevo grupo"
+msgstr "Crear nuevo menú iPXE"
 
 #, fuzzy
 msgid "Create New LDAP Group"
@@ -2028,9 +2024,8 @@ msgstr "Crear nuevo grupo"
 msgid "Create New Location"
 msgstr "Crear nuevo grupo"
 
-#, fuzzy
 msgid "Create New Module"
-msgstr "Crear nuevo grupo"
+msgstr "Crear nuevo módulo"
 
 #, fuzzy
 msgid "Create New OU"
@@ -2040,37 +2035,31 @@ msgstr "Crear nuevo grupo"
 msgid "Create New OpenID Connect Provider"
 msgstr "Crear nuevo grupo"
 
-#, fuzzy
 msgid "Create New Printer"
-msgstr "Crear nuevo grupo"
+msgstr "Crear nueva impresora"
 
 #, fuzzy
 msgid "Create New Provider Group"
 msgstr "Crear nuevo grupo"
 
-#, fuzzy
 msgid "Create New Role"
-msgstr "Crear nuevo grupo"
+msgstr "Crear nuevo rol"
 
 #, fuzzy
 msgid "Create New Scheduled"
 msgstr "Crear nuevo grupo"
 
-#, fuzzy
 msgid "Create New Site"
-msgstr "Crear nuevo grupo"
+msgstr "Crear nuevo sitio"
 
-#, fuzzy
 msgid "Create New Snapin"
-msgstr "Crear nuevo grupo"
+msgstr "Crear nuevo snapin"
 
-#, fuzzy
 msgid "Create New Storage Group"
-msgstr "Grupo de almacenamiento"
+msgstr "Crear nuevo grupo de almacenamiento"
 
-#, fuzzy
 msgid "Create New Storage Node"
-msgstr "Crear nuevo grupo"
+msgstr "Crear nuevo nodo de almacenamiento"
 
 #, fuzzy
 msgid "Create New Subnet Group"
@@ -2084,13 +2073,11 @@ msgstr "Crear nuevo grupo"
 msgid "Create New Task Type"
 msgstr "Crear nuevo grupo"
 
-#, fuzzy
 msgid "Create New User"
-msgstr "Crear nuevo grupo"
+msgstr "Crear nuevo usuario"
 
-#, fuzzy
 msgid "Create New User Group"
-msgstr "Crear nuevo grupo"
+msgstr "Crear nuevo grupo de usuarios"
 
 #, fuzzy
 msgid "Create New Windows Key"
@@ -5605,9 +5592,8 @@ msgstr "Modelo"
 msgid "Models"
 msgstr "Modelo"
 
-#, fuzzy
 msgid "Module"
-msgstr "Nombre del módulo"
+msgstr "Módulo"
 
 #, fuzzy
 msgid "Module Create Fail"
@@ -6962,9 +6948,8 @@ msgstr "Grupo de almacenamiento"
 msgid "Primary User"
 msgstr "usuario principal"
 
-#, fuzzy
 msgid "Printer"
-msgstr "impresora IP"
+msgstr "Impresora"
 
 #, fuzzy
 msgid "Printer Associations"
@@ -7460,9 +7445,8 @@ msgstr "Volviendo valor de clave"
 msgid "Reverse"
 msgstr ""
 
-#, fuzzy
 msgid "Role"
-msgstr "Nombre del módulo"
+msgstr "Rol"
 
 #, fuzzy
 msgid "Role Association"
@@ -8076,9 +8060,8 @@ msgstr ""
 msgid "Single Logout"
 msgstr "snapin"
 
-#, fuzzy
 msgid "Site"
-msgstr "minutos"
+msgstr "Sitio"
 
 #, fuzzy
 msgid "Site Create Fail"
@@ -10287,9 +10270,8 @@ msgstr "creado por el usuario"
 msgid "User DN"
 msgstr "Nombre de usuario"
 
-#, fuzzy
 msgid "User Group"
-msgstr "Grupo"
+msgstr "Grupo de usuarios"
 
 #, fuzzy
 msgid "User Group Association"
@@ -11088,9 +11070,8 @@ msgstr "actualización de servicio no pudo"
 msgid "iPXE Management"
 msgstr "Gestión de usuarios"
 
-#, fuzzy
 msgid "iPXE Menu"
-msgstr "Crear nueva entrada de menú gpxe"
+msgstr "Menú iPXE"
 
 #, fuzzy
 msgid "iPXE Menu Configuration"
@@ -12452,3 +12433,46 @@ msgstr ""
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Versión"
+
+#. GH-435: seeded from this catalog's own "List All %s" /
+#. "Create New %s" and noun, so the label renders exactly as it
+#. did before those format strings became whole phrases.
+
+msgid "List All Groups"
+msgstr "Listar todos los grupos"
+
+msgid "List All Hosts"
+msgstr "Listar todos los anfitriones"
+
+msgid "List All Images"
+msgstr "Listar todas las imágenes"
+
+msgid "List All Ipxe Menus"
+msgstr "Listar todos los menús iPXE"
+
+msgid "List All Modules"
+msgstr "Listar todos los módulos"
+
+msgid "List All Printers"
+msgstr "Listar todas las impresoras"
+
+msgid "List All Roles"
+msgstr "Listar todos los roles"
+
+msgid "List All Sites"
+msgstr "Listar todos los sitios"
+
+msgid "List All Snapins"
+msgstr "Listar todos los snapins"
+
+msgid "List All Storage Groups"
+msgstr "Listar todos los grupos de almacenamiento"
+
+msgid "List All Storage Nodes"
+msgstr "Listar todos los nodos de almacenamiento"
+
+msgid "List All User Groups"
+msgstr "Listar todos los grupos de usuarios"
+
+msgid "List All Users"
+msgstr "Listar todos los usuarios"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5201,9 +5201,42 @@ msgstr "Línea"
 msgid "List All %s"
 msgstr ""
 
+msgid "List All Groups"
+msgstr "Listar todos los grupos"
+
+msgid "List All Hosts"
+msgstr "Listar todos los anfitriones"
+
+msgid "List All Images"
+msgstr "Listar todas las imágenes"
+
+msgid "List All Ipxe Menus"
+msgstr "Listar todos los menús iPXE"
+
+msgid "List All Modules"
+msgstr "Listar todos los módulos"
+
 #, fuzzy
 msgid "List All Plugins"
 msgstr "Nombre de la impresora"
+
+msgid "List All Printers"
+msgstr "Listar todas las impresoras"
+
+msgid "List All Roles"
+msgstr "Listar todos los roles"
+
+msgid "List All Sites"
+msgstr "Listar todos los sitios"
+
+msgid "List All Snapins"
+msgstr "Listar todos los snapins"
+
+msgid "List All Storage Groups"
+msgstr "Listar todos los grupos de almacenamiento"
+
+msgid "List All Storage Nodes"
+msgstr "Listar todos los nodos de almacenamiento"
 
 #, fuzzy
 msgid "List All Task States"
@@ -5212,6 +5245,12 @@ msgstr "Nombre de la tarea"
 #, fuzzy
 msgid "List All Task Types"
 msgstr "Tipo de tarea"
+
+msgid "List All User Groups"
+msgstr "Listar todos los grupos de usuarios"
+
+msgid "List All Users"
+msgstr "Listar todos los usuarios"
 
 #, fuzzy
 msgid "List Available Plugins"
@@ -12433,46 +12472,3 @@ msgstr ""
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Versión"
-
-#. GH-435: seeded from this catalog's own "List All %s" /
-#. "Create New %s" and noun, so the label renders exactly as it
-#. did before those format strings became whole phrases.
-
-msgid "List All Groups"
-msgstr "Listar todos los grupos"
-
-msgid "List All Hosts"
-msgstr "Listar todos los anfitriones"
-
-msgid "List All Images"
-msgstr "Listar todas las imágenes"
-
-msgid "List All Ipxe Menus"
-msgstr "Listar todos los menús iPXE"
-
-msgid "List All Modules"
-msgstr "Listar todos los módulos"
-
-msgid "List All Printers"
-msgstr "Listar todas las impresoras"
-
-msgid "List All Roles"
-msgstr "Listar todos los roles"
-
-msgid "List All Sites"
-msgstr "Listar todos los sitios"
-
-msgid "List All Snapins"
-msgstr "Listar todos los snapins"
-
-msgid "List All Storage Groups"
-msgstr "Listar todos los grupos de almacenamiento"
-
-msgid "List All Storage Nodes"
-msgstr "Listar todos los nodos de almacenamiento"
-
-msgid "List All User Groups"
-msgstr "Listar todos los grupos de usuarios"
-
-msgid "List All Users"
-msgstr "Listar todos los usuarios"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5102,9 +5102,42 @@ msgstr "Alle %s auflisten"
 msgid "List All %s"
 msgstr "Alle %s auflisten"
 
+msgid "List All Groups"
+msgstr "Alle Gruppes auflisten"
+
+msgid "List All Hosts"
+msgstr "Alle Hosts auflisten"
+
+msgid "List All Images"
+msgstr "Alle Images auflisten"
+
+msgid "List All Ipxe Menus"
+msgstr "Alle Ipxe Menus auflisten"
+
+msgid "List All Modules"
+msgstr "Alle Modulnames auflisten"
+
 #, fuzzy
 msgid "List All Plugins"
 msgstr "Plugins installieren"
+
+msgid "List All Printers"
+msgstr "Alle Druckers auflisten"
+
+msgid "List All Roles"
+msgstr "Alle Rollennames auflisten"
+
+msgid "List All Sites"
+msgstr "Alle Sitess auflisten"
+
+msgid "List All Snapins"
+msgstr "Alle Snapins auflisten"
+
+msgid "List All Storage Groups"
+msgstr "Alle Storage Groups auflisten"
+
+msgid "List All Storage Nodes"
+msgstr "Alle Storage Nodes auflisten"
 
 #, fuzzy
 msgid "List All Task States"
@@ -5113,6 +5146,12 @@ msgstr "Task Status"
 #, fuzzy
 msgid "List All Task Types"
 msgstr "Task-Typen"
+
+msgid "List All User Groups"
+msgstr "Alle User Groups auflisten"
+
+msgid "List All Users"
+msgstr "Alle Benutzers auflisten"
 
 #, fuzzy
 msgid "List Available Plugins"
@@ -11990,9 +12029,6 @@ msgstr ""
 #~ msgid "Latest SVN Version"
 #~ msgstr "Neueste SVN-Version"
 
-msgid "List All Roles"
-msgstr "Alle Rollennames auflisten"
-
 #, fuzzy
 #~ msgid "List All Rules"
 #~ msgstr "Alle %s auflisten"
@@ -12326,43 +12362,3 @@ msgstr "Alle Rollennames auflisten"
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Version"
-
-#. GH-435: seeded from this catalog's own "List All %s" /
-#. "Create New %s" and noun, so the label renders exactly as it
-#. did before those format strings became whole phrases.
-
-msgid "List All Groups"
-msgstr "Alle Gruppes auflisten"
-
-msgid "List All Hosts"
-msgstr "Alle Hosts auflisten"
-
-msgid "List All Images"
-msgstr "Alle Images auflisten"
-
-msgid "List All Ipxe Menus"
-msgstr "Alle Ipxe Menus auflisten"
-
-msgid "List All Modules"
-msgstr "Alle Modulnames auflisten"
-
-msgid "List All Printers"
-msgstr "Alle Druckers auflisten"
-
-msgid "List All Sites"
-msgstr "Alle Sitess auflisten"
-
-msgid "List All Snapins"
-msgstr "Alle Snapins auflisten"
-
-msgid "List All Storage Groups"
-msgstr "Alle Storage Groups auflisten"
-
-msgid "List All Storage Nodes"
-msgstr "Alle Storage Nodes auflisten"
-
-msgid "List All User Groups"
-msgstr "Alle User Groups auflisten"
-
-msgid "List All Users"
-msgstr "Alle Benutzers auflisten"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1970,29 +1970,25 @@ msgstr "Neue %s erstellen"
 msgid "Create New Capone"
 msgstr "Neues Snapin erstellen"
 
-#, fuzzy
 msgid "Create New Group"
-msgstr "Neuen Schlüssel erstellen"
+msgstr "Neue Gruppe erstellen"
 
 #, fuzzy
 msgid "Create New Hello World"
 msgstr "Neue %s erstellen"
 
-#, fuzzy
 msgid "Create New Host"
-msgstr "Neue %s erstellen"
+msgstr "Neue Host erstellen"
 
-#, fuzzy
 msgid "Create New Image"
-msgstr "Neuen Schlüssel erstellen"
+msgstr "Neue Image erstellen"
 
 #, fuzzy
 msgid "Create New Immediate"
 msgstr "Neuen Schlüssel erstellen"
 
-#, fuzzy
 msgid "Create New Ipxe Menu"
-msgstr "Neuen Schlüssel erstellen"
+msgstr "Neue Ipxe Menu erstellen"
 
 #, fuzzy
 msgid "Create New LDAP Group"
@@ -2006,9 +2002,8 @@ msgstr "Neuen Drucker erstellen"
 msgid "Create New Location"
 msgstr "Neuen Standort erstellen"
 
-#, fuzzy
 msgid "Create New Module"
-msgstr "Neuen Schlüssel erstellen"
+msgstr "Neue Modulname erstellen"
 
 #, fuzzy
 msgid "Create New OU"
@@ -2018,37 +2013,31 @@ msgstr "Neue %s erstellen"
 msgid "Create New OpenID Connect Provider"
 msgstr "Neuen Drucker erstellen"
 
-#, fuzzy
 msgid "Create New Printer"
-msgstr "Neuen Drucker erstellen"
+msgstr "Neue Drucker erstellen"
 
 #, fuzzy
 msgid "Create New Provider Group"
 msgstr "Neuen Schlüssel erstellen"
 
-#, fuzzy
 msgid "Create New Role"
-msgstr "Neuen Schlüssel erstellen"
+msgstr "Neue Rollenname erstellen"
 
 #, fuzzy
 msgid "Create New Scheduled"
 msgstr "Neuen Schlüssel erstellen"
 
-#, fuzzy
 msgid "Create New Site"
-msgstr "Neuen Drucker erstellen"
+msgstr "Neue Sites erstellen"
 
-#, fuzzy
 msgid "Create New Snapin"
-msgstr "Neues Snapin erstellen"
+msgstr "Neue Snapin erstellen"
 
-#, fuzzy
 msgid "Create New Storage Group"
-msgstr "Speichergruppe"
+msgstr "Neue Storage Group erstellen"
 
-#, fuzzy
 msgid "Create New Storage Node"
-msgstr "Neuen Drucker erstellen"
+msgstr "Neue Storage Node erstellen"
 
 #, fuzzy
 msgid "Create New Subnet Group"
@@ -2062,13 +2051,11 @@ msgstr "Neuen Drucker erstellen"
 msgid "Create New Task Type"
 msgstr "Neue %s erstellen"
 
-#, fuzzy
 msgid "Create New User"
-msgstr "Neue %s erstellen"
+msgstr "Neue Benutzer erstellen"
 
-#, fuzzy
 msgid "Create New User Group"
-msgstr "Neuen Schlüssel erstellen"
+msgstr "Neue User Group erstellen"
 
 #, fuzzy
 msgid "Create New Windows Key"
@@ -12003,9 +11990,8 @@ msgstr ""
 #~ msgid "Latest SVN Version"
 #~ msgstr "Neueste SVN-Version"
 
-#, fuzzy
-#~ msgid "List All Roles"
-#~ msgstr "Alle %s auflisten"
+msgid "List All Roles"
+msgstr "Alle Rollennames auflisten"
 
 #, fuzzy
 #~ msgid "List All Rules"
@@ -12340,3 +12326,43 @@ msgstr ""
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Version"
+
+#. GH-435: seeded from this catalog's own "List All %s" /
+#. "Create New %s" and noun, so the label renders exactly as it
+#. did before those format strings became whole phrases.
+
+msgid "List All Groups"
+msgstr "Alle Gruppes auflisten"
+
+msgid "List All Hosts"
+msgstr "Alle Hosts auflisten"
+
+msgid "List All Images"
+msgstr "Alle Images auflisten"
+
+msgid "List All Ipxe Menus"
+msgstr "Alle Ipxe Menus auflisten"
+
+msgid "List All Modules"
+msgstr "Alle Modulnames auflisten"
+
+msgid "List All Printers"
+msgstr "Alle Druckers auflisten"
+
+msgid "List All Sites"
+msgstr "Alle Sitess auflisten"
+
+msgid "List All Snapins"
+msgstr "Alle Snapins auflisten"
+
+msgid "List All Storage Groups"
+msgstr "Alle Storage Groups auflisten"
+
+msgid "List All Storage Nodes"
+msgstr "Alle Storage Nodes auflisten"
+
+msgid "List All User Groups"
+msgstr "Alle User Groups auflisten"
+
+msgid "List All Users"
+msgstr "Alle Benutzers auflisten"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -5102,9 +5102,42 @@ msgstr "Lister tous les %s"
 msgid "List All %s"
 msgstr "Lister tous les %s"
 
+msgid "List All Groups"
+msgstr "Lister tous les groupes"
+
+msgid "List All Hosts"
+msgstr "Lister toutes les machines"
+
+msgid "List All Images"
+msgstr "Lister toutes les images"
+
+msgid "List All Ipxe Menus"
+msgstr "Lister tous les menus iPXE"
+
+msgid "List All Modules"
+msgstr "Lister tous les modules"
+
 #, fuzzy
 msgid "List All Plugins"
 msgstr "Installer Plugins"
+
+msgid "List All Printers"
+msgstr "Lister toutes les imprimantes"
+
+msgid "List All Roles"
+msgstr "Lister tous les rôles"
+
+msgid "List All Sites"
+msgstr "Lister tous les sites"
+
+msgid "List All Snapins"
+msgstr "Lister tous les snapins"
+
+msgid "List All Storage Groups"
+msgstr "Lister tous les groupes de stockage"
+
+msgid "List All Storage Nodes"
+msgstr "Lister tous les nœuds de stockage"
 
 #, fuzzy
 msgid "List All Task States"
@@ -5113,6 +5146,12 @@ msgstr "Unis Groupe"
 #, fuzzy
 msgid "List All Task Types"
 msgstr "Types de tâches"
+
+msgid "List All User Groups"
+msgstr "Lister tous les groupes d'utilisateurs"
+
+msgid "List All Users"
+msgstr "Lister tous les utilisateurs"
 
 #, fuzzy
 msgid "List Available Plugins"
@@ -11966,9 +12005,6 @@ msgstr ""
 #~ msgid "Latest SVN Version"
 #~ msgstr "Dernière version"
 
-msgid "List All Roles"
-msgstr "Lister tous les rôles"
-
 #, fuzzy
 #~ msgid "List All Rules"
 #~ msgstr "Lister tous les %s"
@@ -12272,43 +12308,3 @@ msgstr "Lister tous les rôles"
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Version"
-
-#. GH-435: seeded from this catalog's own "List All %s" /
-#. "Create New %s" and noun, so the label renders exactly as it
-#. did before those format strings became whole phrases.
-
-msgid "List All Groups"
-msgstr "Lister tous les groupes"
-
-msgid "List All Hosts"
-msgstr "Lister toutes les machines"
-
-msgid "List All Images"
-msgstr "Lister toutes les images"
-
-msgid "List All Ipxe Menus"
-msgstr "Lister tous les menus iPXE"
-
-msgid "List All Modules"
-msgstr "Lister tous les modules"
-
-msgid "List All Printers"
-msgstr "Lister toutes les imprimantes"
-
-msgid "List All Sites"
-msgstr "Lister tous les sites"
-
-msgid "List All Snapins"
-msgstr "Lister tous les snapins"
-
-msgid "List All Storage Groups"
-msgstr "Lister tous les groupes de stockage"
-
-msgid "List All Storage Nodes"
-msgstr "Lister tous les nœuds de stockage"
-
-msgid "List All User Groups"
-msgstr "Lister tous les groupes d'utilisateurs"
-
-msgid "List All Users"
-msgstr "Lister tous les utilisateurs"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1974,29 +1974,25 @@ msgstr "Créer un nouveau %s"
 msgid "Create New Capone"
 msgstr "Créer un nouveau %s"
 
-#, fuzzy
 msgid "Create New Group"
-msgstr "Créer un nouveau %s"
+msgstr "Créer un nouveau groupe"
 
 #, fuzzy
 msgid "Create New Hello World"
 msgstr "Créer un nouveau %s"
 
-#, fuzzy
 msgid "Create New Host"
-msgstr "Créer un nouveau %s"
+msgstr "Créer une nouvelle machine"
 
-#, fuzzy
 msgid "Create New Image"
-msgstr "Créer un nouveau %s"
+msgstr "Créer une nouvelle image"
 
 #, fuzzy
 msgid "Create New Immediate"
 msgstr "Créer un nouveau %s"
 
-#, fuzzy
 msgid "Create New Ipxe Menu"
-msgstr "Créer un nouveau %s"
+msgstr "Créer un nouveau menu iPXE"
 
 #, fuzzy
 msgid "Create New LDAP Group"
@@ -2010,9 +2006,8 @@ msgstr "Créer un nouveau %s"
 msgid "Create New Location"
 msgstr "Créer un nouveau %s"
 
-#, fuzzy
 msgid "Create New Module"
-msgstr "Créer un nouveau %s"
+msgstr "Créer un nouveau module"
 
 #, fuzzy
 msgid "Create New OU"
@@ -2022,37 +2017,31 @@ msgstr "Créer un nouveau %s"
 msgid "Create New OpenID Connect Provider"
 msgstr "Créer un nouveau %s"
 
-#, fuzzy
 msgid "Create New Printer"
-msgstr "Créer un nouveau %s"
+msgstr "Créer une nouvelle imprimante"
 
 #, fuzzy
 msgid "Create New Provider Group"
 msgstr "Créer un nouveau %s"
 
-#, fuzzy
 msgid "Create New Role"
-msgstr "Créer un nouveau %s"
+msgstr "Créer un nouveau rôle"
 
 #, fuzzy
 msgid "Create New Scheduled"
 msgstr "Créer un nouveau %s"
 
-#, fuzzy
 msgid "Create New Site"
-msgstr "Créer un nouveau %s"
+msgstr "Créer un nouveau site"
 
-#, fuzzy
 msgid "Create New Snapin"
-msgstr "Créer un nouveau %s"
+msgstr "Créer un nouveau snapin"
 
-#, fuzzy
 msgid "Create New Storage Group"
-msgstr "Groupe de stockage"
+msgstr "Créer un nouveau groupe de stockage"
 
-#, fuzzy
 msgid "Create New Storage Node"
-msgstr "Créer un nouveau %s"
+msgstr "Créer un nouveau nœud de stockage"
 
 #, fuzzy
 msgid "Create New Subnet Group"
@@ -2066,13 +2055,11 @@ msgstr "Créer un nouveau %s"
 msgid "Create New Task Type"
 msgstr "Créer un nouveau %s"
 
-#, fuzzy
 msgid "Create New User"
-msgstr "Créer un nouveau %s"
+msgstr "Créer un nouvel utilisateur"
 
-#, fuzzy
 msgid "Create New User Group"
-msgstr "Créer un nouveau %s"
+msgstr "Créer un nouveau groupe d'utilisateurs"
 
 #, fuzzy
 msgid "Create New Windows Key"
@@ -5492,9 +5479,8 @@ msgstr "Modèle"
 msgid "Models"
 msgstr "Modèle"
 
-#, fuzzy
 msgid "Module"
-msgstr "Nom du module"
+msgstr "Module"
 
 #, fuzzy
 msgid "Module Create Fail"
@@ -7317,9 +7303,8 @@ msgstr "De retour valeur de clé"
 msgid "Reverse"
 msgstr ""
 
-#, fuzzy
 msgid "Role"
-msgstr "Nom du module"
+msgstr "Rôle"
 
 #, fuzzy
 msgid "Role Association"
@@ -7928,9 +7913,8 @@ msgstr ""
 msgid "Single Logout"
 msgstr "Se déconnecter"
 
-#, fuzzy
 msgid "Site"
-msgstr "minutes"
+msgstr "Site"
 
 #, fuzzy
 msgid "Site Create Fail"
@@ -11982,9 +11966,8 @@ msgstr ""
 #~ msgid "Latest SVN Version"
 #~ msgstr "Dernière version"
 
-#, fuzzy
-#~ msgid "List All Roles"
-#~ msgstr "Lister tous les %s"
+msgid "List All Roles"
+msgstr "Lister tous les rôles"
 
 #, fuzzy
 #~ msgid "List All Rules"
@@ -12289,3 +12272,43 @@ msgstr ""
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Version"
+
+#. GH-435: seeded from this catalog's own "List All %s" /
+#. "Create New %s" and noun, so the label renders exactly as it
+#. did before those format strings became whole phrases.
+
+msgid "List All Groups"
+msgstr "Lister tous les groupes"
+
+msgid "List All Hosts"
+msgstr "Lister toutes les machines"
+
+msgid "List All Images"
+msgstr "Lister toutes les images"
+
+msgid "List All Ipxe Menus"
+msgstr "Lister tous les menus iPXE"
+
+msgid "List All Modules"
+msgstr "Lister tous les modules"
+
+msgid "List All Printers"
+msgstr "Lister toutes les imprimantes"
+
+msgid "List All Sites"
+msgstr "Lister tous les sites"
+
+msgid "List All Snapins"
+msgstr "Lister tous les snapins"
+
+msgid "List All Storage Groups"
+msgstr "Lister tous les groupes de stockage"
+
+msgid "List All Storage Nodes"
+msgstr "Lister tous les nœuds de stockage"
+
+msgid "List All User Groups"
+msgstr "Lister tous les groupes d'utilisateurs"
+
+msgid "List All Users"
+msgstr "Lister tous les utilisateurs"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -4944,9 +4944,42 @@ msgstr "Elencare tutti %s"
 msgid "List All %s"
 msgstr "Elencare tutti %s"
 
+msgid "List All Groups"
+msgstr "Elencare tutti Gruppos"
+
+msgid "List All Hosts"
+msgstr "Elencare tutti Hosts"
+
+msgid "List All Images"
+msgstr "Elencare tutti Immagines"
+
+msgid "List All Ipxe Menus"
+msgstr "Elencare tutti Ipxe Menus"
+
+msgid "List All Modules"
+msgstr "Elencare tutti Nome Modulos"
+
 #, fuzzy
 msgid "List All Plugins"
 msgstr "installare plugin"
+
+msgid "List All Printers"
+msgstr "Elencare tutti Stampantes"
+
+msgid "List All Roles"
+msgstr "Elencare tutti Nome regolas"
+
+msgid "List All Sites"
+msgstr "Elencare tutti Sitis"
+
+msgid "List All Snapins"
+msgstr "Elencare tutti Snapins"
+
+msgid "List All Storage Groups"
+msgstr "Elencare tutti Storage Groups"
+
+msgid "List All Storage Nodes"
+msgstr "Elencare tutti Storage Nodes"
 
 #, fuzzy
 msgid "List All Task States"
@@ -4955,6 +4988,12 @@ msgstr "Stati attività"
 #, fuzzy
 msgid "List All Task Types"
 msgstr "Tipi di attività"
+
+msgid "List All User Groups"
+msgstr "Elencare tutti User Groups"
+
+msgid "List All Users"
+msgstr "Elencare tutti Utentes"
 
 #, fuzzy
 msgid "List Available Plugins"
@@ -11604,9 +11643,6 @@ msgstr ""
 #~ msgid "Latest SVN Version"
 #~ msgstr "Ultima versione di SVN"
 
-msgid "List All Roles"
-msgstr "Elencare tutti Nome regolas"
-
 #, fuzzy
 #~ msgid "List All Rules"
 #~ msgstr "Elencare tutti %s"
@@ -11922,43 +11958,3 @@ msgstr "Elencare tutti Nome regolas"
 
 #~ msgid "version"
 #~ msgstr "versione"
-
-#. GH-435: seeded from this catalog's own "List All %s" /
-#. "Create New %s" and noun, so the label renders exactly as it
-#. did before those format strings became whole phrases.
-
-msgid "List All Groups"
-msgstr "Elencare tutti Gruppos"
-
-msgid "List All Hosts"
-msgstr "Elencare tutti Hosts"
-
-msgid "List All Images"
-msgstr "Elencare tutti Immagines"
-
-msgid "List All Ipxe Menus"
-msgstr "Elencare tutti Ipxe Menus"
-
-msgid "List All Modules"
-msgstr "Elencare tutti Nome Modulos"
-
-msgid "List All Printers"
-msgstr "Elencare tutti Stampantes"
-
-msgid "List All Sites"
-msgstr "Elencare tutti Sitis"
-
-msgid "List All Snapins"
-msgstr "Elencare tutti Snapins"
-
-msgid "List All Storage Groups"
-msgstr "Elencare tutti Storage Groups"
-
-msgid "List All Storage Nodes"
-msgstr "Elencare tutti Storage Nodes"
-
-msgid "List All User Groups"
-msgstr "Elencare tutti User Groups"
-
-msgid "List All Users"
-msgstr "Elencare tutti Utentes"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1914,29 +1914,25 @@ msgstr "Crea nuovo %s"
 msgid "Create New Capone"
 msgstr "Crea nuovo snapin"
 
-#, fuzzy
 msgid "Create New Group"
-msgstr "Crea nuovo %s"
+msgstr "Crea nuovo Gruppo"
 
 #, fuzzy
 msgid "Create New Hello World"
 msgstr "Crea nuovo %s"
 
-#, fuzzy
 msgid "Create New Host"
-msgstr "Crea nuovo %s"
+msgstr "Crea nuovo Host"
 
-#, fuzzy
 msgid "Create New Image"
-msgstr "Crea nuovo %s"
+msgstr "Crea nuovo Immagine"
 
 #, fuzzy
 msgid "Create New Immediate"
 msgstr "Crea nuovo %s"
 
-#, fuzzy
 msgid "Create New Ipxe Menu"
-msgstr "Crea nuovo %s"
+msgstr "Crea nuovo Ipxe Menu"
 
 #, fuzzy
 msgid "Create New LDAP Group"
@@ -1949,9 +1945,8 @@ msgstr "Crea nuova stampante"
 msgid "Create New Location"
 msgstr "Crea nuova posizione"
 
-#, fuzzy
 msgid "Create New Module"
-msgstr "Crea nuovo %s"
+msgstr "Crea nuovo Nome Modulo"
 
 #, fuzzy
 msgid "Create New OU"
@@ -1961,37 +1956,31 @@ msgstr "Crea nuovo %s"
 msgid "Create New OpenID Connect Provider"
 msgstr "Crea nuova stampante"
 
-#, fuzzy
 msgid "Create New Printer"
-msgstr "Crea nuova stampante"
+msgstr "Crea nuovo Stampante"
 
 #, fuzzy
 msgid "Create New Provider Group"
 msgstr "Crea nuovo %s"
 
-#, fuzzy
 msgid "Create New Role"
-msgstr "Crea nuovo %s"
+msgstr "Crea nuovo Nome regola"
 
 #, fuzzy
 msgid "Create New Scheduled"
 msgstr "Crea nuovo %s"
 
-#, fuzzy
 msgid "Create New Site"
-msgstr "Crea nuova stampante"
+msgstr "Crea nuovo Siti"
 
-#, fuzzy
 msgid "Create New Snapin"
-msgstr "Crea nuovo snapin"
+msgstr "Crea nuovo Snapin"
 
-#, fuzzy
 msgid "Create New Storage Group"
-msgstr "gruppo di archiviazione"
+msgstr "Crea nuovo Storage Group"
 
-#, fuzzy
 msgid "Create New Storage Node"
-msgstr "Crea nuova stampante"
+msgstr "Crea nuovo Storage Node"
 
 #, fuzzy
 msgid "Create New Subnet Group"
@@ -2005,13 +1994,11 @@ msgstr "Crea nuova stampante"
 msgid "Create New Task Type"
 msgstr "Crea nuovo %s"
 
-#, fuzzy
 msgid "Create New User"
-msgstr "Crea nuovo %s"
+msgstr "Crea nuovo Utente"
 
-#, fuzzy
 msgid "Create New User Group"
-msgstr "Crea nuovo %s"
+msgstr "Crea nuovo User Group"
 
 #, fuzzy
 msgid "Create New Windows Key"
@@ -11617,9 +11604,8 @@ msgstr ""
 #~ msgid "Latest SVN Version"
 #~ msgstr "Ultima versione di SVN"
 
-#, fuzzy
-#~ msgid "List All Roles"
-#~ msgstr "Elencare tutti %s"
+msgid "List All Roles"
+msgstr "Elencare tutti Nome regolas"
 
 #, fuzzy
 #~ msgid "List All Rules"
@@ -11936,3 +11922,43 @@ msgstr ""
 
 #~ msgid "version"
 #~ msgstr "versione"
+
+#. GH-435: seeded from this catalog's own "List All %s" /
+#. "Create New %s" and noun, so the label renders exactly as it
+#. did before those format strings became whole phrases.
+
+msgid "List All Groups"
+msgstr "Elencare tutti Gruppos"
+
+msgid "List All Hosts"
+msgstr "Elencare tutti Hosts"
+
+msgid "List All Images"
+msgstr "Elencare tutti Immagines"
+
+msgid "List All Ipxe Menus"
+msgstr "Elencare tutti Ipxe Menus"
+
+msgid "List All Modules"
+msgstr "Elencare tutti Nome Modulos"
+
+msgid "List All Printers"
+msgstr "Elencare tutti Stampantes"
+
+msgid "List All Sites"
+msgstr "Elencare tutti Sitis"
+
+msgid "List All Snapins"
+msgstr "Elencare tutti Snapins"
+
+msgid "List All Storage Groups"
+msgstr "Elencare tutti Storage Groups"
+
+msgid "List All Storage Nodes"
+msgstr "Elencare tutti Storage Nodes"
+
+msgid "List All User Groups"
+msgstr "Elencare tutti User Groups"
+
+msgid "List All Users"
+msgstr "Elencare tutti Utentes"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1898,29 +1898,25 @@ msgstr "WOL ブロードキャストを作成しますか？"
 msgid "Create New Capone"
 msgstr "新しいスナップインを作成"
 
-#, fuzzy
 msgid "Create New Group"
-msgstr "新しいグループを作成"
+msgstr "新しい グループ を作成"
 
 #, fuzzy
 msgid "Create New Hello World"
 msgstr "新しいキーを作成"
 
-#, fuzzy
 msgid "Create New Host"
-msgstr "新しい %s を作成"
+msgstr "新しい ホスト を作成"
 
-#, fuzzy
 msgid "Create New Image"
-msgstr "イメージを作成"
+msgstr "新しい イメージ を作成"
 
 #, fuzzy
 msgid "Create New Immediate"
 msgstr "新しいプリンターを作成"
 
-#, fuzzy
 msgid "Create New Ipxe Menu"
-msgstr "新しいキーを作成"
+msgstr "新しい Ipxe Menu を作成"
 
 #, fuzzy
 msgid "Create New LDAP Group"
@@ -1933,9 +1929,8 @@ msgstr "新しい LDAP を作成"
 msgid "Create New Location"
 msgstr "新しいロケーションを作成"
 
-#, fuzzy
 msgid "Create New Module"
-msgstr "新しいキーを作成"
+msgstr "新しい モジュール MD5 を作成"
 
 #, fuzzy
 msgid "Create New OU"
@@ -1952,28 +1947,24 @@ msgstr "新しいプリンターを作成"
 msgid "Create New Provider Group"
 msgstr "新しいサブネットグループを作成しますか？"
 
-#, fuzzy
 msgid "Create New Role"
-msgstr "新しいキーを作成"
+msgstr "新しい ロール を作成"
 
 #, fuzzy
 msgid "Create New Scheduled"
 msgstr "新しい電源管理スケジュールを作成"
 
-#, fuzzy
 msgid "Create New Site"
-msgstr "新しいプリンターを作成"
+msgstr "新しい サイト を作成"
 
 msgid "Create New Snapin"
 msgstr "新しいスナップインを作成"
 
-#, fuzzy
 msgid "Create New Storage Group"
-msgstr "ストレージグループを作成"
+msgstr "新しい Storage Group を作成"
 
-#, fuzzy
 msgid "Create New Storage Node"
-msgstr "ストレージノードを作成"
+msgstr "新しい Storage Node を作成"
 
 #, fuzzy
 msgid "Create New Subnet Group"
@@ -1987,13 +1978,11 @@ msgstr "タスク状態を作成"
 msgid "Create New Task Type"
 msgstr "タスクタイプを作成"
 
-#, fuzzy
 msgid "Create New User"
-msgstr "新しい %s を作成"
+msgstr "新しい ユーザー を作成"
 
-#, fuzzy
 msgid "Create New User Group"
-msgstr "新しいサブネットグループを作成しますか？"
+msgstr "新しい User Group を作成"
 
 #, fuzzy
 msgid "Create New Windows Key"
@@ -13575,3 +13564,46 @@ msgstr ""
 
 #~ msgid "would you like to install it now"
 #~ msgstr "今すぐインストールしますか？"
+
+#. GH-435: seeded from this catalog's own "List All %s" /
+#. "Create New %s" and noun, so the label renders exactly as it
+#. did before those format strings became whole phrases.
+
+msgid "List All Groups"
+msgstr "すべての グループs を一覧表示"
+
+msgid "List All Hosts"
+msgstr "すべての ホストs を一覧表示"
+
+msgid "List All Images"
+msgstr "すべての イメージs を一覧表示"
+
+msgid "List All Ipxe Menus"
+msgstr "すべての Ipxe Menus を一覧表示"
+
+msgid "List All Modules"
+msgstr "すべての モジュール MD5s を一覧表示"
+
+msgid "List All Printers"
+msgstr "すべての プリンターs を一覧表示"
+
+msgid "List All Roles"
+msgstr "すべての ロールs を一覧表示"
+
+msgid "List All Sites"
+msgstr "すべての サイトs を一覧表示"
+
+msgid "List All Snapins"
+msgstr "すべての スナップインs を一覧表示"
+
+msgid "List All Storage Groups"
+msgstr "すべての Storage Groups を一覧表示"
+
+msgid "List All Storage Nodes"
+msgstr "すべての Storage Nodes を一覧表示"
+
+msgid "List All User Groups"
+msgstr "すべての User Groups を一覧表示"
+
+msgid "List All Users"
+msgstr "すべての ユーザーs を一覧表示"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -4909,9 +4909,42 @@ msgstr "すべての %s を一覧表示"
 msgid "List All %s"
 msgstr "すべての %s を一覧表示"
 
+msgid "List All Groups"
+msgstr "すべての グループs を一覧表示"
+
+msgid "List All Hosts"
+msgstr "すべての ホストs を一覧表示"
+
+msgid "List All Images"
+msgstr "すべての イメージs を一覧表示"
+
+msgid "List All Ipxe Menus"
+msgstr "すべての Ipxe Menus を一覧表示"
+
+msgid "List All Modules"
+msgstr "すべての モジュール MD5s を一覧表示"
+
 #, fuzzy
 msgid "List All Plugins"
 msgstr "プラグインをインストール"
+
+msgid "List All Printers"
+msgstr "すべての プリンターs を一覧表示"
+
+msgid "List All Roles"
+msgstr "すべての ロールs を一覧表示"
+
+msgid "List All Sites"
+msgstr "すべての サイトs を一覧表示"
+
+msgid "List All Snapins"
+msgstr "すべての スナップインs を一覧表示"
+
+msgid "List All Storage Groups"
+msgstr "すべての Storage Groups を一覧表示"
+
+msgid "List All Storage Nodes"
+msgstr "すべての Storage Nodes を一覧表示"
 
 #, fuzzy
 msgid "List All Task States"
@@ -4920,6 +4953,12 @@ msgstr "タスク状態"
 #, fuzzy
 msgid "List All Task Types"
 msgstr "タスクタイプ"
+
+msgid "List All User Groups"
+msgstr "すべての User Groups を一覧表示"
+
+msgid "List All Users"
+msgstr "すべての ユーザーs を一覧表示"
 
 #, fuzzy
 msgid "List Available Plugins"
@@ -13564,46 +13603,3 @@ msgstr ""
 
 #~ msgid "would you like to install it now"
 #~ msgstr "今すぐインストールしますか？"
-
-#. GH-435: seeded from this catalog's own "List All %s" /
-#. "Create New %s" and noun, so the label renders exactly as it
-#. did before those format strings became whole phrases.
-
-msgid "List All Groups"
-msgstr "すべての グループs を一覧表示"
-
-msgid "List All Hosts"
-msgstr "すべての ホストs を一覧表示"
-
-msgid "List All Images"
-msgstr "すべての イメージs を一覧表示"
-
-msgid "List All Ipxe Menus"
-msgstr "すべての Ipxe Menus を一覧表示"
-
-msgid "List All Modules"
-msgstr "すべての モジュール MD5s を一覧表示"
-
-msgid "List All Printers"
-msgstr "すべての プリンターs を一覧表示"
-
-msgid "List All Roles"
-msgstr "すべての ロールs を一覧表示"
-
-msgid "List All Sites"
-msgstr "すべての サイトs を一覧表示"
-
-msgid "List All Snapins"
-msgstr "すべての スナップインs を一覧表示"
-
-msgid "List All Storage Groups"
-msgstr "すべての Storage Groups を一覧表示"
-
-msgid "List All Storage Nodes"
-msgstr "すべての Storage Nodes を一覧表示"
-
-msgid "List All User Groups"
-msgstr "すべての User Groups を一覧表示"
-
-msgid "List All Users"
-msgstr "すべての ユーザーs を一覧表示"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -4343,13 +4343,52 @@ msgstr ""
 msgid "List All %s"
 msgstr ""
 
+msgid "List All Groups"
+msgstr ""
+
+msgid "List All Hosts"
+msgstr ""
+
+msgid "List All Images"
+msgstr ""
+
+msgid "List All Ipxe Menus"
+msgstr ""
+
+msgid "List All Modules"
+msgstr ""
+
 msgid "List All Plugins"
+msgstr ""
+
+msgid "List All Printers"
+msgstr ""
+
+msgid "List All Roles"
+msgstr ""
+
+msgid "List All Sites"
+msgstr ""
+
+msgid "List All Snapins"
+msgstr ""
+
+msgid "List All Storage Groups"
+msgstr ""
+
+msgid "List All Storage Nodes"
 msgstr ""
 
 msgid "List All Task States"
 msgstr ""
 
 msgid "List All Task Types"
+msgstr ""
+
+msgid "List All User Groups"
+msgstr ""
+
+msgid "List All Users"
 msgstr ""
 
 msgid "List Available Plugins"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1973,29 +1973,25 @@ msgstr "Criar novo %s"
 msgid "Create New Capone"
 msgstr "Criar novo %s"
 
-#, fuzzy
 msgid "Create New Group"
-msgstr "Criar novo %s"
+msgstr "Criar novo Grupo"
 
 #, fuzzy
 msgid "Create New Hello World"
 msgstr "Criar novo %s"
 
-#, fuzzy
 msgid "Create New Host"
-msgstr "Criar novo %s"
+msgstr "Criar novo Anfitrião"
 
-#, fuzzy
 msgid "Create New Image"
-msgstr "Criar novo %s"
+msgstr "Criar novo Imagem"
 
 #, fuzzy
 msgid "Create New Immediate"
 msgstr "Criar novo %s"
 
-#, fuzzy
 msgid "Create New Ipxe Menu"
-msgstr "Criar novo %s"
+msgstr "Criar novo Ipxe Menu"
 
 #, fuzzy
 msgid "Create New LDAP Group"
@@ -2009,9 +2005,8 @@ msgstr "Criar novo %s"
 msgid "Create New Location"
 msgstr "Criar novo %s"
 
-#, fuzzy
 msgid "Create New Module"
-msgstr "Criar novo %s"
+msgstr "Criar novo Nome do módulo"
 
 #, fuzzy
 msgid "Create New OU"
@@ -2021,37 +2016,31 @@ msgstr "Criar novo %s"
 msgid "Create New OpenID Connect Provider"
 msgstr "Criar novo %s"
 
-#, fuzzy
 msgid "Create New Printer"
-msgstr "Criar novo %s"
+msgstr "Criar novo Impressora"
 
 #, fuzzy
 msgid "Create New Provider Group"
 msgstr "Criar novo %s"
 
-#, fuzzy
 msgid "Create New Role"
-msgstr "Criar novo %s"
+msgstr "Criar novo Nome do módulo"
 
 #, fuzzy
 msgid "Create New Scheduled"
 msgstr "Criar novo %s"
 
-#, fuzzy
 msgid "Create New Site"
-msgstr "Criar novo %s"
+msgstr "Criar novo minutos"
 
-#, fuzzy
 msgid "Create New Snapin"
-msgstr "Criar novo %s"
+msgstr "Criar novo Snapin"
 
-#, fuzzy
 msgid "Create New Storage Group"
-msgstr "Grupo de armazenamento"
+msgstr "Criar novo Storage Group"
 
-#, fuzzy
 msgid "Create New Storage Node"
-msgstr "Criar novo %s"
+msgstr "Criar novo Storage Node"
 
 #, fuzzy
 msgid "Create New Subnet Group"
@@ -2065,13 +2054,11 @@ msgstr "Criar novo %s"
 msgid "Create New Task Type"
 msgstr "Criar novo %s"
 
-#, fuzzy
 msgid "Create New User"
-msgstr "Criar novo %s"
+msgstr "Criar novo Do utilizador"
 
-#, fuzzy
 msgid "Create New User Group"
-msgstr "Criar novo %s"
+msgstr "Criar novo User Group"
 
 #, fuzzy
 msgid "Create New Windows Key"
@@ -11981,9 +11968,8 @@ msgstr ""
 #~ msgid "Latest SVN Version"
 #~ msgstr "Última versão"
 
-#, fuzzy
-#~ msgid "List All Roles"
-#~ msgstr "Listar todos os %s"
+msgid "List All Roles"
+msgstr "Listar todos os Nome do módulos"
 
 #, fuzzy
 #~ msgid "List All Rules"
@@ -12288,3 +12274,43 @@ msgstr ""
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Versão"
+
+#. GH-435: seeded from this catalog's own "List All %s" /
+#. "Create New %s" and noun, so the label renders exactly as it
+#. did before those format strings became whole phrases.
+
+msgid "List All Groups"
+msgstr "Listar todos os Grupos"
+
+msgid "List All Hosts"
+msgstr "Listar todos os Anfitriãos"
+
+msgid "List All Images"
+msgstr "Listar todos os Imagems"
+
+msgid "List All Ipxe Menus"
+msgstr "Listar todos os Ipxe Menus"
+
+msgid "List All Modules"
+msgstr "Listar todos os Nome do módulos"
+
+msgid "List All Printers"
+msgstr "Listar todos os Impressoras"
+
+msgid "List All Sites"
+msgstr "Listar todos os minutoss"
+
+msgid "List All Snapins"
+msgstr "Listar todos os Snapins"
+
+msgid "List All Storage Groups"
+msgstr "Listar todos os Storage Groups"
+
+msgid "List All Storage Nodes"
+msgstr "Listar todos os Storage Nodes"
+
+msgid "List All User Groups"
+msgstr "Listar todos os User Groups"
+
+msgid "List All Users"
+msgstr "Listar todos os Do utilizadors"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -5101,9 +5101,42 @@ msgstr "Listar todos os %s"
 msgid "List All %s"
 msgstr "Listar todos os %s"
 
+msgid "List All Groups"
+msgstr "Listar todos os Grupos"
+
+msgid "List All Hosts"
+msgstr "Listar todos os Anfitriãos"
+
+msgid "List All Images"
+msgstr "Listar todos os Imagems"
+
+msgid "List All Ipxe Menus"
+msgstr "Listar todos os Ipxe Menus"
+
+msgid "List All Modules"
+msgstr "Listar todos os Nome do módulos"
+
 #, fuzzy
 msgid "List All Plugins"
 msgstr "instalar Plugins"
+
+msgid "List All Printers"
+msgstr "Listar todos os Impressoras"
+
+msgid "List All Roles"
+msgstr "Listar todos os Nome do módulos"
+
+msgid "List All Sites"
+msgstr "Listar todos os minutoss"
+
+msgid "List All Snapins"
+msgstr "Listar todos os Snapins"
+
+msgid "List All Storage Groups"
+msgstr "Listar todos os Storage Groups"
+
+msgid "List All Storage Nodes"
+msgstr "Listar todos os Storage Nodes"
 
 #, fuzzy
 msgid "List All Task States"
@@ -5112,6 +5145,12 @@ msgstr "Unidos Task"
 #, fuzzy
 msgid "List All Task Types"
 msgstr "Tipos de tarefa"
+
+msgid "List All User Groups"
+msgstr "Listar todos os User Groups"
+
+msgid "List All Users"
+msgstr "Listar todos os Do utilizadors"
 
 #, fuzzy
 msgid "List Available Plugins"
@@ -11968,9 +12007,6 @@ msgstr ""
 #~ msgid "Latest SVN Version"
 #~ msgstr "Última versão"
 
-msgid "List All Roles"
-msgstr "Listar todos os Nome do módulos"
-
 #, fuzzy
 #~ msgid "List All Rules"
 #~ msgstr "Listar todos os %s"
@@ -12274,43 +12310,3 @@ msgstr "Listar todos os Nome do módulos"
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "Versão"
-
-#. GH-435: seeded from this catalog's own "List All %s" /
-#. "Create New %s" and noun, so the label renders exactly as it
-#. did before those format strings became whole phrases.
-
-msgid "List All Groups"
-msgstr "Listar todos os Grupos"
-
-msgid "List All Hosts"
-msgstr "Listar todos os Anfitriãos"
-
-msgid "List All Images"
-msgstr "Listar todos os Imagems"
-
-msgid "List All Ipxe Menus"
-msgstr "Listar todos os Ipxe Menus"
-
-msgid "List All Modules"
-msgstr "Listar todos os Nome do módulos"
-
-msgid "List All Printers"
-msgstr "Listar todos os Impressoras"
-
-msgid "List All Sites"
-msgstr "Listar todos os minutoss"
-
-msgid "List All Snapins"
-msgstr "Listar todos os Snapins"
-
-msgid "List All Storage Groups"
-msgstr "Listar todos os Storage Groups"
-
-msgid "List All Storage Nodes"
-msgstr "Listar todos os Storage Nodes"
-
-msgid "List All User Groups"
-msgstr "Listar todos os User Groups"
-
-msgid "List All Users"
-msgstr "Listar todos os Do utilizadors"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1973,29 +1973,25 @@ msgstr "新建%s"
 msgid "Create New Capone"
 msgstr "新建%s"
 
-#, fuzzy
 msgid "Create New Group"
-msgstr "新建%s"
+msgstr "新建组"
 
 #, fuzzy
 msgid "Create New Hello World"
 msgstr "新建%s"
 
-#, fuzzy
 msgid "Create New Host"
-msgstr "新建%s"
+msgstr "新建主办"
 
-#, fuzzy
 msgid "Create New Image"
-msgstr "新建%s"
+msgstr "新建图片"
 
 #, fuzzy
 msgid "Create New Immediate"
 msgstr "新建%s"
 
-#, fuzzy
 msgid "Create New Ipxe Menu"
-msgstr "新建%s"
+msgstr "新建Ipxe Menu"
 
 #, fuzzy
 msgid "Create New LDAP Group"
@@ -2009,9 +2005,8 @@ msgstr "新建%s"
 msgid "Create New Location"
 msgstr "新建%s"
 
-#, fuzzy
 msgid "Create New Module"
-msgstr "新建%s"
+msgstr "新建模块名称"
 
 #, fuzzy
 msgid "Create New OU"
@@ -2021,37 +2016,31 @@ msgstr "新建%s"
 msgid "Create New OpenID Connect Provider"
 msgstr "新建%s"
 
-#, fuzzy
 msgid "Create New Printer"
-msgstr "新建%s"
+msgstr "新建打印机"
 
 #, fuzzy
 msgid "Create New Provider Group"
 msgstr "新建%s"
 
-#, fuzzy
 msgid "Create New Role"
-msgstr "新建%s"
+msgstr "新建模块名称"
 
 #, fuzzy
 msgid "Create New Scheduled"
 msgstr "新建%s"
 
-#, fuzzy
 msgid "Create New Site"
-msgstr "新建%s"
+msgstr "新建分钟"
 
-#, fuzzy
 msgid "Create New Snapin"
-msgstr "新建%s"
+msgstr "新建管理单元"
 
-#, fuzzy
 msgid "Create New Storage Group"
-msgstr "存储组"
+msgstr "新建Storage Group"
 
-#, fuzzy
 msgid "Create New Storage Node"
-msgstr "新建%s"
+msgstr "新建Storage Node"
 
 #, fuzzy
 msgid "Create New Subnet Group"
@@ -2065,13 +2054,11 @@ msgstr "新建%s"
 msgid "Create New Task Type"
 msgstr "新建%s"
 
-#, fuzzy
 msgid "Create New User"
-msgstr "新建%s"
+msgstr "新建用户"
 
-#, fuzzy
 msgid "Create New User Group"
-msgstr "新建%s"
+msgstr "新建User Group"
 
 #, fuzzy
 msgid "Create New Windows Key"
@@ -11981,9 +11968,8 @@ msgstr ""
 #~ msgid "Latest SVN Version"
 #~ msgstr "最新版本"
 
-#, fuzzy
-#~ msgid "List All Roles"
-#~ msgstr "列表中的所有%s"
+msgid "List All Roles"
+msgstr "列表中的所有模块名称s"
 
 #, fuzzy
 #~ msgid "List All Rules"
@@ -12288,3 +12274,43 @@ msgstr ""
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "版"
+
+#. GH-435: seeded from this catalog's own "List All %s" /
+#. "Create New %s" and noun, so the label renders exactly as it
+#. did before those format strings became whole phrases.
+
+msgid "List All Groups"
+msgstr "列表中的所有组s"
+
+msgid "List All Hosts"
+msgstr "列表中的所有主办s"
+
+msgid "List All Images"
+msgstr "列表中的所有图片s"
+
+msgid "List All Ipxe Menus"
+msgstr "列表中的所有Ipxe Menus"
+
+msgid "List All Modules"
+msgstr "列表中的所有模块名称s"
+
+msgid "List All Printers"
+msgstr "列表中的所有打印机s"
+
+msgid "List All Sites"
+msgstr "列表中的所有分钟s"
+
+msgid "List All Snapins"
+msgstr "列表中的所有管理单元s"
+
+msgid "List All Storage Groups"
+msgstr "列表中的所有Storage Groups"
+
+msgid "List All Storage Nodes"
+msgstr "列表中的所有Storage Nodes"
+
+msgid "List All User Groups"
+msgstr "列表中的所有User Groups"
+
+msgid "List All Users"
+msgstr "列表中的所有用户s"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -5101,9 +5101,42 @@ msgstr "列表中的所有%s"
 msgid "List All %s"
 msgstr "列表中的所有%s"
 
+msgid "List All Groups"
+msgstr "列表中的所有组s"
+
+msgid "List All Hosts"
+msgstr "列表中的所有主办s"
+
+msgid "List All Images"
+msgstr "列表中的所有图片s"
+
+msgid "List All Ipxe Menus"
+msgstr "列表中的所有Ipxe Menus"
+
+msgid "List All Modules"
+msgstr "列表中的所有模块名称s"
+
 #, fuzzy
 msgid "List All Plugins"
 msgstr "安装插件"
+
+msgid "List All Printers"
+msgstr "列表中的所有打印机s"
+
+msgid "List All Roles"
+msgstr "列表中的所有模块名称s"
+
+msgid "List All Sites"
+msgstr "列表中的所有分钟s"
+
+msgid "List All Snapins"
+msgstr "列表中的所有管理单元s"
+
+msgid "List All Storage Groups"
+msgstr "列表中的所有Storage Groups"
+
+msgid "List All Storage Nodes"
+msgstr "列表中的所有Storage Nodes"
 
 #, fuzzy
 msgid "List All Task States"
@@ -5112,6 +5145,12 @@ msgstr "任务的国家"
 #, fuzzy
 msgid "List All Task Types"
 msgstr "任务类型"
+
+msgid "List All User Groups"
+msgstr "列表中的所有User Groups"
+
+msgid "List All Users"
+msgstr "列表中的所有用户s"
 
 #, fuzzy
 msgid "List Available Plugins"
@@ -11968,9 +12007,6 @@ msgstr ""
 #~ msgid "Latest SVN Version"
 #~ msgstr "最新版本"
 
-msgid "List All Roles"
-msgstr "列表中的所有模块名称s"
-
 #, fuzzy
 #~ msgid "List All Rules"
 #~ msgstr "列表中的所有%s"
@@ -12274,43 +12310,3 @@ msgstr "列表中的所有模块名称s"
 #, fuzzy
 #~ msgid "version"
 #~ msgstr "版"
-
-#. GH-435: seeded from this catalog's own "List All %s" /
-#. "Create New %s" and noun, so the label renders exactly as it
-#. did before those format strings became whole phrases.
-
-msgid "List All Groups"
-msgstr "列表中的所有组s"
-
-msgid "List All Hosts"
-msgstr "列表中的所有主办s"
-
-msgid "List All Images"
-msgstr "列表中的所有图片s"
-
-msgid "List All Ipxe Menus"
-msgstr "列表中的所有Ipxe Menus"
-
-msgid "List All Modules"
-msgstr "列表中的所有模块名称s"
-
-msgid "List All Printers"
-msgstr "列表中的所有打印机s"
-
-msgid "List All Sites"
-msgstr "列表中的所有分钟s"
-
-msgid "List All Snapins"
-msgstr "列表中的所有管理单元s"
-
-msgid "List All Storage Groups"
-msgstr "列表中的所有Storage Groups"
-
-msgid "List All Storage Nodes"
-msgstr "列表中的所有Storage Nodes"
-
-msgid "List All User Groups"
-msgstr "列表中的所有User Groups"
-
-msgid "List All Users"
-msgstr "列表中的所有用户s"

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -971,6 +971,141 @@ abstract class FOGPage extends FOGBase
     }
 
     /**
+     * The "List All X" / "Create New X" pair for one node, written out.
+     *
+     * GH-435. These used to be built by sprintf()ing a translated noun into a
+     * translated format string -- `List All %s` and `Create New %s` -- and
+     * that cannot be translated correctly, in any language that inflects.
+     *
+     * French was the report: `Creer un nouveau %s` is masculine, so
+     * `machine` and `image` (both feminine) need `une nouvelle`, and
+     * `utilisateur` needs `nouvel` before its vowel. One format string cannot
+     * be all three. `Lister tous les %s` has the same problem in the plural.
+     * German inflects the adjective the same way -- `Neue %s erstellen`
+     * should be `Neuen Benutzer erstellen` for a masculine noun.
+     *
+     * The plural was broken independently of gender: the list label appended
+     * a literal `s` to the ALREADY TRANSLATED noun, which is an English rule
+     * applied to a French, German or Japanese word. Japanese marks no plural
+     * at all, German `Rechner` is its own plural, and French nouns ending in
+     * -al take -aux.
+     *
+     * Whole phrases fix both at once, and cost nothing anywhere else: each is
+     * an ordinary literal xgettext extracts, and a translator sees the entire
+     * sentence rather than a fragment with a hole in it. The codebase already
+     * writes them this way where the string is not composed -- ImageManagement
+     * has _('Create New Image'), UserManagement has _('Create New User').
+     *
+     * Nodes NOT listed here fall back to the composed form, which is what
+     * plugins get: a plugin's node name is not knowable from here, and a
+     * plugin can ship its own catalog. The fallback is no worse for them than
+     * it was before this change.
+     *
+     * @param string $node lowercase node name
+     *
+     * @return array empty when the node has no written-out pair
+     */
+    private static function _nodeMenuStrings($node)
+    {
+        switch ($node) {
+            case 'group':
+                return ['list' => _('List All Groups'),
+                        'add' => _('Create New Group')];
+            case 'host':
+                // host and image reach here too. The switch below only INSERTS
+                // extra entries for them (Pending Hosts, Multicast Image); it
+                // never replaces the pair built here, unlike task/report/plugin
+                // which assign over it. They are also the two the GH-435 reporter
+                // actually cited -- machine and image are both feminine, so
+                // `Creer un nouveau %s` was wrong for exactly them.
+                return ['list' => _('List All Hosts'),
+                        'add' => _('Create New Host')];
+            case 'image':
+                return ['list' => _('List All Images'),
+                        'add' => _('Create New Image')];
+            case 'ipxe':
+                return ['list' => _('List All Ipxe Menus'),
+                        'add' => _('Create New Ipxe Menu')];
+            case 'module':
+                return ['list' => _('List All Modules'),
+                        'add' => _('Create New Module')];
+            case 'printer':
+                return ['list' => _('List All Printers'),
+                        'add' => _('Create New Printer')];
+            case 'role':
+                return ['list' => _('List All Roles'),
+                        'add' => _('Create New Role')];
+            case 'site':
+                return ['list' => _('List All Sites'),
+                        'add' => _('Create New Site')];
+            case 'snapin':
+                return ['list' => _('List All Snapins'),
+                        'add' => _('Create New Snapin')];
+            case 'storagegroup':
+                return ['list' => _('List All Storage Groups'),
+                        'add' => _('Create New Storage Group')];
+            case 'storagenode':
+                return ['list' => _('List All Storage Nodes'),
+                        'add' => _('Create New Storage Node')];
+            case 'user':
+                return ['list' => _('List All Users'),
+                        'add' => _('Create New User')];
+            case 'usergroup':
+                return ['list' => _('List All User Groups'),
+                        'add' => _('Create New User Group')];
+        }
+        return [];
+    }
+
+    /**
+     * sprintf() for a format string that came out of a translation catalog.
+     *
+     * The catalog is edited by translators, so this format string is not under
+     * the codebase's control -- and a bad one fails DIFFERENTLY on the two PHP
+     * versions this project supports, which is why both arms below are needed.
+     * Measured, not assumed:
+     *
+     *   PHP 8.3   sprintf('Lister 100% des %s', $n)  ArgumentCountError
+     *             sprintf('List %q of %s', $n)       ValueError
+     *   PHP 7.4   both of the above                  warning, returns false
+     *
+     * So on 8 an uncaught one takes the whole navigation menu out with a 500
+     * on every page, and on 7.4 -- the supported floor -- nothing throws at
+     * all and `false` flows on to be rendered as an empty menu label. A
+     * Throwable catch alone would silently leave the 7.4 half broken.
+     *
+     * Not hypothetical for these two strings specifically: es_ES already ships
+     * `Crear nuevo grupo` for `Create New %s`, having dropped the placeholder
+     * and hardcoded one entity's name. A catalog that can lose a specifier can
+     * just as easily gain a stray one.
+     *
+     * Falling back to the untranslated argument keeps the menu rendering. It
+     * is not a good label, but it is a legible one, and it degrades in the one
+     * language whose catalog is at fault rather than everywhere. The 7.4
+     * warning is deliberately not suppressed -- it is the only record that the
+     * catalog needs fixing.
+     *
+     * @param string $format translated format string
+     * @param string $value  already-translated noun to substitute
+     *
+     * @return string
+     */
+    private static function _composeMenuLabel($format, $value)
+    {
+        try {
+            $out = sprintf((string)$format, $value);
+        } catch (\Throwable $e) {
+            return (string)$value;
+        }
+        // The cast is the 7.4 arm, not decoration: there sprintf() returns
+        // FALSE rather than throwing, and (string)false is ''. Comparing to ''
+        // rather than to false covers both that and a catalog entry that is
+        // simply empty, and phpstan -- whose sprintf() stub returns string at
+        // every version in the configured 7.4-8.3 range -- can typecheck it.
+        return '' === (string)$out ? (string)$value : (string)$out;
+    }
+
+    /**
      * Creates the sub menu items.
      *
      * @param string $refNode The node to "append"
@@ -982,24 +1117,27 @@ abstract class FOGPage extends FOGBase
         $node = strtolower($refNode);
         $refNode = ucfirst($refNode);
         $refNode = _($refNode);
-        $menu = [];
-        $menu = [
-            /**
-             * No _() around the sprintf: $refNode was already translated on
-             * its own above, and a msgid built at runtime can never match the
-             * literal xgettext extracted -- so the outer call was a guaranteed
-             * miss that returned its own argument. Dropping it changes nothing
-             * at runtime and stops the line claiming to be translatable.
-             */
-            'list' => sprintf(
-                self::$foglang['ListAll'],
-                sprintf('%ss', $refNode)
-            ),
-            'add' => sprintf(
-                self::$foglang['CreateNew'],
-                $refNode
-            )
-        ];
+        $menu = self::_nodeMenuStrings($node);
+        if (!count($menu)) {
+            $menu = [
+                /**
+                 * No _() around the sprintf: $refNode was already translated
+                 * on its own above, and a msgid built at runtime can never
+                 * match the literal xgettext extracted -- so the outer call
+                 * was a guaranteed miss that returned its own argument.
+                 * Dropping it changes nothing at runtime and stops the line
+                 * claiming to be translatable.
+                 */
+                'list' => self::_composeMenuLabel(
+                    self::$foglang['ListAll'],
+                    sprintf('%ss', $refNode)
+                ),
+                'add' => self::_composeMenuLabel(
+                    self::$foglang['CreateNew'],
+                    $refNode
+                )
+            ];
+        }
         if (isset(self::$foglang[$refNode])) {
             $menu['export'] = self::$foglang['Export'] . ' ' . self::$foglang[$refNode];
             $menu['import'] = self::$foglang['Import'] . ' ' . self::$foglang[$refNode];

--- a/tests/menu-labels-are-whole-phrases.test.php
+++ b/tests/menu-labels-are-whole-phrases.test.php
@@ -246,9 +246,25 @@ foreach ($catalogs as $po) {
     $entries = [];
     $n = count($lines);
     for ($i = 0; $i < $n; $i++) {
-        // Live entries only. An obsolete `#~` entry is not compiled and is not
-        // shown to anyone.
+        // COMPILED entries only, which is a narrower thing than "live". An
+        // obsolete `#~` entry is not compiled, and neither is a `#, fuzzy`
+        // one -- msgfmt drops both, so gettext falls back to the msgid and
+        // nothing in either is ever shown to a user.
+        //
+        // That distinction is load-bearing here rather than pedantic. The
+        // `regenerate` job runs msgmerge on every pull request, and msgmerge
+        // FILLS an empty msgstr with a fuzzy guess: the eight `List All X`
+        // msgids this change adds came back from it holding `List All %s` in
+        // en_US. Asserting over those would fail the build for a state the
+        // catalog reaches on its own, on entries no user can see. What must
+        // never carry a %s is a CONFIRMED entry, and that is what is checked.
         if (!preg_match('/^msgid "(.*)"$/', $lines[$i], $m)) {
+            continue;
+        }
+        if ($i > 0
+            && 0 === strpos($lines[$i - 1], '#,')
+            && false !== strpos($lines[$i - 1], 'fuzzy')
+        ) {
             continue;
         }
         if (isset($lines[$i + 1])

--- a/tests/menu-labels-are-whole-phrases.test.php
+++ b/tests/menu-labels-are-whole-phrases.test.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * Gate: the node sub-menu labels are whole translatable phrases.
+ *
+ * GH-435. `List All X` / `Create New X` used to be built by sprintf()ing a
+ * translated noun into a translated format string. That cannot be translated
+ * correctly in any language that inflects: `Creer un nouveau %s` is masculine,
+ * so `machine` and `image` need `une nouvelle` and `utilisateur` needs
+ * `nouvel`. One format string cannot be all three. The list label additionally
+ * appended a literal English `s` to an already-translated noun.
+ *
+ * WHAT THIS PINS, AND WHY IN THIS SHAPE
+ *
+ * The methods are lifted out of FOGPage.php and executed, not grepped for.
+ * Grepping for the name `_nodeMenuStrings` passes when the body has been
+ * gutted, and grepping the call site passes when the call site is dead. Both
+ * bodies here are self-contained -- no $DB, no session, no FOGBase -- so
+ * running them costs nothing and is the only thing that actually goes red when
+ * a case is dropped or the degradation arm is removed.
+ *
+ * The wiring in _buildSubMenuItems() cannot be executed the same way (it needs
+ * self::$foglang and a booted class), so it is anchored as source: both the
+ * call AND the guard that keeps the composed fallback reachable for plugins.
+ * Anchoring the guard as well as the call is deliberate -- a change that keeps
+ * the call but drops `if (!count($menu))` would silently take the fallback out
+ * from under every plugin node.
+ *
+ * Usage: php tests/menu-labels-are-whole-phrases.test.php
+ * Exit 0 = clean, 1 = at least one failure.
+ */
+
+$root = dirname(__DIR__);
+$src = $root . '/packages/web/src/Base/FOGPage.php';
+$fails = [];
+
+$text = file_get_contents($src);
+if (false === $text) {
+    fwrite(STDERR, "cannot read $src\n");
+    exit(1);
+}
+
+/**
+ * Lift one method's source, brace-matched from its signature.
+ *
+ * @param string $text  file contents
+ * @param string $name  method name
+ *
+ * @return string empty when not found
+ */
+function liftMethod($text, $name)
+{
+    $at = strpos($text, ' function ' . $name . '(');
+    if (false === $at) {
+        return '';
+    }
+    $open = strpos($text, '{', $at);
+    if (false === $open) {
+        return '';
+    }
+    // Brace matching is enough here: neither method contains a brace inside a
+    // string or a comment. A method that gains one will fail loudly at eval,
+    // which is the right outcome -- it means this lift needs revisiting.
+    $depth = 0;
+    $n = strlen($text);
+    for ($i = $open; $i < $n; $i++) {
+        if ('{' === $text[$i]) {
+            $depth++;
+        } elseif ('}' === $text[$i]) {
+            $depth--;
+            if (0 === $depth) {
+                $head = strrpos(substr($text, 0, $at), "\n");
+                return substr($text, $head + 1, $i - $head);
+            }
+        }
+    }
+    return '';
+}
+
+$lifted = '';
+foreach (['_nodeMenuStrings', '_composeMenuLabel'] as $m) {
+    $body = liftMethod($text, $m);
+    if ('' === $body) {
+        $fails[] = "FOGPage::$m() not found -- GH-435 wiring removed?";
+        continue;
+    }
+    $lifted .= $body . "\n";
+}
+
+if (count($fails)) {
+    foreach ($fails as $f) {
+        echo "FAIL: $f\n";
+    }
+    exit(1);
+}
+
+// `_()` is gettext, which is not loaded in a bare CLI test and would translate
+// against the test runner's own locale if it were. Identity keeps the
+// assertions about the msgids the source actually passes.
+if (!function_exists('_')) {
+    /**
+     * Stand-in for gettext.
+     *
+     * @param string $s msgid
+     *
+     * @return string
+     */
+    function _($s)
+    {
+        return $s;
+    }
+}
+
+eval('class MenuProbe { ' . $lifted . ' 
+    public static function strings($n) { return self::_nodeMenuStrings($n); }
+    public static function compose($f, $v) { return self::_composeMenuLabel($f, $v); }
+}');
+
+/*
+ * Every node whose pair must be written out. This list is the point of the
+ * change: these are core nodes, so their labels are ours to get right, and a
+ * node dropped from the switch silently goes back to the composed form.
+ */
+$nodes = [
+    'group' => 'Group', 'host' => 'Host', 'image' => 'Image',
+    'ipxe' => 'Ipxe Menu', 'module' => 'Module', 'printer' => 'Printer',
+    'role' => 'Role', 'site' => 'Site', 'snapin' => 'Snapin',
+    'storagegroup' => 'Storage Group', 'storagenode' => 'Storage Node',
+    'user' => 'User', 'usergroup' => 'User Group',
+];
+
+$msgids = [];
+foreach ($nodes as $node => $noun) {
+    $pair = MenuProbe::strings($node);
+    if (!isset($pair['list'], $pair['add'])) {
+        $fails[] = "node '$node' has no written-out label pair";
+        continue;
+    }
+    // The msgid must be the whole phrase. A pair that still carries a %s is
+    // the composed form wearing a switch case.
+    foreach ($pair as $which => $phrase) {
+        if (false !== strpos($phrase, '%')) {
+            $fails[] = "node '$node' $which label '$phrase' still has a placeholder";
+        }
+    }
+    if (false === strpos($pair['add'], $noun)) {
+        $fails[] = "node '$node' add label '{$pair['add']}' does not name '$noun'";
+    }
+    $msgids[] = $pair['list'];
+    $msgids[] = $pair['add'];
+}
+
+/*
+ * Plugins are NOT in the switch and must keep the composed fallback: a
+ * plugin's node name is not knowable from core, and a plugin ships its own
+ * catalog. A `default:` arm added to the switch would break every one of them.
+ */
+if ([] !== MenuProbe::strings('helloworld')) {
+    $fails[] = 'unknown node did not fall through to the composed form';
+}
+
+/*
+ * The catalog is edited by translators, so the format string in the fallback
+ * is not under the codebase's control -- and a bad one fails DIFFERENTLY on
+ * the two PHP versions this project supports. PHP 8 throws (ArgumentCountError
+ * for a stray %, ValueError for an unknown specifier); 7.4 warns and returns
+ * false. Uncaught, that is a 500 on every page on 8 and an empty menu label on
+ * 7.4, so both arms are needed and both are exercised here.
+ *
+ * Not hypothetical: es_ES shipped `Crear nuevo grupo` for `Create New %s`,
+ * having dropped the placeholder entirely.
+ */
+$degrade = [
+    'stray percent' => 'Lister 100% des %s',
+    'unknown specifier' => 'List %q of %s',
+    'no placeholder at all' => 'Crear nuevo grupo',
+];
+foreach ($degrade as $why => $format) {
+    // @ suppresses only the 7.4 warning, which is real output, not the value
+    // under test. The assertion is on what comes back.
+    $got = @MenuProbe::compose($format, 'Hosts');
+    if ('' === (string)$got || false === $got) {
+        $fails[] = "compose() returned nothing for a $why catalog format";
+    }
+}
+if ('List All Hosts' !== MenuProbe::compose('List All %s', 'Hosts')) {
+    $fails[] = 'compose() broke the ordinary substitution';
+}
+
+/*
+ * The degrade loop above covers BOTH arms, but only when both interpreters
+ * run it. PHP 8 sprintf() never returns false -- it throws -- so on 8.3 the
+ * catch handles every case and deleting the `false === $out` arm leaves every
+ * assertion green; mutation-checked on this box, which has only 8.3. The
+ * suite runs on 7.4 as well (`fogproject / tests (PHP 7.4)` is one of the
+ * required contexts), and there it is the reverse: nothing throws, sprintf
+ * returns false, and that arm is the only thing between a bad catalog and an
+ * empty menu label.
+ *
+ * So the loop is the real gate and this is the half of it 8.3 cannot see.
+ * Anchored on the whole statement rather than the method name, because a name
+ * survives the body being gutted.
+ */
+$compose = liftMethod($text, '_composeMenuLabel');
+if (false === strpos($compose, "return '' === (string)\$out ? (string)\$value : (string)\$out;")) {
+    $fails[] = 'compose() lost the PHP 7.4 arm -- sprintf() returns false there, '
+        . 'it does not throw, so the catch alone leaves 7.4 broken';
+}
+
+/*
+ * The wiring. _buildSubMenuItems() must call the switch AND must keep the
+ * composed fallback reachable behind an emptiness guard.
+ */
+$build = liftMethod($text, '_buildSubMenuItems');
+if ('' === $build) {
+    $fails[] = 'FOGPage::_buildSubMenuItems() not found';
+} else {
+    if (false === strpos($build, '_nodeMenuStrings(')) {
+        $fails[] = '_buildSubMenuItems() no longer calls _nodeMenuStrings()';
+    }
+    if (false === strpos($build, 'if (!count($menu))')) {
+        $fails[] = '_buildSubMenuItems() lost the fallback guard for plugin nodes';
+    }
+    if (false === strpos($build, '_composeMenuLabel(')) {
+        $fails[] = '_buildSubMenuItems() no longer composes safely for plugin nodes';
+    }
+}
+
+/*
+ * Catalog side. Two separate claims:
+ *
+ *  - fr_FR and es_ES were hand-written for GH-435, so an empty msgstr there is
+ *    a regression to English on the very locales the issue was raised about.
+ *  - NO locale may render a literal %s. Those msgids predate this change and
+ *    several catalogs held `Neue %s erstellen` under msgid `Create New Host`,
+ *    from a fuzzy match somebody accepted. That IS the user-visible bug.
+ */
+$catalogs = glob($root . '/packages/web/management/languages/*.UTF-8/LC_MESSAGES/messages.po');
+if (count($catalogs) < 2) {
+    $fails[] = 'no gettext catalogs found to check';
+}
+$handWritten = ['fr_FR', 'es_ES'];
+foreach ($catalogs as $po) {
+    preg_match('#/([^/]+)\.UTF-8/#', $po, $lm);
+    $locale = $lm[1] ?? $po;
+    $lines = file($po, FILE_IGNORE_NEW_LINES);
+    $entries = [];
+    $n = count($lines);
+    for ($i = 0; $i < $n; $i++) {
+        // Live entries only. An obsolete `#~` entry is not compiled and is not
+        // shown to anyone.
+        if (!preg_match('/^msgid "(.*)"$/', $lines[$i], $m)) {
+            continue;
+        }
+        if (isset($lines[$i + 1])
+            && preg_match('/^msgstr "(.*)"$/', $lines[$i + 1], $s)
+        ) {
+            $entries[stripcslashes($m[1])] = stripcslashes($s[1]);
+        }
+    }
+    foreach ($msgids as $msgid) {
+        if (!array_key_exists($msgid, $entries)) {
+            continue;
+        }
+        $str = $entries[$msgid];
+        if (false !== strpos($str, '%s')) {
+            $fails[] = "$locale renders a literal %s for '$msgid'";
+        }
+        if (in_array($locale, $handWritten, true) && '' === $str) {
+            $fails[] = "$locale lost its hand-written translation of '$msgid'";
+        }
+    }
+    foreach ($handWritten as $hw) {
+        if ($locale !== $hw) {
+            continue;
+        }
+        foreach ($msgids as $msgid) {
+            if (!array_key_exists($msgid, $entries)) {
+                $fails[] = "$locale has no entry for '$msgid'";
+            }
+        }
+    }
+}
+
+/*
+ * The only two CONFIRMED translations these msgids had before GH-435. Every
+ * other `Create New X` entry in every catalog was `#, fuzzy` -- msgmerge's
+ * guess, excluded from the compiled .mo, never seen by anyone, and frequently
+ * nonsense (de_DE offered "Neuen Drucker erstellen", Create New PRINTER, for
+ * `Create New Storage Node`). The migration composes over fuzzy entries for
+ * that reason, and these two are what it must NOT touch: they are a person's
+ * work, and they read better than anything composition produces -- no space
+ * around the noun, which is correct Japanese.
+ */
+$confirmed = [
+    'Create New Printer' => '新しいプリンターを作成',
+    'Create New Snapin' => '新しいスナップインを作成',
+];
+$ja = $root . '/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po';
+$jaText = file_get_contents($ja);
+foreach ($confirmed as $msgid => $msgstr) {
+    $want = 'msgid "' . $msgid . '"' . "\n" . 'msgstr "' . $msgstr . '"';
+    if (false === strpos((string)$jaText, $want)) {
+        $fails[] = "ja_JP lost its confirmed translation of '$msgid'";
+    }
+}
+
+if (count($fails)) {
+    foreach ($fails as $f) {
+        echo "FAIL: $f\n";
+    }
+    echo count($fails) . " failure(s)\n";
+    exit(1);
+}
+
+echo 'OK: ' . count($msgids) . " menu labels are whole phrases, "
+    . count($catalogs) . " catalogs clean\n";
+exit(0);


### PR DESCRIPTION
Closes #435.

## The bug

Every node's sub-menu built its two entries by `sprintf()`ing a translated noun into a translated format string:

```php
'list' => sprintf(self::$foglang['ListAll'], sprintf('%ss', $refNode)),
'add'  => sprintf(self::$foglang['CreateNew'], $refNode)
```

That cannot be translated correctly in any language that inflects.

**Gender.** French `Créer un nouveau %s` is masculine. `machine` and `image` are feminine and need `une nouvelle`; `utilisateur` is masculine but vowel-initial and needs `nouvel`. One format string cannot be all three. German has the same problem — `Neue %s erstellen` needs `Neuen` before a masculine noun.

**Plural.** Independently broken: the list label appended a literal `s` to the *already translated* noun. That is an English rule applied to a French, German or Japanese word. Japanese marks no plural at all; German `Rechner` is its own plural.

## The change

`FOGPage::_nodeMenuStrings()` returns the whole phrase for each of the thirteen core nodes, so a translator sees a complete sentence instead of a fragment with a hole in it. This is already how the codebase writes these strings where they are not composed — `ImageManagement` has `_('Create New Image')`, `UserManagement` has `_('Create New User')`.

Plugins keep the composed fallback: a plugin's node name is not knowable from core, and a plugin ships its own catalog. It is no worse for them than before, and it is now *safe* — `_composeMenuLabel()` handles a bad catalog format string, which **throws on PHP 8 and returns `false` on 7.4**, so both arms are needed. Not hypothetical: `es_ES` shipped `Crear nuevo grupo` for `Create New %s`, having dropped the placeholder entirely.

## Why the catalog diff is large

All thirteen `Create New X` msgids already existed in all nine catalogs — and **every one was `#, fuzzy`**. Fuzzy entries are `msgmerge`'s unconfirmed guesses and are excluded from the compiled `.mo`, so nothing in one had ever been shown to a user. Several were nonsense:

| catalog | msgid | msgstr | means |
|---|---|---|---|
| de_DE | `Create New Storage Node` | `Neuen Drucker erstellen` | Create New **Printer** |
| de_DE | `Create New Group` | `Neuen Schlüssel erstellen` | Create New **Key** |
| es_ES | *all thirteen* | `Crear nuevo grupo` | Create New **Group** |

Making these msgids live for the first time without addressing that would have promoted nine catalogs' worth of unreviewed guesses into text users finally see.

So `bin/migrate-menu-translations.php` composes each new msgstr from **that catalog's own** format string and noun, reproducing exactly what the page rendered before. No locale regresses to English. Where a catalog never translated the noun either (`Storage Group`, `iPXE Menu`, …) it composes with the English noun, which is what shipped — and better than what shipped, since the old code passed `_(ucfirst($node))` and rendered `Alle Storagegroups auflisten`, a word in no language.

The two genuinely confirmed translations in the whole set — `ja_JP`'s `Create New Printer` and `Create New Snapin` — are preserved byte for byte. The test pins that.

**French and Spanish are hand-written on top**, because for those two what the page rendered before *is* the bug. Spanish was the worse: a Spanish user on the host page was told they were creating a group. Their bare nouns were damaged the same way and are corrected too — French `Site` read "minutes", Spanish `Site` read "minutos", and `Role` and `Module` both read "Nombre del módulo".

A msgstr still carrying a literal `%s` after all that is blanked rather than guessed at, so gettext falls back to the English msgid: the wrong language, but a real phrase rather than a placeholder on screen.

Grammar that composition cannot fix is left as composition produced it — German `Neue Host erstellen` should be `Neuen`. That is now a one-line fix a German speaker can make against a whole sentence, which is the entire point of the change.

## Test

`tests/menu-labels-are-whole-phrases.test.php` **lifts both new methods out of `FOGPage.php` and executes them** rather than grepping for their names — a name survives its body being gutted.

Eight mutations were run; all eight go red:

| mutation | result |
|---|---|
| drop `case 'host':` | `node 'host' has no written-out label pair` |
| add a `default:` arm (would break every plugin) | `unknown node did not fall through to the composed form` |
| remove the `Throwable` catch | fatal, exit 255 |
| remove the PHP 7.4 arm | `compose() lost the PHP 7.4 arm` |
| drop the `if (!count($menu))` fallback guard | `lost the fallback guard for plugin nodes` |
| reintroduce a literal `%s` to de_DE | `de_DE renders a literal %s for 'Create New Host'` |
| blank a hand-written French entry | `fr_FR lost its hand-written translation` |
| overwrite a confirmed Japanese entry | `ja_JP lost its confirmed translation` |

One assertion is a source anchor rather than a behavioral one, and the file says why: PHP 8 `sprintf()` never returns `false`, so on 8.3 — the only interpreter on this box — deleting the 7.4 arm leaves every behavioral assertion green. CI runs the suite on 7.4 as well, where the degrade loop covers it properly.

## Verification

- `tests/run-all.sh`: **265 passed, 0 failed**
- `phpstan analyse` and `phpstan analyse -c phpstan-tests.neon`: **no errors**
- `msgfmt --check-format` on all nine catalogs: clean
- migration re-run on a clean checkout is idempotent

## Notes

- `messages.pot` does not yet carry the new msgids; `bin/fetch-plugins.sh` has not been run in this worktree so the hook's regeneration refuses (ADR 0009, correctly). The `regenerate` job covers it — and it will pick them up, since they are ordinary literals in the source now.
- `bin/migrate-menu-translations.php` ships alongside `import-core-classes.php`, `namespace-fog-classes.php` and `prefix-global-classes.php`, which are one-shot migrations kept for the same reason: it is the only readable record of how 350 lines of catalog diff were derived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uy6adEBWi2ytXsuxKMqgFN