### PR TITLE
Read the tasking form's account as a string, not as NULL

### DIFF
--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -1565,8 +1565,29 @@ abstract class FOGPage extends FOGBase
             $TaskType = new TaskType($type);
             /**
              * Account Setup.
+             *
+             * Cast, because filter_input() answers NULL for a POST key that
+             * is not there -- and only a password reset task's form carries
+             * `account`. That NULL used to be harmless: PDODB cleared
+             * sql_mode on every connection, so the server quietly coerced it
+             * to '' on the way into `tasks`.`taskPassreset`, which is
+             * varchar(250) NOT NULL. GH-1245 removed the clear, so the same
+             * NULL is now
+             *
+             *   SQLSTATE[23000]: 1048 Column 'taskPassreset' cannot be null
+             *
+             * and the whole statement is refused. It bites a GROUP task and
+             * not a single-host one because Group::createImagePackage()
+             * batch-inserts a fixed column list that always names passreset,
+             * while Host::createImagePackage() only sets it when it holds
+             * something. Reported on forum topic 18232 against group
+             * multicast; group deploy takes the same path.
+             *
+             * trim() as well, so an account of nothing but spaces is caught
+             * by the emptiness check below rather than stored. Same
+             * expression working-1.6 already uses.
              */
-            $passreset = filter_input(INPUT_POST, 'account');
+            $passreset = trim((string)filter_input(INPUT_POST, 'account'));
             /**
              * Snapin Setup.
              */

--- a/tests/group-tasking-passreset-never-null.test.php
+++ b/tests/group-tasking-passreset-never-null.test.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * A group task must not bind NULL into `tasks`.`taskPassreset`.
+ *
+ * Forum topic 18232. Creating a multicast deployment for a GROUP fails
+ * before PXE with "Failed to create tasking" and:
+ *
+ *   SQLSTATE[23000]: Integrity constraint violation: 1048 Column
+ *   'taskPassreset' cannot be null
+ *
+ * Three things have to line up, and only the last of them is new:
+ *
+ *  - `account` is posted only by a password reset task's form, and
+ *    filter_input() answers NULL -- not '' -- for a POST key that is not
+ *    there. So every other task type carried a NULL in $passreset.
+ *  - Group::createImagePackage() batch-inserts a FIXED column list which
+ *    always names passreset, so that NULL is always bound. The single-host
+ *    path is unaffected because Host::createImagePackage() only sets the
+ *    field when it holds something, which is why the report is about groups.
+ *  - GH-1245 removed PDODB's `SET SESSION sql_mode=''`. For nine years the
+ *    server silently coerced the NULL to '' on the way into a varchar(250)
+ *    NOT NULL column; without the clear it refuses the statement instead.
+ *
+ * That last point is the whole reason this reproduces on dev-branch and not
+ * on the 1.5.10 release, which is exactly what the reporter observed. It is
+ * a NULL that was always wrong and was always being covered up.
+ *
+ * WHAT THIS PINS, and what it deliberately does not. The fault is a single
+ * expression inside FOGPage::_tasking(), which is private, several hundred
+ * lines long, and cannot be reached without a live database, a valid image,
+ * a storage group and an optimal node -- none of which the fault has
+ * anything to do with. So the expression is pinned as SOURCE, whole, rather
+ * than by grepping for a function name that would still match a rewritten
+ * line. The two facts that make it matter -- the column cannot hold NULL,
+ * and the batch always names it -- are asserted separately, so a future
+ * change to either fails here and this test gets revisited rather than
+ * silently guarding nothing.
+ *
+ * Usage: php tests/group-tasking-passreset-never-null.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$web = dirname(__DIR__) . '/packages/web';
+$failures = [];
+$checks = 0;
+
+/**
+ * Records one assertion.
+ *
+ * @param string $label what is being asserted
+ * @param bool   $cond  the assertion
+ *
+ * @return void
+ */
+function check($label, $cond)
+{
+    global $failures, $checks;
+    ++$checks;
+    if (!$cond) {
+        $failures[] = $label;
+    }
+}
+
+// -------------------------------------------------------------------------
+// 1. The fix itself.
+// -------------------------------------------------------------------------
+$page = (string)file_get_contents($web . '/lib/fog/fogpage.class.php');
+
+check(
+    'the tasking form reads `account` as a string, never as NULL',
+    (bool)preg_match(
+        '/\$passreset\s*=\s*trim\(\s*\(string\)\s*'
+        . 'filter_input\(\s*INPUT_POST\s*,\s*\'account\'\s*\)\s*\)\s*;/',
+        $page
+    )
+);
+// The bare form is the bug. Named separately so a partial revert -- a cast
+// with no trim, a trim with no cast -- is reported as what it is rather
+// than as the check above simply not matching.
+check(
+    'and the uncast form is gone',
+    !preg_match(
+        '/\$passreset\s*=\s*filter_input\(\s*INPUT_POST\s*,\s*\'account\'\s*\)\s*;/',
+        $page
+    )
+);
+
+// -------------------------------------------------------------------------
+// 2. Why it matters: the batch always binds the column.
+//
+//    If a later change stops naming passreset in these lists the NULL can no
+//    longer reach the server and this test is guarding nothing -- so the
+//    premise is asserted rather than assumed.
+// -------------------------------------------------------------------------
+$group = (string)file_get_contents($web . '/lib/fog/group.class.php');
+
+preg_match_all(
+    '/\$batchFields\s*=\s*array\((.*?)\);/s',
+    $group,
+    $lists
+);
+$binding = 0;
+foreach ((array)$lists[1] as $list) {
+    if (false !== strpos($list, "'passreset'")) {
+        ++$binding;
+    }
+}
+check(
+    'group tasking still batch-inserts passreset unconditionally',
+    $binding > 0
+);
+
+// -------------------------------------------------------------------------
+// 3. And why NULL is refused: the column cannot hold one.
+// -------------------------------------------------------------------------
+$schema = (string)file_get_contents($web . '/commons/schema.php');
+check(
+    'tasks.taskPassreset is declared NOT NULL',
+    (bool)preg_match(
+        '/`taskPassreset`\s*"\s*\.\s*"\s*varchar\(250\)\s*NOT\s+NULL/i',
+        $schema
+    )
+);
+
+// -------------------------------------------------------------------------
+if (count($failures) > 0) {
+    fwrite(STDERR, sprintf("FAIL (%d of %d):\n", count($failures), $checks));
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+printf("ok  %d checks passed\n", $checks);
+exit(0);


### PR DESCRIPTION
Fixes the group-tasking failure reported on [forums #18232](https://forums.fogproject.org/topic/18232/group-multicast-dev-branch):

```
Tasking Failed / Failed to create tasking

Failed to query: Error: SQLSTATE[23000]: Integrity constraint violation: 1048
Column 'taskPassreset' cannot be null
Debug: SQL: INSERT INTO tasks (taskName,taskCreateBy,taskHostID,taskForce,taskStateID,
taskTypeID,taskNFSGroupID,taskNFSMemberID,taskWOL,taskImageID,taskShutdown,taskIsDebug,
taskPassreset,taskLastMemberID) VALUES (:name_0,…,:passreset_0,…),(:name_1,…)
```

The reporter's other observation is the one that explains it: the same server, same image
and same host group work on the **stable** branch and fail only here.

## Why

Three things line up, and only the last of them is new.

1. `account` is posted only by a **password reset** task's form, and `filter_input()`
   answers `NULL` — not `''` — for a POST key that is not there. Every other task type has
   been carrying a `NULL` in `$passreset` all along.
2. `Group::createImagePackage()` batch-inserts a **fixed** column list that always names
   `passreset`, so that `NULL` is always bound. `Host::createImagePackage()` only sets the
   field when it holds something — which is why a single host is fine and a group is not,
   and why the report is specifically about groups. (Group deploy takes the same path as
   group multicast; both field lists name it.)
3. **GH-1245 removed PDODB's `SET SESSION sql_mode=''`.** For nine years that clear was what
   made the server quietly coerce the `NULL` to `''` on the way into
   `tasks`.`taskPassreset`, `varchar(250) NOT NULL`. Without it the server refuses the
   statement outright.

So the `NULL` was always wrong and the `sql_mode` clear was covering it up. That is precisely
why stable looks fine — it is not a regression in the tasking code, it is a nine-year-old
bug that stopped being invisible.

## The fix

One line, and it is the expression `working-1.6` already uses in `GroupManagement`:

```php
$passreset = trim((string)filter_input(INPUT_POST, 'account'));
```

`trim()` as well as the cast, so an account of nothing but spaces is caught by the emptiness
check a few lines down (`Password reset requires a user account to reset`) rather than stored.

Checked the rest of the batch while I was there: `$wol`, `$enableShutdown` and `$enableDebug`
are plain booleans initialized to `false`, so `$passreset` was the only value that could
arrive as `NULL`.

## Test

`tests/group-tasking-passreset-never-null.test.php` pins the whole expression as **source**.
`FOGPage::_tasking()` is private, several hundred lines long, and cannot be reached without a
live database, a valid image, a storage group and an optimal node — none of which the fault
has anything to do with — and this branch has no fake-database harness. So the two facts that
make the expression matter are asserted separately instead of assumed: the batch still names
`passreset`, and `tasks`.`taskPassreset` is still declared `NOT NULL`. If either changes, this
test fails and gets revisited rather than silently guarding nothing.

Mutation-tested: restoring the bare `filter_input()` fails two of the four checks. Full PHP
suite green locally.

## Not working-1.6

`working-1.6` already casts (`GroupManagement.php`), so it does not have this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144vtTvLgBYS6NC7dYgxp2f