### PR TITLE
Let the pre-commit hook exit 0 when an optional tool is missing (GH-1581)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -188,3 +188,15 @@ psrfix
 # with the branch, was removed in the same change: with nothing stamping a
 # version there is nothing for it to guard, and it would have blocked every
 # push instead.
+
+# GH-1581: the hook's exit status is the status of the last command, which was
+# psrfix -- and psrfix returns 1 when php-cs-fixer is not installed, via
+# require_tools. So a machine without the optional tools printed "the commit
+# will proceed WITHOUT those changes" and then blocked the commit, with git
+# exiting 1 and saying nothing.
+#
+# Every step above is deliberately advisory: require_tools exists so a missing
+# formatter is a skip, not a failure, and CI regenerates all of it. Nothing in
+# this hook is a gate. Say so explicitly rather than leaving the status to
+# whichever helper happens to run last -- post-commit already ends this way.
+exit 0


### PR DESCRIPTION
Fixes #1581.

`.githooks/pre-commit` ended on a call to `psrfix` followed by a comment block, so the hook's exit status was `psrfix`'s. `psrfix` goes through `require_tools`, which returns 1 when `php-cs-fixer` is not installed — so the hook printed

```
pre-commit: SKIPPING PSR2 formatting -- not installed: php-cs-fixer
pre-commit: the commit will proceed WITHOUT those changes; CI regenerates them.
```

and then blocked the commit. `git commit` exited 1 with no message of its own, which reads as git failing rather than a hook rejecting.

Nothing in this hook is a gate — `require_tools` exists precisely so a missing formatter or gettext is a *skip*, and CI regenerates every artifact it would have written. `post-commit` already ends with `exit 0` and `pre-merge-commit` with `:`; `pre-commit` was the one missing the guard.

Without this, a contributor without both `gettext` and `php-cs-fixer` cannot commit at all, and the workaround they reach for is `--no-verify` — which also skips the line-ending and version checks the hook is actually there to run.

### Verifying

On a machine without `php-cs-fixer`:

```bash
bash .githooks/pre-commit; echo $?   # 0 after this change, 1 before
```

### Also worth knowing (not changed here)

`core.hooksPath` set to an *absolute* path makes every worktree run that one checkout's hooks. On a `working-1.6` worktree that means running `dev-branch`'s `pre-commit`, which stamps a version into `packages/web/lib/fog/system.class.php` — a path working-1.6 moved to `packages/web/src/` — and dies with `fatal: pathspec ... did not match any files`. Setting it to the relative `.githooks` makes each worktree use its own branch's hooks. Noted in #1581 as a CONTRIBUTING.md candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtZHpyWZWDPSxePdTViGZy
