### PR TITLE
Cast request input before handing it to a string function

### DIFF
--- a/packages/web/lib/fog/fogpage.class.php
+++ b/packages/web/lib/fog/fogpage.class.php
@@ -1749,7 +1749,7 @@ abstract class FOGPage extends FOGBase
              * Schedule Type Setup.
              */
             $scheduleType = strtolower(
-                filter_input(INPUT_POST, 'scheduleType')
+                (string)filter_input(INPUT_POST, 'scheduleType')
             );
             $scheduleTypes = array(
                 'cron',

--- a/packages/web/lib/fog/fogpagemanager.class.php
+++ b/packages/web/lib/fog/fogpagemanager.class.php
@@ -360,7 +360,7 @@ class FOGPageManager extends FOGBase
                     ' ',
                     '_',
                     base64_decode(
-                        filter_input(INPUT_GET, 'f')
+                        (string)filter_input(INPUT_GET, 'f')
                     )
                 );
             }

--- a/packages/web/lib/fog/fogsubmenu.class.php
+++ b/packages/web/lib/fog/fogsubmenu.class.php
@@ -600,7 +600,7 @@ class FOGSubMenu extends FOGBase
         return !empty($components['host'])
             && strcasecmp(
                 $components['host'],
-                filter_input(INPUT_SERVER, 'HTTP_HOST')
+                (string)filter_input(INPUT_SERVER, 'HTTP_HOST')
             );
     }
 }

--- a/packages/web/lib/pages/fogconfigurationpage.class.php
+++ b/packages/web/lib/pages/fogconfigurationpage.class.php
@@ -1486,7 +1486,7 @@ class FOGConfigurationPage extends FOGPage
                     'hostCpairs'
                 );
                 $timeout = trim(
-                    filter_input(INPUT_POST, 'timeout')
+                    (string)filter_input(INPUT_POST, 'timeout')
                 );
                 $timeoutt = (is_numeric($timeout) &&  $timeout >= 0);
                 if (!$timeoutt) {
@@ -1511,7 +1511,7 @@ class FOGConfigurationPage extends FOGPage
                 $noMenu = (int)isset($_POST['nomenu']);
                 $hideMenu = (int)isset($_POST['hidemenu']);
                 $hidetimeout = trim(
-                    filter_input(INPUT_POST, 'hidetimeout')
+                    (string)filter_input(INPUT_POST, 'hidetimeout')
                 );
                 $hidetimeoutt = (is_numeric($hidetimeout) && $hidetimeout >= 0);
                 if (!$hidetimeoutt) {

--- a/packages/web/lib/pages/groupmanagementpage.class.php
+++ b/packages/web/lib/pages/groupmanagementpage.class.php
@@ -278,19 +278,19 @@ class GroupManagementPage extends FOGPage
     {
         self::$HookManager->processEvent('GROUP_ADD_POST');
         $name = trim(
-            filter_input(INPUT_POST, 'name')
+            (string)filter_input(INPUT_POST, 'name')
         );
         $desc = trim(
-            filter_input(INPUT_POST, 'description')
+            (string)filter_input(INPUT_POST, 'description')
         );
         $kern = trim(
-            filter_input(INPUT_POST, 'kern')
+            (string)filter_input(INPUT_POST, 'kern')
         );
         $args = trim(
-            filter_input(INPUT_POST, 'args')
+            (string)filter_input(INPUT_POST, 'args')
         );
         $dev = trim(
-            filter_input(INPUT_POST, 'dev')
+            (string)filter_input(INPUT_POST, 'dev')
         );
         try {
             if (!$name) {
@@ -1833,19 +1833,19 @@ class GroupManagementPage extends FOGPage
             global $tab;
             $hostids = $this->obj->get('hosts');
             $name = trim(
-                filter_input(INPUT_POST, 'name')
+                (string)filter_input(INPUT_POST, 'name')
             );
             $desc = trim(
-                filter_input(INPUT_POST, 'description')
+                (string)filter_input(INPUT_POST, 'description')
             );
             $kern = trim(
-                filter_input(INPUT_POST, 'kern')
+                (string)filter_input(INPUT_POST, 'kern')
             );
             $args = trim(
-                filter_input(INPUT_POST, 'args')
+                (string)filter_input(INPUT_POST, 'args')
             );
             $dev = trim(
-                filter_input(INPUT_POST, 'dev')
+                (string)filter_input(INPUT_POST, 'dev')
             );
             $key = filter_input(INPUT_POST, 'key');
             $image = filter_input(INPUT_POST, 'image');

--- a/packages/web/lib/pages/hostmanagementpage.class.php
+++ b/packages/web/lib/pages/hostmanagementpage.class.php
@@ -577,33 +577,33 @@ class HostManagementPage extends FOGPage
     {
         self::$HookManager->processEvent('HOST_ADD_POST');
         $name = trim(
-            filter_input(INPUT_POST, 'host')
+            (string)filter_input(INPUT_POST, 'host')
         );
         $mac = trim(
-            filter_input(INPUT_POST, 'mac')
+            (string)filter_input(INPUT_POST, 'mac')
         );
         $desc = trim(
-            filter_input(INPUT_POST, 'description')
+            (string)filter_input(INPUT_POST, 'description')
         );
         $password = trim(
-            filter_input(INPUT_POST, 'domainpassword')
+            (string)filter_input(INPUT_POST, 'domainpassword')
         );
         $useAD = (int)isset($_POST['domain']);
         $domain = trim(
-            filter_input(INPUT_POST, 'domainname')
+            (string)filter_input(INPUT_POST, 'domainname')
         );
         $ou = trim(
-            filter_input(INPUT_POST, 'ou')
+            (string)filter_input(INPUT_POST, 'ou')
         );
         $user = trim(
-            filter_input(INPUT_POST, 'domainuser')
+            (string)filter_input(INPUT_POST, 'domainuser')
         );
         $pass = $password;
         $passlegacy = trim(
-            filter_input(INPUT_POST, 'domainpasswordlegacy')
+            (string)filter_input(INPUT_POST, 'domainpasswordlegacy')
         );
         $key = trim(
-            filter_input(INPUT_POST, 'key')
+            (string)filter_input(INPUT_POST, 'key')
         );
         $productKey = preg_replace(
             '/([\w+]{5})/',
@@ -618,22 +618,22 @@ class HostManagementPage extends FOGPage
         $enforce = (int)isset($_POST['enforcesel']);
         $image = (int)filter_input(INPUT_POST, 'image');
         $kernel = trim(
-            filter_input(INPUT_POST, 'kern')
+            (string)filter_input(INPUT_POST, 'kern')
         );
         $kernelArgs = trim(
-            filter_input(INPUT_POST, 'args')
+            (string)filter_input(INPUT_POST, 'args')
         );
         $kernelDevice = trim(
-            filter_input(INPUT_POST, 'dev')
+            (string)filter_input(INPUT_POST, 'dev')
         );
         $init = trim(
-            filter_input(INPUT_POST, 'init')
+            (string)filter_input(INPUT_POST, 'init')
         );
         $bootTypeExit = trim(
-            filter_input(INPUT_POST, 'bootTypeExit')
+            (string)filter_input(INPUT_POST, 'bootTypeExit')
         );
         $efiBootTypeExit = trim(
-            filter_input(INPUT_POST, 'efiBootTypeExit')
+            (string)filter_input(INPUT_POST, 'efiBootTypeExit')
         );
         try {
             if (!$name) {
@@ -1316,20 +1316,20 @@ class HostManagementPage extends FOGPage
     public function hostGeneralPost()
     {
         $name = trim(
-            filter_input(INPUT_POST, 'host')
+            (string)filter_input(INPUT_POST, 'host')
         );
         $mac = trim(
-            filter_input(INPUT_POST, 'mac')
+            (string)filter_input(INPUT_POST, 'mac')
         );
         $desc = trim(
-            filter_input(INPUT_POST, 'description')
+            (string)filter_input(INPUT_POST, 'description')
         );
         $imageID = trim(
-            filter_input(INPUT_POST, 'image')
+            (string)filter_input(INPUT_POST, 'image')
         );
         $key = strtoupper(
             trim(
-                filter_input(INPUT_POST, 'key')
+                (string)filter_input(INPUT_POST, 'key')
             )
         );
         $productKey = preg_replace(
@@ -1343,22 +1343,22 @@ class HostManagementPage extends FOGPage
         );
         $productKey = substr($productKey, 0, 29);
         $kern = trim(
-            filter_input(INPUT_POST, 'kern')
+            (string)filter_input(INPUT_POST, 'kern')
         );
         $args = trim(
-            filter_input(INPUT_POST, 'args')
+            (string)filter_input(INPUT_POST, 'args')
         );
         $dev = trim(
-            filter_input(INPUT_POST, 'dev')
+            (string)filter_input(INPUT_POST, 'dev')
         );
         $init = trim(
-            filter_input(INPUT_POST, 'init')
+            (string)filter_input(INPUT_POST, 'init')
         );
         $bte = trim(
-            filter_input(INPUT_POST, 'bootTypeExit')
+            (string)filter_input(INPUT_POST, 'bootTypeExit')
         );
         $ebte = trim(
-            filter_input(INPUT_POST, 'efiBootTypeExit')
+            (string)filter_input(INPUT_POST, 'efiBootTypeExit')
         );
         if (empty($name)) {
             throw new Exception(_('Please enter a hostname'));
@@ -3351,37 +3351,37 @@ class HostManagementPage extends FOGPage
     {
         $useAD = isset($_POST['domain']);
         $domain = trim(
-            filter_input(
+            (string)filter_input(
                 INPUT_POST,
                 'domainname'
             )
         );
         $ou = trim(
-            filter_input(
+            (string)filter_input(
                 INPUT_POST,
                 'ou'
             )
         );
         $user = trim(
-            filter_input(
+            (string)filter_input(
                 INPUT_POST,
                 'domainuser'
             )
         );
         $pass = trim(
-            filter_input(
+            (string)filter_input(
                 INPUT_POST,
                 'domainpassword'
             )
         );
         $passlegacy = trim(
-            filter_input(
+            (string)filter_input(
                 INPUT_POST,
                 'domainpasswordlegacy'
             )
         );
         $productKey = trim(
-            filter_input(
+            (string)filter_input(
                 INPUT_POST,
                 'productkey'
             )
@@ -3462,37 +3462,37 @@ class HostManagementPage extends FOGPage
         }
         if (isset($_POST['pmsubmit'])) {
             $min = trim(
-                filter_input(
+                (string)filter_input(
                     INPUT_POST,
                     'scheduleCronMin'
                 )
             );
             $hour = trim(
-                filter_input(
+                (string)filter_input(
                     INPUT_POST,
                     'scheduleCronHour'
                 )
             );
             $dom = trim(
-                filter_input(
+                (string)filter_input(
                     INPUT_POST,
                     'scheduleCronDOM'
                 )
             );
             $month = trim(
-                filter_input(
+                (string)filter_input(
                     INPUT_POST,
                     'scheduleCronMonth'
                 )
             );
             $dow = trim(
-                filter_input(
+                (string)filter_input(
                     INPUT_POST,
                     'scheduleCronDOW'
                 )
             );
             $action = trim(
-                filter_input(
+                (string)filter_input(
                     INPUT_POST,
                     'action'
                 )

--- a/packages/web/lib/pages/imagemanagementpage.class.php
+++ b/packages/web/lib/pages/imagemanagementpage.class.php
@@ -688,13 +688,13 @@ class ImageManagementPage extends FOGPage
     {
         self::$HookManager->processEvent('IMAGE_ADD_POST');
         $file = trim(
-            filter_input(INPUT_POST, 'file')
+            (string)filter_input(INPUT_POST, 'file')
         );
         $name = trim(
-            filter_input(INPUT_POST, 'name')
+            (string)filter_input(INPUT_POST, 'name')
         );
         $desc = trim(
-            filter_input(INPUT_POST, 'description')
+            (string)filter_input(INPUT_POST, 'description')
         );
         $storagegroup = (int)filter_input(INPUT_POST, 'storagegroup');
         $os = (int)filter_input(INPUT_POST, 'os');
@@ -870,7 +870,7 @@ class ImageManagementPage extends FOGPage
             $toprot = '';
         }
         $file = trim(
-            filter_input(INPUT_POST, 'file')
+            (string)filter_input(INPUT_POST, 'file')
         );
         if (!$file) {
             $file = $this->obj->get('path');
@@ -1314,13 +1314,13 @@ class ImageManagementPage extends FOGPage
             );
         global $tab;
         $name = trim(
-            filter_input(INPUT_POST, 'name')
+            (string)filter_input(INPUT_POST, 'name')
         );
         $file = trim(
-            filter_input(INPUT_POST, 'file')
+            (string)filter_input(INPUT_POST, 'file')
         );
         $desc = trim(
-            filter_input(INPUT_POST, 'description')
+            (string)filter_input(INPUT_POST, 'description')
         );
         $os = (int)filter_input(INPUT_POST, 'os');
         $imagetype = (int)filter_input(INPUT_POST, 'imagetype');
@@ -1665,7 +1665,7 @@ class ImageManagementPage extends FOGPage
     {
         try {
             $name = trim(
-                filter_input(INPUT_POST, 'name')
+                (string)filter_input(INPUT_POST, 'name')
             );
             $image = (int)filter_input(INPUT_POST, 'image');
             $timeout = (int)filter_input(INPUT_POST, 'timeout');

--- a/packages/web/lib/pages/pluginmanagementpage.class.php
+++ b/packages/web/lib/pages/pluginmanagementpage.class.php
@@ -212,7 +212,7 @@ class PluginManagementPage extends FOGPage
             )
         );
         $runset = trim(
-            filter_input(INPUT_GET, 'run')
+            (string)filter_input(INPUT_GET, 'run')
         );
         echo '<div class="col-xs-9">';
         if ($runset) {
@@ -260,7 +260,7 @@ class PluginManagementPage extends FOGPage
             )
         );
         $runset = trim(
-            filter_input(INPUT_GET, 'run')
+            (string)filter_input(INPUT_GET, 'run')
         );
         echo '<div class="col-xs-9">';
         if ($runset) {

--- a/packages/web/lib/pages/printermanagementpage.class.php
+++ b/packages/web/lib/pages/printermanagementpage.class.php
@@ -507,7 +507,7 @@ class PrinterManagementPage extends FOGPage
         $ip = filter_input(INPUT_POST, 'ip');
         $configFile = filter_input(INPUT_POST, 'configFile');
         $config = strtolower(
-            filter_input(INPUT_POST, 'printertype')
+            (string)filter_input(INPUT_POST, 'printertype')
         );
         $desc = filter_input(INPUT_POST, 'description');
         try {
@@ -928,7 +928,7 @@ class PrinterManagementPage extends FOGPage
         $ip = filter_input(INPUT_POST, 'ip');
         $configFile = filter_input(INPUT_POST, 'configFile');
         $config = strtolower(
-            filter_input(INPUT_POST, 'printertype')
+            (string)filter_input(INPUT_POST, 'printertype')
         );
         $desc = filter_input(INPUT_POST, 'description');
         if (!$alias) {

--- a/packages/web/lib/pages/snapinmanagementpage.class.php
+++ b/packages/web/lib/pages/snapinmanagementpage.class.php
@@ -412,7 +412,7 @@ class SnapinManagementPage extends FOGPage
         );
         $storagegroup = filter_input(INPUT_POST, 'storagegroup');
         $snapinfileexist = basename(
-            filter_input(INPUT_POST, 'snapinfileexist')
+            (string)filter_input(INPUT_POST, 'snapinfileexist')
         );
         $name = filter_input(INPUT_POST, 'name');
         $desc = filter_input(INPUT_POST, 'description');
@@ -714,7 +714,7 @@ class SnapinManagementPage extends FOGPage
         $runWithArgs = filter_input(INPUT_POST, 'rwa');
         $storagegroup = (int)filter_input(INPUT_POST, 'storagegroup');
         $snapinfile = basename(
-            filter_input(INPUT_POST, 'snapinfileexist')
+            (string)filter_input(INPUT_POST, 'snapinfileexist')
         );
         $uploadfile = basename(
             isset($_FILES['snapin']['name']) ? $_FILES['snapin']['name'] : ''
@@ -905,7 +905,7 @@ class SnapinManagementPage extends FOGPage
             '${input}'
         );
         $snapinfileexists = basename(
-            filter_input(INPUT_POST, 'snapinfileexist')
+            (string)filter_input(INPUT_POST, 'snapinfileexist')
         );
         if (!$snapinfileexists) {
             $snapinfileexists = $this->obj->get('file');
@@ -1464,7 +1464,7 @@ class SnapinManagementPage extends FOGPage
         $runWith = htmlspecialchars_decode(filter_input(INPUT_POST, 'rw'), ENT_QUOTES | ENT_SUBSTITUTE);
         $runWithArgs = htmlspecialchars_decode(filter_input(INPUT_POST, 'rwa'), ENT_QUOTES | ENT_SUBSTITUTE);
         $snapinfile = basename(
-            filter_input(INPUT_POST, 'snapinfileexist')
+            (string)filter_input(INPUT_POST, 'snapinfileexist')
         );
         $uploadfile = basename(
             isset($_FILES['snapin']['name']) ? $_FILES['snapin']['name'] : ''

--- a/packages/web/lib/pages/usermanagementpage.class.php
+++ b/packages/web/lib/pages/usermanagementpage.class.php
@@ -266,14 +266,14 @@ class UserManagementPage extends FOGPage
         self::$HookManager->processEvent('USER_ADD_POST');
         $name = strtolower(
             trim(
-                filter_input(INPUT_POST, 'name')
+                (string)filter_input(INPUT_POST, 'name')
             )
         );
         $password = trim(
-            filter_input(INPUT_POST, 'password')
+            (string)filter_input(INPUT_POST, 'password')
         );
         $friendly = trim(
-            filter_input(INPUT_POST, 'display')
+            (string)filter_input(INPUT_POST, 'display')
         );
         $apien = (int)isset($_POST['apienabled']);
         $token = self::createSecToken();
@@ -651,11 +651,11 @@ class UserManagementPage extends FOGPage
     {
         $name = strtolower(
             trim(
-                filter_input(INPUT_POST, 'name')
+                (string)filter_input(INPUT_POST, 'name')
             )
         );
         $display = trim(
-            filter_input(INPUT_POST, 'display')
+            (string)filter_input(INPUT_POST, 'display')
         );
         if ($this->obj->get('name') != $name
             && self::getClass('UserManager')->exists(
@@ -679,7 +679,7 @@ class UserManagementPage extends FOGPage
     public function userChangePWPost()
     {
         $password = trim(
-            filter_input(INPUT_POST, 'password')
+            (string)filter_input(INPUT_POST, 'password')
         );
         $this->obj
             ->set('password', $password);
@@ -693,7 +693,7 @@ class UserManagementPage extends FOGPage
     {
         $apien = (int)isset($_POST['apienabled']);
         $apitoken = base64_decode(
-            filter_input(INPUT_POST, 'apitoken')
+            (string)filter_input(INPUT_POST, 'apitoken')
         );
         $this->obj
             ->set('api', $apien)

--- a/packages/web/lib/reg-task/registration.class.php
+++ b/packages/web/lib/reg-task/registration.class.php
@@ -165,7 +165,7 @@ class Registration extends FOGBase
             $username = (false === $username) ? '' : $username;
             $password = (false === $password) ? '' : $password;
             self::stripAndDecode($_REQUEST);
-            $productKey = trim(filter_var($_REQUEST['productKey'] ?? '', FILTER_UNSAFE_RAW));
+            $productKey = trim((string)filter_var($_REQUEST['productKey'] ?? '', FILTER_UNSAFE_RAW));
             if ($productKey !== '' && !preg_match('/^[A-Za-z0-9\\-]{1,29}$/', $productKey)) {
                 throw new Exception(_('Invalid product key supplied'));
             }
@@ -431,7 +431,7 @@ class Registration extends FOGBase
                 ->addPriMAC($this->PriMAC)
                 ->addAddMAC($this->MACs);
             if (self::getSetting('FOG_QUICKREG_PROD_KEY_BIOS') > 0) {
-                $productKey = trim(base64_decode(filter_var($_REQUEST['productKey'] ?? '', FILTER_UNSAFE_RAW)));
+                $productKey = trim(base64_decode((string)filter_var($_REQUEST['productKey'] ?? '', FILTER_UNSAFE_RAW)));
                 if ($productKey !== '' && !preg_match('/^[A-Za-z0-9\\-]{1,29}$/', $productKey)) {
                     throw new Exception(_('Invalid product key supplied'));
                 }
@@ -493,7 +493,7 @@ class Registration extends FOGBase
                 ->addPriMAC($this->PriMAC)
                 ->addAddMAC($this->MACs);
             if (self::getSetting('FOG_QUICKREG_PROD_KEY_BIOS') > 0) {
-                $productKey = trim(base64_decode(filter_var($_REQUEST['productKey'] ?? '', FILTER_UNSAFE_RAW)));
+                $productKey = trim(base64_decode((string)filter_var($_REQUEST['productKey'] ?? '', FILTER_UNSAFE_RAW)));
                 if ($productKey !== '' && !preg_match('/^[A-Za-z0-9\\-]{1,29}$/', $productKey)) {
                     throw new Exception(_('Invalid product key supplied'));
                 }

--- a/packages/web/lib/reports/user_tracking.report.php
+++ b/packages/web/lib/reports/user_tracking.report.php
@@ -268,7 +268,7 @@ class User_Tracking extends ReportManagementPage
             ->addCSVCell(_('Description'))
             ->endCSVLine();
         $userID = base64_decode(
-            filter_input(INPUT_GET, 'userID')
+            (string)filter_input(INPUT_GET, 'userID')
         );
         $hostID = filter_input(INPUT_GET, 'hostID');
         if (!$userID) {

--- a/packages/web/lib/router/route.class.php
+++ b/packages/web/lib/router/route.class.php
@@ -894,7 +894,7 @@ class Route extends FOGBase
     private static function _testToken()
     {
         $passtoken = base64_decode(
-            filter_input(INPUT_SERVER, 'HTTP_FOG_API_TOKEN')
+            (string)filter_input(INPUT_SERVER, 'HTTP_FOG_API_TOKEN')
         );
         if ($passtoken !== self::$_token) {
             self::sendResponse(
@@ -910,7 +910,7 @@ class Route extends FOGBase
     private static function _testAuth()
     {
         $usertoken = base64_decode(
-            filter_input(INPUT_SERVER, 'HTTP_FOG_USER_TOKEN')
+            (string)filter_input(INPUT_SERVER, 'HTTP_FOG_USER_TOKEN')
         );
         $pwtoken = self::getClass('User')
             ->set('token', $usertoken)

--- a/packages/web/status/logtoview.php
+++ b/packages/web/status/logtoview.php
@@ -174,7 +174,7 @@ $ip = trim($ip);
 if (filter_var($ip, FILTER_VALIDATE_IP) === false) {
     return print json_encode(_('IP Passed is incorrect'));
 }
-if (false !== strpos(filter_input(INPUT_SERVER, 'HTTP_HOST'), $ip)) {
+if (false !== strpos((string)filter_input(INPUT_SERVER, 'HTTP_HOST'), $ip)) {
     $str = vals(
         $reverse,
         $HookManager,

--- a/tests/request-input-is-cast-before-string-use.test.php
+++ b/tests/request-input-is-cast-before-string-use.test.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * A request value goes into a string function as a string, never as null.
+ *
+ * `filter_input()` answers **null** for a key that is not in the request --
+ * not '' -- and `filter_var()` answers **false** for a value it rejects. PHP
+ * 8.1 deprecated passing null to a non-nullable parameter of an internal
+ * function, so `trim(filter_input(INPUT_POST, 'account'))` emits
+ *
+ *   Deprecated: trim(): Passing null to parameter #1 ($string) of type
+ *   string is deprecated
+ *
+ * on every server running 8.1 or newer -- which is most of them. FOG buffers
+ * its own output through `Initiator::sanitizeOutput()`, so a deprecation
+ * raised mid-page is emitted into the response body ahead of whatever the
+ * page was building, and on an AJAX endpoint that is a JSON reply the
+ * browser cannot parse.
+ *
+ * The runtime VALUE is unaffected -- PHP still coerces the null to '' -- so
+ * every one of these sites has always produced the right answer, which is
+ * exactly why the shape spread to 83 call sites without anyone noticing.
+ * The cast is not a behavior change; it is the same coercion written down,
+ * which is the same argument GH-1245 made about `sql_mode`.
+ *
+ * IT IS NOT ALWAYS COSMETIC, and forum topic 18232 is the proof -- reported
+ * against this branch. `FOGPage::_tasking()` read `account` with a bare
+ * `filter_input()` and no trim at all, so the null was not coerced by
+ * anything -- it went straight into `Group::createImagePackage()`'s batch
+ * insert and hit `tasks`.`taskPassreset`, which is NOT NULL:
+ *
+ *   SQLSTATE[23000]: 1048 Column 'taskPassreset' cannot be null
+ *
+ * and no group could be tasked at all. Once the value escapes the string
+ * function the coercion that was hiding the null is gone. That is the case
+ * this test exists to make impossible to reintroduce.
+ *
+ * WHAT IS SCANNED. Core only. `packages/web/lib/plugins` is not repo source
+ * -- it is the installed artifact of the fog-plugins release (ADR 0009), is
+ * gitignored, and has its own repository and its own pull requests; a test
+ * here cannot fix it and must not fail on it. `packages/web/vendor` is other
+ * people's code.
+ *
+ * HOW. Tokens, not a regex. Nearly every site in this tree is written over
+ * three lines --
+ *
+ *     $ip = trim(
+ *         filter_input(INPUT_POST, 'ip')
+ *     );
+ *
+ * -- so a line-oriented pattern sees none of them, and an argument in the
+ * second position (`explode(',', filter_input(...))`) needs the enclosing
+ * call to be tracked rather than the preceding characters. The walk keeps a
+ * stack of enclosing calls, which answers both.
+ *
+ * Usage: php tests/request-input-is-cast-before-string-use.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+
+/*
+ * Functions whose relevant parameter is declared `string` and which FOG
+ * actually calls on request data. Deliberately a list rather than
+ * reflection over every internal function: the point is to name the ones in
+ * use, so that adding a call to something else is a decision someone makes
+ * here rather than a silent gap.
+ *
+ * str_replace() and preg_replace() accept array|string, but filter_input()
+ * only returns an array when asked with FILTER_REQUIRE_ARRAY, which nothing
+ * in core does -- and filter_input_array() is a different function this does
+ * not match. So they belong on the list.
+ */
+$stringFns = array_flip(
+    [
+        'trim', 'ltrim', 'rtrim', 'strtolower', 'strtoupper', 'strlen',
+        'substr', 'str_replace', 'preg_replace', 'preg_match', 'preg_split',
+        'explode', 'ucfirst', 'ucwords', 'htmlspecialchars', 'htmlentities',
+        'base64_decode', 'base64_encode', 'str_split', 'strrev', 'nl2br',
+        'urldecode', 'urlencode', 'rawurldecode', 'md5', 'sha1', 'hash',
+        'strip_tags', 'addslashes', 'str_pad', 'wordwrap', 'strpos',
+        'stripos', 'strstr', 'str_contains', 'str_starts_with',
+        'str_ends_with', 'strcmp', 'strcasecmp', 'implode', 'password_verify',
+        'escapeshellarg', 'basename', 'dirname', 'pathinfo', 'mb_strlen',
+        'mb_substr', 'mb_strtolower', 'mb_strtoupper', 'preg_quote',
+        'strtotime', 'html_entity_decode', 'stripslashes', 'str_repeat',
+        'substr_count', 'json_decode', 'number_format', 'str_word_count',
+    ]
+);
+
+$paths = [
+    '/packages/web/lib',
+    '/packages/web/commons',
+    '/packages/web/api',
+    '/packages/web/management',
+    '/packages/web/client',
+    '/packages/web/maintenance',
+    '/packages/web/status',
+    '/packages/service',
+];
+
+$casts = [
+    T_STRING_CAST, T_INT_CAST, T_BOOL_CAST, T_DOUBLE_CAST, T_ARRAY_CAST,
+];
+
+$findings = [];
+$scanned = 0;
+
+foreach ($paths as $sub) {
+    $dir = $root . $sub;
+    if (!is_dir($dir)) {
+        continue;
+    }
+    $it = new \RecursiveIteratorIterator(
+        new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+    );
+    foreach ($it as $file) {
+        if ($file->getExtension() !== 'php') {
+            continue;
+        }
+        $path = $file->getPathname();
+        if (preg_match('#/(vendor|plugins)/#', $path)) {
+            continue;
+        }
+        $src = (string)file_get_contents($path);
+        if (false === strpos($src, 'filter_input')
+            && false === strpos($src, 'filter_var')
+        ) {
+            continue;
+        }
+        ++$scanned;
+        $tokens = token_get_all($src);
+
+        // Significant tokens only, so whitespace and comments cannot hide
+        // the shape of a call.
+        $sig = [];
+        foreach ($tokens as $i => $t) {
+            if (is_array($t)
+                && in_array(
+                    $t[0],
+                    [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT],
+                    true
+                )
+            ) {
+                continue;
+            }
+            $sig[] = $i;
+        }
+
+        $stack = [];
+        foreach ($sig as $p => $i) {
+            $t = $tokens[$i];
+            $text = is_array($t) ? $t[1] : $t;
+
+            if ('(' === $text) {
+                // The name in front of the paren, when there is one, is the
+                // call this argument list belongs to.
+                $callee = null;
+                if ($p >= 1) {
+                    $prev = $tokens[$sig[$p - 1]];
+                    if (is_array($prev) && T_STRING === $prev[0]) {
+                        $callee = strtolower($prev[1]);
+                    }
+                }
+                $stack[] = $callee;
+                continue;
+            }
+            if (')' === $text) {
+                array_pop($stack);
+                continue;
+            }
+            if (!is_array($t) || T_STRING !== $t[0]) {
+                continue;
+            }
+            $name = strtolower($t[1]);
+            if ('filter_input' !== $name && 'filter_var' !== $name) {
+                continue;
+            }
+            // A call, not a bare mention of the name.
+            if (!isset($sig[$p + 1])) {
+                continue;
+            }
+            $next = $tokens[$sig[$p + 1]];
+            if ('(' !== (is_array($next) ? $next[1] : $next)) {
+                continue;
+            }
+            // Guarded already.
+            if ($p >= 1) {
+                $prev = $tokens[$sig[$p - 1]];
+                if (is_array($prev) && in_array($prev[0], $casts, true)) {
+                    continue;
+                }
+            }
+            $enclosing = end($stack);
+            if (false === $enclosing || null === $enclosing) {
+                continue;
+            }
+            if (!isset($stringFns[$enclosing])) {
+                continue;
+            }
+            $findings[] = sprintf(
+                '%s:%d  %s(%s(...))',
+                ltrim(str_replace($root, '', $path), '/'),
+                $t[2],
+                $enclosing,
+                $name
+            );
+        }
+    }
+}
+
+/*
+ * The scan finding nothing because it looked at nothing is the failure this
+ * test could not otherwise report. Core reads request input in dozens of
+ * files, so a run that opened none of them means the paths above are wrong.
+ */
+if ($scanned < 20) {
+    fwrite(
+        STDERR,
+        sprintf(
+            "FAIL: only %d files carry filter_input/filter_var -- the scan"
+            . " paths are wrong, not the code\n",
+            $scanned
+        )
+    );
+    exit(1);
+}
+
+if (count($findings) > 0) {
+    fwrite(
+        STDERR,
+        sprintf(
+            "FAIL: %d request value(s) reach a string function uncast.\n"
+            . "filter_input() returns null for an absent key; PHP 8.1+"
+            . " deprecates that. Write (string) in front of it.\n",
+            count($findings)
+        )
+    );
+    foreach ($findings as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+printf("ok  %d files scanned, no uncast request input\n", $scanned);
+exit(0);


### PR DESCRIPTION
The `dev-branch` half of the cleanup pass. `working-1.6` counterpart: #1574.

## What

`filter_input()` answers **null** for a key that is not in the request — not `''` — and
`filter_var()` answers `false` for a value it rejects. PHP 8.1 deprecated passing null to a
non-nullable parameter of an internal function, so 83 sites across core emit

```
Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated
```

on every server running 8.1 or newer, which is most of them. FOG buffers its own output, so a
deprecation raised mid-page lands in the response body ahead of whatever the page was
building — and on an AJAX endpoint that is a JSON reply the browser cannot parse.

## Strictly behavior-preserving

PHP already coerces the null to `''` and `false` to `''`, which is what every one of these
sites has always stored. The cast writes that coercion down instead of relying on it — the
same argument GH-1245 made about `sql_mode`, and the same reason it matters: **the coercion
only exists while the value is inside the string function.** Forum topic 18232, reported
against this branch, is what happens when it is not — `FOGPage::_tasking()` read the tasking
form's `account` with a bare `filter_input()` and no `trim()` at all, the null went into
`Group::createImagePackage()`'s batch insert, hit `taskPassreset` which is `NOT NULL`, and no
group could be tasked. That one line is fixed separately in #1573; this pass is the rest of
the shape.

## How

Applied over the **token stream**, not by hand and not by regex. Nearly every site is written
across three lines —

```php
$ip = trim(
    filter_input(INPUT_POST, 'ip')
);
```

— which no line-oriented pattern sees, and an argument in second position needs the enclosing
call tracked rather than the preceding characters. 83 lines changed, 83 lines added; the token
round-trip means nothing else in any file moved. Every changed file passes `php -l`.

## Scope

Core only. `packages/web/lib/plugins` carries about **100 more** of these and they belong in
their own change.

## Test

`tests/request-input-is-cast-before-string-use.test.php` walks the same token stream and fails
on any uncast site, so the shape cannot grow back. It also refuses to pass when it scanned
fewer than 20 files — a scan that looked at nothing would otherwise report success, which is
the one failure a source-scanning test cannot otherwise tell you about.

Mutation-tested in both shapes it has to catch:

| mutation | result |
|---|---|
| remove the cast from a three-line `trim()` in `hostmanagementpage` | FAIL, names `:580` |
| remove the cast from the inline `strpos()` in `status/logtoview.php` | FAIL, names `:177` |
| neither | `ok  54 files scanned, no uncast request input` |

Full PHP suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144vtTvLgBYS6NC7dYgxp2f