### PR TITLE
Restore what the installer promised to preserve (GH-1579, GH-1580)

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -1351,6 +1351,11 @@ while [[ -z $blGo ]]; do
                     checkDatabaseConnection
                     backupReports
                     configureMinHttpd
+                    # GH-1580: configureMinHttpd calls configureHttpd, so the
+                    # rm -rf $webdirdest applies to a storage node as well --
+                    # this path backs the reports up and so has to put them
+                    # back too.
+                    restoreReports
                     configureStorage
                     # Before configureDHCP, not with the rest of the TFTP
                     # staging in configureTFTPandPXE. The generated DHCP config
@@ -1456,6 +1461,13 @@ while [[ -z $blGo ]]; do
                     # into that package, so they have to be there first.
                     downloadplugins
                     configureHttpd
+                    # GH-1580: straight after the rm -rf/rebuild that removed
+                    # them. Unlike restorePreservedCustomizations, this has no
+                    # reason to wait for configureTFTPandPXE -- nothing between
+                    # here and there re-lays management/reports, and restoring
+                    # before checkWebTier means the tier is checked in the
+                    # state it will actually be served in.
+                    restoreReports
                     checkWebTier
                     backupDB
                     updateDB

--- a/docs/SUPPORTED_CUSTOMIZATIONS.md
+++ b/docs/SUPPORTED_CUSTOMIZATIONS.md
@@ -324,6 +324,30 @@ hangs off and are already signed by their vendors.
 
 ---
 
+## Reports you have written
+
+**Automatic**, on both a full server and a storage node.
+
+Reports you add under `<webroot>/management/reports/` are copied aside before
+the web tree is rebuilt and copied back afterward, so they survive every
+install and upgrade.
+
+| Customization | How it is preserved |
+|---|---|
+| A report file you wrote or edited | Backed up before the web tree is rebuilt, restored after |
+| A report that ships with FOG, edited in place | Restored over the new release's copy — so your edit wins, and you stop receiving FOG's changes to that file |
+
+That second row is the trade-off worth knowing about: the restore does not try
+to tell your file apart from a newer FOG one of the same name. If you want
+FOG's version back, delete yours and re-run the installer.
+
+> Before FOG 1.6 these were backed up and never restored — the backup was
+> written and nothing read it, so an administrator's own reports were lost on
+> every run (GH-1580). If you are upgrading from an affected version, your
+> reports are in `<backuppath>/fog_web_<version>.BACKUP/management/reports`.
+
+---
+
 ## What is NOT automatically preserved
 
 Listed plainly so none of it is a surprise.
@@ -338,7 +362,10 @@ Listed plainly so none of it is a surprise.
   that generation re-signs with the *current* key, which is correct, but any
   client enrolled against the old key still needs re-enrollment.
 - **More than `--kernel-backup-count` generations back.** The oldest is
-  evicted on each run; the default keeps three.
+  evicted on each run; the default keeps three. On FOG before GH-1579 the
+  rotation never ran, so only ever one generation existed no matter what this
+  was set to — if `restorekernel.sh --list` shows a single generation on an
+  older server, that is why.
 - **`php.ini` / MariaDB config beyond FOG's own lines.** FOG patches only the
   specific directives it manages and leaves the rest of those files alone, so
   your edits generally survive — but they are not backed up, and are not

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -286,7 +286,16 @@ backupPreservedCustomizations() {
     if [[ -d $ipxedir ]]; then
         mkdir -p "$kbdir" >>$error_log 2>&1 || warn=1
         rm -rf "${kbdir}/gen-${BOOT_kernel_backups_kept}" >>$error_log 2>&1
-        for ((k = kernelBackupGenerations - 1; k >= 1; k--)); do
+        # GH-1579: rotate on BOOT_kernel_backups_kept, not on the retired
+        # pre-GH-1120 spelling kernelBackupGenerations. That name now survives
+        # only as a migration source (see migrateDeprecatedKeys) and in the
+        # deprecated-key strip list, so on a migrated install -- and on every
+        # fresh one -- it is unset, bash reads it as 0, k starts at -1 and this
+        # loop never runs. gen-1 was overwritten in place forever and gen-2
+        # onward were never created, which silently made
+        # --kernel-backup-count a no-op and restorekernel.sh --generation N
+        # unusable for any N above 1.
+        for ((k = BOOT_kernel_backups_kept - 1; k >= 1; k--)); do
             [[ -d "${kbdir}/gen-${k}" ]] && mv "${kbdir}/gen-${k}" "${kbdir}/gen-$((k + 1))" >>$error_log 2>&1
         done
         mkdir -p "${kbdir}/gen-1" >>$error_log 2>&1 || warn=1
@@ -2105,14 +2114,26 @@ join() {
     shift
     echo "$*"
 }
+# GH-1580: the other half of backupReports(). This function existed but had no
+# call site anywhere, so configureHttpd()'s rm -rf $webdirdest took an admin's
+# own reports on every install and upgrade -- the backup was written to
+# ../rpttmp and then never read.
+#
+# Never fatal. An absent or empty ../rpttmp is the ordinary fresh-install case
+# rather than a failure, and aborting an otherwise good install over a report
+# that was not there is a worse outcome than the one this exists to prevent.
 restoreReports() {
+    local warn=0
+    [[ -d $webdirdest/management/reports && -d ../rpttmp ]] || return 0
+    # find, not a glob: `cp -a ../rpttmp/*` passes the unexpanded pattern
+    # through to cp when the directory is empty, which fails.
+    [[ -n $(find ../rpttmp -mindepth 1 -print -quit 2>/dev/null) ]] || return 0
     dots "Restoring user reports"
-    if [[ -d $webdirdest/management/reports ]]; then
-        if [[ -d ../rpttmp/ ]]; then
-            cp -a ../rpttmp/* $webdirdest/management/reports/
-        fi
-    fi
-    errorStat $?
+    # /. so dotfiles come along and the copy lands INSIDE the target rather
+    # than creating ../rpttmp underneath it.
+    cp -a ../rpttmp/. $webdirdest/management/reports/ >>$error_log 2>&1 || warn=1
+    [[ $warn -ne 0 ]] && echo -n "(some reports could not be restored) "
+    errorStat 0
 }
 installFOGServices() {
     dots "Setting up FOG Services"

--- a/tests/kernel-backup-rotation.test.sh
+++ b/tests/kernel-backup-rotation.test.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+#
+# Kernel backup generations actually rotate.
+#
+#   tests/kernel-backup-rotation.test.sh
+#
+# GH-1579. backupPreservedCustomizations() prunes the oldest generation using
+# BOOT_kernel_backups_kept and then shifts the rest up by one -- except the
+# shift loop read `kernelBackupGenerations`, the retired pre-GH-1120 spelling.
+# That name survives only as a migration source and in the deprecated-key strip
+# list, so on a migrated install, and on every fresh one, it is unset. Bash
+# evaluates an unset name as 0 in arithmetic, so `k` started at -1 and the loop
+# body never ran: gen-1 was overwritten in place forever and gen-2 onward were
+# never created.
+#
+# Nothing failed. --kernel-backup-count silently did nothing, and
+# restorekernel.sh --generation N was unusable for every N above 1 -- which is
+# every N worth asking for, since gen-1 is the snapshot you already have.
+#
+# The rotation is EXECUTED against a fixture, not read. A textual check for the
+# right variable name passes on a loop that names it and gets the direction
+# backwards, and the direction is the whole of the behaviour: rotating the
+# wrong way overwrites the newest snapshot with the oldest.
+#
+# No root, no network, no FOG install.
+#
+# Usage: bash tests/kernel-backup-rotation.test.sh
+# Exit status 0 = pass, 1 = fail.
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+functions="$root/lib/common/functions.sh"
+
+pass=0
+fail=0
+
+check() {
+    if [[ $2 -eq 0 ]]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        printf '  FAIL  %s\n' "$1"
+    fi
+}
+
+if [[ ! -r $functions ]]; then
+    echo "FAIL: cannot read $functions" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# The prune-and-rotate block, lifted out of backupPreservedCustomizations().
+# ---------------------------------------------------------------------------
+snippet=$(awk '
+    /BOOT_kernel_backups_kept\} -lt 1 \]\] &&/ { grab = 1 }
+    grab { print }
+    grab && /mkdir -p "\$\{kbdir\}\/gen-1"/ { exit }
+' "$functions")
+
+if [[ -z $snippet ]]; then
+    echo "FAIL: could not find the kernel-backup rotation block in" >&2
+    echo "  lib/common/functions.sh. If it moved or was rewritten, point this" >&2
+    echo "  test at it -- do not delete the assertion." >&2
+    exit 1
+fi
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+error_log="$work/error.log"
+
+# The block opens `if [[ -d $ipxedir ]]` and the extraction stops before its
+# `fi`, so the closer is supplied here. Everything else -- the default, the
+# prune, the shift -- is the real code. It computes $kbdir from
+# $customizationsDir itself, so the fixture drives it through that rather than
+# passing a path in.
+eval "rotate() {
+    local warn=0
+$snippet
+    fi
+}"
+
+# Entering the block at all requires a live iPXE directory, and $webdirsrc is
+# read for the shipped-file subtraction further down the real function.
+ipxedir="$work/ipxe"
+webdirsrc="$work/src"
+mkdir -p "$ipxedir" "$webdirsrc/service/ipxe"
+
+# One install: rotate, then leave a marker in the fresh gen-1 so a later run
+# can say which snapshot ended up where.
+install() {
+    rotate
+    echo "$1" > "${customizationsDir}/kernel-backups/gen-1/marker"
+}
+
+# ---------------------------------------------------------------------------
+# Three installs in a row, with the default retention.
+# ---------------------------------------------------------------------------
+customizationsDir="$work/default"
+kbdir="$customizationsDir/kernel-backups"
+unset BOOT_kernel_backups_kept kernelBackupGenerations
+
+for gen in first second third fourth; do
+    install "$gen"
+done
+
+check "gen-2 is created (it never was: the loop did not run)" \
+    "$([[ -d $kbdir/gen-2 ]]; echo $?)"
+
+check "gen-3 is created" \
+    "$([[ -d $kbdir/gen-3 ]]; echo $?)"
+
+check "the default keeps three generations, not four" \
+    "$([[ ! -d $kbdir/gen-4 ]]; echo $?)"
+
+# Rotation direction: gen-1 is always the newest, and each older snapshot has
+# moved DOWN the list by exactly one install.
+check "gen-1 holds the newest snapshot" \
+    "$([[ $(cat "$kbdir/gen-1/marker" 2>/dev/null) == fourth ]]; echo $?)"
+
+check "gen-2 holds the one before it" \
+    "$([[ $(cat "$kbdir/gen-2/marker" 2>/dev/null) == third ]]; echo $?)"
+
+check "gen-3 holds the one before that" \
+    "$([[ $(cat "$kbdir/gen-3/marker" 2>/dev/null) == second ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# --kernel-backup-count actually changes retention. This is what the bug made
+# a no-op, and a rotation that hardcoded 3 would still pass everything above.
+# ---------------------------------------------------------------------------
+customizationsDir="$work/kb-five"
+kbdir="$customizationsDir/kernel-backups"
+BOOT_kernel_backups_kept=5
+
+for gen in 1 2 3 4 5 6; do
+    install "$gen"
+done
+
+check "a retention of 5 keeps gen-5" \
+    "$([[ -d $kbdir/gen-5 ]]; echo $?)"
+
+check "a retention of 5 prunes gen-6" \
+    "$([[ ! -d $kbdir/gen-6 ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# A retention of 1 must not fall into the same off-by-one from the other side:
+# the loop is skipped legitimately here, and gen-1 is simply replaced.
+# ---------------------------------------------------------------------------
+customizationsDir="$work/kb-one"
+kbdir="$customizationsDir/kernel-backups"
+BOOT_kernel_backups_kept=1
+
+for gen in old new; do
+    install "$gen"
+done
+
+check "a retention of 1 keeps only gen-1" \
+    "$([[ -d $kbdir/gen-1 && ! -d $kbdir/gen-2 ]]; echo $?)"
+
+check "a retention of 1 still holds the newest snapshot" \
+    "$([[ $(cat "$kbdir/gen-1/marker" 2>/dev/null) == new ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# And that the retired name cannot come back. A tree where the rotation reads
+# kernelBackupGenerations again passes every fixture above whenever that name
+# happens to be set, which is exactly the legacy install the bug hid on.
+# ---------------------------------------------------------------------------
+# Comments stripped: the prose above the loop names the retired spelling
+# in order to explain why it must not be read, and that explanation is
+# worth keeping.
+check "the rotation does not read the retired kernelBackupGenerations" \
+    "$(! sed 's/#.*//' <<< "$snippet" | grep -q 'kernelBackupGenerations'; echo $?)"
+
+printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$pass" "$fail"
+[[ $fail -eq 0 ]]

--- a/tests/kernel-backup-rotation.test.sh
+++ b/tests/kernel-backup-rotation.test.sh
@@ -19,7 +19,7 @@
 #
 # The rotation is EXECUTED against a fixture, not read. A textual check for the
 # right variable name passes on a loop that names it and gets the direction
-# backwards, and the direction is the whole of the behaviour: rotating the
+# backwards, and the direction is the whole of the behavior: rotating the
 # wrong way overwrites the newest snapshot with the oldest.
 #
 # No root, no network, no FOG install.

--- a/tests/reports-preserved.test.sh
+++ b/tests/reports-preserved.test.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+#
+# User-authored reports survive an install.
+#
+#   tests/reports-preserved.test.sh
+#
+# GH-1580. backupReports() copied $webdirdest/management/reports into ../rpttmp
+# on both install paths, and restoreReports() was defined and never called from
+# anywhere. configureHttpd()'s `rm -rf $webdirdest` then took the live copy, so
+# an administrator's own reports were destroyed on every install and upgrade
+# and left only in a temporary directory nothing ever read.
+#
+# Two assertions, and both are needed. The behaviour test alone passes on a
+# correct function that is still never called -- which is precisely the state
+# this fixes -- so the call sites are pinned separately. The call-site test
+# alone passes on a function that is called and then fails the install, which
+# is what the unguarded `cp -a ../rpttmp/*` did on a fresh install where
+# ../rpttmp is empty.
+#
+# No root, no network, no FOG install.
+#
+# Usage: bash tests/reports-preserved.test.sh
+# Exit status 0 = pass, 1 = fail.
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+functions="$root/lib/common/functions.sh"
+installer="$root/bin/installfog.sh"
+
+pass=0
+fail=0
+
+check() {
+    if [[ $2 -eq 0 ]]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        printf '  FAIL  %s\n' "$1"
+    fi
+}
+
+for f in "$functions" "$installer"; do
+    if [[ ! -r $f ]]; then
+        echo "FAIL: cannot read $f" >&2
+        exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# restoreReports() is CALLED, on both install paths.
+#
+# configureMinHttpd() calls configureHttpd(), so the storage-node path wipes
+# the web root exactly as the normal path does. It backs the reports up, so it
+# has to put them back -- a restore on the normal path only would have left
+# storage nodes with the original bug.
+# ---------------------------------------------------------------------------
+uncommented=$(sed 's/#.*//' "$installer")
+
+check "restoreReports is called at all" \
+    "$(grep -qE '^[[:space:]]*restoreReports[[:space:]]*$' <<< "$uncommented"; echo $?)"
+
+check "it is called as many times as backupReports (both install paths)" \
+    "$([[ $(grep -cE '^[[:space:]]*restoreReports[[:space:]]*$' <<< "$uncommented") \
+        -eq $(grep -cE '^[[:space:]]*backupReports[[:space:]]*$' <<< "$uncommented") ]]; echo $?)"
+
+# Ordering: restoring before the wipe would be pointless, so each restore must
+# follow the configureHttpd/configureMinHttpd that rebuilt the tree.
+firstrestore=$(grep -nE '^[[:space:]]*restoreReports[[:space:]]*$' <<< "$uncommented" | head -1 | cut -d: -f1)
+firstwipe=$(grep -nE '^[[:space:]]*configure(Min)?Httpd[[:space:]]*$' <<< "$uncommented" | head -1 | cut -d: -f1)
+
+check "the first restore comes after the first web-tree rebuild" \
+    "$([[ -n $firstrestore && -n $firstwipe && $firstrestore -gt $firstwipe ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# And that it does the right thing when called.
+# ---------------------------------------------------------------------------
+snippet=$(awk '
+    /^restoreReports\(\) \{/ { grab = 1 }
+    grab { print }
+    grab && /^\}/ && !/^restoreReports/ { exit }
+' "$functions")
+
+if [[ -z $snippet ]]; then
+    echo "FAIL: could not find restoreReports() in lib/common/functions.sh." >&2
+    echo "  If it moved or was renamed, point this test at it -- do not" >&2
+    echo "  delete the assertion." >&2
+    exit 1
+fi
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+error_log="$work/error.log"
+# The real ones print progress and, for errorStat, exit the installer on a
+# non-zero status. Stubbed so a failure is observable here instead of killing
+# the test run.
+dots() { :; }
+# Recorded to a FILE, not a variable: runcase() invokes the function in a
+# subshell so the cd cannot leak between cases, and a variable set in there
+# would never reach the assertions -- which would make every errorStat check
+# below silently vacuous.
+errorStat() { echo "$1" > "$statfile"; return 0; }
+
+eval "$snippet"
+
+# The function reads ../rpttmp relative to the caller's cwd, which in a real
+# run is the repo's bin/. Each case gets its own directory pair.
+runcase() {
+    local case_dir="$work/$1"
+    mkdir -p "$case_dir/bin"
+    webdirdest="$case_dir/web/"
+    statfile="$case_dir/errorstat"
+    rm -f "$statfile"
+    ( cd "$case_dir/bin" && restoreReports )
+}
+
+# Empty when errorStat was never reached, which is a pass: the function
+# returned early because there was nothing to restore.
+reportedstat() {
+    cat "$work/$1/errorstat" 2>/dev/null
+}
+
+# --- an administrator's report is restored ---------------------------------
+mkdir -p "$work/normal/web/management/reports" "$work/normal/rpttmp"
+echo mine > "$work/normal/rpttmp/my-report.php"
+runcase normal
+
+check "an administrator's report is restored into the rebuilt tree" \
+    "$([[ -e $work/normal/web/management/reports/my-report.php ]]; echo $?)"
+
+check "its contents survive intact" \
+    "$([[ $(cat "$work/normal/web/management/reports/my-report.php" 2>/dev/null) == mine ]]; echo $?)"
+
+# --- dotfiles come along ---------------------------------------------------
+mkdir -p "$work/dotfile/web/management/reports" "$work/dotfile/rpttmp"
+echo hidden > "$work/dotfile/rpttmp/.htaccess"
+runcase dotfile
+
+check "a dotfile is restored too (cp -a of ./, not a bare glob)" \
+    "$([[ -e $work/dotfile/web/management/reports/.htaccess ]]; echo $?)"
+
+# --- an empty rpttmp is not a failure --------------------------------------
+# The fresh-install case. `cp -a ../rpttmp/*` passed the unexpanded pattern to
+# cp here, which fails -- and errorStat would have ended the install over a
+# report that was never there.
+mkdir -p "$work/empty/web/management/reports" "$work/empty/rpttmp"
+runcase empty
+
+check "an empty rpttmp does not report a failure" \
+    "$([[ -z $(reportedstat empty) || $(reportedstat empty) -eq 0 ]]; echo $?)"
+
+check "an empty rpttmp does not create anything" \
+    "$([[ -z $(ls -A "$work/empty/web/management/reports") ]]; echo $?)"
+
+# --- no rpttmp at all is not a failure -------------------------------------
+mkdir -p "$work/none/web/management/reports"
+runcase none
+
+check "a missing rpttmp does not report a failure" \
+    "$([[ -z $(reportedstat none) || $(reportedstat none) -eq 0 ]]; echo $?)"
+
+# --- no reports directory in the rebuilt tree ------------------------------
+mkdir -p "$work/notree/rpttmp"
+echo mine > "$work/notree/rpttmp/my-report.php"
+runcase notree
+
+check "a rebuilt tree without management/reports does not report a failure" \
+    "$([[ -z $(reportedstat notree) || $(reportedstat notree) -eq 0 ]]; echo $?)"
+
+printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$pass" "$fail"
+[[ $fail -eq 0 ]]

--- a/tests/reports-preserved.test.sh
+++ b/tests/reports-preserved.test.sh
@@ -10,7 +10,7 @@
 # an administrator's own reports were destroyed on every install and upgrade
 # and left only in a temporary directory nothing ever read.
 #
-# Two assertions, and both are needed. The behaviour test alone passes on a
+# Two assertions, and both are needed. The behavior test alone passes on a
 # correct function that is still never called -- which is precisely the state
 # this fixes -- so the call sites are pinned separately. The call-site test
 # alone passes on a function that is called and then fails the install, which


### PR DESCRIPTION
Fixes #1579. Fixes #1580.

Two documented preservation promises that the code did not keep. **Stacked on #1582** — nothing can be committed to this repo without that fix, so review it first; the base will become `working-1.6` once it merges.

## GH-1579 — kernel backup generations never rotate

`backupPreservedCustomizations()` shifted generations with:

```bash
for ((k = kernelBackupGenerations - 1; k >= 1; k--)); do
```

`kernelBackupGenerations` is the retired pre-GH-1120 spelling. It survives only as a migration source and in the deprecated-key strip list, so on a migrated install — and on **every fresh one** — it is unset. Bash reads an unset name as 0 in arithmetic, `k` starts at `-1`, and the loop body never runs.

`gen-1` was overwritten in place forever and `gen-2` onward were never created. That silently made `--kernel-backup-count` a no-op and `restorekernel.sh --generation N` unusable for every `N` above 1 — which is every `N` worth asking for, since `gen-1` is the snapshot you already have. `SUPPORTED_CUSTOMIZATIONS.md`'s "Three generations are kept by default" was not true.

The prune on the line above already used the migrated name; only the shift did not. It works **only** on servers still carrying the legacy key, which is why it survived.

## GH-1580 — user-authored reports destroyed every run

`restoreReports()` was defined and called from **nowhere**. `backupReports()` ran on both install paths, `configureHttpd()`'s `rm -rf $webdirdest` then took the live copy, and the backup in `../rpttmp` was never read.

Called now after the web tree is rebuilt, on both paths — `configureMinHttpd()` calls `configureHttpd()`, so a storage node wipes the tree exactly as a full server does, and a restore on the normal path alone would have left storage nodes with the original bug.

It also needed hardening before it could be called. It ended in `errorStat $?` after an unguarded `cp -a ../rpttmp/*`, which fails when `../rpttmp` is empty — the ordinary fresh-install case — and `errorStat` would have ended the install over a report that was never there. It now returns early when there is nothing to restore, copies `../rpttmp/.` so dotfiles come along, and warns instead of aborting.

## Tests

Both execute the real code against a fixture rather than reading it, following `tests/webroot-preserved-files.test.sh`.

That matters in both directions here. A textual check for the right variable name passes on a rotation that names it and shifts the *wrong way* — so `kernel-backup-rotation.test.sh` asserts which snapshot lands in which generation, that `--kernel-backup-count` actually changes retention, and that a retention of 1 does not trip the same off-by-one from the other side. And a behaviour test for `restoreReports()` passes on a correct function that is still never called — which was exactly the bug — so `reports-preserved.test.sh` pins the call sites separately, including that there are as many restores as backups and that each follows its web-tree rebuild.

Both were confirmed to fail against the unfixed code before being kept: 6 of 11 and 3 of 10 respectively.

## Docs

New "Reports you have written" section, including the trade-off that an edited FOG-shipped report wins over the new release's copy. The kernel retention bullet now says why an older server shows only one generation.

## Not fixed here

`tests/ipxe-tree-preservation.test.sh` fails one assertion — "a CHANGED CA rebuilds at the same tag (expected 'rebuild', got 'skip')" — on a clean `working-1.6` checkout, before any of this. Unrelated and left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtZHpyWZWDPSxePdTViGZy
