### PR TITLE
Every multicast session save was refused; write NULL for a nullable int

### DIFF
--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -5872,9 +5872,29 @@ abstract class FOGBase
      * already performing, written down and made legal:
      *
      *   date/time  ->  NULL          (was '0000-00-00 00:00:00')
-     *   integer    ->  0             (was 0, via error 1366 downgraded)
+     *   integer    ->  NULL if the column is nullable, else 0
      *   enum/set   ->  first member  (was '', the error value at index 0)
      *   anything   ->  ''            (unchanged; '' is a real value here)
+     *
+     * The nullable half of the integer rule is GH-1572's, arrived at here
+     * a second time. That fixed the branch save() takes for a key ending
+     * in "id"; this is the branch it takes for every other key, and the
+     * two have to answer the same way because the column does not care
+     * what the model calls it. Once ADR 0031 gave a nullable int a real
+     * foreign key, 0 stopped being a spelling of "no reference" and became
+     * a reference to a row that does not exist -- error 1452, and the save
+     * is refused outright.
+     *
+     * `multicastSessions`.`msSenderNode` is the column that proves it. Its
+     * model key is `sendernode`, which does not end in "id", so it misses
+     * GH-1572's branch entirely; step 386 made it nullable and step 388
+     * gave it a foreign key to `nfsGroupMembers`. A session is created
+     * before any udp-sender exists, so the field is always unset at
+     * INSERT -- which means EVERY multicast session save on this branch
+     * failed, from the group page, the host page and the image page
+     * alike. save() reports that failure by returning false rather than
+     * throwing, so Group::createImagePackage() carried on and built the
+     * per-host tasks against a session id that was never allocated.
      *
      * The integer and enum choices deliberately match the coercion rather
      * than the column's DEFAULT. `hosts.hostEnforce` is declared
@@ -5902,7 +5922,11 @@ abstract class FOGBase
             return null;
         }
         if (preg_match('/^(tiny|small|medium|big)?int\b/i', $type)) {
-            return 0;
+            // NULL where the column can hold one: it is the honest spelling
+            // of "no value", and it is the only one a foreign key accepts.
+            // 0 stays for a NOT NULL column, where omitting the value is
+            // error 1364 and NULL is error 1048.
+            return self::columnIsNullable($table, $column) ? null : 0;
         }
         if (preg_match("/^(enum|set)\\s*\\(\\s*'((?:[^']|'')*)'/i", $type, $match)) {
             return str_replace("''", "'", $match[2]);

--- a/tests/nullable-int-columns-write-null.test.php
+++ b/tests/nullable-int-columns-write-null.test.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * An unset nullable integer column is written as NULL, not as 0.
+ *
+ * GH-1572 established this for the branch save() takes when a model key
+ * ends in "id": once ADR 0031 gave a nullable int column a real foreign
+ * key, 0 stopped being a spelling of "no reference" and became a reference
+ * to a row that does not exist -- error 1452, and the whole save refused.
+ *
+ * That fix reached one branch of one method. Every model key that does NOT
+ * end in "id" takes the other branch, which asks FOGBase::emptyValueFor()
+ * what an unset optional field should be written as, and that answered 0
+ * for every integer column whether or not it could hold NULL. So the same
+ * bug survived under a different name.
+ *
+ * `multicastSessions`.`msSenderNode` is the column that proves it. Its
+ * model key is `sendernode`; schema step 386 made the column nullable and
+ * step 388 gave it a foreign key to `nfsGroupMembers`(`ngmID`). A session
+ * is created before any udp-sender exists, so the field is ALWAYS unset at
+ * INSERT -- which meant every multicast session save on this branch failed
+ * with 1452, from all three places that create one:
+ *
+ *   Group::createImagePackage()      group multicast, and the host list's
+ *                                    Queue Task, which routes through it
+ *   Host::createImagePackage()       multicast from a single host
+ *   ImageManagement::_newSession()   "create session" on the image page
+ *
+ * The failure was silent in the way that costs the most time. save()
+ * reports it by RETURNING FALSE rather than throwing, so
+ * createImagePackage() carried on and built the per-host task rows against
+ * a session id that had never been allocated -- and what the user saw was
+ * a complaint about `multicastSessionsAssoc`.`msID` being empty, naming a
+ * table two steps downstream of the one that actually refused the write.
+ *
+ * WHAT IS ASSERTED, and why in two layers. The unit half pins
+ * emptyValueFor() against the four shapes that have to stay distinguished;
+ * the behavioral half drives the real save() through a fake database and
+ * reads the parameters it bound, because emptyValueFor() answering null is
+ * worth nothing if save() then declines to bind it. Either half alone
+ * passes on a broken implementation.
+ *
+ * The premises are pinned too. Both facts this rests on live in files
+ * nothing else in the suite watches for this purpose: the column is still
+ * nullable in the manifest, and the foreign key that makes 0 unstorable is
+ * still declared. If either changes, this test should be re-read rather
+ * than silently kept green.
+ *
+ * Usage: php tests/nullable-int-columns-write-null.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+use FOG\Base\FOGBase;
+use FOG\Items\MulticastSession;
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('nullable-int-columns-write-null');
+FogTestHarness::fakeDb();
+
+$t = new FogChecks();
+
+// -------------------------------------------------------------------------
+// 1. emptyValueFor() itself. Reflection because it is protected, and it is
+//    protected for a good reason -- this is the only caller outside the
+//    class hierarchy and it is a test.
+// -------------------------------------------------------------------------
+$empty = new \ReflectionMethod(FOGBase::class, 'emptyValueFor');
+$empty->setAccessible(true);
+/**
+ * What an unset optional field on this column would be written as.
+ *
+ * @param string $table  the database table
+ * @param string $column the database column
+ *
+ * @return mixed
+ */
+$valueFor = static function ($table, $column) use ($empty) {
+    return $empty->invoke(null, $table, $column);
+};
+
+// The column the bug was found on: nullable int, carries a foreign key.
+$t->check(
+    'a nullable int column answers NULL',
+    null === $valueFor('multicastSessions', 'msSenderNode')
+);
+// Nullable for the same reason (step 386, taskStates has no tsID 0) but
+// with no foreign key, so this one is the rule applying generally rather
+// than the foreign key forcing it.
+$t->check(
+    'a nullable int column with no foreign key answers NULL too',
+    null === $valueFor('multicastSessions', 'msState')
+);
+// The half that must NOT change. NULL is not storable in a NOT NULL
+// column -- that is error 1048 -- and omitting the value is 1364, so 0
+// remains the only answer here.
+$t->check(
+    'a NOT NULL int column still answers 0',
+    0 === $valueFor('multicastSessions', 'msSenderPID')
+);
+$t->check(
+    'a NOT NULL int column with no default still answers 0',
+    0 === $valueFor('multicastSessions', 'msNFSGroupID')
+);
+// The neighbors, so a change to the integer rule cannot quietly take the
+// others with it.
+$t->check(
+    'a nullable datetime column still answers NULL',
+    null === $valueFor('multicastSessions', 'msStartDateTime')
+);
+$t->check(
+    "a NOT NULL string column still answers ''",
+    '' === $valueFor('multicastSessions', 'msName')
+);
+// An unknown table or column is the "assume a string" fallback, and it has
+// to stay that way: guessing NULL for something the manifest cannot see
+// would turn a plugin's NOT NULL column into error 1048.
+$t->check(
+    "an unknown column still answers ''",
+    '' === $valueFor('multicastSessions', 'msNoSuchColumn')
+);
+
+// -------------------------------------------------------------------------
+// 2. The premises, which live in two files nothing else watches for this.
+// -------------------------------------------------------------------------
+$manifest = (string) file_get_contents(
+    dirname(__DIR__) . '/packages/web/commons/schema-expected.php'
+);
+$t->check(
+    'msSenderNode is still declared nullable in the manifest',
+    false !== strpos($manifest, "'msSenderNode' => 'int(11) DEFAULT NULL'")
+);
+$constraints = (string) file_get_contents(
+    dirname(__DIR__) . '/packages/web/commons/schema-constraints.php'
+);
+$t->check(
+    'msSenderNode still carries the foreign key that makes 0 unstorable',
+    1 === preg_match(
+        "/'child' => 'multicastSessions',\s*'column' => 'msSenderNode',"
+        . "\s*'parent' => 'nfsGroupMembers'/",
+        $constraints
+    )
+);
+
+// -------------------------------------------------------------------------
+// 3. The whole chain: what save() actually binds for a session built the
+//    way all three creation sites build one.
+// -------------------------------------------------------------------------
+$db = FogTestHarness::fakeDb();
+$captured = [];
+$db->responder = static function ($sql, $params) use ($db, &$captured) {
+    $db->error = false;
+    if (0 === stripos(ltrim($sql), 'INSERT INTO `multicastSessions`')) {
+        $captured = $params;
+    }
+
+    return null;
+};
+
+// Exactly the fields the three sites set, minus the ones that vary between
+// them. Notably `sendernode` is NOT set -- that is the point: no
+// udp-sender exists yet, so nothing has a value to give it.
+$Session = new MulticastSession();
+$Session->set('name', 'Multi-Cast Task - 3 selected hosts')
+    ->set('port', 63100)
+    ->set('logpath', '/images/test')
+    ->set('image', 1)
+    ->set('interface', 'eth0')
+    ->set('stateID', null)
+    ->set('starttime', '2026-08-31 21:44:09')
+    ->set('percent', 0)
+    ->set('isDD', 1)
+    ->set('maxwait', 600)
+    ->set('storagegroupID', 1);
+$Session->save();
+
+$t->check(
+    'the INSERT was built at all',
+    count($captured) > 0
+);
+/*
+ * Absent from the parameter list is the other way save() spells NULL for a
+ * nullable column -- the null guard omits it and the server's DEFAULT NULL
+ * applies. Both spellings are correct; a bound 0 or '' is not. Asserting
+ * "not 0" alone would pass on a bound empty string, so the check is that
+ * the parameter is either absent or a real null.
+ */
+$sender = ':msSenderNode_insert';
+$t->check(
+    'msSenderNode is bound as NULL, or left out entirely',
+    !array_key_exists($sender, $captured) || null === $captured[$sender]
+);
+// The counterpart, in the same statement, so the two halves of the rule
+// are proven against one another rather than in isolation.
+$pid = ':msSenderPID_insert';
+$t->check(
+    'msSenderPID in the same statement is still bound as 0',
+    array_key_exists($pid, $captured) && 0 === (int) $captured[$pid]
+);
+
+$t->finish();


### PR DESCRIPTION
Creating a multicast session has been impossible on this branch since ADR
0031 landed — from the group page, from a single host, and from the image
page's *create session* alike. All three go through
`MulticastSession::save()`, and all three were answered with:

```
SQLSTATE[23000]: 1452 Cannot add or update a child row: a foreign key
constraint fails (`fog`.`multicastSessions`, CONSTRAINT
`fk_multicastSessions_msSenderNode` FOREIGN KEY (`msSenderNode`)
REFERENCES `nfsGroupMembers` (`ngmID`) ON DELETE SET NULL)
```

`save()` reports that by **returning false rather than throwing**, so
`createImagePackage()` carried on and built the per-host task rows against
a session id that had never been allocated. What the user saw was a
complaint about `multicastSessionsAssoc`.`msID` being empty — a table two
steps downstream of the one that actually refused the write — and a set of
tasks with nothing to stream.

Found while exercising #1576's Queue Task against the lab database; the new
button routes through `Group::createImagePackage()`, so it hit the same
wall the group page already did.

## Cause

This is #1572's bug, reached by the other road.

| model key | branch `save()` takes | fixed by |
|---|---|---|
| ends in `id` (`taskNFSGroupID`) | the `*id` branch | #1572 |
| anything else (`sendernode`) | `FOGBase::emptyValueFor()` | **this** |

#1572 established that once a nullable int column carries a real foreign
key, `0` is not "no reference" — it is a reference to a row that does not
exist. `emptyValueFor()` answered `0` for *every* integer column, nullable
or not, so the same defect survived under a different name.

`multicastSessions`.`msSenderNode` is where the two diverge. Its model key
is `sendernode`, so it misses #1572's branch entirely; step 386 made the
column nullable and step 388 gave it the foreign key. A session is created
before any udp-sender exists, so the field is **always** unset at INSERT.

## Fix

`emptyValueFor()` now answers `NULL` for a nullable int and keeps `0` for a
NOT NULL one — the same rule #1572 wrote, in the one place that serves
every model rather than at three call sites.

Setting `sendernode` to null explicitly at the three sites was tried first
and **does not work**: `get()` reads an unset field back as `''`, so the
value is empty either way and lands in exactly this method. Worth recording
because it is the obvious fix and it looks like it should work.

The NOT NULL half is unchanged and has to be: `NULL` there is error 1048,
and omitting the value is 1364.

## Verified

End to end against the lab database from a shadow tree (no writes to
`/var/www`), using three throwaway hosts on locally-administered MACs that
match no hardware:

| | before | after |
|---|---|---|
| `POST ?sub=deployMulti&type=8` ×3 hosts | HTTP 400, 3 orphan tasks | **HTTP 201** |
| `multicastSessions` rows | 0 | 1 |
| `multicastSessionsAssoc` rows | 0 | 3 |
| `msSenderNode` | (no row) | `NULL` |

`tests/nullable-int-columns-write-null.test.php` — 12 checks, pinning both
directions of the rule plus the two premises it rests on (the column is
still nullable in the manifest; the foreign key is still declared). Both
mutations were run:

| Mutation | Checks that went red |
|---|---|
| `return 0;` — the old behavior | both nullable checks, and the bound-parameter check |
| `return null;` — over-applied | both NOT NULL checks |

269 passed, 0 failed. Both `phpstan` passes green on a cold `/tmp/phpstan`.

## Scope note

`emptyValueFor()` serves every model, so this changes what an unset
nullable int is written as everywhere — deliberately, since that is the
point. Today the affected columns are `msSenderNode` and `msState`; every
other nullable int in core reaches the database through the `*id` branch
#1572 already corrected, so this brings the two branches into agreement
rather than moving one of them somewhere new.

Not ported to `dev-branch`: there are no foreign keys there and the columns
are NOT NULL, so `0` is still the right value and NULL would be a 1048.

Co-Authored-By: Claude <noreply@anthropic.com>
