### PR TITLE
Cast request input before handing it to a string function

### DIFF
--- a/packages/web/maintenance/create_update_node.php
+++ b/packages/web/maintenance/create_update_node.php
@@ -50,7 +50,7 @@ foreach ((array)$_POST as $key => &$val) {
         continue;
     }
     $stripped[$key] = trim(
-        base64_decode(filter_input(INPUT_POST, $key))
+        base64_decode((string)filter_input(INPUT_POST, $key))
     );
     unset($val);
 }

--- a/packages/web/src/Base/FOGPagePost.php
+++ b/packages/web/src/Base/FOGPagePost.php
@@ -420,7 +420,7 @@ trait FOGPagePost
     protected function validateScheduleType()
     {
         $scheduleType = strtolower(
-            filter_input(INPUT_POST, 'scheduleType')
+            (string)filter_input(INPUT_POST, 'scheduleType')
         );
         $scheduleTypes = [
             'cron',

--- a/packages/web/src/Boot/Registration.php
+++ b/packages/web/src/Boot/Registration.php
@@ -166,7 +166,7 @@ class Registration extends FOGBase
     {
         try {
             $stripped = self::stripAndDecode($_POST);
-            $productKey = trim(filter_var($stripped['productKey'] ?? '', FILTER_UNSAFE_RAW));
+            $productKey = trim((string)filter_var($stripped['productKey'] ?? '', FILTER_UNSAFE_RAW));
             if ($productKey !== '' && !preg_match('/^[A-Za-z0-9\\-]{1,29}$/', $productKey)) {
                 throw new \Exception(_('Invalid product key supplied'));
             }
@@ -492,7 +492,7 @@ class Registration extends FOGBase
                 ->addGroup($groupsToJoin)
                 ->addPriMAC($this->PriMAC);
             if ($prodkeyget > 0) {
-                $productKey = trim(filter_var($stripped['productKey'] ?? '', FILTER_UNSAFE_RAW));
+                $productKey = trim((string)filter_var($stripped['productKey'] ?? '', FILTER_UNSAFE_RAW));
                 if ($productKey !== '' && !preg_match('/^[A-Za-z0-9\\-]{1,29}$/', $productKey)) {
                     throw new \Exception(_('Invalid product key supplied'));
                 }
@@ -549,7 +549,7 @@ class Registration extends FOGBase
                 ->addPriMAC($this->PriMAC)
                 ->addMAC($this->MACs);
             if ($prodkeyget > 0) {
-                $productKey = trim(filter_var($stripped['productKey'] ?? '', FILTER_UNSAFE_RAW));
+                $productKey = trim((string)filter_var($stripped['productKey'] ?? '', FILTER_UNSAFE_RAW));
                 if ($productKey !== '' && !preg_match('/^[A-Za-z0-9\\-]{1,29}$/', $productKey)) {
                     throw new \Exception(_('Invalid product key supplied'));
                 }

--- a/packages/web/src/Pages/FOGConfigurationPage.php
+++ b/packages/web/src/Pages/FOGConfigurationPage.php
@@ -1580,7 +1580,7 @@ class FOGConfigurationPage extends FOGPage
     {
         self::checkAuthAndCSRF();
         $dstName = filter_input(INPUT_POST, 'dstName');
-        $file = trim(base64_decode(filter_input(INPUT_POST, 'file')));
+        $file = trim(base64_decode((string)filter_input(INPUT_POST, 'file')));
         // With Secure Boot signing configured, a KERNEL download has to land in
         // the staging directory the root signing helper works on -- the helper
         // takes no arguments, so the path is how it is told what to sign.
@@ -3480,7 +3480,7 @@ class FOGConfigurationPage extends FOGPage
                 $id = self::_settingIdFor($key);
                 $Setting = Route::getItem('setting', $id);
                 if (!isset($_FILES[$key]) || !$_FILES[$key]) {
-                    $set = trim(filter_var($val));
+                    $set = trim((string)filter_var($val));
                 }
                 if (!$Setting) {
                     continue;

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -999,51 +999,51 @@ class HostManagement extends FOGPage
             _('Host Create Fail'),
             function (&$serverFault) {
                 $host = trim(
-                    filter_input(INPUT_POST, 'host')
+                    (string)filter_input(INPUT_POST, 'host')
                 );
                 $mac = trim(
-                    filter_input(INPUT_POST, 'mac')
+                    (string)filter_input(INPUT_POST, 'mac')
                 );
                 $description = trim(
-                    filter_input(INPUT_POST, 'description')
+                    (string)filter_input(INPUT_POST, 'description')
                 );
                 $password = trim(
-                    filter_input(INPUT_POST, 'domainpassword')
+                    (string)filter_input(INPUT_POST, 'domainpassword')
                 );
                 $useAD = (int)isset($_POST['domain']);
                 $domain = trim(
-                    filter_input(INPUT_POST, 'domainname')
+                    (string)filter_input(INPUT_POST, 'domainname')
                 );
                 $ou = trim(
-                    filter_input(INPUT_POST, 'ou')
+                    (string)filter_input(INPUT_POST, 'ou')
                 );
                 $user = trim(
-                    filter_input(INPUT_POST, 'domainuser')
+                    (string)filter_input(INPUT_POST, 'domainuser')
                 );
                 $pass = $password;
                 $key = trim(
-                    filter_input(INPUT_POST, 'key')
+                    (string)filter_input(INPUT_POST, 'key')
                 );
                 $productKey = self::productKeyResolve($key, '');
                 $enforce = filter_has_var(INPUT_POST, 'enforce') ? 1 : 0;
                 $image = (int)filter_input(INPUT_POST, 'image');
                 $kernel = trim(
-                    filter_input(INPUT_POST, 'kernel')
+                    (string)filter_input(INPUT_POST, 'kernel')
                 );
                 $kernelArgs = trim(
-                    filter_input(INPUT_POST, 'args')
+                    (string)filter_input(INPUT_POST, 'args')
                 );
                 $kernelDevice = trim(
-                    filter_input(INPUT_POST, 'dev')
+                    (string)filter_input(INPUT_POST, 'dev')
                 );
                 $init = trim(
-                    filter_input(INPUT_POST, 'init')
+                    (string)filter_input(INPUT_POST, 'init')
                 );
                 $bootTypeExit = trim(
-                    filter_input(INPUT_POST, 'bootTypeExit')
+                    (string)filter_input(INPUT_POST, 'bootTypeExit')
                 );
                 $efiBootTypeExit = trim(
-                    filter_input(INPUT_POST, 'efiBootTypeExit')
+                    (string)filter_input(INPUT_POST, 'efiBootTypeExit')
                 );
 
                 $exists = self::getClass('HostManager')
@@ -1642,38 +1642,38 @@ class HostManagement extends FOGPage
     {
         self::checkAuthAndCSRF();
         $host = trim(
-            filter_input(INPUT_POST, 'host')
+            (string)filter_input(INPUT_POST, 'host')
         );
         $description = trim(
-            filter_input(INPUT_POST, 'description')
+            (string)filter_input(INPUT_POST, 'description')
         );
         $imageID = trim(
-            filter_input(INPUT_POST, 'image')
+            (string)filter_input(INPUT_POST, 'image')
         );
         $key = trim(
-            filter_input(INPUT_POST, 'key')
+            (string)filter_input(INPUT_POST, 'key')
         );
         $productKey = self::productKeyResolve(
             $key,
             $this->obj->get('productKey')
         );
         $kernel = trim(
-            filter_input(INPUT_POST, 'kernel')
+            (string)filter_input(INPUT_POST, 'kernel')
         );
         $args = trim(
-            filter_input(INPUT_POST, 'args')
+            (string)filter_input(INPUT_POST, 'args')
         );
         $dev = trim(
-            filter_input(INPUT_POST, 'dev')
+            (string)filter_input(INPUT_POST, 'dev')
         );
         $init = trim(
-            filter_input(INPUT_POST, 'init')
+            (string)filter_input(INPUT_POST, 'init')
         );
         $bte = trim(
-            filter_input(INPUT_POST, 'bootTypeExit')
+            (string)filter_input(INPUT_POST, 'bootTypeExit')
         );
         $ebte = trim(
-            filter_input(INPUT_POST, 'efiBootTypeExit')
+            (string)filter_input(INPUT_POST, 'efiBootTypeExit')
         );
         $enforce = filter_has_var(INPUT_POST, 'enforce') ? 1 : 0;
         // The blank "- Please select -" option means "not recorded", which is
@@ -1983,7 +1983,7 @@ class HostManagement extends FOGPage
         self::checkAuthAndCSRF();
         if (isset($_POST['macadd'])) {
             $mac = trim(
-                filter_input(
+                (string)filter_input(
                     INPUT_POST,
                     'newMac'
                 )
@@ -2251,16 +2251,16 @@ class HostManagement extends FOGPage
         self::checkAuthAndCSRF();
         $useAD = isset($_POST['domain']);
         $domain = trim(
-            filter_input(INPUT_POST, 'domainname')
+            (string)filter_input(INPUT_POST, 'domainname')
         );
         $ou = trim(
-            filter_input(INPUT_POST, 'ou')
+            (string)filter_input(INPUT_POST, 'ou')
         );
         $user = trim(
-            filter_input(INPUT_POST, 'domainuser')
+            (string)filter_input(INPUT_POST, 'domainuser')
         );
         $pass = trim(
-            filter_input(INPUT_POST, 'domainpassword')
+            (string)filter_input(INPUT_POST, 'domainpassword')
         );
         $this->obj->setAD(
             $useAD,
@@ -2979,37 +2979,37 @@ class HostManagement extends FOGPage
         if (isset($_POST['pmadd']) || isset($_POST['pmaddod'])) {
             $onDemand = (int)isset($_POST['pmaddod']);
             $min = trim(
-                filter_input(
+                (string)filter_input(
                     INPUT_POST,
                     'scheduleCronMin'
                 )
             );
             $hour = trim(
-                filter_input(
+                (string)filter_input(
                     INPUT_POST,
                     'scheduleCronHour'
                 )
             );
             $dom = trim(
-                filter_input(
+                (string)filter_input(
                     INPUT_POST,
                     'scheduleCronDOM'
                 )
             );
             $month = trim(
-                filter_input(
+                (string)filter_input(
                     INPUT_POST,
                     'scheduleCronMonth'
                 )
             );
             $dow = trim(
-                filter_input(
+                (string)filter_input(
                     INPUT_POST,
                     'scheduleCronDOW'
                 )
             );
             $action = trim(
-                filter_input(
+                (string)filter_input(
                     INPUT_POST,
                     'action'
                 )
@@ -4787,7 +4787,7 @@ class HostManagement extends FOGPage
             }
             // Password reset setup
             $passreset = trim(
-                filter_input(INPUT_POST, 'account')
+                (string)filter_input(INPUT_POST, 'account')
             );
             if (TaskType::PASSWORD_RESET == $TaskType->id
                 && !$passreset

--- a/packages/web/src/Pages/ImageManagement.php
+++ b/packages/web/src/Pages/ImageManagement.php
@@ -426,36 +426,36 @@ class ImageManagement extends FOGPage
             _('Image Create Fail'),
             function (&$serverFault) {
                 $image = trim(
-                    filter_input(INPUT_POST, 'image')
+                    (string)filter_input(INPUT_POST, 'image')
                 );
                 $description = trim(
-                    filter_input(INPUT_POST, 'description')
+                    (string)filter_input(INPUT_POST, 'description')
                 );
                 $storagegroup = (int)trim(
-                    filter_input(INPUT_POST, 'storagegroup')
+                    (string)filter_input(INPUT_POST, 'storagegroup')
                 );
                 if (!$storagegroup) {
                     $storagegroup = @min(Route::getIds('storagegroup', false));
                 }
                 $os = (int)trim(
-                    filter_input(INPUT_POST, 'os')
+                    (string)filter_input(INPUT_POST, 'os')
                 );
                 $path = trim(
-                    filter_input(INPUT_POST, 'path')
+                    (string)filter_input(INPUT_POST, 'path')
                 );
                 $imagetype = (int)trim(
-                    filter_input(INPUT_POST, 'imagetype')
+                    (string)filter_input(INPUT_POST, 'imagetype')
                 );
                 $imagepartitiontype = (int)trim(
-                    filter_input(INPUT_POST, 'imagepartitiontype')
+                    (string)filter_input(INPUT_POST, 'imagepartitiontype')
                 );
                 $isEnabled = (int)isset($_POST['isEnabled']);
                 $toReplicate = (int)isset($_POST['toReplicate']);
                 $compress = (int)trim(
-                    filter_input(INPUT_POST, 'compression')
+                    (string)filter_input(INPUT_POST, 'compression')
                 );
                 $imagemanage = (int)trim(
-                    filter_input(INPUT_POST, 'imagemanage')
+                    (string)filter_input(INPUT_POST, 'imagemanage')
                 );
                 $exists = self::getClass('ImageManager')
                     ->exists($image);
@@ -845,22 +845,22 @@ class ImageManagement extends FOGPage
     {
         self::checkAuthAndCSRF();
         $image = trim(
-            filter_input(INPUT_POST, 'image')
+            (string)filter_input(INPUT_POST, 'image')
         );
         $description = trim(
-            filter_input(INPUT_POST, 'description')
+            (string)filter_input(INPUT_POST, 'description')
         );
         $osID = (int)trim(
-            filter_input(INPUT_POST, 'os')
+            (string)filter_input(INPUT_POST, 'os')
         );
         $path = trim(
-            filter_input(INPUT_POST, 'path')
+            (string)filter_input(INPUT_POST, 'path')
         );
         $itID = (int)trim(
-            filter_input(INPUT_POST, 'imagetype')
+            (string)filter_input(INPUT_POST, 'imagetype')
         );
         $iptID = (int)trim(
-            filter_input(INPUT_POST, 'imagepartitiontype')
+            (string)filter_input(INPUT_POST, 'imagepartitiontype')
         );
         // The blank "- Please select -" option means "not recorded", which is
         // a real value here and not the absence of one: Architecture::canRun()
@@ -876,13 +876,13 @@ class ImageManagement extends FOGPage
         $toReplicate = (int)isset($_POST['toReplicate']);
         $exists = self::getClass('ImageManager')->exists($image);
         $compress = (int)trim(
-            filter_input(INPUT_POST, 'compression')
+            (string)filter_input(INPUT_POST, 'compression')
         );
         if ($this->obj->get('name') != $image && $exists) {
             throw new \Exception(_('An image with this name already exists!'));
         }
         $imagemanage = (int)trim(
-            filter_input(INPUT_POST, 'imagemanage')
+            (string)filter_input(INPUT_POST, 'imagemanage')
         );
         $this->obj
             ->set('name', $image)
@@ -1908,16 +1908,16 @@ class ImageManagement extends FOGPage
     public function sessionCreate()
     {
         $sessionname = trim(
-            filter_input(INPUT_POST, 'sessionname')
+            (string)filter_input(INPUT_POST, 'sessionname')
         );
         $image = (int)trim(
-            filter_input(INPUT_POST, 'image')
+            (string)filter_input(INPUT_POST, 'image')
         );
         $sessiontimeout = (int)trim(
-            filter_input(INPUT_POST, 'sessiontimeout')
+            (string)filter_input(INPUT_POST, 'sessiontimeout')
         );
         $sessioncount = (int)trim(
-            filter_input(INPUT_POST, 'sessioncount')
+            (string)filter_input(INPUT_POST, 'sessioncount')
         );
         $sessionshutdown = (int)isset($_POST['sessionshutdown']);
         if (!$image) {

--- a/packages/web/src/Pages/IpxeManagement.php
+++ b/packages/web/src/Pages/IpxeManagement.php
@@ -243,24 +243,24 @@ class IpxeManagement extends FOGPage
             _('iPXE Menu Create Fail'),
             function (&$serverFault) {
                 $ipxe = trim(
-                    filter_input(INPUT_POST, 'ipxe')
+                    (string)filter_input(INPUT_POST, 'ipxe')
                 );
                 $description = trim(
-                    filter_input(INPUT_POST, 'description')
+                    (string)filter_input(INPUT_POST, 'description')
                 );
                 $params = trim(
-                    filter_input(INPUT_POST, 'params')
+                    (string)filter_input(INPUT_POST, 'params')
                 );
                 $options = trim(
-                    filter_input(INPUT_POST, 'options')
+                    (string)filter_input(INPUT_POST, 'options')
                 );
                 $regmenu = trim(
-                    filter_input(INPUT_POST, 'regmenu')
+                    (string)filter_input(INPUT_POST, 'regmenu')
                 );
                 $default = isset($_POST['default']);
                 $hotkey = isset($_POST['hotkey']);
                 $keysequence = trim(
-                    filter_input(INPUT_POST, 'keysequence')
+                    (string)filter_input(INPUT_POST, 'keysequence')
                 );
                 $exists = self::getClass('PXEMenuOptionsManager')
                     ->exists($ipxe);
@@ -472,24 +472,24 @@ class IpxeManagement extends FOGPage
     {
         self::checkAuthAndCSRF();
         $ipxe = trim(
-            filter_input(INPUT_POST, 'ipxe')
+            (string)filter_input(INPUT_POST, 'ipxe')
         );
         $description = trim(
-            filter_input(INPUT_POST, 'description')
+            (string)filter_input(INPUT_POST, 'description')
         );
         $params = trim(
-            filter_input(INPUT_POST, 'params')
+            (string)filter_input(INPUT_POST, 'params')
         );
         $options = trim(
-            filter_input(INPUT_POST, 'options')
+            (string)filter_input(INPUT_POST, 'options')
         );
         $regmenu = trim(
-            filter_input(INPUT_POST, 'regmenu')
+            (string)filter_input(INPUT_POST, 'regmenu')
         );
         $default = isset($_POST['default']);
         $hotkey = isset($_POST['hotkey']);
         $keysequence = trim(
-            filter_input(INPUT_POST, 'keysequence')
+            (string)filter_input(INPUT_POST, 'keysequence')
         );
         $exists = self::getClass('PXEMenuOptionsManager')
             ->exists($ipxe);

--- a/packages/web/src/Pages/ModuleManagement.php
+++ b/packages/web/src/Pages/ModuleManagement.php
@@ -169,13 +169,13 @@ class ModuleManagement extends FOGPage
             _('Module Create Fail'),
             function (&$serverFault) {
                 $module = trim(
-                    filter_input(INPUT_POST, 'module')
+                    (string)filter_input(INPUT_POST, 'module')
                 );
                 $description = trim(
-                    filter_input(INPUT_POST, 'description')
+                    (string)filter_input(INPUT_POST, 'description')
                 );
                 $shortname = trim(
-                    filter_input(INPUT_POST, 'shortname')
+                    (string)filter_input(INPUT_POST, 'shortname')
                 );
                 $isDefault = (int)isset($_POST['isDefault']);
                 $exists = self::getClass('ModuleManager')
@@ -318,13 +318,13 @@ class ModuleManagement extends FOGPage
     {
         self::checkAuthAndCSRF();
         $module = trim(
-            filter_input(INPUT_POST, 'module')
+            (string)filter_input(INPUT_POST, 'module')
         );
         $description = trim(
-            filter_input(INPUT_POST, 'description')
+            (string)filter_input(INPUT_POST, 'description')
         );
         $shortname = trim(
-            filter_input(INPUT_POST, 'shortname')
+            (string)filter_input(INPUT_POST, 'shortname')
         );
         $isDefault = (int)isset($_POST['isDefault']);
         if ($module != $this->obj->get('name')) {

--- a/packages/web/src/Pages/RoleManagement.php
+++ b/packages/web/src/Pages/RoleManagement.php
@@ -184,10 +184,10 @@ class RoleManagement extends FOGPage
             _('Role Create Fail'),
             function (&$serverFault) {
                 $role = trim(
-                    filter_input(INPUT_POST, 'role')
+                    (string)filter_input(INPUT_POST, 'role')
                 );
                 $description = trim(
-                    filter_input(INPUT_POST, 'description')
+                    (string)filter_input(INPUT_POST, 'description')
                 );
                 $exists = self::getClass('RoleManager')
                     ->exists($role);
@@ -286,10 +286,10 @@ class RoleManagement extends FOGPage
     {
         self::checkAuthAndCSRF();
         $role = trim(
-            filter_input(INPUT_POST, 'role')
+            (string)filter_input(INPUT_POST, 'role')
         );
         $description = trim(
-            filter_input(INPUT_POST, 'description')
+            (string)filter_input(INPUT_POST, 'description')
         );
 
         $exists = self::getClass('RoleManager')

--- a/packages/web/src/Pages/SiteManagement.php
+++ b/packages/web/src/Pages/SiteManagement.php
@@ -144,10 +144,10 @@ class SiteManagement extends FOGPage
             _('Site Create Fail'),
             function (&$serverFault) {
                 $site = trim(
-                    filter_input(INPUT_POST, 'site')
+                    (string)filter_input(INPUT_POST, 'site')
                 );
                 $description = trim(
-                    filter_input(INPUT_POST, 'description')
+                    (string)filter_input(INPUT_POST, 'description')
                 );
                 // `sites`.`siteName` is UNIQUE, and save() builds an
                 // INSERT ... ON DUPLICATE KEY UPDATE -- so without this
@@ -302,10 +302,10 @@ class SiteManagement extends FOGPage
     {
         self::checkAuthAndCSRF();
         $site = trim(
-            filter_input(INPUT_POST, 'site')
+            (string)filter_input(INPUT_POST, 'site')
         );
         $description = trim(
-            filter_input(INPUT_POST, 'description')
+            (string)filter_input(INPUT_POST, 'description')
         );
 
         // Same silent-overwrite guard as addPost(); a rename onto an

--- a/packages/web/src/Pages/SnapinManagement.php
+++ b/packages/web/src/Pages/SnapinManagement.php
@@ -241,7 +241,7 @@ class SnapinManagement extends FOGPage
         $description = filter_input(INPUT_POST, 'description');
         $storagegroup = filter_input(INPUT_POST, 'storagegroup');
         $snapinfileexist = basename(
-            filter_input(INPUT_POST, 'snapinfileexist')
+            (string)filter_input(INPUT_POST, 'snapinfileexist')
         );
         $packtype = (int)filter_input(INPUT_POST, 'packtype');
         $rw = filter_input(INPUT_POST, 'rw');
@@ -680,7 +680,7 @@ class SnapinManagement extends FOGPage
             $this->obj->get('packtype')
         );
         $snapinfileexists = basename(
-            filter_input(INPUT_POST, 'snapinfileexist') ?:
+            (string)filter_input(INPUT_POST, 'snapinfileexist') ?:
             $this->obj->get('file')
         );
         $rw = (
@@ -1112,13 +1112,13 @@ class SnapinManagement extends FOGPage
     public function snapinGeneralPost()
     {
         self::checkAuthAndCSRF();
-        $snapin = trim(filter_input(INPUT_POST, 'snapin'));
-        $description = trim(filter_input(INPUT_POST, 'description'));
-        $packtype = trim(filter_input(INPUT_POST, 'packtype'));
-        $runWith = trim(filter_input(INPUT_POST, 'rw'));
-        $runWithArgs = trim(filter_input(INPUT_POST, 'rwa'));
+        $snapin = trim((string)filter_input(INPUT_POST, 'snapin'));
+        $description = trim((string)filter_input(INPUT_POST, 'description'));
+        $packtype = trim((string)filter_input(INPUT_POST, 'packtype'));
+        $runWith = trim((string)filter_input(INPUT_POST, 'rw'));
+        $runWithArgs = trim((string)filter_input(INPUT_POST, 'rwa'));
         $snapinfile = basename(
-            trim(filter_input(INPUT_POST, 'snapinfileexist'))
+            trim((string)filter_input(INPUT_POST, 'snapinfileexist'))
         );
         $uploadfile = basename(
             trim($_FILES['snapinfile']['name'])
@@ -1130,9 +1130,9 @@ class SnapinManagement extends FOGPage
         $isEnabled = (int)isset($_POST['isEnabled']);
         $toReplicate = (int)isset($_POST['toReplicate']);
         $hide = (int)isset($_POST['isHidden']);
-        $timeout = trim(filter_input(INPUT_POST, 'timeout'));
-        $action = trim(filter_input(INPUT_POST, 'action'));
-        $args = trim(filter_input(INPUT_POST, 'args'));
+        $timeout = trim((string)filter_input(INPUT_POST, 'timeout'));
+        $action = trim((string)filter_input(INPUT_POST, 'action'));
+        $args = trim((string)filter_input(INPUT_POST, 'args'));
 
         $exists = self::getClass('SnapinManager')
             ->exists($snapin);

--- a/packages/web/src/Pages/StorageGroupManagement.php
+++ b/packages/web/src/Pages/StorageGroupManagement.php
@@ -146,13 +146,13 @@ class StorageGroupManagement extends FOGPage
         header('Content-Type: application/json');
         self::$HookManager->processEvent('STORAGEGROUP_ADD_POST');
         $storagegroup = trim(
-            filter_input(INPUT_POST, 'storagegroup')
+            (string)filter_input(INPUT_POST, 'storagegroup')
         );
         $description = trim(
-            filter_input(INPUT_POST, 'description')
+            (string)filter_input(INPUT_POST, 'description')
         );
         $trustedcidrs = trim(
-            filter_input(INPUT_POST, 'trustedcidrs')
+            (string)filter_input(INPUT_POST, 'trustedcidrs')
         );
 
         $serverFault = false;
@@ -304,13 +304,13 @@ class StorageGroupManagement extends FOGPage
     {
         self::checkAuthAndCSRF();
         $storagegroup = trim(
-            filter_input(INPUT_POST, 'storagegroup')
+            (string)filter_input(INPUT_POST, 'storagegroup')
         );
         $description = trim(
-            filter_input(INPUT_POST, 'description')
+            (string)filter_input(INPUT_POST, 'description')
         );
         $trustedcidrs = trim(
-            filter_input(INPUT_POST, 'trustedcidrs')
+            (string)filter_input(INPUT_POST, 'trustedcidrs')
         );
 
         $exists = self::getClass('StorageGroupManager')

--- a/packages/web/src/Pages/StorageNodeManagement.php
+++ b/packages/web/src/Pages/StorageNodeManagement.php
@@ -436,61 +436,61 @@ class StorageNodeManagement extends FOGPage
         self::$HookManager->processEvent('STORAGENODE_ADD_POST');
         // Setup and filter our vars.
         $storagenode = trim(
-            filter_input(INPUT_POST, 'storagenode')
+            (string)filter_input(INPUT_POST, 'storagenode')
         );
         $ip = trim(
-            filter_input(INPUT_POST, 'ip')
+            (string)filter_input(INPUT_POST, 'ip')
         );
         $maxClients = (int)trim(
-            filter_input(INPUT_POST, 'maxClients')
+            (string)filter_input(INPUT_POST, 'maxClients')
         );
         $interface = trim(
-            filter_input(INPUT_POST, 'interface')
+            (string)filter_input(INPUT_POST, 'interface')
         );
         $user = trim(
-            filter_input(INPUT_POST, 'user')
+            (string)filter_input(INPUT_POST, 'user')
         );
         $pass = trim(
-            filter_input(INPUT_POST, 'pass')
+            (string)filter_input(INPUT_POST, 'pass')
         );
         $bandwidth = trim(
-            filter_input(INPUT_POST, 'bandwidth')
+            (string)filter_input(INPUT_POST, 'bandwidth')
         );
         $description = trim(
-            filter_input(INPUT_POST, 'description')
+            (string)filter_input(INPUT_POST, 'description')
         );
         $webroot = trim(
-            filter_input(INPUT_POST, 'webroot')
+            (string)filter_input(INPUT_POST, 'webroot')
         );
         $isen = (int)isset($_POST['isEnabled']);
         $isgren = (int)isset($_POST['isGraphEnabled']);
         $isMaster = (int)isset($_POST['isMaster']);
         $storagegroupID = (int)trim(
-            filter_input(INPUT_POST, 'storagegroupID')
+            (string)filter_input(INPUT_POST, 'storagegroupID')
         );
         if (!$storagegroupID) {
             $storagegroupID = @min(Route::getIds('storagegroup', false));
         }
         $graphcolor = trim(
-            filter_input(INPUT_POST, 'graphcolor')
+            (string)filter_input(INPUT_POST, 'graphcolor')
         );
         $path = trim(
-            filter_input(INPUT_POST, 'path')
+            (string)filter_input(INPUT_POST, 'path')
         );
         $ftppath = trim(
-            filter_input(INPUT_POST, 'ftppath')
+            (string)filter_input(INPUT_POST, 'ftppath')
         );
         $snapinpath = trim(
-            filter_input(INPUT_POST, 'snapinpath')
+            (string)filter_input(INPUT_POST, 'snapinpath')
         );
         $sslpath = trim(
-            filter_input(INPUT_POST, 'sslpath')
+            (string)filter_input(INPUT_POST, 'sslpath')
         );
         $bitrate = trim(
-            filter_input(INPUT_POST, 'bitrate')
+            (string)filter_input(INPUT_POST, 'bitrate')
         );
         $helloInterval = (int)trim(
-            filter_input(INPUT_POST, 'helloInterval')
+            (string)filter_input(INPUT_POST, 'helloInterval')
         );
 
         $serverFault = false;
@@ -1098,22 +1098,22 @@ class StorageNodeManagement extends FOGPage
         self::checkAuthAndCSRF();
         // Setup and filter our vars.
         $storagenode = trim(
-            filter_input(INPUT_POST, 'storagenode')
+            (string)filter_input(INPUT_POST, 'storagenode')
         );
         $ip = trim(
-            filter_input(INPUT_POST, 'ip')
+            (string)filter_input(INPUT_POST, 'ip')
         );
         $maxClients = (int)trim(
-            filter_input(INPUT_POST, 'maxClients')
+            (string)filter_input(INPUT_POST, 'maxClients')
         );
         $interface = trim(
-            filter_input(INPUT_POST, 'interface')
+            (string)filter_input(INPUT_POST, 'interface')
         );
         $user = trim(
-            filter_input(INPUT_POST, 'user')
+            (string)filter_input(INPUT_POST, 'user')
         );
         $pass = trim(
-            filter_input(INPUT_POST, 'pass')
+            (string)filter_input(INPUT_POST, 'pass')
         );
         // Three unrelated things can fail here -- the node can be off the
         // network, its SSH service can refuse the handshake, or the account
@@ -1161,43 +1161,43 @@ class StorageNodeManagement extends FOGPage
             }
         }
         $bandwidth = trim(
-            filter_input(INPUT_POST, 'bandwidth')
+            (string)filter_input(INPUT_POST, 'bandwidth')
         );
         $description = trim(
-            filter_input(INPUT_POST, 'description')
+            (string)filter_input(INPUT_POST, 'description')
         );
         $webroot = trim(
-            filter_input(INPUT_POST, 'webroot')
+            (string)filter_input(INPUT_POST, 'webroot')
         );
         $isen = (int)isset($_POST['isEnabled']);
         $isgren = (int)isset($_POST['isGraphEnabled']);
         $isMaster = (int)isset($_POST['isMaster']);
         $graphcolor = trim(
-            filter_input(INPUT_POST, 'graphcolor')
+            (string)filter_input(INPUT_POST, 'graphcolor')
         );
         $storagegroupID = (int)trim(
-            filter_input(INPUT_POST, 'storagegroupID')
+            (string)filter_input(INPUT_POST, 'storagegroupID')
         );
         if (!$storagegroupID) {
             $storagegroupID = @min(Route::getIds('storagegroup', false));
         }
         $path = trim(
-            filter_input(INPUT_POST, 'path')
+            (string)filter_input(INPUT_POST, 'path')
         );
         $ftppath = trim(
-            filter_input(INPUT_POST, 'ftppath')
+            (string)filter_input(INPUT_POST, 'ftppath')
         );
         $snapinpath = trim(
-            filter_input(INPUT_POST, 'snapinpath')
+            (string)filter_input(INPUT_POST, 'snapinpath')
         );
         $sslpath = trim(
-            filter_input(INPUT_POST, 'sslpath')
+            (string)filter_input(INPUT_POST, 'sslpath')
         );
         $bitrate = trim(
-            filter_input(INPUT_POST, 'bitrate')
+            (string)filter_input(INPUT_POST, 'bitrate')
         );
         $helloInterval = (int)trim(
-            filter_input(INPUT_POST, 'helloInterval')
+            (string)filter_input(INPUT_POST, 'helloInterval')
         );
         if (!$storagenode) {
             throw new \Exception(self::$foglang['StorageNameRequired']);

--- a/packages/web/src/Pages/UserGroupManagement.php
+++ b/packages/web/src/Pages/UserGroupManagement.php
@@ -138,10 +138,10 @@ class UserGroupManagement extends FOGPage
             _('User Group Create Fail'),
             function (&$serverFault) {
                 $usergroup = trim(
-                    filter_input(INPUT_POST, 'usergroup')
+                    (string)filter_input(INPUT_POST, 'usergroup')
                 );
                 $description = trim(
-                    filter_input(INPUT_POST, 'description')
+                    (string)filter_input(INPUT_POST, 'description')
                 );
                 $exists = self::getClass('UserGroupManager')
                     ->exists($usergroup);
@@ -241,10 +241,10 @@ class UserGroupManagement extends FOGPage
     {
         self::checkAuthAndCSRF();
         $usergroup = trim(
-            filter_input(INPUT_POST, 'usergroup')
+            (string)filter_input(INPUT_POST, 'usergroup')
         );
         $description = trim(
-            filter_input(INPUT_POST, 'description')
+            (string)filter_input(INPUT_POST, 'description')
         );
 
         $exists = self::getClass('UserGroupManager')

--- a/packages/web/src/Pages/UserManagement.php
+++ b/packages/web/src/Pages/UserManagement.php
@@ -302,7 +302,7 @@ class UserManagement extends FOGPage
             . _('It must be between 3 and 50 characters.');
         $user = strtolower(
             trim(
-                filter_input(INPUT_POST, 'user')
+                (string)filter_input(INPUT_POST, 'user')
             )
         );
         // Cast before trim(). The API-only toggle DISABLES this field, and a
@@ -314,7 +314,7 @@ class UserManagement extends FOGPage
             (string)filter_input(INPUT_POST, 'password')
         );
         $friendly = trim(
-            filter_input(INPUT_POST, 'display')
+            (string)filter_input(INPUT_POST, 'display')
         );
         $apien = (int)isset($_POST['apienabled']);
         $apionly = (int)isset($_POST['apionly']);
@@ -618,11 +618,11 @@ class UserManagement extends FOGPage
             . _('It must be between 3 and 50 characters.');
         $user = strtolower(
             trim(
-                filter_input(INPUT_POST, 'user')
+                (string)filter_input(INPUT_POST, 'user')
             )
         );
         $display = trim(
-            filter_input(INPUT_POST, 'display')
+            (string)filter_input(INPUT_POST, 'display')
         );
         if (!preg_match($userPat, $user)) {
             throw new \Exception($userErr);
@@ -794,7 +794,7 @@ class UserManagement extends FOGPage
             );
         }
         $password = trim(
-            filter_input(INPUT_POST, 'password')
+            (string)filter_input(INPUT_POST, 'password')
         );
         $this->obj
             ->set('password', $password);
@@ -1354,7 +1354,7 @@ class UserManagement extends FOGPage
         // target with this one, so the discriminator is gone with it.
         $apien = (int)isset($_POST['apienabled']);
         $apitoken = base64_decode(
-            filter_input(INPUT_POST, 'apitoken')
+            (string)filter_input(INPUT_POST, 'apitoken')
         );
         $this->obj
             ->set('api', $apien)

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -1799,7 +1799,7 @@ class Route extends FOGBase
     private static function _testToken()
     {
         $passtoken = base64_decode(
-            filter_input(INPUT_SERVER, 'HTTP_FOG_API_TOKEN')
+            (string)filter_input(INPUT_SERVER, 'HTTP_FOG_API_TOKEN')
         );
         $passtoken = trim($passtoken);
         if (hash_equals((string)self::$_token, (string)$passtoken)) {
@@ -2050,7 +2050,7 @@ class Route extends FOGBase
     private static function _testAuth()
     {
         $usertoken = base64_decode(
-            filter_input(INPUT_SERVER, 'HTTP_FOG_USER_TOKEN')
+            (string)filter_input(INPUT_SERVER, 'HTTP_FOG_USER_TOKEN')
         );
         $usertoken = trim($usertoken);
         $pwtoken = self::getClass('User')

--- a/tests/request-input-is-cast-before-string-use.test.php
+++ b/tests/request-input-is-cast-before-string-use.test.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * A request value goes into a string function as a string, never as null.
+ *
+ * `filter_input()` answers **null** for a key that is not in the request --
+ * not '' -- and `filter_var()` answers **false** for a value it rejects. PHP
+ * 8.1 deprecated passing null to a non-nullable parameter of an internal
+ * function, so `trim(filter_input(INPUT_POST, 'account'))` emits
+ *
+ *   Deprecated: trim(): Passing null to parameter #1 ($string) of type
+ *   string is deprecated
+ *
+ * on every server running 8.1 or newer -- which is most of them. FOG buffers
+ * its own output through `Initiator::sanitizeOutput()`, so a deprecation
+ * raised mid-page is emitted into the response body ahead of whatever the
+ * page was building, and on an AJAX endpoint that is a JSON reply the
+ * browser cannot parse.
+ *
+ * The runtime VALUE is unaffected -- PHP still coerces the null to '' -- so
+ * every one of these sites has always produced the right answer, which is
+ * exactly why the shape spread to 153 call sites without anyone noticing.
+ * The cast is not a behavior change; it is the same coercion written down,
+ * which is the same argument GH-1245 made about `sql_mode`.
+ *
+ * IT IS NOT ALWAYS COSMETIC, and forum topic 18232 is the proof. On
+ * dev-branch the tasking form read `account` with a bare `filter_input()`
+ * and no trim at all, so the null was not coerced by anything -- it went
+ * straight into `Group::createImagePackage()`'s batch insert and hit
+ * `tasks`.`taskPassreset`, which is NOT NULL:
+ *
+ *   SQLSTATE[23000]: 1048 Column 'taskPassreset' cannot be null
+ *
+ * and no group could be tasked at all. Once the value escapes the string
+ * function the coercion that was hiding the null is gone. That is the case
+ * this test exists to make impossible to reintroduce.
+ *
+ * WHAT IS SCANNED. Core only. `packages/web/lib/plugins` is not repo source
+ * -- it is the installed artifact of the fog-plugins release (ADR 0009), is
+ * gitignored, and has its own repository and its own pull requests; a test
+ * here cannot fix it and must not fail on it. `packages/web/vendor` is other
+ * people's code.
+ *
+ * HOW. Tokens, not a regex. Nearly every site in this tree is written over
+ * three lines --
+ *
+ *     $ip = trim(
+ *         filter_input(INPUT_POST, 'ip')
+ *     );
+ *
+ * -- so a line-oriented pattern sees none of them, and an argument in the
+ * second position (`explode(',', filter_input(...))`) needs the enclosing
+ * call to be tracked rather than the preceding characters. The walk keeps a
+ * stack of enclosing calls, which answers both.
+ *
+ * Usage: php tests/request-input-is-cast-before-string-use.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+
+/*
+ * Functions whose relevant parameter is declared `string` and which FOG
+ * actually calls on request data. Deliberately a list rather than
+ * reflection over every internal function: the point is to name the ones in
+ * use, so that adding a call to something else is a decision someone makes
+ * here rather than a silent gap.
+ *
+ * str_replace() and preg_replace() accept array|string, but filter_input()
+ * only returns an array when asked with FILTER_REQUIRE_ARRAY, which nothing
+ * in core does -- and filter_input_array() is a different function this does
+ * not match. So they belong on the list.
+ */
+$stringFns = array_flip(
+    [
+        'trim', 'ltrim', 'rtrim', 'strtolower', 'strtoupper', 'strlen',
+        'substr', 'str_replace', 'preg_replace', 'preg_match', 'preg_split',
+        'explode', 'ucfirst', 'ucwords', 'htmlspecialchars', 'htmlentities',
+        'base64_decode', 'base64_encode', 'str_split', 'strrev', 'nl2br',
+        'urldecode', 'urlencode', 'rawurldecode', 'md5', 'sha1', 'hash',
+        'strip_tags', 'addslashes', 'str_pad', 'wordwrap', 'strpos',
+        'stripos', 'strstr', 'str_contains', 'str_starts_with',
+        'str_ends_with', 'strcmp', 'strcasecmp', 'implode', 'password_verify',
+        'escapeshellarg', 'basename', 'dirname', 'pathinfo', 'mb_strlen',
+        'mb_substr', 'mb_strtolower', 'mb_strtoupper', 'preg_quote',
+        'strtotime', 'html_entity_decode', 'stripslashes', 'str_repeat',
+        'substr_count', 'json_decode', 'number_format', 'str_word_count',
+    ]
+);
+
+$paths = [
+    '/packages/web/src',
+    '/packages/web/commons',
+    '/packages/web/api',
+    '/packages/web/management',
+    '/packages/web/client',
+    '/packages/web/maintenance',
+    '/packages/web/status',
+    '/packages/web/lib/router',
+    '/packages/service',
+];
+
+$casts = [
+    T_STRING_CAST, T_INT_CAST, T_BOOL_CAST, T_DOUBLE_CAST, T_ARRAY_CAST,
+];
+
+$findings = [];
+$scanned = 0;
+
+foreach ($paths as $sub) {
+    $dir = $root . $sub;
+    if (!is_dir($dir)) {
+        continue;
+    }
+    $it = new \RecursiveIteratorIterator(
+        new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+    );
+    foreach ($it as $file) {
+        if ($file->getExtension() !== 'php') {
+            continue;
+        }
+        $path = $file->getPathname();
+        if (preg_match('#/(vendor|plugins)/#', $path)) {
+            continue;
+        }
+        $src = (string)file_get_contents($path);
+        if (false === strpos($src, 'filter_input')
+            && false === strpos($src, 'filter_var')
+        ) {
+            continue;
+        }
+        ++$scanned;
+        $tokens = token_get_all($src);
+
+        // Significant tokens only, so whitespace and comments cannot hide
+        // the shape of a call.
+        $sig = [];
+        foreach ($tokens as $i => $t) {
+            if (is_array($t)
+                && in_array(
+                    $t[0],
+                    [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT],
+                    true
+                )
+            ) {
+                continue;
+            }
+            $sig[] = $i;
+        }
+
+        $stack = [];
+        foreach ($sig as $p => $i) {
+            $t = $tokens[$i];
+            $text = is_array($t) ? $t[1] : $t;
+
+            if ('(' === $text) {
+                // The name in front of the paren, when there is one, is the
+                // call this argument list belongs to.
+                $callee = null;
+                if ($p >= 1) {
+                    $prev = $tokens[$sig[$p - 1]];
+                    if (is_array($prev) && T_STRING === $prev[0]) {
+                        $callee = strtolower($prev[1]);
+                    }
+                }
+                $stack[] = $callee;
+                continue;
+            }
+            if (')' === $text) {
+                array_pop($stack);
+                continue;
+            }
+            if (!is_array($t) || T_STRING !== $t[0]) {
+                continue;
+            }
+            $name = strtolower($t[1]);
+            if ('filter_input' !== $name && 'filter_var' !== $name) {
+                continue;
+            }
+            // A call, not a bare mention of the name.
+            if (!isset($sig[$p + 1])) {
+                continue;
+            }
+            $next = $tokens[$sig[$p + 1]];
+            if ('(' !== (is_array($next) ? $next[1] : $next)) {
+                continue;
+            }
+            // Guarded already.
+            if ($p >= 1) {
+                $prev = $tokens[$sig[$p - 1]];
+                if (is_array($prev) && in_array($prev[0], $casts, true)) {
+                    continue;
+                }
+            }
+            $enclosing = end($stack);
+            if (false === $enclosing || null === $enclosing) {
+                continue;
+            }
+            if (!isset($stringFns[$enclosing])) {
+                continue;
+            }
+            $findings[] = sprintf(
+                '%s:%d  %s(%s(...))',
+                ltrim(str_replace($root, '', $path), '/'),
+                $t[2],
+                $enclosing,
+                $name
+            );
+        }
+    }
+}
+
+/*
+ * The scan finding nothing because it looked at nothing is the failure this
+ * test could not otherwise report. Core reads request input in dozens of
+ * files, so a run that opened none of them means the paths above are wrong.
+ */
+if ($scanned < 20) {
+    fwrite(
+        STDERR,
+        sprintf(
+            "FAIL: only %d files carry filter_input/filter_var -- the scan"
+            . " paths are wrong, not the code\n",
+            $scanned
+        )
+    );
+    exit(1);
+}
+
+if (count($findings) > 0) {
+    fwrite(
+        STDERR,
+        sprintf(
+            "FAIL: %d request value(s) reach a string function uncast.\n"
+            . "filter_input() returns null for an absent key; PHP 8.1+"
+            . " deprecates that. Write (string) in front of it.\n",
+            count($findings)
+        )
+    );
+    foreach ($findings as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+printf("ok  %d files scanned, no uncast request input\n", $scanned);
+exit(0);


### PR DESCRIPTION
The cleanup pass I flagged while fixing #1572 and #1573.

## What

`filter_input()` answers **null** for a key that is not in the request — not `''` — and
`filter_var()` answers `false` for a value it rejects. PHP 8.1 deprecated passing null to a
non-nullable parameter of an internal function, so 153 sites across core emit

```
Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated
```

on every server running 8.1 or newer, which is most of them. FOG buffers its own output
through `Initiator::sanitizeOutput()`, so a deprecation raised mid-page lands in the response
body ahead of whatever the page was building — and on an AJAX endpoint that is a JSON reply
the browser cannot parse.

## Strictly behavior-preserving

PHP already coerces the null to `''` and `false` to `''`, which is what every one of these
sites has always stored. The cast writes that coercion down instead of relying on it — the
same argument GH-1245 made about `sql_mode`, and the same reason it matters: **the coercion
only exists while the value is inside the string function.** Forum topic 18232 is what
happens when it is not — `dev-branch` read the tasking form's `account` with a bare
`filter_input()` and no `trim()` at all, the null went into a batch insert, hit
`taskPassreset` which is `NOT NULL`, and no group could be tasked (#1573).

## How

Applied over the **token stream**, not by hand and not by regex. Nearly every site in this
tree is written across three lines —

```php
$ip = trim(
    filter_input(INPUT_POST, 'ip')
);
```

— which no line-oriented pattern sees, and an argument in second position
(`explode(',', filter_input(...))`) needs the enclosing call tracked rather than the
preceding characters. 153 lines changed, 153 lines added; the token round-trip means nothing
else in any file moved. Every changed file passes `php -l`.

## Scope

Core only. `packages/web/lib/plugins` is the installed artifact of the fog-plugins release
(ADR 0009), gitignored here, with its own repository — it carries about **100 more** of these
(`LDAPManagement` 27, `TasktypeeditManagement` 16, `LocationManagement` 10, …) and they
belong in its own pull request. Happy to open that next.

## Test

`tests/request-input-is-cast-before-string-use.test.php` walks the same token stream and fails
on any uncast site, so the shape cannot grow back. It also refuses to pass when it scanned
fewer than 20 files — a scan that looked at nothing would otherwise report success, which is
the one failure a source-scanning test cannot otherwise tell you about.

Mutation-tested in both shapes it has to catch:

| mutation | result |
|---|---|
| remove the cast from a three-line `trim()` in `StorageNodeManagement` | FAIL, names `:439` |
| remove the cast from the inline `base64_decode()` in `FOGConfigurationPage` | FAIL, names `:1583` |
| neither | `ok  69 files scanned, no uncast request input` |

Full PHP suite green locally; both `phpstan` passes green after `rm -rf /tmp/phpstan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144vtTvLgBYS6NC7dYgxp2f