### PR TITLE
Task the hosts you have ticked, from the host list

### DIFF
--- a/packages/web/management/js/fog/host/fog.host.list.js
+++ b/packages/web/management/js/fog/host/fog.host.list.js
@@ -1,6 +1,8 @@
 (function($) {
     var addToGroup = $('#addSelectedToGroup'),
         deleteSelected = $('#deleteSelected'),
+        queueTask = $('#queueTask'),
+        queueTaskModal = $('#queueTaskModal'),
         groupModal = $('#addToGroupModal'),
         groupModalSelect = $('#groupSelect'),
         createnewBtn = $('#createnew'),
@@ -8,10 +10,15 @@
         createForm = $('#create-form'),
         createnewSendBtn = $('#send');
     var groupList = [];
+    // How many rows were ticked when the Queue Task modal was opened. Read
+    // again at submit time rather than trusted: the grid stays interactive
+    // behind the modal.
+    var queueCount = 0;
 
     function disableButtons(disable) {
         addToGroup.prop('disabled', disable);
         deleteSelected.prop('disabled', disable);
+        queueTask.prop('disabled', disable);
     }
     disableButtons(true);
 
@@ -386,5 +393,142 @@
 
     addToGroup.on('click', function() {
         groupModal.modal('show');
+    });
+
+    // ---------------------------------------------------------------
+    // QUEUE TASK
+    //
+    // Two panes in one modal: the Basic/Advanced accordion, then the chosen
+    // task's options form fetched from the server. The Create button belongs
+    // to the second pane only, so it stays hidden until there is a form for
+    // it to submit.
+    var queuePicker = $('#queue-task-picker'),
+        queueHolder = $('#queue-task-form-holder'),
+        queueSend = $('#queueTaskSend'),
+        queueName = $('.queue-task-name');
+
+    // Which task types a selection of this size can actually run.
+    //
+    // The two exceptions are the whole reason the count matters. Multi-Cast
+    // ships as ttIsAccess='group' because one session serves many hosts, so
+    // it means nothing for a single host; Capture ships as ttIsAccess='host'
+    // because an image comes off exactly one machine. Everything else is
+    // 'both'. The server refuses the same two cases in
+    // assertSelectionTaskable(), so this is the courtesy, not the guard.
+    function applyTaskAvailability(count) {
+        $('.queuetaskitem').each(function() {
+            var access = $(this).attr('data-access'),
+                usable = true;
+            if (access === 'group' && count < 2) {
+                usable = false;
+            }
+            if (access === 'host' && count > 1) {
+                usable = false;
+            }
+            // The description cell beside it goes too, or the table shows a
+            // row of prose with nothing to click.
+            $(this).closest('tr').toggleClass('d-none', !usable);
+        });
+    }
+
+    function showQueuePicker() {
+        queueHolder.empty().addClass('d-none');
+        queuePicker.removeClass('d-none');
+        queueSend.addClass('d-none').off('click');
+        queueName.text('');
+    }
+
+    queueTask.on('click', function() {
+        queueCount = $.getSelectedIds(table).length;
+        if (queueCount < 1) {
+            return;
+        }
+        applyTaskAvailability(queueCount);
+        showQueuePicker();
+        queueTaskModal.modal('show');
+    });
+
+    queueTaskModal.on('hidden.bs.modal', function() {
+        showQueuePicker();
+    });
+
+    $('.queuetaskitem').on('click', function(e) {
+        e.preventDefault();
+        var type = $(this).attr('data-type'),
+            taskName = $(this).text(),
+            hosts = $.getSelectedIds(table);
+
+        if (hosts.length < 1) {
+            return;
+        }
+        queueCount = hosts.length;
+
+        queuePicker.addClass('d-none');
+        queueHolder.removeClass('d-none').html('Loading, please wait...');
+        queueName.text(' - ' + taskName);
+        $('#queueTaskModal .modal-dialog').setLoading(true);
+
+        Pace.track(function() {
+            $.ajax({
+                type: 'get',
+                url: '../management/index.php?node=host&sub=deployMulti'
+                    + '&type=' + encodeURIComponent(type)
+                    + '&count=' + encodeURIComponent(hosts.length),
+                dataType: 'json',
+                success: function(data) {
+                    $('#queueTaskModal .modal-dialog').setLoading(false);
+                    queueHolder.html($.parseHTML(data.msg));
+
+                    var form = $('#host-deploy-multi-form');
+                    Common.iCheck('#queue-task-form-holder input');
+
+                    // Debug hides the schedule fields on the single-host
+                    // form; there are none here, but the same checkbox still
+                    // gates the shutdown row.
+                    $('#checkdebug', form).on('change', function() {
+                        $('.hideFromDebug', form).toggleClass(
+                            'd-none',
+                            this.checked
+                        );
+                    });
+
+                    queueSend.removeClass('d-none').off('click').on(
+                        'click',
+                        function(e) {
+                            e.stopImmediatePropagation();
+                            // Read the selection again HERE. The grid is
+                            // still live behind the modal, so what was ticked
+                            // when the form was fetched is not necessarily
+                            // what is ticked now, and the ids are what the
+                            // server tasks.
+                            var current = $.getSelectedIds(table);
+                            $('input.queued-host', form).remove();
+                            $.each(current, function(i, id) {
+                                $('<input>').attr({
+                                    type: 'hidden',
+                                    name: 'hosts[]',
+                                    'class': 'queued-host'
+                                }).val(id).appendTo(form);
+                            });
+                            form.processForm(function(err) {
+                                if (err) {
+                                    return;
+                                }
+                                queueTaskModal.modal('hide');
+                                table.rows({selected: true}).deselect();
+                            });
+                        }
+                    );
+                },
+                error: function(jqXHR, textStatus) {
+                    if (textStatus == 'abort') {
+                        return;
+                    }
+                    $('#queueTaskModal .modal-dialog').setLoading(false);
+                    queueTaskModal.modal('hide');
+                    $.notifyFromAPI(jqXHR.responseJSON, jqXHR);
+                }
+            });
+        });
     });
 })(jQuery);

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -118,6 +118,10 @@ msgstr ""
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "%d selected hosts"
+msgstr "Ausgewählten MAcs freigeben"
+
 #, php-format
 msgid "%d token(s) disabled."
 msgstr ""
@@ -148,6 +152,10 @@ msgstr ""
 
 #, php-format
 msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
+msgstr ""
+
+#, php-format
+msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
@@ -189,6 +197,10 @@ msgstr ""
 #, php-format
 msgid "%s is required"
 msgstr "%s ist erforderlich"
+
+#, php-format
+msgid "%s needs more than one host"
+msgstr ""
 
 #, php-format
 msgid "%s replaced. Install it to apply any new database steps."
@@ -5868,6 +5880,10 @@ msgid "No hosts are assigned an image"
 msgstr ""
 
 #, fuzzy
+msgid "No hosts are selected"
+msgstr "Keine Hosts für Aufgaben (Task) verfügbar"
+
+#, fuzzy
 msgid "No hosts associated to this group yet"
 msgstr "Keine Snapins mit dieser Gruppe als Master verbunden"
 
@@ -7049,9 +7065,17 @@ msgstr "Task-Typ erstellen fehlgeschlagen"
 msgid "Queue Deletion Cancel Success"
 msgstr "Task-Typ erfolgreich erstellt"
 
+#, fuzzy
+msgid "Queue Task"
+msgstr "Debug"
+
 #, php-format
 msgid "Queue a task against a %s"
 msgstr ""
+
+#, fuzzy
+msgid "Queue task on selected hosts"
+msgstr "Ausgewählte löschen"
 
 msgid "Queued"
 msgstr "In der Warteschlange"
@@ -8929,6 +8953,10 @@ msgstr "Task-Typ ist nicht gültig"
 #, fuzzy
 msgid "Task type update failed!"
 msgstr "Task-Typ aktualisieren fehlgeschlagen"
+
+#, php-format
+msgid "Tasking created for %d hosts"
+msgstr ""
 
 msgid "Tasks"
 msgstr "Tasks"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -123,6 +123,10 @@ msgstr ""
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "%d selected hosts"
+msgstr "Approve selected Hosts"
+
 #, php-format
 msgid "%d token(s) disabled."
 msgstr ""
@@ -153,6 +157,10 @@ msgstr ""
 
 #, php-format
 msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
+msgstr ""
+
+#, php-format
+msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
@@ -194,6 +202,10 @@ msgstr ""
 #, php-format
 msgid "%s is required"
 msgstr "%s is required"
+
+#, php-format
+msgid "%s needs more than one host"
+msgstr ""
 
 #, php-format
 msgid "%s replaced. Install it to apply any new database steps."
@@ -5880,6 +5892,10 @@ msgid "No hosts are assigned an image"
 msgstr ""
 
 #, fuzzy
+msgid "No hosts are selected"
+msgstr "Hosts in Task"
+
+#, fuzzy
 msgid "No hosts associated to this group yet"
 msgstr "There are no snapins associated with this host"
 
@@ -7060,9 +7076,17 @@ msgstr "User created"
 msgid "Queue Deletion Cancel Success"
 msgstr "User created"
 
+#, fuzzy
+msgid "Queue Task"
+msgstr "Debug"
+
 #, php-format
 msgid "Queue a task against a %s"
 msgstr ""
+
+#, fuzzy
+msgid "Queue task on selected hosts"
+msgstr "Delete Selected"
 
 msgid "Queued"
 msgstr "Queued"
@@ -8938,6 +8962,10 @@ msgstr "Task type is not valid"
 #, fuzzy
 msgid "Task type update failed!"
 msgstr "User update failed"
+
+#, php-format
+msgid "Tasking created for %d hosts"
+msgstr ""
 
 msgid "Tasks"
 msgstr "Tasks"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -121,6 +121,10 @@ msgstr ""
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "%d selected hosts"
+msgstr "retirar"
+
 #, php-format
 msgid "%d token(s) disabled."
 msgstr ""
@@ -151,6 +155,10 @@ msgstr ""
 
 #, php-format
 msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
+msgstr ""
+
+#, php-format
+msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
@@ -192,6 +200,10 @@ msgstr ""
 #, fuzzy, php-format
 msgid "%s is required"
 msgstr "%s se requiere"
+
+#, php-format
+msgid "%s needs more than one host"
+msgstr ""
 
 #, php-format
 msgid "%s replaced. Install it to apply any new database steps."
@@ -5988,6 +6000,10 @@ msgid "No hosts are assigned an image"
 msgstr ""
 
 #, fuzzy
+msgid "No hosts are selected"
+msgstr "Anfitriones en tareas"
+
+#, fuzzy
 msgid "No hosts associated to this group yet"
 msgstr "No hay snapins asociados con este anfitrión"
 
@@ -7184,9 +7200,17 @@ msgstr "creado por el usuario"
 msgid "Queue Deletion Cancel Success"
 msgstr "creado por el usuario"
 
+#, fuzzy
+msgid "Queue Task"
+msgstr "Opciones de arranque:"
+
 #, php-format
 msgid "Queue a task against a %s"
 msgstr ""
+
+#, fuzzy
+msgid "Queue task on selected hosts"
+msgstr "Eliminar seleccionado"
 
 msgid "Queued"
 msgstr ""
@@ -9102,6 +9126,10 @@ msgstr "tipo de tarea no es válida"
 #, fuzzy
 msgid "Task type update failed!"
 msgstr "actualización Valoración falló"
+
+#, php-format
+msgid "Tasking created for %d hosts"
+msgstr ""
 
 msgid "Tasks"
 msgstr "Tareas"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -118,6 +118,10 @@ msgstr ""
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "%d selected hosts"
+msgstr "Ausgewählten MAcs freigeben"
+
 #, php-format
 msgid "%d token(s) disabled."
 msgstr ""
@@ -148,6 +152,10 @@ msgstr ""
 
 #, php-format
 msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
+msgstr ""
+
+#, php-format
+msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
@@ -189,6 +197,10 @@ msgstr ""
 #, php-format
 msgid "%s is required"
 msgstr "%s ist erforderlich"
+
+#, php-format
+msgid "%s needs more than one host"
+msgstr ""
 
 #, php-format
 msgid "%s replaced. Install it to apply any new database steps."
@@ -5869,6 +5881,10 @@ msgid "No hosts are assigned an image"
 msgstr ""
 
 #, fuzzy
+msgid "No hosts are selected"
+msgstr "Keine Hosts für Aufgaben (Task) verfügbar"
+
+#, fuzzy
 msgid "No hosts associated to this group yet"
 msgstr "Keine Snapins mit dieser Gruppe als Master verbunden"
 
@@ -7050,9 +7066,17 @@ msgstr "Task-Typ erstellen fehlgeschlagen"
 msgid "Queue Deletion Cancel Success"
 msgstr "Task-Typ erfolgreich erstellt"
 
+#, fuzzy
+msgid "Queue Task"
+msgstr "Debug"
+
 #, php-format
 msgid "Queue a task against a %s"
 msgstr ""
+
+#, fuzzy
+msgid "Queue task on selected hosts"
+msgstr "Ausgewählte löschen"
 
 msgid "Queued"
 msgstr "In der Warteschlange"
@@ -8930,6 +8954,10 @@ msgstr "Task-Typ ist nicht gültig"
 #, fuzzy
 msgid "Task type update failed!"
 msgstr "Task-Typ aktualisieren fehlgeschlagen"
+
+#, php-format
+msgid "Tasking created for %d hosts"
+msgstr ""
 
 msgid "Tasks"
 msgstr "Tasks"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -124,6 +124,10 @@ msgstr ""
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "%d selected hosts"
+msgstr "Approuver hôtes sélectionnés"
+
 #, php-format
 msgid "%d token(s) disabled."
 msgstr ""
@@ -154,6 +158,10 @@ msgstr ""
 
 #, php-format
 msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
+msgstr ""
+
+#, php-format
+msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
@@ -195,6 +203,10 @@ msgstr ""
 #, php-format
 msgid "%s is required"
 msgstr "%s est requis"
+
+#, php-format
+msgid "%s needs more than one host"
+msgstr ""
 
 #, php-format
 msgid "%s replaced. Install it to apply any new database steps."
@@ -5867,6 +5879,10 @@ msgid "No hosts are assigned an image"
 msgstr ""
 
 #, fuzzy
+msgid "No hosts are selected"
+msgstr "Hôtes sur Task"
+
+#, fuzzy
 msgid "No hosts associated to this group yet"
 msgstr "Il n'y a pas snapins associés à cet hôte"
 
@@ -7047,9 +7063,17 @@ msgstr "utilisateur créé"
 msgid "Queue Deletion Cancel Success"
 msgstr "utilisateur créé"
 
+#, fuzzy
+msgid "Queue Task"
+msgstr "Déboguer"
+
 #, php-format
 msgid "Queue a task against a %s"
 msgstr ""
+
+#, fuzzy
+msgid "Queue task on selected hosts"
+msgstr "Supprimer sélectionnée"
 
 msgid "Queued"
 msgstr "Queued"
@@ -8923,6 +8947,10 @@ msgstr "Type de tâche n'est pas valide"
 #, fuzzy
 msgid "Task type update failed!"
 msgstr "mise à jour de l'utilisateur a échoué"
+
+#, php-format
+msgid "Tasking created for %d hosts"
+msgstr ""
 
 msgid "Tasks"
 msgstr "les tâches"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -123,6 +123,10 @@ msgstr ""
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "%d selected hosts"
+msgstr "Approvare MAC selezionati"
+
 #, php-format
 msgid "%d token(s) disabled."
 msgstr ""
@@ -153,6 +157,10 @@ msgstr ""
 
 #, php-format
 msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
+msgstr ""
+
+#, php-format
+msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
@@ -194,6 +202,10 @@ msgstr ""
 #, php-format
 msgid "%s is required"
 msgstr "%s è richiesto"
+
+#, php-format
+msgid "%s needs more than one host"
+msgstr ""
 
 #, php-format
 msgid "%s replaced. Install it to apply any new database steps."
@@ -5694,6 +5706,10 @@ msgid "No hosts are assigned an image"
 msgstr ""
 
 #, fuzzy
+msgid "No hosts are selected"
+msgstr "Nessun host disponibile per task"
+
+#, fuzzy
 msgid "No hosts associated to this group yet"
 msgstr "Nessun snapins associato a questo gruppo come master"
 
@@ -6840,9 +6856,17 @@ msgstr "Aggiunta tipo attività fallita"
 msgid "Queue Deletion Cancel Success"
 msgstr "Aggiunta tipo attività riuscita"
 
+#, fuzzy
+msgid "Queue Task"
+msgstr "mettere a punto"
+
 #, php-format
 msgid "Queue a task against a %s"
 msgstr ""
+
+#, fuzzy
+msgid "Queue task on selected hosts"
+msgstr "Cancella selezionato"
 
 msgid "Queued"
 msgstr "In coda"
@@ -8646,6 +8670,10 @@ msgstr "Tipo di attività non è valido"
 #, fuzzy
 msgid "Task type update failed!"
 msgstr "Aggiornamento tipo attività fallita"
+
+#, php-format
+msgid "Tasking created for %d hosts"
+msgstr ""
 
 msgid "Tasks"
 msgstr "Attività"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -114,6 +114,10 @@ msgstr ""
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "%d selected hosts"
+msgstr "選択したホストを承認"
+
 #, php-format
 msgid "%d token(s) disabled."
 msgstr ""
@@ -144,6 +148,10 @@ msgstr ""
 
 #, php-format
 msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
+msgstr ""
+
+#, php-format
+msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
@@ -185,6 +193,10 @@ msgstr ""
 #, php-format
 msgid "%s is required"
 msgstr "%s は必須です"
+
+#, php-format
+msgid "%s needs more than one host"
+msgstr ""
 
 #, php-format
 msgid "%s replaced. Install it to apply any new database steps."
@@ -5658,6 +5670,10 @@ msgid "No hosts are assigned an image"
 msgstr ""
 
 #, fuzzy
+msgid "No hosts are selected"
+msgstr "ルールが選択されていません"
+
+#, fuzzy
 msgid "No hosts associated to this group yet"
 msgstr "このグループにマスターとして関連付けられたスナップインはありません"
 
@@ -6809,9 +6825,17 @@ msgstr "ルールの削除に失敗しました"
 msgid "Queue Deletion Cancel Success"
 msgstr "ルールを削除しました"
 
+#, fuzzy
+msgid "Queue Task"
+msgstr "デバッグ"
+
 #, php-format
 msgid "Queue a task against a %s"
 msgstr ""
+
+#, fuzzy
+msgid "Queue task on selected hosts"
+msgstr "選択したホストを削除"
 
 msgid "Queued"
 msgstr "キュー済み"
@@ -8590,6 +8614,10 @@ msgstr "タスクタイプが無効です"
 #, fuzzy
 msgid "Task type update failed!"
 msgstr "タスクタイプの更新に失敗しました"
+
+#, php-format
+msgid "Tasking created for %d hosts"
+msgstr ""
 
 msgid "Tasks"
 msgstr "タスク"
@@ -12471,9 +12499,6 @@ msgstr ""
 
 #~ msgid "No query sent"
 #~ msgstr "クエリが送信されていません"
-
-#~ msgid "No rule selected"
-#~ msgstr "ルールが選択されていません"
 
 #~ msgid "No valid Image defined for this host"
 #~ msgstr "このホストに有効なイメージが定義されていません"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -100,6 +100,10 @@ msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, php-format
+msgid "%d selected hosts"
+msgstr ""
+
+#, php-format
 msgid "%d token(s) disabled."
 msgstr ""
 
@@ -129,6 +133,10 @@ msgstr ""
 
 #, php-format
 msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
+msgstr ""
+
+#, php-format
+msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
@@ -169,6 +177,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is required"
+msgstr ""
+
+#, php-format
+msgid "%s needs more than one host"
 msgstr ""
 
 #, php-format
@@ -5003,6 +5015,9 @@ msgstr ""
 msgid "No hosts are assigned an image"
 msgstr ""
 
+msgid "No hosts are selected"
+msgstr ""
+
 msgid "No hosts associated to this group yet"
 msgstr ""
 
@@ -6011,8 +6026,14 @@ msgstr ""
 msgid "Queue Deletion Cancel Success"
 msgstr ""
 
+msgid "Queue Task"
+msgstr ""
+
 #, php-format
 msgid "Queue a task against a %s"
+msgstr ""
+
+msgid "Queue task on selected hosts"
 msgstr ""
 
 msgid "Queued"
@@ -7596,6 +7617,10 @@ msgid "Task type is invalid"
 msgstr ""
 
 msgid "Task type update failed!"
+msgstr ""
+
+#, php-format
+msgid "Tasking created for %d hosts"
 msgstr ""
 
 msgid "Tasks"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -123,6 +123,10 @@ msgstr ""
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "%d selected hosts"
+msgstr "Aprovar Hosts selecionados"
+
 #, php-format
 msgid "%d token(s) disabled."
 msgstr ""
@@ -153,6 +157,10 @@ msgstr ""
 
 #, php-format
 msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
+msgstr ""
+
+#, php-format
+msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
@@ -194,6 +202,10 @@ msgstr ""
 #, php-format
 msgid "%s is required"
 msgstr "%s é necessária"
+
+#, php-format
+msgid "%s needs more than one host"
+msgstr ""
 
 #, php-format
 msgid "%s replaced. Install it to apply any new database steps."
@@ -5867,6 +5879,10 @@ msgid "No hosts are assigned an image"
 msgstr ""
 
 #, fuzzy
+msgid "No hosts are selected"
+msgstr "Hotéis em Task"
+
+#, fuzzy
 msgid "No hosts associated to this group yet"
 msgstr "Não há snapins associados a este alojamento"
 
@@ -7047,9 +7063,17 @@ msgstr "usuário criado"
 msgid "Queue Deletion Cancel Success"
 msgstr "usuário criado"
 
+#, fuzzy
+msgid "Queue Task"
+msgstr "Depurar"
+
 #, php-format
 msgid "Queue a task against a %s"
 msgstr ""
+
+#, fuzzy
+msgid "Queue task on selected hosts"
+msgstr "Delete Selected"
 
 msgid "Queued"
 msgstr "Enfileiradas"
@@ -8925,6 +8949,10 @@ msgstr "tipo de tarefa não é válido"
 #, fuzzy
 msgid "Task type update failed!"
 msgstr "atualização do utilizador falhou"
+
+#, php-format
+msgid "Tasking created for %d hosts"
+msgstr ""
 
 msgid "Tasks"
 msgstr "tarefas"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -123,6 +123,10 @@ msgstr ""
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "%d selected hosts"
+msgstr "批准选定主机"
+
 #, php-format
 msgid "%d token(s) disabled."
 msgstr ""
@@ -153,6 +157,10 @@ msgstr ""
 
 #, php-format
 msgid "%s already has a token called \"%s\". Names have to be unique per user so a token can be told apart from its neighbors when it comes time to revoke one."
+msgstr ""
+
+#, php-format
+msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
@@ -194,6 +202,10 @@ msgstr ""
 #, php-format
 msgid "%s is required"
 msgstr "%s是必需的"
+
+#, php-format
+msgid "%s needs more than one host"
+msgstr ""
 
 #, php-format
 msgid "%s replaced. Install it to apply any new database steps."
@@ -5867,6 +5879,10 @@ msgid "No hosts are assigned an image"
 msgstr ""
 
 #, fuzzy
+msgid "No hosts are selected"
+msgstr "在任务主机"
+
+#, fuzzy
 msgid "No hosts associated to this group yet"
 msgstr "没有与此主机关联snapins"
 
@@ -7047,9 +7063,17 @@ msgstr "用户创建"
 msgid "Queue Deletion Cancel Success"
 msgstr "用户创建"
 
+#, fuzzy
+msgid "Queue Task"
+msgstr "调试"
+
 #, php-format
 msgid "Queue a task against a %s"
 msgstr ""
+
+#, fuzzy
+msgid "Queue task on selected hosts"
+msgstr "删除所选"
 
 msgid "Queued"
 msgstr "排队"
@@ -8925,6 +8949,10 @@ msgstr "任务类型无效"
 #, fuzzy
 msgid "Task type update failed!"
 msgstr "用户更新失败"
+
+#, php-format
+msgid "Tasking created for %d hosts"
+msgstr ""
 
 msgid "Tasks"
 msgstr "任务"

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -1835,6 +1835,17 @@ abstract class FOGPage extends FOGBase
                         'btn btn-danger float-start'
                     );
                     $actionbox .= '<div class="btn-group float-end">';
+                    // Picked up the same way addModal() is, so the toolbar
+                    // stays generic: a page that can task its selection says
+                    // so by defining the method. The button is emitted first
+                    // because this is a btn-group -- a flex container, where
+                    // emission order IS left-to-right and the float classes
+                    // do nothing -- so the primary "Add" stays rightmost.
+                    if (method_exists($this, 'queueTaskActions')) {
+                        $queue = $this->queueTaskActions();
+                        $actionbox .= $queue['button'];
+                        $modals .= $queue['modal'];
+                    }
                     if (method_exists($this, 'addModal')) {
                         if ($node == 'host') {
                             $actionbox .= self::makeButton(

--- a/packages/web/src/Base/FOGPageRender.php
+++ b/packages/web/src/Base/FOGPageRender.php
@@ -838,6 +838,291 @@ trait FOGPageRender
     }
 
     /**
+     * Builds the Basic/Advanced task-type accordion.
+     *
+     * `taskTypes` already carries both axes this needs. `ttIsAdvanced`
+     * splits the two panes -- Deploy and Multi-Cast are basic, everything
+     * from Memtest to Password Reset is advanced -- and `ttIsAccess` says
+     * which kind of target a type applies to: `host`, `group`, or `both`.
+     * Neither is derived here; the caller passes the access values it wants
+     * and gets back the accordion.
+     *
+     * The anchor is the caller's, because the two users of this need
+     * different links from the same rows: the host edit page tasks one host
+     * and names it in the URL, while the list tasks whatever is selected and
+     * has to defer that to the browser. Everything around the anchor -- the
+     * two collapsible cards, the striped tables, the hooks a plugin adds
+     * rows through -- is the same either way.
+     *
+     * @param array    $access       ttIsAccess values to include.
+     * @param callable $anchor       fn(stdClass $TaskType): string, the link.
+     * @param string   $accordionId  DOM id for the accordion wrapper.
+     * @param string   $basicHook    Event fired with the basic rows.
+     * @param string   $advancedHook Event fired with the advanced rows.
+     *
+     * @return string The accordion markup.
+     */
+    protected function taskTypeAccordion(
+        array $access,
+        callable $anchor,
+        $accordionId,
+        $basicHook = '',
+        $advancedHook = ''
+    ) {
+        $items = Route::getList(
+            'tasktype',
+            ['access' => $access],
+            'AND',
+            'id'
+        );
+
+        $panes = [];
+        foreach ([0, 1] as $advanced) {
+            $data = [];
+            foreach ($items as $TaskType) {
+                if ($advanced != $TaskType->isAdvanced) {
+                    continue;
+                }
+                $data[$anchor($TaskType)] = $TaskType->description;
+            }
+            $hook = $advanced ? $advancedHook : $basicHook;
+            if ($hook) {
+                self::$HookManager->processEvent($hook, ['data' => &$data]);
+            }
+            $panes[$advanced] = self::stripedTable($data);
+        }
+
+        ob_start();
+        echo '<div id="' . $accordionId . '">';
+        foreach ([0, 1] as $advanced) {
+            $paneId = $accordionId . ($advanced ? 'Advanced' : 'Basic');
+            echo '<div class="card card-'
+                . ($advanced ? 'warning' : 'primary')
+                . ' card-outline">';
+            echo '<div class="card-header">';
+            echo '<h4 class="card-title">';
+            echo '<a href="#' . $paneId . '" class="" data-bs-toggle="collapse" '
+                . 'data-bs-parent="#' . $accordionId . '">';
+            echo $advanced ? _('Advanced Tasks') : _('Basic Tasks');
+            echo '</a>';
+            echo '</h4>';
+            echo '</div>';
+            echo '<div id="' . $paneId . '" class="collapse'
+                . ($advanced ? '' : ' show')
+                . '">';
+            echo '<div class="card-body">';
+            echo '<table class="table table-striped">';
+            echo '<tbody>';
+            echo $panes[$advanced];
+            echo '</tbody>';
+            echo '</table>';
+            echo '</div>';
+            echo '</div>';
+            echo '</div>';
+        }
+        echo '</div>';
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Builds the task-option form fields shared by every create-task form:
+     * the snapin picker, the password-reset account, and the abort/bitlocker/
+     * shutdown/wake/debug checkboxes. The caller adds scheduleTypeFields()
+     * after these, and owns the form tag and its own hook.
+     *
+     * Extracted from HostManagement::deploy() and GroupManagement::deploy(),
+     * which carried the same 200 lines twice and had already drifted: only
+     * the host copy offered the bitlocker bypass. Keeping one copy is what
+     * lets deployMulti() exist without a third. The bitlocker block is gated
+     * on the task being a capture, and a group cannot capture, so folding
+     * the two together adds nothing to a group's form.
+     *
+     * Takes the type ID rather than a task-type object on purpose. The two
+     * callers hold two different things under the same name -- deploy() on
+     * the host page holds the decoded API row Route::getItem() answers with,
+     * where the predicates are properties, and the group page holds the
+     * model, where they are methods. Building the model here is what lets
+     * one body serve both.
+     *
+     * @param int    $type       The task type id.
+     * @param string $labelClass The label class used by the deploy form.
+     *
+     * @return array The field fragment to fastmerge onto the form fields.
+     */
+    protected function taskingOptionFields($type, $labelClass)
+    {
+        $TaskType = self::getClass('TaskType', $type);
+        $issnapintask = $TaskType->isSnapinTasking();
+        $isinitneeded = $TaskType->isInitNeededTasking();
+        $iscapturetask = $TaskType->isCapture();
+        $isdebug = $TaskType->isDebug();
+
+        $fields = [];
+
+        if ($issnapintask
+            && TaskType::SINGLE_SNAPIN == $type
+        ) {
+            $fields[
+                self::makeLabel(
+                    $labelClass,
+                    'snapin',
+                    _('Select Snapin to run')
+                )
+            ] = self::getClass('SnapinManager')
+                ->buildSelectBox('', 'snapin');
+        } elseif (TaskType::PASSWORD_RESET == $type) {
+            $fields[
+                self::makeLabel(
+                    $labelClass,
+                    'account',
+                    _('Account Name')
+                )
+            ] = self::makeInput(
+                'form-control',
+                'account',
+                _('Administrator'),
+                'text',
+                'account',
+                '',
+                true
+            );
+        }
+        if ($TaskType->isSnapinTask()) {
+            $fields = self::fastmerge(
+                $fields,
+                [
+                    self::makeLabel(
+                        $labelClass,
+                        'snapinAbortOnFailure',
+                        _('Abort snapin sequence on failure')
+                    ) => self::makeInput(
+                        '',
+                        'snapinAbortOnFailure',
+                        '',
+                        'checkbox',
+                        'snapinAbortOnFailure'
+                    )
+                ]
+            );
+        }
+        if ($isinitneeded) {
+            if ($iscapturetask) {
+                $fields = self::fastmerge(
+                    $fields,
+                    [
+                        self::makeLabel(
+                            $labelClass,
+                            'bitlocker',
+                            _('Bypass Bitlocker Detection')
+                        ) => self::makeInput(
+                            '',
+                            'bitlocker',
+                            '',
+                            'checkbox',
+                            'bitlocker',
+                            '',
+                            false,
+                            false,
+                            -1,
+                            -1,
+                            ''
+                        )
+                    ]
+                );
+            }
+            if (!$isdebug) {
+                $shutdownchecked = self::getSetting(
+                    'FOG_TASKING_ADV_SHUTDOWN_ENABLED'
+                ) ? ' checked' : '';
+                $fields = self::fastmerge(
+                    $fields,
+                    [
+                        '<div class="hideFromDebug deploy-field-group">'
+                        . self::makeLabel(
+                            $labelClass,
+                            'shutdown',
+                            _('Shutdown when complete')
+                        ) => self::makeInput(
+                            '',
+                            'shutdown',
+                            '',
+                            'checkbox',
+                            'shutdown',
+                            '',
+                            false,
+                            false,
+                            -1,
+                            -1,
+                            $shutdownchecked
+                        )
+                        . '</div>'
+                    ]
+                );
+            }
+        }
+        if (TaskType::WAKE_UP != $type) {
+            $wolchecked = self::getSetting(
+                'FOG_TASKING_ADV_WOL_ENABLED'
+            ) ? ' checked' : '';
+            $fields = self::fastmerge(
+                $fields,
+                [
+                    self::makeLabel(
+                        $labelClass,
+                        'wol',
+                        _('Wake Up')
+                    ) => self::makeInput(
+                        '',
+                        'wol',
+                        '',
+                        'checkbox',
+                        'wol',
+                        '',
+                        false,
+                        false,
+                        -1,
+                        -1,
+                        $wolchecked
+                    )
+                ]
+            );
+        }
+        if (TaskType::PASSWORD_RESET != $type
+            && !$isdebug
+            && $isinitneeded
+        ) {
+            $debugchecked = self::getSetting(
+                'FOG_TASKING_ADV_DEBUG_ENABLED'
+            ) ? ' checked' : '';
+            $fields = self::fastmerge(
+                $fields,
+                [
+                    self::makeLabel(
+                        $labelClass,
+                        'checkdebug',
+                        _('Debug Task')
+                    ) => self::makeInput(
+                        '',
+                        'isDebugTask',
+                        '',
+                        'checkbox',
+                        'checkdebug',
+                        '',
+                        false,
+                        false,
+                        -1,
+                        -1,
+                        $debugchecked
+                    )
+                ]
+            );
+        }
+
+        return $fields;
+    }
+
+    /**
      * Builds the schedule-type form fields shared by the host/group deploy()
      * create-task forms: the always-present "Schedule Immediately" radio plus,
      * unless this is a debug or password-reset task, the "Schedule Later"

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -131,7 +131,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 401);
-        define('FOG_BCACHE_VER', 354);
+        define('FOG_BCACHE_VER', 355);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/src/Items/Group.php
+++ b/packages/web/src/Items/Group.php
@@ -1152,10 +1152,27 @@ class Group extends FOGController
     /**
      * Loads hosts in this group.
      *
+     * A group with no id has no associations to load, and asking anyway is
+     * two pointless queries whose filters are both the empty-value shape
+     * that means "no filter" somewhere else in this codebase: `gmGroupID =
+     * ''` against groupMembers, then a COUNT of hosts filtered by an empty
+     * id list. Neither is currently wrong, and neither is worth relying on.
+     *
+     * Not a hypothetical. HostManagement::deployMulti() drives a Group that
+     * is deliberately never saved -- it is the carrier for an ad-hoc host
+     * selection, so that one multicast session covers the whole selection
+     * the way it does for a real group -- and set('hosts', ...) reaches
+     * here before the ids it is about to write land.
+     *
      * @return void
      */
     protected function loadHosts()
     {
+        if (!$this->get('id')) {
+            $this->set('hosts', []);
+
+            return;
+        }
         $this->_loadHostIds(
             'groupassociation',
             ['groupID' => $this->get('id')],

--- a/packages/web/src/Pages/GroupManagement.php
+++ b/packages/web/src/Pages/GroupManagement.php
@@ -3188,8 +3188,6 @@ class GroupManagement extends FOGPage
 
             $imagingTypes = $TaskType->isImagingTask();
             $iscapturetask = $TaskType->isCapture();
-            $issnapintask = $TaskType->isSnapinTasking();
-            $isinitneeded = $TaskType->isInitNeededTasking();
             $isdebug = $TaskType->isDebug();
             $hosts = $this->obj->get('hosts');
 
@@ -3205,143 +3203,9 @@ class GroupManagement extends FOGPage
 
             $labelClass = 'col-sm-3 col-form-label';
 
-            $fields = [];
-
-            if ($issnapintask
-                && TaskType::SINGLE_SNAPIN == $type
-            ) {
-                $snapinSelector = self::getClass('SnapinManager')
-                    ->buildSelectBox('', 'snapin');
-                $fields[
-                    self::makeLabel(
-                        $labelClass,
-                        'snapin',
-                        _('Select Snapin to run')
-                    )
-                ] = $snapinSelector;
-            } elseif (TaskType::PASSWORD_RESET == $type) {
-                $fields [
-                    self::makeLabel(
-                        $labelClass,
-                        'account',
-                        _('Account Name')
-                    )
-                ] = self::makeInput(
-                    'form-control',
-                    'account',
-                    'Administrator',
-                    'text',
-                    'account',
-                    '',
-                    true
-                );
-            }
-            if ($TaskType->isSnapinTask()) {
-                $fields = self::fastmerge(
-                    $fields,
-                    [
-                        self::makeLabel(
-                            $labelClass,
-                            'snapinAbortOnFailure',
-                            _('Abort snapin sequence on failure')
-                        ) => self::makeInput(
-                            '',
-                            'snapinAbortOnFailure',
-                            '',
-                            'checkbox',
-                            'snapinAbortOnFailure'
-                        )
-                    ]
-                );
-            }
-            if ($isinitneeded
-                && !$isdebug
-            ) {
-                $shutdownchecked = self::getSetting(
-                    'FOG_TASKING_ADV_SHUTDOWN_ENABLED'
-                ) ? ' checked' : '';
-                $fields = self::fastmerge(
-                    $fields,
-                    [
-                        '<div class="hideFromDebug deploy-field-group">'
-                        . self::makeLabel(
-                            $labelClass,
-                            'shutdown',
-                            _('Shutdown when complete')
-                        ) => self::makeInput(
-                            '',
-                            'shutdown',
-                            '',
-                            'checkbox',
-                            'shutdown',
-                            '',
-                            false,
-                            false,
-                            -1,
-                            -1,
-                            $shutdownchecked
-                        )
-                        . '</div>'
-                    ]
-                );
-            }
-            if (TaskType::WAKE_UP != $type) {
-                $wolchecked = self::getSetting(
-                    'FOG_TASKING_ADV_WOL_ENABLED'
-                ) ? ' checked' : '';
-                $fields = self::fastmerge(
-                    $fields,
-                    [
-                        self::makeLabel(
-                            $labelClass,
-                            'wol',
-                            _('Wake Up')
-                        ) => self::makeInput(
-                            '',
-                            'wol',
-                            '',
-                            'checkbox',
-                            'wol',
-                            '',
-                            false,
-                            false,
-                            -1,
-                            -1,
-                            $wolchecked
-                        )
-                    ]
-                );
-            }
-            if (TaskType::PASSWORD_RESET != $type
-                && !$isdebug
-                && $isinitneeded
-            ) {
-                $debugchecked = self::getSetting(
-                    'FOG_TASKING_ADV_DEBUG_ENABLED'
-                ) ? ' checked' : '';
-                $fields = self::fastmerge(
-                    $fields,
-                    [
-                        self::makeLabel(
-                            $labelClass,
-                            'checkdebug',
-                            _('Debug Task')
-                        ) => self::makeInput(
-                            '',
-                            'isDebugTask',
-                            '',
-                            'checkbox',
-                            'checkdebug',
-                            '',
-                            false,
-                            false,
-                            -1,
-                            -1,
-                            $debugchecked
-                        )
-                    ]
-                );
-            }
+            // Shared with HostManagement::deploy() and deployMulti(); the
+            // three forms differ only in which hosts they apply to.
+            $fields = $this->taskingOptionFields($type, $labelClass);
             $fields = self::fastmerge(
                 $fields,
                 $this->scheduleTypeFields($labelClass, $isdebug, $type)

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -4332,77 +4332,26 @@ class HostManagement extends FOGPage
      */
     public function hostTasks()
     {
-        // Predefine needed variables for closure function.
         global $id;
-        $data = [];
-        /**
-         * Closure allowing us to iterate from a common point.
-         *
-         * @param stdClass $TaskType The Task Type data.
-         * @param int      $advanced The advanced flag.
-         *
-         * @uses array $data The data to store into.
-         * @uses int   $id   The id of the object we are on.
-         *
-         * @return void
-         */
-        $taskTypeIterator = function ($TaskType, $advanced) use (
-            &$data,
-            $id
-        ) {
-            if ($advanced != $TaskType->isAdvanced) {
-                return;
-            }
-            $data['<a href="?node=host&sub=deploy&id='
-                . $id
-                . '&type='
-                . $TaskType->id
-                . '" class="taskitem"><i class="fas fa-'
-                . $TaskType->icon
-                . ' fa-2x"></i><br/>'
-                . $TaskType->name
-                . '</a>'
-            ] = $TaskType->description;
-        };
-        // The keys we need to search for.
-        $key = [
-            'access' => [
-                'host',
-                'both'
-            ]
-        ];
-        // The items we're getting.
-        $items = Route::getList(
-            'tasktype',
-            $key,
-            'AND',
-            'id'
-        );
-        // Loop 1, the basic non-advanced tasks.
-        foreach ($items as &$TaskType) {
-            $taskTypeIterator($TaskType, 0);
-            unset($TaskType);
-        }
-        self::$HookManager->processEvent(
-            'HOST_BASICTASKS_DATA',
-            ['data' => &$data]
-        );
-        $basic = self::stripedTable($data);
 
-        $data = [];
-        $advanced = 1;
-        // Loop 2, the advanced tasks.
-        foreach ($items as &$TaskType) {
-            $taskTypeIterator($TaskType, 1);
-            unset($TaskType);
-        }
-        self::$HookManager->processEvent(
-            'HOST_ADVANCEDTASKS_DATA',
-            ['data' => &$data]
+        $accordion = $this->taskTypeAccordion(
+            ['host', 'both'],
+            function ($TaskType) use ($id) {
+                return '<a href="?node=host&sub=deploy&id='
+                    . $id
+                    . '&type='
+                    . $TaskType->id
+                    . '" class="taskitem"><i class="fas fa-'
+                    . $TaskType->icon
+                    . ' fa-2x"></i><br/>'
+                    . $TaskType->name
+                    . '</a>';
+            },
+            'taskAccordian',
+            'HOST_BASICTASKS_DATA',
+            'HOST_ADVANCEDTASKS_DATA'
         );
-        $advanced = self::stripedTable($data);
-        unset($data);
-        unset($items);
+
         $modalApprovalBtns = self::makeButton(
             'tasking-send',
             _('Create'),
@@ -4427,56 +4376,417 @@ class HostManagement extends FOGPage
 
         echo '<div class="card" id="host-tasks">';
         echo '<div class="card-body">';
-        echo '<div id="taskAccordian">';
-
-        // Basic Tasks
-        echo '<div class="card card-primary card-outline">';
-        echo '<div class="card-header">';
-        echo '<h4 class="card-title">';
-        echo '<a href="#tasksBasic" class="" data-bs-toggle="collapse" '
-            . 'data-bs-parent="#taskAccordian">';
-        echo _('Basic Tasks');
-        echo '</a>';
-        echo '</h4>';
-        echo '</div>';
-        echo '<div id="tasksBasic" class="collapse show">';
-        echo '<div class="card-body">';
-        echo '<table class="table table-striped">';
-        echo '<tbody>';
-        echo $basic;
-        echo '</tbody>';
-        echo '</table>';
-        echo '</div>';
-        echo '</div>';
-        echo '</div>';
-
-        // Advanced Tasks
-        echo '<div class="card card-warning card-outline">';
-        echo '<div class="card-header">';
-        echo '<h4 class="card-title">';
-        echo '<a href="#tasksAdvanced" class="" data-bs-toggle="collapse" '
-            . 'data-bs-parent="#taskAccordian">';
-        echo _('Advanced Tasks');
-        echo '</a>';
-        echo '</h4>';
-        echo '</div>';
-        echo '<div id="tasksAdvanced" class="collapse">';
-        echo '<div class="card-body">';
-        echo '<table class="table table-striped">';
-        echo '<tbody>';
-        echo $advanced;
-        echo '</tbody>';
-        echo '</table>';
-        echo '</div>';
-        echo '</div>';
-        echo '</div>';
-
+        echo $accordion;
         echo '</div>';
         echo '<div class="card-footer">';
         echo $taskModal;
         echo '</div>';
         echo '</div>';
-        echo '</div>';
+    }
+    /**
+     * The Queue Task control for the host list: one button, one modal.
+     *
+     * Called by FOGPage::process() when the page defines it, the same way
+     * addModal() is picked up, so the generic list toolbar stays generic.
+     *
+     * The modal holds the same Basic/Advanced accordion the host edit page
+     * shows, built from the same taskTypes rows. What differs is the anchor:
+     * no `id` in the href, because which hosts are tasked is whatever is
+     * ticked at the moment of the click, and only the browser knows that.
+     * Each row carries its `access` value instead, which is what lets the
+     * script show Multi-Cast only when more than one row is selected (it is
+     * `ttIsAccess = 'group'`) and Capture only when exactly one is (it is
+     * `ttIsAccess = 'host'`).
+     *
+     * @return array ['button' => string, 'modal' => string]
+     */
+    public function queueTaskActions()
+    {
+        $accordion = $this->taskTypeAccordion(
+            ['host', 'group', 'both'],
+            function ($TaskType) {
+                return '<a href="#" class="taskitem queuetaskitem" '
+                    . 'data-type="' . (int)$TaskType->id . '" '
+                    . 'data-access="'
+                    . \Initiator::e($TaskType->access)
+                    . '"><i class="fas fa-'
+                    . \Initiator::e($TaskType->icon)
+                    . ' fa-2x"></i><br/>'
+                    . \Initiator::e($TaskType->name)
+                    . '</a>';
+            },
+            'queueTaskAccordion',
+            'HOST_BASICTASKS_DATA',
+            'HOST_ADVANCEDTASKS_DATA'
+        );
+
+        $button = self::makeButton(
+            'queueTask',
+            _('Queue Task'),
+            'btn btn-secondary'
+        );
+
+        $modal = self::makeModal(
+            'queueTaskModal',
+            '<h4 class="card-title">'
+            . _('Queue task on selected hosts')
+            . '<span class="queue-task-name"></span></h4>',
+            '<div id="queue-task-picker">' . $accordion . '</div>'
+            . '<div id="queue-task-form-holder"></div>',
+            self::makeButton(
+                'queueTaskClose',
+                _('Cancel'),
+                'btn btn-outline-secondary float-start',
+                'data-bs-dismiss="modal"'
+            )
+            . self::makeButton(
+                'queueTaskSend',
+                _('Create'),
+                'btn btn-primary float-end d-none'
+            ),
+            '',
+            'success',
+            'modal-lg'
+        );
+
+        return ['button' => $button, 'modal' => $modal];
+    }
+    /**
+     * The task options form for an ad-hoc selection of hosts.
+     *
+     * Deliberately takes a COUNT and not the ids. The form does not vary by
+     * which hosts were picked -- only by task type -- and putting a few
+     * hundred ids in a query string to build a form that ignores them buys
+     * nothing and eventually exceeds the request line. The ids are posted to
+     * deployMultiPost(), which is where they are checked and used.
+     *
+     * The count is not decoration: it decides whether the chosen type is
+     * even applicable. `ttIsAccess = 'group'` (Multi-Cast) needs more than
+     * one host to mean anything, and `ttIsAccess = 'host'` (Capture) needs
+     * exactly one -- capturing an image from several machines at once is not
+     * a thing. The script hides those entries, and this refuses them, so a
+     * hand-made request gets the same answer as the UI.
+     *
+     * @return void
+     */
+    public function deployMulti()
+    {
+        header('Content-type: application/json');
+        global $type;
+
+        try {
+            if (!is_numeric($type) || $type < 1) {
+                $type = 1;
+            }
+            $count = (int)filter_input(INPUT_GET, 'count');
+            if ($count < 1) {
+                throw new \Exception(_('No hosts are selected'));
+            }
+
+            $TaskType = self::getClass('TaskType', $type);
+            if (!$TaskType->isValid()) {
+                throw new \Exception(
+                    sprintf(
+                        _('Task type %d is missing from this server.'),
+                        $type
+                    )
+                );
+            }
+            $this->assertSelectionTaskable($TaskType, $count);
+
+            $this->title = $TaskType->get('name');
+
+            $labelClass = 'col-sm-3 col-form-label';
+            $fields = $this->taskingOptionFields($type, $labelClass);
+
+            $buttons = '';
+            self::$HookManager->processEvent(
+                'HOST_CREATE_TASKING',
+                [
+                    'fields' => &$fields,
+                    'buttons' => &$buttons,
+                    'Host' => &$this->obj
+                ]
+            );
+            $rendered = self::formFields($fields);
+            unset($fields);
+            ob_start();
+            echo self::makeFormTag(
+                '',
+                'host-deploy-multi-form',
+                '../management/index.php?node=host&sub=deployMulti&type='
+                . (int)$type,
+                'post',
+                'application/x-www-form-urlencoded',
+                true
+            );
+            echo $rendered;
+            echo $buttons;
+            echo '</form>';
+            $msg = json_encode(
+                [
+                    'msg' => ob_get_clean(),
+                    'title' => _('Create task form success')
+                ]
+            );
+            $code = HTTPResponseCodes::HTTP_SUCCESS;
+        } catch (\Exception $e) {
+            $msg = json_encode(
+                [
+                    'error' => $e->getMessage(),
+                    'title' => _('Create task form fail')
+                ]
+            );
+            $code = HTTPResponseCodes::HTTP_BAD_REQUEST;
+        }
+        $this->jsonSend($code, $msg);
+    }
+    /**
+     * Refuses a task type the selection size cannot support.
+     *
+     * Shared by the form builder and the create, so a request that skips the
+     * UI is answered the same way the UI would have.
+     *
+     * @param object $TaskType the task type being created
+     * @param int    $count    how many hosts are selected
+     *
+     * @throws \Exception
+     *
+     * @return void
+     */
+    private function assertSelectionTaskable($TaskType, $count)
+    {
+        $access = $TaskType->get('access');
+        if ('group' === $access && $count < 2) {
+            throw new \Exception(
+                sprintf(
+                    _('%s needs more than one host'),
+                    $TaskType->get('name')
+                )
+            );
+        }
+        if ('host' === $access && $count > 1) {
+            throw new \Exception(
+                sprintf(
+                    _('%s can only be run on one host at a time'),
+                    $TaskType->get('name')
+                )
+            );
+        }
+    }
+    /**
+     * Creates the tasking for an ad-hoc selection of hosts.
+     *
+     * Instant only. A scheduled task is one `scheduledTasks` row carrying a
+     * single hostID plus an isGroupTask flag, so it can name a host or a
+     * group and has nowhere to put a set of hosts that is neither. Giving it
+     * one is a schema change; until then the list creates tasks now and the
+     * edit page still schedules them per host or per group.
+     *
+     * The work itself goes through Group::createImagePackage() on a Group
+     * that is built here and never saved. That is not a shortcut around the
+     * host path -- it is the only path that gets Multi-Cast right. One
+     * multicast session has to cover the whole selection: one port, one
+     * sender, one row per host in multicastSessionsAssoc. Looping
+     * Host::createImagePackage() would create a separate session per host
+     * and none of them would ever stream.
+     *
+     * @return void
+     */
+    public function deployMultiPost()
+    {
+        self::checkAuthAndCSRF();
+        header('Content-type: application/json');
+        self::$HookManager->processEvent('HOST_DEPLOY_POST');
+
+        $serverFault = false;
+        try {
+            global $type;
+            if (!is_numeric($type) || $type < 1) {
+                $type = 1;
+            }
+
+            $hosts = filter_input(
+                INPUT_POST,
+                'hosts',
+                FILTER_DEFAULT,
+                FILTER_REQUIRE_ARRAY
+            );
+            $hosts = array_values(
+                array_unique(
+                    array_filter(
+                        array_map('intval', (array)$hosts)
+                    )
+                )
+            );
+            if (count($hosts) < 1) {
+                throw new \Exception(_('No hosts are selected'));
+            }
+            // Airtight: one id outside the caller's site scope denies the
+            // whole request rather than quietly tasking the rest. The ids
+            // come from the browser, so this is the only place they are
+            // bounded.
+            Authorization::requirePageObjectScopeMass('host', $hosts);
+
+            $TaskType = self::getClass('TaskType', $type);
+            if (!$TaskType->isValid()) {
+                throw new \Exception(
+                    sprintf(
+                        _('Task type %d is missing from this server.'),
+                        $type
+                    )
+                );
+            }
+            $this->assertSelectionTaskable($TaskType, count($hosts));
+
+            // Pending hosts cannot be tasked -- the same refusal the single
+            // host path makes, applied to the selection.
+            $hosts = Route::getIds(
+                'host',
+                [
+                    'id' => $hosts,
+                    'pending' => ['', 0]
+                ]
+            );
+            if (count($hosts ?: []) < 1) {
+                throw new \Exception(_('No hosts available to be tasked'));
+            }
+
+            if ($TaskType->isImagingTask()) {
+                $images = [];
+                $withImage = [];
+                foreach (Route::getList('host', ['id' => $hosts]) as $Host) {
+                    if (!$Host->imageID) {
+                        continue;
+                    }
+                    $withImage[] = (int)$Host->id;
+                    $images[] = (int)$Host->imageID;
+                }
+                if (count($withImage) < 1) {
+                    throw new \Exception(_('No hosts are assigned an image'));
+                }
+                // One session, one image. Checked here rather than left to
+                // the replicator, which would otherwise start a stream the
+                // odd host out can never use.
+                if (TaskType::MULTICAST == $type
+                    && count(array_unique($images)) !== 1
+                ) {
+                    throw new \Exception(
+                        _('All hosts must have the same image assigned')
+                    );
+                }
+                $hosts = $withImage;
+            }
+
+            // Password reset setup
+            $passreset = trim(
+                (string)filter_input(INPUT_POST, 'account')
+            );
+            if (TaskType::PASSWORD_RESET == $type
+                && !$passreset
+            ) {
+                throw new \Exception(_('Password reset requires a user account'));
+            }
+
+            // Snapin setup
+            $enableSnapins = (int)filter_input(INPUT_POST, 'snapin');
+            if (0 === $enableSnapins) {
+                $enableSnapins = -1;
+            }
+            if (TaskType::DEPLOY_NO_SNAPINS === $type || $enableSnapins < -1) {
+                $enableSnapins = 0;
+            }
+            $snapinAbortOnFailure = isset($_POST['snapinAbortOnFailure']);
+
+            $enableShutdown = isset($_POST['shutdown']);
+
+            $enableDebug = isset($_POST['debug']) || isset($_POST['isDebugTask']);
+
+            $wol = (TaskType::WAKE_UP == $type) || isset($_POST['wol']);
+
+            // The carrier for the selection. Never saved -- nothing reads it
+            // back and a groups row would outlive the tasking it exists for.
+            // Group::loadHosts() short circuits on an unsaved group, so the
+            // ids set here are the ids used.
+            $Selection = self::getClass('Group')
+                ->set(
+                    'name',
+                    sprintf(
+                        /* translators: %d is a number of hosts */
+                        _('%d selected hosts'),
+                        count($hosts)
+                    )
+                )
+                ->set('hosts', $hosts);
+
+            // getItem(), not indiv(): a deleted task type used to end the
+            // response with a 404 rather than report it. Refs ADR 0011.
+            $tasktype = Route::getItem('tasktype', $type);
+            if (!$tasktype) {
+                throw new \Exception(
+                    sprintf(
+                        _('Task type %d is missing from this server.'),
+                        $type
+                    )
+                );
+            }
+            $Selection->createImagePackage(
+                $tasktype,
+                sprintf('%s Task', $TaskType->get('name')),
+                $enableShutdown,
+                $enableDebug,
+                $enableSnapins,
+                true,
+                self::$FOGUser->get('name'),
+                $passreset,
+                false,
+                $wol,
+                false,
+                $snapinAbortOnFailure
+            );
+
+            $code = HTTPResponseCodes::HTTP_CREATED;
+            $hook = 'HOST_DEPLOY_SUCCESS';
+            $msg = json_encode(
+                [
+                    'msg' => sprintf(
+                        /* translators: %d is a number of hosts */
+                        _('Tasking created for %d hosts'),
+                        count($hosts)
+                    ),
+                    'title' => _('Create Task Success')
+                ]
+            );
+        } catch (\Exception $e) {
+            // Always 400, unlike deployPost(). Everything this method can
+            // refuse is a property of the REQUEST -- an empty or
+            // out-of-scope selection, a task type the selection size cannot
+            // support, hosts with no image -- and all of it is checked
+            // before anything is written. What createImagePackage() itself
+            // throws is configuration the caller has to fix as well (image
+            // not enabled, not replicated to the group), so there is no arm
+            // here that means "the server failed". $serverFault stays in the
+            // hook payload because a listener may still set it.
+            $code = HTTPResponseCodes::HTTP_BAD_REQUEST;
+            $hook = 'HOST_DEPLOY_FAIL';
+            $msg = json_encode(
+                [
+                    'error' => $e->getMessage(),
+                    'title' => _('Create Task Fail')
+                ]
+            );
+        }
+
+        $this->jsonHookResponse(
+            [
+                'Host' => &$this->obj,
+                'hook' => &$hook,
+                'code' => &$code,
+                'msg' => &$msg,
+                'serverFault' => &$serverFault
+            ],
+            $hook
+        );
     }
     /**
      * Tasking for this host.
@@ -4513,10 +4823,6 @@ class HostManagement extends FOGPage
 
             $iscapturetask = $TaskType->isCapture;
 
-            $issnapintask = $TaskType->isSnapinTasking;
-
-            $isinitneeded = $TaskType->isInitNeeded;
-
             $isdebug = $TaskType->isDebug;
 
             $image = $this->obj->getImage();
@@ -4541,166 +4847,9 @@ class HostManagement extends FOGPage
                 throw new \Exception(_('Assigned image is protected'));
             }
             $labelClass = 'col-sm-3 col-form-label';
-            $fields = [];
-            if ($issnapintask
-                && TaskType::SINGLE_SNAPIN == $type
-            ) {
-                $snapinSelector = self::getClass('SnapinManager')
-                    ->buildSelectBox('', 'snapin');
-                $fields[
-                    self::makeLabel(
-                        $labelClass,
-                        'snapin',
-                        _('Select Snapin to run')
-                    )
-                ] = $snapinSelector;
-            } elseif (TaskType::PASSWORD_RESET == $type) {
-                $fields [
-                    self::makeLabel(
-                        $labelClass,
-                        'account',
-                        _('Account Name')
-                    )
-                ] = self::makeInput(
-                    'form-control',
-                    'account',
-                    _('Administrator'),
-                    'text',
-                    'account',
-                    '',
-                    true
-                );
-            }
-            if ($TaskType->isSnapinTask) {
-                $fields = self::fastmerge(
-                    $fields,
-                    [
-                        self::makeLabel(
-                            $labelClass,
-                            'snapinAbortOnFailure',
-                            _('Abort snapin sequence on failure')
-                        ) => self::makeInput(
-                            '',
-                            'snapinAbortOnFailure',
-                            '',
-                            'checkbox',
-                            'snapinAbortOnFailure'
-                        )
-                    ]
-                );
-            }
-            if ($isinitneeded) {
-                if ($iscapturetask) {
-                    $fields = self::fastmerge(
-                        $fields,
-                        [
-                            self::makeLabel(
-                                $labelClass,
-                                'bitlocker',
-                                _('Bypass Bitlocker Detection')
-                            ) => self::makeInput(
-                                '',
-                                'bitlocker',
-                                '',
-                                'checkbox',
-                                'bitlocker',
-                                '',
-                                false,
-                                false,
-                                -1,
-                                -1,
-                                ''
-                            )
-                        ]
-                    );
-                }
-                if (!$isdebug) {
-                    $shutdownchecked = self::getSetting(
-                        'FOG_TASKING_ADV_SHUTDOWN_ENABLED'
-                    ) ? ' checked' : '';
-                    $fields = self::fastmerge(
-                        $fields,
-                        [
-                            '<div class="hideFromDebug deploy-field-group">'
-                            . self::makeLabel(
-                                $labelClass,
-                                'shutdown',
-                                _('Shutdown when complete')
-                            ) => self::makeInput(
-                                '',
-                                'shutdown',
-                                '',
-                                'checkbox',
-                                'shutdown',
-                                '',
-                                false,
-                                false,
-                                -1,
-                                -1,
-                                $shutdownchecked
-                            )
-                            . '</div>'
-                        ]
-                    );
-                }
-            }
-            if (TaskType::WAKE_UP != $type) {
-                $wolchecked = self::getSetting(
-                    'FOG_TASKING_ADV_WOL_ENABLED'
-                ) ? ' checked' : '';
-                $fields = self::fastmerge(
-                    $fields,
-                    [
-                        self::makeLabel(
-                            $labelClass,
-                            'wol',
-                            _('Wake Up')
-                        ) => self::makeInput(
-                            '',
-                            'wol',
-                            '',
-                            'checkbox',
-                            'wol',
-                            '',
-                            false,
-                            false,
-                            -1,
-                            -1,
-                            $wolchecked
-                        )
-                    ]
-                );
-            }
-            if (TaskType::PASSWORD_RESET != $type
-                && !$isdebug
-                && $isinitneeded
-            ) {
-                $debugchecked = self::getSetting(
-                    'FOG_TASKING_ADV_DEBUG_ENABLED'
-                ) ? ' checked' : '';
-                $fields = self::fastmerge(
-                    $fields,
-                    [
-                        self::makeLabel(
-                            $labelClass,
-                            'checkdebug',
-                            _('Debug Task')
-                        ) => self::makeInput(
-                            '',
-                            'isDebugTask',
-                            '',
-                            'checkbox',
-                            'checkdebug',
-                            '',
-                            false,
-                            false,
-                            -1,
-                            -1,
-                            $debugchecked
-                        )
-                    ]
-                );
-            }
+            // Shared with GroupManagement::deploy() and deployMulti(); the
+            // three forms differ only in which hosts they apply to.
+            $fields = $this->taskingOptionFields($type, $labelClass);
             $fields = self::fastmerge(
                 $fields,
                 $this->scheduleTypeFields($labelClass, $isdebug, $type)

--- a/tests/host-list-queue-task.test.php
+++ b/tests/host-list-queue-task.test.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Queue Task on the host list: the three things that are not obvious.
+ *
+ * The list gained a Queue Task button that tasks whatever rows are ticked.
+ * Most of it is markup and a fetch, and neither is worth a test. Three
+ * pieces are, because each is load-bearing and each fails silently when
+ * wrong.
+ *
+ * 1. THE PERMISSION IS IMPLICIT. Nothing registers `host.task` for the new
+ *    subs. They are gated because Authorization::_subToAction() reads the
+ *    `deploy` prefix off the sub name and answers `task` -- so the whole
+ *    gate is a naming convention, and renaming the method to something
+ *    tidier (`queueTask`, `taskSelected`) would silently reclassify it as
+ *    `host.view` for the GET and `host.edit` for the POST. Both would be
+ *    granted to people who must not be able to task a fleet. Executed
+ *    through the same resolvePagePermission() the dispatcher calls.
+ *
+ * 2. THE SELECTION SIZE DECIDES WHICH TASK TYPES APPLY, and the rule comes
+ *    from data rather than from a list of ids: `ttIsAccess` is 'group' for
+ *    Multi-Cast (one session serves many hosts, so it means nothing for
+ *    one), 'host' for Capture (an image comes off exactly one machine), and
+ *    'both' for everything else. The script hides the entries that do not
+ *    apply; assertSelectionTaskable() is what makes a request that skipped
+ *    the UI get the same answer. Driven directly, since the browser half
+ *    cannot be.
+ *
+ * 3. THE SELECTION IS CARRIED BY AN UNSAVED GROUP. That is not a shortcut
+ *    around the host path -- it is the only path that gets Multi-Cast right,
+ *    because one session has to cover the whole selection. It only works
+ *    because Group::loadHosts() short circuits when there is no id; without
+ *    that, set('hosts', ...) triggers a load whose filters are the
+ *    empty-value shape that means "no filter" elsewhere in this codebase.
+ *    Asserted as "no query was issued AND the ids survive", because either
+ *    half alone would pass on a broken implementation.
+ *
+ * Usage: php tests/host-list-queue-task.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+use FOG\Auth\Authorization;
+use FOG\Base\FOGCore;
+use FOG\Pages\HostManagement;
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('host-list-queue-task');
+// resolvePagePermission() runs the real chain, which fires a hook, which
+// asks the router for the known events. It needs a database to answer to.
+FogTestHarness::fakeDb();
+
+$t = new FogChecks();
+
+// -------------------------------------------------------------------------
+// 1. The permission the naming convention buys.
+// -------------------------------------------------------------------------
+$t->check(
+    'GET ?sub=deployMulti resolves to host.task',
+    'host.task' === Authorization::resolvePagePermission(
+        'host',
+        'deployMulti',
+        false
+    )
+);
+$t->check(
+    'POST ?sub=deployMulti resolves to host.task',
+    'host.task' === Authorization::resolvePagePermission(
+        'host',
+        'deployMulti',
+        true
+    )
+);
+// The control, and the reason this test exists: a name without the prefix
+// lands somewhere far weaker. If someone renames the subs, this is what
+// tells them what they just gave away.
+$t->check(
+    'a name without the deploy prefix would be host.view / host.edit',
+    'host.view' === Authorization::resolvePagePermission(
+        'host',
+        'queueTask',
+        false
+    )
+    && 'host.edit' === Authorization::resolvePagePermission(
+        'host',
+        'queueTask',
+        true
+    )
+);
+
+// -------------------------------------------------------------------------
+// 2. Which task types a selection of a given size can run.
+// -------------------------------------------------------------------------
+$page = new HostManagement();
+$assert = new \ReflectionMethod(HostManagement::class, 'assertSelectionTaskable');
+$assert->setAccessible(true);
+
+/**
+ * A stand-in task type. Only the two fields the rule reads.
+ *
+ * @param string $access ttIsAccess: both, host or group
+ * @param string $name   the task type's name
+ *
+ * @return object
+ */
+$taskType = static function ($access, $name) {
+    return new class($access, $name) {
+        /** @var array */
+        private $_d;
+
+        /**
+         * @param string $access ttIsAccess value
+         * @param string $name   task type name
+         */
+        public function __construct($access, $name)
+        {
+            $this->_d = ['access' => $access, 'name' => $name];
+        }
+
+        /**
+         * @param string $key the field to read
+         *
+         * @return string
+         */
+        public function get($key)
+        {
+            return $this->_d[$key] ?? '';
+        }
+    };
+};
+
+/**
+ * Runs the rule and reports the refusal, or '' when it allowed the size.
+ *
+ * @param string $access ttIsAccess value
+ * @param int    $count  how many hosts are selected
+ *
+ * @return string the exception message, or ''
+ */
+$refusal = static function ($access, $count) use ($page, $assert, $taskType) {
+    try {
+        $assert->invoke($page, $taskType($access, 'Test Type'), $count);
+    } catch (\Exception $e) {
+        return $e->getMessage();
+    }
+
+    return '';
+};
+
+$t->check(
+    "a 'both' type runs on one host",
+    '' === $refusal('both', 1)
+);
+$t->check(
+    "a 'both' type runs on many hosts",
+    '' === $refusal('both', 25)
+);
+$t->check(
+    "Multi-Cast ('group') is refused for a single host",
+    '' !== $refusal('group', 1)
+);
+$t->check(
+    "Multi-Cast ('group') is allowed from two hosts up",
+    '' === $refusal('group', 2)
+);
+$t->check(
+    "Capture ('host') is allowed on exactly one host",
+    '' === $refusal('host', 1)
+);
+$t->check(
+    "Capture ('host') is refused for a selection",
+    '' !== $refusal('host', 2)
+);
+// The message names the type, because a toast that just says "not allowed"
+// against a menu of ten entries tells nobody which one was the problem.
+$t->check(
+    'the refusal names the task type',
+    false !== strpos($refusal('group', 1), 'Test Type')
+);
+
+// -------------------------------------------------------------------------
+// 3. The unsaved Group that carries the selection.
+// -------------------------------------------------------------------------
+$db = FogTestHarness::fakeDb();
+$mark = count($db->log);
+
+$Selection = FOGCore::getClass('Group');
+$Selection->set('name', '3 selected hosts');
+$Selection->set('hosts', [4, 9, 17]);
+$hosts = $Selection->get('hosts');
+
+// Only the membership table matters. A settings read or the storage-epoch
+// lookup can fire from anywhere in the boot chain and says nothing about
+// whether the guard held; a `groupMembers` read is the guard failing.
+$issued = array_filter(
+    array_slice($db->log, $mark),
+    static function ($sql) {
+        return false !== strpos($sql, 'groupMembers');
+    }
+);
+
+$t->check(
+    'the ids set on an unsaved group are the ids it reports',
+    [4, 9, 17] === $hosts
+);
+$t->check(
+    'and it never went to groupMembers to find that out',
+    count($issued) === 0
+);
+
+// The other half of the same guard: a group that DOES have an id must still
+// load its members, or every real group tasking silently tasks nothing.
+$db = FogTestHarness::fakeDb();
+$db->responder = static function ($sql) use ($db) {
+    $db->error = false;
+    if (false !== strpos($sql, 'groupMembers')) {
+        return [['gmHostID' => 7], ['gmHostID' => 8]];
+    }
+
+    return null;
+};
+$Real = FOGCore::getClass('Group');
+$Real->set('id', 3);
+$t->check(
+    'a saved group still loads its members',
+    [7, 8] === array_map('intval', (array)$Real->get('hosts'))
+);
+
+$t->finish();


### PR DESCRIPTION
1.5 could task from the host list. 1.6 could not: the only way to create a
task was to open a host, or to build a group first and task that. For
"image these eleven machines now" that is eleven page loads, or a group
that exists only to be deleted afterward.

The list toolbar gains a **Queue Task** button, enabled by the same
selection that already enables *Add to group* and *Delete*. It opens the
Basic/Advanced accordion the host edit page shows, fetches that task
type's options form, and posts the ticked ids.

## What is shared now

| Was | Is |
|---|---|
| The Basic/Advanced accordion, written out in `HostManagement::hostTasks()` | `FOGPageRender::taskTypeAccordion()`, which takes a callback for the anchor |
| ~200 lines of task options duplicated between `HostManagement::deploy()` and `GroupManagement::deploy()` | `FOGPageRender::taskingOptionFields()` |

The accordion needs the callback because the host edit page links to a sub
with an `id` in the href and the list cannot — which hosts are tasked is
whatever is ticked at the moment of the click, and only the browser knows
that. Each entry carries its `ttIsAccess` value instead.

The options extraction also **fixes a drift**: only the host copy offered
the bitlocker bypass. `taskingOptionFields()` takes the type ID rather
than a task-type object, because the two existing callers hold different
things under the same name — the host page holds the decoded API row,
where the predicates are properties, and the group page holds the model,
where they are methods.

## Which task types a selection can run

`ttIsAccess` decides it, not a list of ids:

- `'group'` — Multi-Cast. One session serves many hosts, so it means
  nothing for one. Shown from two rows up.
- `'host'` — Capture. An image comes off exactly one machine. Shown for
  one row only.
- `'both'` — everything else.

The script hides the entries that do not apply; `assertSelectionTaskable()`
refuses the same two cases server-side, so a request that skipped the UI
gets the same answer.

## The selection is carried by a Group that is never saved

Not a shortcut around the host path — it is the only path that gets
Multi-Cast right. One multicast session has to cover the whole selection:
one port, one sender, one row per host in `multicastSessionsAssoc`.
Looping `Host::createImagePackage()` would create a separate session per
host and none of them would ever stream.

`Group::loadHosts()` gains an early return for a group with no id, so
`set('hosts', …)` does not trigger a load whose filters are the
empty-value shape that means "no filter" elsewhere in this codebase.

## Scope

**Instant tasks only.** A `scheduledTasks` row carries one `hostID` plus
an `isGroupTask` flag, so it can name a host or a group and has nowhere to
put a set that is neither; giving it one is a schema change. The edit
pages still schedule per host and per group.

## Permission

`host.task` for both the GET and the POST. The subs get that by being
named `deployMulti` — `Authorization::_subToAction()` reads the `deploy`
prefix. That is a naming convention doing security work, so the test pins
it: renaming the subs to something tidier would silently reclassify them
as `host.view` and `host.edit`, which nearly every operator holds.

The ids come from the browser, so `deployMultiPost()` bounds them with
`Authorization::requirePageObjectScopeMass('host', $hosts)` — one id
outside the caller's site scope denies the whole request rather than
quietly tasking the rest.

## Tests

`tests/host-list-queue-task.test.php` — 13 checks over the three things
above and nothing else; the markup and the fetch are not worth a test.
Every check was made to fail by mutating the code it guards:

| Mutation | Checks that went red |
|---|---|
| `'deploy'` dropped from `_subToAction()`'s prefix list | the two `host.task` resolutions |
| the `'group'` refusal removed | Multi-Cast on one host, and the named-type message |
| the `'host'` refusal removed | Capture on a selection |
| the refusal message drops the type name | the named-type message |
| `Group::loadHosts()`'s early return removed | "never went to `groupMembers`" |

Full suite: 267 passed, 0 failed. Both `phpstan` passes green on a cold
`/tmp/phpstan`.

`FOG_BCACHE_VER` 354 → 355, since `fog.host.list.js` changed.

## Not verified here

The browser half — the button enabling on selection, the accordion, the
availability toggling, and the round trip — has not been exercised. This
branch is not deployed and I do not deploy.

Co-Authored-By: Claude <noreply@anthropic.com>
