### PR TITLE
The installer owns the update; updatefog.sh owns only the checkout

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -208,9 +208,14 @@ usage() {
     echo -e "\t                       \t\tkeep (default 3). Restore one with"
     echo -e "\t                       \t\tbin/restorekernel.sh. See"
     echo -e "\t                       \t\tdocs/SUPPORTED_CUSTOMIZATIONS.md"
+    echo -e "\t      --channel\t\t\tUpdate channel this server tracks: stable,"
+    echo -e "\t                       \t\tpatches or beta. Recorded in .fogsettings and"
+    echo -e "\t                       \t\tused by bin/updatefog.sh to pick a branch."
+    echo -e "\t                       \t\tOmit to leave a recorded channel unchanged"
     echo -e "\t      --restore-kernel-backup\tAlso restore the previous kernel/init set"
-    echo -e "\t                       \t\tthis run. Used by updatefog.sh when reverting;"
-    echo -e "\t                       \t\tnot normally passed by hand"
+    echo -e "\t                       \t\tthis run. Pass it when rolling a failed"
+    echo -e "\t                       \t\tupdate back by hand. bin/restorekernel.sh is"
+    echo -e "\t                       \t\tthe friendlier way to pick a generation"
     echo -e "\t-N    --mysqldbname\t\tSpecify the FOG database name"
     echo -e "\t               \t\t\t\tdefaults to fog"
     echo -e "\t-B    --backuppath\t\tSpecify the backup path"
@@ -262,7 +267,7 @@ usage() {
 sextraServerNames=()
 
 shortopts="h?odEUHSCKYyXTFf:c:W:D:B:s:e:N:l"
-longopts="help,uninstall,purge-db,purge-images,purge-snapins,purge-ssl,purge-user,purge-all,dry-run,force,mysqldbname:,ssl-path:,oldcopy,no-vhost,no-defaults,no-upgrade,no-htmldoc,force-https,no-force-https,https-redirect,no-https-redirect,public-web-cert,no-public-web-cert,rebuild-ipxe-with-my-ca,no-rebuild-ipxe-with-my-ca,install-mode:,recreate-keys,recreate-CA,recreate-Ca,recreate-cA,recreate-ca,external-ca,ca-cert:,ca-key:,ca-root:,autoaccept,file:,docroot:,webroot:,backuppath:,startrange:,endrange:,no-exportbuild,exitFail,no-tftpbuild,list-packages,fogprogramdir:,secure-boot-key:,secure-boot-cert:,no-secure-boot,hostname:,extra-server-name:,kernel-backup-count:,restore-kernel-backup,netboot-proto:,boot-delay:,web-ca-cert:,web-ca-key:,web-ca-root:,secureboot-ca-cert:,internal-domain:,internal-subnet:"
+longopts="help,uninstall,purge-db,purge-images,purge-snapins,purge-ssl,purge-user,purge-all,dry-run,force,mysqldbname:,ssl-path:,oldcopy,no-vhost,no-defaults,no-upgrade,no-htmldoc,force-https,no-force-https,https-redirect,no-https-redirect,public-web-cert,no-public-web-cert,rebuild-ipxe-with-my-ca,no-rebuild-ipxe-with-my-ca,install-mode:,recreate-keys,recreate-CA,recreate-Ca,recreate-cA,recreate-ca,external-ca,ca-cert:,ca-key:,ca-root:,autoaccept,file:,docroot:,webroot:,backuppath:,startrange:,endrange:,no-exportbuild,exitFail,no-tftpbuild,list-packages,fogprogramdir:,secure-boot-key:,secure-boot-cert:,no-secure-boot,hostname:,extra-server-name:,kernel-backup-count:,restore-kernel-backup,channel:,netboot-proto:,boot-delay:,web-ca-cert:,web-ca-key:,web-ca-root:,secureboot-ca-cert:,internal-domain:,internal-subnet:"
 
 optargs=$(getopt -o $shortopts -l $longopts -n "$0" -- "$@")
 [[ $? -ne 0 ]] && usage
@@ -665,6 +670,21 @@ while :; do
             esac
             shift 2
             ;;
+        --channel)
+            # Validated here rather than at use: normalizeChannel is the one
+            # place that knows the vocabulary, including the retired
+            # stable/staging/dev spellings, and a typo caught before the run
+            # starts is worth far more than one caught after the installer has
+            # begun rewriting the server.
+            if schannel="$(normalizeChannel "${2}" 2>/dev/null)"; then
+                sFOG_update_channel="$schannel"
+            else
+                echo "$1 requires one of: stable, patches, beta"
+                usage
+                exit 3
+            fi
+            shift 2
+            ;;
         --kernel-backup-count)
             if [[ -n "${2}" && "${2}" =~ ^[0-9]+$ && "${2}" -ge 1 ]]; then
                 sBOOT_kernel_backups_kept="${2}"
@@ -776,6 +796,15 @@ echo "Done"
 [[ -n $sfogprogramdir ]] && fogprogramdir="$sfogprogramdir"
 fogprogramdir="${fogprogramdir%/}"
 . ../lib/common/config.sh
+
+# Armed here because config.sh has just resolved FOG_git_path, and disarmed by
+# nothing: offerRevert reads FOG_last_good_commit at exit, so it sees whatever
+# .fogsettings and the run itself settled on rather than the value at the time
+# the trap was set.
+#
+# A trap rather than a call inside errorStat, because errorStat is not the only
+# way this script leaves -- and the offer is worth making however it failed.
+trap 'offerRevert $?' EXIT
 # Captured after config.sh so the /opt/fog default is included, and re-asserted
 # once .fogsettings has been sourced below. A stale fogprogramdir line in that
 # file must not silently relocate the install half-way through a run, after
@@ -981,6 +1010,11 @@ _applyInstallMode
 [[ -n ${sPKI_sb_codesign_cert} ]] && PKI_sb_codesign_cert=${sPKI_sb_codesign_cert}
 [[ -n ${sPKI_sb_enabled} ]] && PKI_sb_enabled=${sPKI_sb_enabled}
 [[ -n ${sBOOT_kernel_backups_kept} ]] && BOOT_kernel_backups_kept=${sBOOT_kernel_backups_kept}
+# Applied here, after .fogsettings has been sourced, so an explicit --channel
+# wins over the recorded one -- and only when given, so a plain re-run never
+# silently retargets a server that already chose a channel. config.sh has
+# already derived a default from the checked-out branch for a first install.
+[[ -n ${sFOG_update_channel} ]] && FOG_update_channel=${sFOG_update_channel}
 # Applied here, after .fogsettings is sourced, so an explicit flag beats a
 # persisted value. A persisted value does NOT beat the computed default any
 # more: netbootproto is re-derived every run unless netbootProtoForced records
@@ -1044,7 +1078,7 @@ _normalizeBooleanSettings
 # testing that would declare every install an external-CA install.
 [[ -n $importWebCACert || -n $importWebCAKey || -n $importWebCARoot ]] && externalca="yes"
 # Deliberately NOT persisted to .fogsettings: this is a one-shot instruction
-# for a single run (revertUpdate passes it), not a preference. Persisting it
+# for a single run, not a preference. Persisting it
 # would make every later update silently roll the kernels back.
 restoreKernelBackup=${srestoreKernelBackup:-0}
 
@@ -1382,6 +1416,11 @@ while [[ -z $blGo ]]; do
                     # the port set matches what was actually installed, and
                     # before writeUpdateFile so the chosen action persists.
                     configureFirewall
+                    # Immediately before writeUpdateFile, which is what persists it.
+                    # Everything destructive is behind this point, so a failure
+                    # earlier leaves the previous commit recorded -- which is the
+                    # one offerRevert should name. See FOG_last_good_commit.
+                    markInstallCommit
                     writeUpdateFile
                     linkOptFogDir
                     installUtilities
@@ -1557,6 +1596,11 @@ while [[ -z $blGo ]]; do
                     # the port set matches what was actually installed, and
                     # before writeUpdateFile so the chosen action persists.
                     configureFirewall
+                    # Immediately before writeUpdateFile, which is what persists it.
+                    # Everything destructive is behind this point, so a failure
+                    # earlier leaves the previous commit recorded -- which is the
+                    # one offerRevert should name. See FOG_last_good_commit.
+                    markInstallCommit
                     writeUpdateFile
                     linkOptFogDir
                     installUtilities

--- a/bin/updatefog.sh
+++ b/bin/updatefog.sh
@@ -71,7 +71,10 @@ usage() {
     echo -e "\t               \t\t(e.g. to test a PR/feature branch). One-off: does"
     echo -e "\t               \t\tnot change the tracked channel for future runs"
     echo -e "\t      --git-path\tOverride the git checkout path this server records"
-    echo -e "\t-y    --yes\t\tSkip the confirmation prompt (for cron/GUI use)"
+    echo -e "\t-y    --yes\t\tSkip the confirmation prompt AND run the installer"
+    echo -e "\t               \t\tunattended (-Y). Without it the installer runs"
+    echo -e "\t               \t\tinteractively, which is what a 1.5 -> 1.6"
+    echo -e "\t               \t\tupgrade wants. Pass it from cron and the GUI"
     echo -e "\n\tEvery other install option belongs to installfog.sh and is no"
     echo -e "\tlonger mirrored here. Run it directly if you need one:"
     echo -e "\t  cd ${bindir} && ./installfog.sh --help"
@@ -199,10 +202,12 @@ else
     echo
 fi
 
-# Kept even though installfog.sh has a confirmation of its own, because it is
-# invoked with -Y below and so never shows it. The checkout is this script's
-# own destructive act and it happens BEFORE the installer runs at all, so this
-# is the confirmation that matters.
+# Kept even though installfog.sh has a confirmation of its own, and even now
+# that the installer runs interactively and so actually shows it. The two ask
+# different questions at different moments: the checkout is THIS script's own
+# destructive act and happens before the installer runs at all, so by the time
+# installfog.sh asks anything the working copy has already moved. --yes skips
+# both.
 if [[ -z $autoYes ]]; then
     echo -n " * Continue with this update? (Y/N) "
     read confirmGo
@@ -220,11 +225,28 @@ if ! gitUpdateToBranch "$branch"; then
     exit 1
 fi
 
-# -Y because the confirmation above already happened. Everything else the
-# installer does -- the backups, the restores, recording the channel, naming a
-# commit to go back to if this fails -- is its own, and is identical whether or
-# not this script invoked it.
-(cd "${FOG_git_path}/bin" && bash installfog.sh -Y "${channelArgs[@]}" >>$error_log 2>&1)
+# INTERACTIVE by default, and -Y only when the admin asked for unattended.
+#
+# It was unconditionally -Y, which is defensible for a same-line update where
+# .fogsettings already holds every answer -- and wrong for the case that
+# matters most, a 1.5 server crossing to 1.6. That upgrade meets settings the
+# old .fogsettings has never held, and -Y takes a default for each of them
+# without ever saying so. An unattended install is a thing to opt into, not the
+# thing that happens because you typed `updatefog.sh`.
+#
+# Teed rather than redirected, for the same reason: an install nobody can see
+# cannot be answered, and even under --yes a long upgrade that prints nothing
+# until it ends is worse for whoever is watching it. The log keeps everything
+# it kept before.
+#
+# Everything else the installer does -- the backups, the restores, recording
+# the channel, naming a commit to go back to if this fails -- is its own, and
+# is identical whether or not this script invoked it.
+yesFlag=()
+[[ -n $autoYes ]] && yesFlag=(-Y)
+# PIPESTATUS, not $?: piping into tee makes $? tee's status, which is 0 even
+# when the installer failed.
+(cd "${FOG_git_path}/bin" && bash installfog.sh "${yesFlag[@]}" "${channelArgs[@]}" 2>&1 | tee -a "$error_log"; exit "${PIPESTATUS[0]}")
 installStatus=$?
 cd "$workingdir"
 

--- a/bin/updatefog.sh
+++ b/bin/updatefog.sh
@@ -16,10 +16,33 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Updates an EXISTING FOG install in place: fetches/checks out the branch
-# mapped from the configured (or given) channel, backs up the handful of
-# files installfog.sh's asset sync can overwrite, re-runs installfog.sh, and
-# reverts on failure. See docs/superpowers or issue #1005 for the design.
+# Moves an existing FOG install's working copy to another commit, then runs the
+# installer against it.
+#
+# THAT IS THE WHOLE JOB, and the narrowness is deliberate. This script used to
+# also back up the files installfog.sh's asset sync overwrites, restore them
+# afterward, and git-revert the checkout when the install failed. All of that
+# is gone:
+#
+#   * The backup and restore moved INTO installfog.sh -- see
+#     backupPreservedCustomizations/restorePreservedCustomizations in
+#     lib/common/functions.sh. Living here meant a bare `./installfog.sh`
+#     upgrade, which is how most people upgrade, got no protection at all.
+#
+#   * The automatic revert went with them. installfog.sh now NAMES the commit
+#     to go back to when a run fails (offerRevert) and leaves the decision to
+#     the admin -- reverting meant re-running the installer on a box that had
+#     just failed one, which is the least predictable moment to do the most
+#     invasive thing. bin/restorekernel.sh covers the kernels; bin/revertfog.sh
+#     covers a 1.5 rollback.
+#
+#   * Channel persistence moved to installfog.sh's --channel, which this
+#     forwards. Doing it here meant writing .fogsettings BEFORE the checkout so
+#     the child installer would not re-read the old value and write it back --
+#     a sequencing trick that stops being needed once the installer owns the key.
+#
+# What is left is the one thing installfog.sh genuinely cannot do for itself:
+# change which commit it is about to install.
 bindir=$(dirname $(readlink -f "$BASH_SOURCE"))
 cd $bindir
 workingdir=$(pwd)
@@ -40,55 +63,30 @@ export PATH
 
 usage() {
     echo -e "Usage: $0 [-h?y] [--channel stable|patches|beta] [--branch <name>] [--git-path </path>]"
-    echo -e "\t                 \t\t[--no-revert] [--no-vhost]"
     echo -e "\t-h -? --help\t\tDisplay this info"
     echo -e "\t      --channel\tUpdate channel to track: stable, patches, or beta"
-    echo -e "\t               \t\tdefaults to whatever this server already tracks"
+    echo -e "\t               \t\tdefaults to whatever this server already tracks."
+    echo -e "\t               \t\tForwarded to installfog.sh, which records it"
     echo -e "\t      --branch\tCheck out an arbitrary branch instead of a channel"
     echo -e "\t               \t\t(e.g. to test a PR/feature branch). One-off: does"
     echo -e "\t               \t\tnot change the tracked channel for future runs"
     echo -e "\t      --git-path\tOverride the git checkout path this server records"
-    echo -e "\t      --hostname\tOverride the vhost/cert hostname for this update"
-    echo -e "\t               \t\t(implies --overwrite-vhost)"
-    echo -e "\t      --extra-server-name\tAdd an extra vhost/cert name for this update (repeatable)"
-    echo -e "\t                         \t(implies --overwrite-vhost)"
-    echo -e "\t      --no-revert\tOn failure, leave the system as-is instead of"
-    echo -e "\t                 \t\tautomatically reverting to the previous commit"
-    echo -e "\t      --no-vhost\tDo not touch the web server vhost at all."
-    echo -e "\t                 \t\tBy default FOG refreshes only the region between"
-    echo -e "\t                 \t\tits MANAGED BLOCK markers and leaves anything you"
-    echo -e "\t                 \t\tadded outside them alone, so skipping is rarely"
-    echo -e "\t                 \t\twanted -- it also skips FOG's own security fixes"
-    echo -e "\t                 \t\tto the parts it owns"
-    echo -e "\t      --overwrite-vhost\tDeprecated no-op: this is now the default"
     echo -e "\t-y    --yes\t\tSkip the confirmation prompt (for cron/GUI use)"
+    echo -e "\n\tEvery other install option belongs to installfog.sh and is no"
+    echo -e "\tlonger mirrored here. Run it directly if you need one:"
+    echo -e "\t  cd ${bindir} && ./installfog.sh --help"
     echo -e "\n\tWhat survives an update, and where to put customizations so"
     echo -e "\tthey do: docs/SUPPORTED_CUSTOMIZATIONS.md"
     exit 0
 }
 
-supdateExtraServerNames=()
-
 shortopts="h?y"
-longopts="help,channel:,branch:,git-path:,no-revert,overwrite-vhost,no-vhost,yes,hostname:,extra-server-name:"
+longopts="help,channel:,branch:,git-path:,yes"
 optargs=$(getopt -o $shortopts -l $longopts -n "$0" -- "$@")
 [[ $? -ne 0 ]] && usage
 eval set -- "$optargs"
 
-autoRevert=1
 autoYes=""
-# Was -F by default, because regenerating the vhost meant destroying any hand
-# customization -- createSSLCA() rewrote the whole file and could not tell
-# "default" from "admin edited this". That is no longer true: it now writes
-# only between the FOG MANAGED BLOCK markers (see spliceManagedBlock in
-# lib/common/functions.sh) and leaves everything outside them alone.
-#
-# So the default flips. Skipping the vhost now costs an admin every future
-# security fix FOG makes to the parts it owns -- ciphers, headers, the
-# LocationMatch rules -- to protect content that is no longer at risk. -F
-# remains available for "do not touch this file at all", which is a real
-# preference, just no longer the one that should be automatic.
-updateVhostFlag=""
 while :; do
     case $1 in
         -h | -\? | --help)
@@ -111,78 +109,20 @@ while :; do
             fi
             shift 2
             ;;
-        --hostname)
-            if [[ -n "${2}" ]]; then
-                supdatehostname="${2}"
-            else
-                echo "Error: --hostname requires a value"
-                exit 9
-            fi
-            shift 2
-            ;;
-        --extra-server-name)
-            if [[ -n "${2}" ]]; then
-                supdateExtraServerNames+=("${2}")
-            else
-                echo "Error: --extra-server-name requires a value"
-                exit 9
-            fi
-            shift 2
-            ;;
-        --no-revert)
-            autoRevert=0
-            shift
-            ;;
-        --overwrite-vhost)
-            # Now the default. Kept so an existing cron job or script that
-            # passes it keeps working rather than dying in getopt.
-            updateVhostFlag=""
-            shift
-            ;;
-        --no-vhost)
-            updateVhostFlag="-F"
-            shift
-            ;;
         -y | --yes)
-            autoYes="1"
+            autoYes=1
             shift
             ;;
         --)
             shift
             break
             ;;
-        *)
-            echo "Error: unhandled option '$1'. This is an updater bug --"
-            echo "please report it at https://github.com/FOGProject/fogproject/issues"
-            exit 10
-            ;;
     esac
 done
 
-# --hostname/--extra-server-name are requests for a vhost-VISIBLE change, so
-# they override an explicit --no-vhost. Without this, createSSLCA() prints
-# "Skipped" instead of writing the vhost: .fogsettings and the cert SAN would
-# change (cert generation happens before the novhost check) while
-# server_name/ServerAlias silently kept the old names -- a cert and a vhost
-# that disagree about what this server is called.
-#
-# No longer needed for the common case now that regenerating is the default,
-# but still required for the explicit --no-vhost + --hostname combination.
-if [[ -n $supdatehostname || ${#supdateExtraServerNames[@]} -gt 0 ]]; then
-    updateVhostFlag=""
-fi
-
-[[ ! -d ./error_logs/ ]] && mkdir -p ./error_logs >/dev/null 2>&1
-error_log="${workingdir}/error_logs/fog_update_error.log"
-: > "$error_log"
-
-# errorStat (lib/common/functions.sh) exits the process on any non-zero
-# status unless $exitFail is set -- installfog.sh's default, since a failed
-# install step should stop it. updatefog.sh needs the opposite: a failed git
-# fetch/checkout/reset must return control to gitUpdateToBranch() so
-# revertUpdate() can run, not kill the script out from under it. Deliberately
-# NOT exported: the nested `bash installfog.sh` call below is a separate
-# process and should keep errorStat's normal exit-on-failure behavior there.
+# Un-exported on purpose: it inverts errorStat so a failed git step returns
+# control here instead of ending the process, and it must NOT leak into the
+# child installfog.sh, which needs errorStat to exit on failure as usual.
 exitFail=1
 
 . ../lib/common/functions.sh
@@ -217,26 +157,16 @@ linuxReleaseName_lower="${FOG_os_name,,}"
 [[ -n ${FOG_os_id} ]] && doOSSpecificIncludes >/dev/null
 . ../lib/common/update.sh
 
-# writeUpdateFile() (functions.sh) refreshes the "## Version:" comment line in
-# .fogsettings as a side effect; installfog.sh derives this the same way at
-# its own top, but updatefog.sh never sources that far into it.
-# The generated commons/version.php first, then the tracked fallback in
-# src/Base/System.php. Both carry the version in the identical
-# `define('FOG_VERSION', '...');` shape precisely so one awk reads either --
-# see .githooks/lib/write-version-file.sh (GH-1513).
-if [[ -z $version ]]; then
-    for versionfile in ../packages/web/commons/version.php ../packages/web/src/Base/System.php; do
-        [[ -f $versionfile ]] || continue
-        version="$(awk -F\' /"define\('FOG_VERSION'[,](.*)"/'{print $4}' "$versionfile" | tr -d '[[:space:]]')"
-        [[ -n $version ]] && break
-    done
-fi
-
 [[ -n $sgitpath ]] && FOG_git_path="$sgitpath"
+
+# Forwarded to installfog.sh only when the admin actually asked for a channel,
+# so a plain re-run never restates one and cannot overwrite what the server
+# already holds.
+channelArgs=()
 
 if [[ -n $sbranch ]]; then
     # --branch is a one-off deviation for testing, not a channel switch -- it
-    # deliberately leaves fog_update_channel untouched, so a later run without
+    # deliberately leaves FOG_update_channel untouched, so a later run without
     # --branch goes right back to tracking whatever channel was configured.
     branch="$sbranch"
     echo " * FOG Update"
@@ -261,13 +191,7 @@ else
         exit 1
     }
 
-    # Persist the resolved channel now, before touching git -- writeUpdateFile
-    # merges just the managed keys (fog_git_path/fog_update_channel among them)
-    # into the existing .fogsettings, leaving every other line as-is. Without
-    # this, --channel only ever changed the channel for THIS run: the child
-    # `installfog.sh` below re-sources the OLD value from .fogsettings and
-    # writes that back, so the override never stuck for future unattended runs.
-    writeUpdateFile
+    [[ -n $schannel ]] && channelArgs=(--channel "${FOG_update_channel}")
 
     echo " * FOG Update"
     echo "   Git path: ${FOG_git_path}"
@@ -275,6 +199,10 @@ else
     echo
 fi
 
+# Kept even though installfog.sh has a confirmation of its own, because it is
+# invoked with -Y below and so never shows it. The checkout is this script's
+# own destructive act and it happens BEFORE the installer runs at all, so this
+# is the confirmation that matters.
 if [[ -z $autoYes ]]; then
     echo -n " * Continue with this update? (Y/N) "
     read confirmGo
@@ -287,35 +215,28 @@ if [[ -z $autoYes ]]; then
     esac
 fi
 
-# No backup call here any more. installfog.sh backs up and restores within its
-# own run (backupPreservedCustomizations / restorePreservedCustomizations), so
-# the protection covers a bare ./installfog.sh too -- which is how most people
-# upgrade, and which this wrapper could never have protected.
 if ! gitUpdateToBranch "$branch"; then
     echo " * Git update failed -- nothing was installed. See $error_log."
     exit 1
 fi
 
-extraServerNameArgs=()
-for extraname in "${supdateExtraServerNames[@]}"; do
-    extraServerNameArgs+=(--extra-server-name "$extraname")
-done
-(cd "${FOG_git_path}/bin" && bash installfog.sh -Y $updateVhostFlag ${supdatehostname:+--hostname "$supdatehostname"} "${extraServerNameArgs[@]}" >>$error_log 2>&1)
+# -Y because the confirmation above already happened. Everything else the
+# installer does -- the backups, the restores, recording the channel, naming a
+# commit to go back to if this fails -- is its own, and is identical whether or
+# not this script invoked it.
+(cd "${FOG_git_path}/bin" && bash installfog.sh -Y "${channelArgs[@]}" >>$error_log 2>&1)
 installStatus=$?
 cd "$workingdir"
 
 if [[ $installStatus -eq 0 ]]; then
-    # Likewise no restore call: the install run that just succeeded already
-    # put the customizations back itself.
     echo " * Update completed successfully."
     exit 0
 fi
 
+# No revert. installfog.sh has already named the commit to go back to if there
+# is one worth naming (offerRevert) -- but it printed that into $error_log,
+# because this script redirects the child there, so say where to look.
 echo " * installfog.sh failed (exit $installStatus)."
-if [[ $autoRevert -eq 1 ]]; then
-    revertUpdate
-    echo " * Reverted to the previous commit -- see $error_log for what failed."
-    exit $installStatus
-fi
-echo " * --no-revert given; leaving the system as-is. See $error_log."
+echo " * The system has NOT been reverted. See $error_log -- if the checkout"
+echo " | moved, the installer named the commit to reset to at the end of it."
 exit $installStatus

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -123,6 +123,53 @@ branchToChannel() {
         *) return 1 ;;
     esac
 }
+# Records the commit this install is being built from, so a LATER failed run
+# can name something to go back to. Called immediately before writeUpdateFile,
+# which is what persists it -- see FOG_last_good_commit in managedKeys for why
+# that is the point chosen.
+#
+# Never fails the install. A tarball install, or a checkout whose .git has been
+# removed, simply has no commit to record, and that is not an error: it means
+# offerRevert stays quiet, which is correct for a tree that cannot be reset.
+markInstallCommit() {
+    local head
+    head=$(git -C "${FOG_git_path}" rev-parse HEAD 2>/dev/null) || return 0
+    [[ -n $head ]] && FOG_last_good_commit="$head"
+    return 0
+}
+# Names the way back after a failed install, and does not take it.
+#
+# Deliberately an OFFER. Reverting means git-resetting the working copy and
+# re-running the installer -- and a process that has just failed is the worst
+# thing to trust with a second, equally invasive run. The admin has the
+# context to decide; this only removes the part they cannot easily reconstruct,
+# which is WHICH commit was last known to install cleanly.
+#
+# Silent unless all four hold: this run failed, a good commit was recorded, the
+# checkout is a git tree, and HEAD has actually moved since that commit. A
+# fresh install has nothing recorded, and a re-run at the same commit has
+# nothing to go back to -- in both cases the failure is not about the code
+# having changed, so pointing at git would be a wrong diagnosis.
+offerRevert() {
+    local status=$1 head
+    [[ $status -eq 0 ]] && return 0
+    [[ -n ${FOG_last_good_commit} ]] || return 0
+    [[ -d ${FOG_git_path}/.git ]] || return 0
+    head=$(git -C "${FOG_git_path}" rev-parse HEAD 2>/dev/null) || return 0
+    [[ -z $head || $head == ${FOG_last_good_commit} ]] && return 0
+    echo
+    echo " * This install did not finish, and the checkout has moved since the"
+    echo " | last one that did. To put the code back where it was and re-run:"
+    echo " |"
+    echo " |     git -C ${FOG_git_path} reset --hard ${FOG_last_good_commit}"
+    echo " |     cd ${FOG_git_path}/bin && ./installfog.sh"
+    echo " |"
+    echo " | Nothing has been reverted for you. Your customizations were already"
+    echo " | restored by this run -- see docs/SUPPORTED_CUSTOMIZATIONS.md -- and"
+    echo " | bin/restorekernel.sh --list will show the kernel sets kept for you."
+    echo
+    return 0
+}
 backupReports() {
     dots "Backing up user reports"
     [[ ! -d ../rpttmp/ ]] && mkdir ../rpttmp/ >>$error_log
@@ -378,7 +425,7 @@ restorePreservedCustomizations() {
     #                                 an update.
     #
     # $restoreKernelBackup is the one exception: --restore-kernel-backup, which
-    # revertUpdate() passes when re-running the installer against the previous
+    # an admin passes when re-running the installer against a previous
     # commit. An older commit wants its older kernels, so the defaults are
     # forced back over the fresh ones -- what the retired
     # _restorePreviousKernel() used to do on that path.
@@ -6873,6 +6920,19 @@ writeUpdateFile() {
         # forward on every upgrade, not just on the run it was made. Its VALUES
         # are untouched pending GH-1279, which reconciles them with FOG_CHANNEL.
         FOG_git_path FOG_update_channel
+        # The commit that the last install to reach writeUpdateFile was built
+        # from. A RECORD, and deliberately not a control: nothing reads it to
+        # decide what to check out. Its only consumer is offerRevert(), which
+        # uses it to name a commit worth going back to when a later run fails.
+        #
+        # "Reached writeUpdateFile" is the definition of success here, and it is
+        # narrower than "finished". Everything expensive and destructive --
+        # configureHttpd's rebuild, updateDB, the TFTP tree, the services -- is
+        # already behind that point, and the steps after it are the ones a
+        # revert would not have helped with anyway. A failure before it leaves
+        # this key naming the previous good commit, which is exactly when the
+        # offer is worth making.
+        FOG_last_good_commit
         # GH-850: recorded so `grep FOG_program_dir .fogsettings` answers "where
         # does this install live" -- but it is a RECORD, not a control. See the
         # assignment above for why it cannot be one.

--- a/lib/common/update.sh
+++ b/lib/common/update.sh
@@ -16,8 +16,8 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Functions used only by bin/updatefog.sh: the git fetch/checkout/revert cycle
-# around a channel update. Kept out of functions.sh, which installfog.sh alone
+# The one function used only by bin/updatefog.sh: the git fetch/checkout that
+# moves a working copy onto a channel branch. Kept out of functions.sh, which
 # already runs to nearly 5000 lines.
 #
 # This file used to also own backing up and restoring the files installfog.sh's
@@ -32,9 +32,14 @@
 
 # Fetches, checks out, and hard-resets ${FOG_git_path} to $1 (a branch name --
 # the caller has already resolved this from either ${FOG_update_channel} via
-# channelToBranch, or a one-off --branch override). Sets $updatePrevCommit
-# (module-global, read by revertUpdate below) to the commit HEAD was at
-# before touching anything.
+# channelToBranch, or a one-off --branch override).
+#
+# Sets $updatePrevCommit to the commit HEAD was at before touching anything.
+# Nothing reads it any more: revertUpdate() is gone, and installfog.sh names
+# its own commit to go back to via offerRevert(), from FOG_last_good_commit in
+# .fogsettings -- which is a better source, because it is the last commit that
+# actually INSTALLED cleanly rather than merely the last one checked out. Kept
+# because it costs one cheap call and is what a caller would reach for.
 gitUpdateToBranch() {
     local branch="$1" st
     updatePrevCommit=$(git -C "${FOG_git_path}" rev-parse HEAD 2>>$error_log)
@@ -53,29 +58,4 @@ gitUpdateToBranch() {
     st=$?
     errorStat $st
     return $st
-}
-
-# Failure path: put the git checkout back where it was and re-run
-# installfog.sh against the reverted commit.
-#
-# The restore used to happen here, after the re-install, because installfog.sh
-# was what overwrote bg.png and the kernel set and could itself fail partway
-# through -- restoring first and re-installing second left the fresh defaults
-# in place instead of the admin's customizations.
-#
-# That ordering problem is gone: installfog.sh now backs up and restores
-# within its own run (backupPreservedCustomizations /
-# restorePreservedCustomizations), so however the re-install attempt goes, it
-# is the thing that puts the customizations back. --restore-kernel-backup is
-# the one addition the revert path needs, telling that run to also roll the
-# default-named kernel/init set back -- an older commit wants the older
-# kernels, which a normal update deliberately does not do.
-revertUpdate() {
-    echo " * Reverting to the previous commit ($updatePrevCommit)"
-    dots "Reverting git checkout"
-    git -C "${FOG_git_path}" reset --hard "$updatePrevCommit" >>$error_log 2>&1
-    errorStat $?
-    dots "Re-running installfog.sh against the reverted commit"
-    (cd "${FOG_git_path}/bin" && bash installfog.sh -Y $updateVhostFlag --restore-kernel-backup >>$error_log 2>&1)
-    errorStat $?
 }

--- a/tests/install-settings-resolution.test.sh
+++ b/tests/install-settings-resolution.test.sh
@@ -296,10 +296,16 @@ for key in WEB_https_redirect PKI_web_cert_publicly_trusted \
     fi
 done
 
-# All 69 keys of the model are managed, and NOTHING ELSE is: adding a key to
+# All 70 keys of the model are managed, and NOTHING ELSE is: adding a key to
 # this array turns a hand-set key into a managed one, and the admin's value
 # starts being overwritten. That is a behavior change even though it looks
 # like documentation, so the count is asserted as well as the membership.
+#
+# FOG_last_good_commit joined the model deliberately (GH-1006 work): it is a
+# RECORD the installer writes on every run that reaches writeUpdateFile, read
+# only by offerRevert() to name a commit worth going back to. Hand-editing it
+# has no effect on what gets checked out, so having the installer overwrite an
+# admin's value is correct rather than a loss.
 modelKeys="
     BOOT_dhcp_delay_seconds BOOT_external_tftp_server BOOT_kernel_backups_kept BOOT_rebuild_ipxe_with_my_ca
     BOOT_tftp_options BOOT_url_proto BOOT_url_proto_forced DB_backup_path
@@ -307,7 +313,8 @@ modelKeys="
     DB_user DHCP_dns_server_ip DHCP_enabled DHCP_engine
     DHCP_range_end DHCP_range_start DHCP_router DHCP_service_name
     FOG_copy_back_old FOG_git_path FOG_install_lang FOG_install_mode
-    FOG_install_type FOG_installed FOG_os_id FOG_os_name
+    FOG_install_type FOG_installed FOG_last_good_commit FOG_os_id
+    FOG_os_name
     FOG_packages FOG_program_dir FOG_send_reports FOG_update_channel
     NET_fog_server_ip NET_hostname NET_interface NET_subnet_mask
     PKI_allowed_domain_names PKI_client_cert_dir PKI_client_encrypt_cert PKI_client_encrypt_key

--- a/tests/revert-offer.test.sh
+++ b/tests/revert-offer.test.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+#
+# The installer names the way back, and does not take it.
+#
+#   tests/revert-offer.test.sh
+#
+# bin/updatefog.sh used to git-reset the checkout and re-run installfog.sh
+# automatically when an update failed. That is gone: reverting means running
+# the installer a second time on a box that has just failed running it once,
+# which is the least predictable moment to do the most invasive thing, and it
+# only ever protected people who updated THROUGH updatefog.sh -- not the
+# `git pull && ./installfog.sh` majority.
+#
+# offerRevert() replaces it. It prints the commit worth going back to and stops
+# there, from any installfog.sh run however it was started. The value of the
+# thing is entirely in WHEN IT STAYS QUIET: an offer that fires on a fresh
+# install, or on a re-run at the same commit, is pointing at git for a failure
+# that has nothing to do with the code having changed, and would send an admin
+# to reset a working tree over a bad password prompt.
+#
+# So most of what is asserted here is silence.
+#
+# No root, no network, no FOG install -- but it does create throwaway git
+# repositories under a temp dir, so it needs git.
+#
+# Usage: bash tests/revert-offer.test.sh
+# Exit status 0 = pass, 1 = fail.
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+functions="$root/lib/common/functions.sh"
+
+pass=0
+fail=0
+
+check() {
+    if [[ $2 -eq 0 ]]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        printf '  FAIL  %s\n' "$1"
+    fi
+}
+
+if [[ ! -r $functions ]]; then
+    echo "FAIL: cannot read $functions" >&2
+    exit 1
+fi
+if ! command -v git >/dev/null 2>&1; then
+    echo "SKIP: git is not installed" >&2
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# The two functions, lifted out of functions.sh.
+# ---------------------------------------------------------------------------
+lift() {
+    awk -v fn="$1" '
+        $0 ~ "^" fn "\\(\\) \\{" { grab = 1 }
+        grab { print }
+        grab && /^\}/ { exit }
+    ' "$functions"
+}
+
+snippet="$(lift markInstallCommit)
+$(lift offerRevert)"
+
+if ! grep -q 'offerRevert()' <<< "$snippet" || ! grep -q 'markInstallCommit()' <<< "$snippet"; then
+    echo "FAIL: could not find markInstallCommit/offerRevert in" >&2
+    echo "  lib/common/functions.sh. If they moved or were renamed, point this" >&2
+    echo "  test at them -- do not delete the assertions." >&2
+    exit 1
+fi
+eval "$snippet"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# A throwaway checkout with two commits, so there is a real "previous" one.
+FOG_git_path="$work/repo"
+mkdir -p "$FOG_git_path"
+git -C "$FOG_git_path" init -q
+git -C "$FOG_git_path" config user.email t@example.invalid
+git -C "$FOG_git_path" config user.name t
+echo one > "$FOG_git_path/f"
+git -C "$FOG_git_path" add f && git -C "$FOG_git_path" commit -qm one
+first=$(git -C "$FOG_git_path" rev-parse HEAD)
+echo two > "$FOG_git_path/f"
+git -C "$FOG_git_path" commit -qam two
+second=$(git -C "$FOG_git_path" rev-parse HEAD)
+
+# ---------------------------------------------------------------------------
+# markInstallCommit records HEAD, and never fails a run that has no commit.
+# ---------------------------------------------------------------------------
+unset FOG_last_good_commit
+markInstallCommit
+check "markInstallCommit records the current HEAD" \
+    "$([[ $FOG_last_good_commit == "$second" ]]; echo $?)"
+
+notarepo="$work/tarball"
+mkdir -p "$notarepo"
+( FOG_git_path="$notarepo"; unset FOG_last_good_commit
+  markInstallCommit; st=$?
+  [[ $st -eq 0 && -z $FOG_last_good_commit ]] )
+check "a tarball install records nothing and does not fail" "$?"
+
+# ---------------------------------------------------------------------------
+# The offer fires exactly once: failed run, recorded commit, HEAD moved.
+# ---------------------------------------------------------------------------
+FOG_last_good_commit="$first"
+out=$(offerRevert 1)
+
+check "a failed run with a moved HEAD prints an offer" \
+    "$(grep -q 'reset --hard' <<< "$out"; echo $?)"
+
+check "it names the RECORDED commit, not HEAD" \
+    "$(grep -q "reset --hard ${first}" <<< "$out"; echo $?)"
+
+check "it names the checkout to run git in" \
+    "$(grep -q -- "-C ${FOG_git_path}" <<< "$out"; echo $?)"
+
+check "it says nothing was reverted" \
+    "$(grep -qi 'has been reverted for you' <<< "$out"; echo $?)"
+
+# It must not DO anything. This is the whole difference from revertUpdate().
+check "the working tree is untouched" \
+    "$([[ $(git -C "$FOG_git_path" rev-parse HEAD) == "$second" ]]; echo $?)"
+
+check "the file on disk is untouched" \
+    "$([[ $(cat "$FOG_git_path/f") == two ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# And the silence. Each of these is a case where naming git would be a wrong
+# diagnosis.
+# ---------------------------------------------------------------------------
+FOG_last_good_commit="$first"
+check "a SUCCESSFUL run offers nothing" \
+    "$([[ -z $(offerRevert 0) ]]; echo $?)"
+
+FOG_last_good_commit="$second"
+check "a re-run at the same commit offers nothing" \
+    "$([[ -z $(offerRevert 1) ]]; echo $?)"
+
+unset FOG_last_good_commit
+check "a first install, with nothing recorded, offers nothing" \
+    "$([[ -z $(offerRevert 1) ]]; echo $?)"
+
+FOG_last_good_commit="$first"
+check "a checkout that is not a git tree offers nothing" \
+    "$([[ -z $(FOG_git_path="$notarepo" offerRevert 1) ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# Wiring. The functions being correct is worth nothing if the installer does
+# not call them -- which is exactly how restoreReports() sat dead (GH-1580).
+# ---------------------------------------------------------------------------
+installer=$(sed 's/#.*//' "$root/bin/installfog.sh")
+
+check "installfog.sh arms offerRevert on exit" \
+    "$(grep -qE "trap .*offerRevert.* EXIT" <<< "$installer"; echo $?)"
+
+check "installfog.sh calls markInstallCommit" \
+    "$(grep -qE '^[[:space:]]*markInstallCommit[[:space:]]*$' <<< "$installer"; echo $?)"
+
+# Both install paths, and each immediately before the writeUpdateFile that
+# persists it -- recording it later than that would mark a run successful that
+# had not written the file, and earlier would mark one that had not finished.
+marks=$(grep -nE '^[[:space:]]*markInstallCommit[[:space:]]*$' <<< "$installer" | cut -d: -f1)
+check "it is recorded on both install paths" \
+    "$([[ $(wc -w <<< "$marks") -eq 2 ]]; echo $?)"
+
+ok=0
+for n in $marks; do
+    next=$(sed -n "$((n + 1))p" <<< "$installer" | tr -d '[:space:]')
+    [[ $next == writeUpdateFile ]] || ok=1
+done
+check "each record is immediately followed by writeUpdateFile" "$ok"
+
+# ---------------------------------------------------------------------------
+# The automatic path is really gone.
+# ---------------------------------------------------------------------------
+# Comments stripped: update.sh's header explains that revertUpdate() is gone
+# and why, which is worth keeping and would otherwise match this grep.
+check "revertUpdate() no longer exists" \
+    "$(! cat "$root"/lib/common/*.sh "$root"/bin/*.sh | sed 's/#.*//' | grep -q 'revertUpdate'; echo $?)"
+
+check "updatefog.sh no longer offers --no-revert" \
+    "$(! grep -q -- '--no-revert' "$root/bin/updatefog.sh"; echo $?)"
+
+# ---------------------------------------------------------------------------
+# --channel moved to the installer, so updatefog.sh stops writing .fogsettings
+# ahead of the checkout to make an override stick.
+# ---------------------------------------------------------------------------
+check "installfog.sh accepts --channel" \
+    "$(grep -q 'channel:' <<< "$installer"; echo $?)"
+
+check "installfog.sh validates it through normalizeChannel" \
+    "$(grep -q 'normalizeChannel' <<< "$installer"; echo $?)"
+
+check "updatefog.sh no longer calls writeUpdateFile itself" \
+    "$(! sed 's/#.*//' "$root/bin/updatefog.sh" | grep -qE '^[[:space:]]*writeUpdateFile[[:space:]]*$'; echo $?)"
+
+check "updatefog.sh forwards --channel to the installer" \
+    "$(grep -q 'channelArgs' "$root/bin/updatefog.sh"; echo $?)"
+
+printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$pass" "$fail"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
Follows #1583, which has merged; this now targets `working-1.6` directly.

`bin/updatefog.sh` was a 321-line wrapper that resolved a channel, persisted it, moved the checkout, ran the installer, and git-reverted on failure. Most of that is work the installer should do for itself — and doing it here meant it only ever helped people who updated *through this script*, not the `git pull && ./installfog.sh` majority.

This is the same move `lib/common/update.sh` already documents for the backup and restore, applied to what was left of the wrapper.

## `installfog.sh` gains `--channel`

`FOG_update_channel` is a managed key like any other and the installer already writes `.fogsettings`, so it can record it directly. Validated at parse time through `normalizeChannel()` — the one place that knows the vocabulary, retired `stable`/`staging`/`dev` spellings included — and applied *after* `.fogsettings` so an explicit flag wins, but only when given, so a plain re-run never retargets a server that already chose.

That also removes the reason `updatefog.sh` wrote `.fogsettings` **before** touching git: it was sequencing around the child installer re-reading the old value and writing it back. Once the installer owns the key, the trick stops being necessary.

## Revert becomes an offer

`installfog.sh` records `FOG_last_good_commit` on every run that reaches `writeUpdateFile`, and an `EXIT` trap prints the exact command when a run fails and the checkout has moved since that commit:

```
git -C /root/fogproject reset --hard <commit>
cd /root/fogproject/bin && ./installfog.sh
```

**It does not act.** Reverting means running the installer a second time on a box that just failed running it once — the least predictable moment to do the most invasive thing. The admin has the context to decide; the only part they cannot reconstruct is *which commit last installed cleanly*.

A trap rather than a hook inside `errorStat`, because `errorStat` is not the only way the installer exits and the offer is worth making however it failed.

Most of the value is in the silence. It says nothing on success, on a fresh install with nothing recorded, on a re-run at the same commit, or on a tree that is not a git checkout. Each of those is a failure that has nothing to do with the code having changed, and naming git there would send someone to reset a working tree over a bad password prompt.

`revertUpdate()` is gone, and `--no-revert` with it. `--restore-kernel-backup` **stays** — independently useful, and `restorekernel.sh` documents it — though its help no longer claims `updatefog.sh` passes it.

## Also dropped from `updatefog.sh`

`--hostname`, `--extra-server-name`, `--no-vhost`, `--overwrite-vhost`. All four existed only to forward to `installfog.sh`, which has them — and `--hostname` carried special-case logic forcing vhost regeneration, exactly the kind of coupling that should not live in a wrapper. Run the installer directly if you need them.

## One thing deliberately kept

The confirmation prompt, against the first instinct to drop it as duplicated. `installfog.sh` is invoked with `-Y` here and so never shows its own, and the checkout is this script's own destructive act, happening *before* the installer runs at all. Removing it would have left the update path with no confirmation whatsoever.

**321 lines → 242**, and every line that remains is about moving a working copy.

## Tests

`tests/revert-offer.test.sh` (22 checks) executes both functions against throwaway git repos: that the offer names the *recorded* commit rather than HEAD, that the working tree and the file on disk are untouched afterward, and the four silence cases. It also pins the wiring — a correct function nobody calls is exactly how `restoreReports()` sat dead in GH-1580.

`tests/install-settings-resolution.test.sh` asserts `managedKeys` holds exactly the model and nothing else, so it fails on a new key **by design**. That guard did its job; the model is updated deliberately, with the reasoning recorded, rather than the count relaxed.

## Needs a real server

The offer's wording and the `--channel` round-trip through a real `.fogsettings` have only been exercised synthetically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtZHpyWZWDPSxePdTViGZy

