### PR TITLE
Queue Task is green, not gray

### DIFF
--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -4420,10 +4420,18 @@ class HostManagement extends FOGPage
             'HOST_ADVANCEDTASKS_DATA'
         );
 
+        // Green, not gray. Tasking is a genuinely different operation from
+        // the two edit actions beside it -- it starts work on machines
+        // rather than changing a record -- and the convention for that is
+        // btn-success, the same reason image replication's Resume Reload is
+        // green next to a blue Create. It also stops the toolbar reading as
+        // two identical gray buttons: the cluster is now
+        // [Queue Task (success)][Add to group (secondary)][Add (primary)],
+        // three distinguishable actions with the commit still rightmost.
         $button = self::makeButton(
             'queueTask',
             _('Queue Task'),
-            'btn btn-secondary'
+            'btn btn-success'
         );
 
         $modal = self::makeModal(


### PR DESCRIPTION
Follow-up to #1576.

The host list toolbar read as two identical gray buttons followed by a
blue one:

```
[Queue Task (secondary)][Add selected to group (secondary)][Add (primary)]
```

Tasking is not the same kind of action as the two beside it — it starts
work on machines rather than changing a record — and the repo's own
convention for that is `btn-success`, the same reason image replication's
*Resume Reload* is green next to a blue *Create*. `btn-info` was the other
candidate and is wrong here: in this theme it is `#0dcaf0`, a bright cyan
that the conventions table already spends on the file-Browse prefix.

Now:

```
[Queue Task (success)][Add selected to group (secondary)][Add (primary)]
```

Three distinguishable actions, one primary, still rightmost.

One line of markup class plus its comment. No JS or CSS changed, so
`FOG_BCACHE_VER` stays where it is. Verified by rendering the host list
from a shadow tree against the lab database — the emitted cluster is
`btn btn-success` / `btn btn-secondary` / `btn btn-primary float-end`.

268 passed, 0 failed. Both `phpstan` passes green.

Co-Authored-By: Claude <noreply@anthropic.com>
