### PR TITLE
Add an rc update channel, resolved to the current release candidate

### DIFF
--- a/.githooks/lib/fog-version.sh
+++ b/.githooks/lib/fog-version.sh
@@ -56,11 +56,18 @@ compute_version() {
     # The channel labels below are the title-case form of the SAME vocabulary
     # lib/common/functions.sh uses for fog_update_channel (GH-1279):
     #
-    #   stable -> Stable   patches -> Patches   beta -> Beta
+    #   stable -> Stable   patches -> Patches   beta -> Beta   rc -> Release Candidate
     #
-    # rc and feature have no update channel -- nobody tracks a release candidate
-    # as a standing preference -- so those two labels are this file's alone.
-    # tests/update-channel-vocabulary.test.sh fails if the two halves drift.
+    # rc is the one label that is not its channel's title-case form: the stored
+    # channel is the abbreviation, this label spells it out. Deliberate, and
+    # pinned as a pair in tests/update-channel-vocabulary.test.sh rather than
+    # derived -- "Release Candidate" is already in released version strings and
+    # nobody reads it as naming something other than rc.
+    #
+    # feature is the only label left with no update channel: nobody tracks a
+    # feature branch as a standing preference. rc used to be in that sentence
+    # too; see channelToBranch in lib/common/functions.sh for why it no longer
+    # is. tests/update-channel-vocabulary.test.sh fails if the halves drift.
     case "$branchon" in
         dev)
             tagversion=$(git describe --tags "$gitcom")

--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -209,8 +209,8 @@ usage() {
     echo -e "\t                       \t\tbin/restorekernel.sh. See"
     echo -e "\t                       \t\tdocs/SUPPORTED_CUSTOMIZATIONS.md"
     echo -e "\t      --channel\t\t\tUpdate channel this server tracks: stable,"
-    echo -e "\t                       \t\tpatches or beta. Recorded in .fogsettings and"
-    echo -e "\t                       \t\tused by bin/updatefog.sh to pick a branch."
+    echo -e "\t                       \t\tpatches, beta or rc. Recorded in .fogsettings"
+    echo -e "\t                       \t\tand used by bin/updatefog.sh to pick a branch."
     echo -e "\t                       \t\tOmit to leave a recorded channel unchanged"
     echo -e "\t      --restore-kernel-backup\tAlso restore the previous kernel/init set"
     echo -e "\t                       \t\tthis run. Pass it when rolling a failed"
@@ -679,7 +679,7 @@ while :; do
             if schannel="$(normalizeChannel "${2}" 2>/dev/null)"; then
                 sFOG_update_channel="$schannel"
             else
-                echo "$1 requires one of: stable, patches, beta"
+                echo "$1 requires one of: stable, patches, beta, rc"
                 usage
                 exit 3
             fi

--- a/bin/updatefog.sh
+++ b/bin/updatefog.sh
@@ -62,10 +62,11 @@ done
 export PATH
 
 usage() {
-    echo -e "Usage: $0 [-h?y] [--channel stable|patches|beta] [--branch <name>] [--git-path </path>]"
+    echo -e "Usage: $0 [-h?y] [--channel stable|patches|beta|rc] [--branch <name>] [--git-path </path>]"
     echo -e "\t-h -? --help\t\tDisplay this info"
-    echo -e "\t      --channel\tUpdate channel to track: stable, patches, or beta"
+    echo -e "\t      --channel\tUpdate channel to track: stable, patches, beta or rc"
     echo -e "\t               \t\tdefaults to whatever this server already tracks."
+    echo -e "\t               \t\trc follows the newest published rc-* branch"
     echo -e "\t               \t\tForwarded to installfog.sh, which records it"
     echo -e "\t      --branch\tCheck out an arbitrary branch instead of a channel"
     echo -e "\t               \t\t(e.g. to test a PR/feature branch). One-off: does"
@@ -181,18 +182,33 @@ else
 
     if [[ -z ${FOG_update_channel} ]]; then
         echo " * No update channel configured for this server, and none given via --channel."
-        echo " * Pass --channel stable|patches|beta, or --branch for a one-off checkout."
+        echo " * Pass --channel stable|patches|beta|rc, or --branch for a one-off checkout."
         exit 1
     fi
 
-    branch=$(channelToBranch "${FOG_update_channel}") || {
-        # Names the retired spellings too. They still WORK -- normalizeChannel
-        # folds them -- so anyone who reaches this line has a genuine typo, and
-        # the two vocabularies were confusable enough to be worth a sentence.
-        echo " * Unknown update channel: ${FOG_update_channel} (expected stable, patches, or beta)"
-        echo " * The retired names staging and dev are still accepted, and mean patches and beta."
-        exit 1
-    }
+    branch=$(channelToBranch "${FOG_update_channel}")
+    case $? in
+        0) ;;
+        2)
+            # A channel FOG knows, that has nothing to point at right now. Not
+            # the admin's mistake, so it must not read like one -- and it is a
+            # state that resolves on its own when the next RC is published.
+            echo " * No release candidate is currently published, so the rc channel"
+            echo " | has nothing to check out. This is normal between releases."
+            echo " |"
+            echo " | Track the beta line instead with --channel beta, or pass a"
+            echo " | specific branch with --branch."
+            exit 1
+            ;;
+        *)
+            # Names the retired spellings too. They still WORK -- normalizeChannel
+            # folds them -- so anyone who reaches this line has a genuine typo, and
+            # the two vocabularies were confusable enough to be worth a sentence.
+            echo " * Unknown update channel: ${FOG_update_channel} (expected stable, patches, beta, or rc)"
+            echo " * The retired names staging and dev are still accepted, and mean patches and beta."
+            exit 1
+            ;;
+    esac
 
     [[ -n $schannel ]] && channelArgs=(--channel "${FOG_update_channel}")
 

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -139,7 +139,9 @@ channelToBranch() {
 # different problems for the admin.
 rcBranch() {
     local ref
-    ref=$(git ls-remote --heads --sort=-v:refname         "${FOG_git_remote:-https://github.com/FOGProject/fogproject.git}" 'rc-*'         2>/dev/null | head -n1) || return 1
+    ref=$(git ls-remote --heads --sort=-v:refname \
+        "${FOG_git_remote:-https://github.com/FOGProject/fogproject.git}" 'rc-*' \
+        2>/dev/null | head -n1) || return 1
     [[ -n $ref ]] || return 1
     ref="${ref##*refs/heads/}"
     [[ -n $ref ]] || return 1

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -137,13 +137,20 @@ channelToBranch() {
 # Returns 1 with no output when nothing matches. The caller is expected to say
 # "no release candidate is published" rather than "unknown channel"; those are
 # different problems for the admin.
+# refs/heads/rc-*, NOT a bare rc-*. ls-remote matches a pattern against the
+# TAIL of each ref at slash boundaries, so `rc-*` also matches
+# refs/heads/feat/rc-update-channel -- a feature branch, offered to an admin as
+# the current release candidate. Anchoring at refs/heads/ makes "rc-" mean the
+# start of the branch name rather than the start of its last path segment, and
+# the sed re-checks that on the way out: matching rules are not the place to
+# rely on one layer alone when the answer decides what gets checked out.
 rcBranch() {
     local ref
     ref=$(git ls-remote --heads --sort=-v:refname \
-        "${FOG_git_remote:-https://github.com/FOGProject/fogproject.git}" 'rc-*' \
-        2>/dev/null | head -n1) || return 1
-    [[ -n $ref ]] || return 1
-    ref="${ref##*refs/heads/}"
+        "${FOG_git_remote:-https://github.com/FOGProject/fogproject.git}" 'refs/heads/rc-*' \
+        2>/dev/null \
+        | sed -n 's#^[0-9a-f]\{7,\}[[:space:]]\{1,\}refs/heads/\(rc-[^/]\{1,\}\)$#\1#p' \
+        | head -n1) || return 1
     [[ -n $ref ]] || return 1
     echo "$ref"
 }
@@ -225,6 +232,59 @@ offerRevert() {
     echo " | restored by this run -- see docs/SUPPORTED_CUSTOMIZATIONS.md -- and"
     echo " | bin/restorekernel.sh --list will show the kernel sets kept for you."
     echo
+    return 0
+}
+# Which of FOG's four packaging families this box belongs to, so a caller can
+# pick a package manager instead of hardcoding one.
+#
+# Sets linuxReleaseName / OSVersion / linuxReleaseName_lower -- the same three
+# globals installfog.sh has always derived at this point in its flow -- plus
+# $osfamily. Each is guarded with [[ -z ]] like the values it replaces, so a
+# caller that has already set them (a test, an override) is left alone.
+#
+# MUST be called directly, never as $(detectOSFamily): command substitution
+# runs it in a subshell and every one of those globals is lost.
+#
+# The patterns are lib/common/input.sh's, which were the more complete of the
+# two copies -- installfog.sh's inline block did not know *mageia*. That is the
+# drift this exists to end: the distro-name parse lived in installfog.sh, the
+# family map lived in input.sh, and neither could see the other.
+#
+# Returns 1 with $osfamily empty for a distro matching none of the four. It
+# does NOT fall back to redhat the way input.sh's suggestion does, and the
+# difference is deliberate: there, redhat is a pre-filled answer to a prompt a
+# person can correct; here it would be a guess about which package-manager
+# binary actually exists, made by something with nobody watching.
+detectOSFamily() {
+    if [[ -f /etc/os-release ]]; then
+        [[ -z $linuxReleaseName ]] && linuxReleaseName=$(sed -n 's/^NAME=\(.*\)/\1/p' /etc/os-release | tr -d '"')
+        [[ -z $OSVersion ]] && OSVersion=$(sed -n 's/^VERSION_ID=\([^.]*\).*/\1/p' /etc/os-release | tr -d '"')
+    elif [[ -f /etc/redhat-release ]]; then
+        [[ -z $linuxReleaseName ]] && linuxReleaseName=$(cat /etc/redhat-release | awk '{print $1}')
+        [[ -z $OSVersion ]] && OSVersion=$(cat /etc/redhat-release | sed s/.*release\ // | sed s/\ .*// | awk -F. '{print $1}')
+    elif [[ -f /etc/debian_version ]]; then
+        [[ -z $linuxReleaseName ]] && linuxReleaseName='Debian'
+        [[ -z $OSVersion ]] && OSVersion=$(cat /etc/debian_version)
+    fi
+    linuxReleaseName_lower=$(echo "$linuxReleaseName" | tr [:upper:] [:lower:])
+    osfamily=""
+    case $linuxReleaseName_lower in
+        *fedora*|*red*hat*|*centos*|*mageia*|*alma*|*rocky*)
+            osfamily="redhat"
+            ;;
+        *ubuntu*|*bian*|*mint*)
+            osfamily="debian"
+            ;;
+        *alpine*)
+            osfamily="alpine"
+            ;;
+        *arch*|*manjaro*)
+            osfamily="arch"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
     return 0
 }
 backupReports() {

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -64,12 +64,42 @@ linkIfAbsent() {
 #   stable        stable    Stable
 #   dev-branch    patches   Patches
 #   working-1.6   beta      Beta
-#   rc-*          --        Release Candidate
+#   rc-*          rc        Release Candidate
 #   feature-*     --        Feature
 #
-# The last two have no update channel: nobody tracks a release candidate or a
-# feature branch as a standing preference, so FOG_CHANNEL is a superset rather
-# than a mismatch.
+# feature has no update channel: nobody tracks a feature branch as a standing
+# preference, so FOG_CHANNEL stays a superset rather than a mismatch.
+#
+# rc DID have none, for the stated reason that nobody tracks a release
+# candidate as a standing preference. That turned out to be wrong about who is
+# tracking one. The 1.5 -> 1.6 crossing is the case: a 1.5 server moving onto
+# 1.6 wants the release candidate, not the beta branch, and "track the current
+# RC until it becomes stable" is exactly a standing preference. So the reason
+# is retired rather than the decision quietly reversed.
+#
+# rc is also the one channel that is a QUERY rather than a constant. The others
+# name a branch that always exists; rc-* is a family whose members come and go,
+# so channelToBranch has to ask the remote which one is current. Two
+# consequences that are not obvious:
+#
+#   * It can legitimately resolve to NOTHING, when no release candidate is
+#     published. That is not the same failure as a misspelled channel and does
+#     not deserve the same message, so channelToBranch returns 2 for it and 1
+#     for an unknown name.
+#   * "Current" is the highest VERSION, not the newest commit date. Version
+#     order is what an RC series means (rc-1.6.10 follows rc-1.6.2, which a
+#     lexical sort gets backwards), it survives someone pushing a fix to an
+#     older RC branch, and -- the deciding reason -- it is answerable from
+#     `git ls-remote`, which reports no dates at all. bin/bootstrap.sh has to
+#     resolve this before it has a clone to run for-each-ref against, so a
+#     date-based answer could not be shared with it.
+#
+# And rc is the one label that is not its channel's title-case form: the stored
+# value is the abbreviation, the label spells it out. That is a deliberate
+# exception to the rule above rather than a drift -- "Release Candidate" is
+# already in released version strings, and nobody reads it as naming something
+# other than rc. tests/update-channel-vocabulary.test.sh pins the pair
+# explicitly instead of deriving it.
 #
 # WHY THIS DIRECTION, given GH-1012 deliberately chose stable/staging/dev to
 # match README.md's table. That decision was "match README", not "these three
@@ -89,8 +119,31 @@ channelToBranch() {
         stable) echo "stable" ;;
         patches) echo "dev-branch" ;;
         beta) echo "working-1.6" ;;
+        rc) rcBranch || return 2 ;;
         *) return 1 ;;
     esac
+}
+# The current release-candidate branch, or nothing.
+#
+# Asked of the REMOTE, not of local refs: a checkout that has never fetched
+# has no origin/rc-* to find, and bin/bootstrap.sh runs before there is a
+# checkout at all. ls-remote answers both cases identically and needs no fetch.
+#
+# --sort=-v:refname is a version sort, so rc-1.6.10 beats rc-1.6.2 -- which a
+# plain lexical sort gets backwards, and which is the whole point of asking.
+# Sorting by date is not an option here even if it were preferable: the remote
+# ref advertisement carries no commit dates.
+#
+# Returns 1 with no output when nothing matches. The caller is expected to say
+# "no release candidate is published" rather than "unknown channel"; those are
+# different problems for the admin.
+rcBranch() {
+    local ref
+    ref=$(git ls-remote --heads --sort=-v:refname         "${FOG_git_remote:-https://github.com/FOGProject/fogproject.git}" 'rc-*'         2>/dev/null | head -n1) || return 1
+    [[ -n $ref ]] || return 1
+    ref="${ref##*refs/heads/}"
+    [[ -n $ref ]] || return 1
+    echo "$ref"
 }
 # Folds a channel name to its canonical spelling, so exactly one place knows the
 # retired names. Returns 1 for anything unrecognized rather than echoing it
@@ -108,6 +161,7 @@ normalizeChannel() {
         stable) echo "stable" ;;
         patches|staging) echo "patches" ;;
         beta|dev) echo "beta" ;;
+        rc) echo "rc" ;;
         *) return 1 ;;
     esac
 }
@@ -120,6 +174,7 @@ branchToChannel() {
         stable) echo "stable" ;;
         dev-branch) echo "patches" ;;
         working-1.6) echo "beta" ;;
+        rc-*) echo "rc" ;;
         *) return 1 ;;
     esac
 }

--- a/tests/rc-channel-resolution.test.sh
+++ b/tests/rc-channel-resolution.test.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+#
+# The rc channel resolves to the CURRENT release candidate.
+#
+#   tests/rc-channel-resolution.test.sh
+#
+# rc is the only channel that is a query rather than a constant. stable,
+# patches and beta each name a branch that always exists; rc-* is a family
+# whose members come and go, so channelToBranch has to ask the remote which one
+# is current.
+#
+# Two things that follow from that, and that this pins:
+#
+#   * The answer is the highest VERSION, not the newest commit. A lexical sort
+#     puts rc-1.6.2 above rc-1.6.10, which is backwards for every series that
+#     runs past nine; and a date sort would follow a late fix pushed to a
+#     superseded RC. It also has to be answerable from `git ls-remote`, which
+#     reports no dates at all -- bin/bootstrap.sh resolves this before it has a
+#     clone to run for-each-ref against.
+#
+#   * "No release candidate published" is a real, ordinary state -- it is true
+#     of origin right now -- and it is NOT the same failure as a misspelled
+#     channel. channelToBranch returns 2 for it and 1 for an unknown name, so
+#     the caller can say something true instead of blaming the admin.
+#
+# Runs against a local throwaway repository used as a remote, so it needs git
+# but no network, no root, and no FOG install.
+#
+# Usage: bash tests/rc-channel-resolution.test.sh
+# Exit status 0 = pass, 1 = fail.
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+functions="$root/lib/common/functions.sh"
+
+pass=0
+fail=0
+
+check() {
+    if [[ $2 -eq 0 ]]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        printf '  FAIL  %s\n' "$1"
+    fi
+}
+
+if [[ ! -r $functions ]]; then
+    echo "FAIL: cannot read $functions" >&2
+    exit 1
+fi
+if ! command -v git >/dev/null 2>&1; then
+    echo "SKIP: git is not installed" >&2
+    exit 0
+fi
+
+lift() {
+    awk -v fn="$1" '
+        $0 ~ "^" fn "\\(\\) \\{" { grab = 1 }
+        grab { print }
+        grab && /^\}/ { exit }
+    ' "$functions"
+}
+
+snippet="$(lift normalizeChannel)
+$(lift channelToBranch)
+$(lift rcBranch)
+$(lift branchToChannel)"
+
+for fn in normalizeChannel channelToBranch rcBranch branchToChannel; do
+    if ! grep -q "^${fn}() {" <<< "$snippet"; then
+        echo "FAIL: could not find ${fn}() in lib/common/functions.sh." >&2
+        echo "  If it moved or was renamed, point this test at it -- do not" >&2
+        echo "  delete the assertions." >&2
+        exit 1
+    fi
+done
+eval "$snippet"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# A bare repository standing in for origin. FOG_git_remote is what rcBranch
+# asks, so pointing it here keeps the whole test off the network.
+FOG_git_remote="$work/remote.git"
+seed="$work/seed"
+git init -q --bare "$FOG_git_remote"
+git init -q "$seed"
+git -C "$seed" config user.email t@example.invalid
+git -C "$seed" config user.name t
+echo x > "$seed/f"
+git -C "$seed" add f && git -C "$seed" commit -qm seed
+git -C "$seed" remote add origin "$FOG_git_remote"
+
+publish() {
+    git -C "$seed" branch -f "$1" >/dev/null 2>&1
+    git -C "$seed" push -q origin "$1" >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Nothing published: a known channel with nothing to point at.
+# ---------------------------------------------------------------------------
+publish stable
+publish working-1.6
+
+out=$(channelToBranch rc); st=$?
+check "rc with no release candidate returns 2, not 1" \
+    "$([[ $st -eq 2 ]]; echo $?)"
+check "and prints nothing to stand in for a branch name" \
+    "$([[ -z $out ]]; echo $?)"
+
+# The distinction is only useful if a genuine typo still says something else.
+channelToBranch nonsense >/dev/null 2>&1
+check "an unknown channel still returns 1" \
+    "$([[ $? -eq 1 ]]; echo $?)"
+
+# The three constant channels must be unaffected by any of this.
+check "stable still resolves without asking the remote" \
+    "$([[ $(channelToBranch stable) == stable ]]; echo $?)"
+check "patches still resolves" \
+    "$([[ $(channelToBranch patches) == dev-branch ]]; echo $?)"
+check "beta still resolves" \
+    "$([[ $(channelToBranch beta) == working-1.6 ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# One published.
+# ---------------------------------------------------------------------------
+publish rc-1.6.0
+check "a single rc-* branch resolves to itself" \
+    "$([[ $(channelToBranch rc) == rc-1.6.0 ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# Several published. This is the assertion the whole design turns on.
+# ---------------------------------------------------------------------------
+publish rc-1.6.1
+publish rc-1.6.2
+check "the newest of several is chosen" \
+    "$([[ $(channelToBranch rc) == rc-1.6.2 ]]; echo $?)"
+
+# Pushed LAST but lowest -- a date or push-order answer picks this one, a
+# version sort does not.
+publish rc-1.6.10
+check "rc-1.6.10 beats rc-1.6.2 (version order, not lexical)" \
+    "$([[ $(channelToBranch rc) == rc-1.6.10 ]]; echo $?)"
+
+publish rc-1.5.99
+check "a stale lower series pushed later does not win" \
+    "$([[ $(channelToBranch rc) == rc-1.6.10 ]]; echo $?)"
+
+# Nothing about the query may leak into the other channels.
+check "beta is unaffected by published release candidates" \
+    "$([[ $(channelToBranch beta) == working-1.6 ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# The inverse, and the vocabulary.
+# ---------------------------------------------------------------------------
+check "an rc-* branch maps back to the rc channel" \
+    "$([[ $(branchToChannel rc-1.6.10) == rc ]]; echo $?)"
+check "rc is its own canonical spelling" \
+    "$([[ $(normalizeChannel rc) == rc ]]; echo $?)"
+check "a feature branch still has no channel" \
+    "$(! branchToChannel feature-x >/dev/null 2>&1; echo $?)"
+
+# ---------------------------------------------------------------------------
+# The callers say the right thing about each failure.
+# ---------------------------------------------------------------------------
+updater=$(sed 's/#.*//' "$root/bin/updatefog.sh")
+
+check "updatefog.sh handles the 'nothing published' case separately" \
+    "$(grep -q '2)' <<< "$updater"; echo $?)"
+
+check "it says no release candidate is published, not 'unknown channel'" \
+    "$(grep -qi 'No release candidate is currently published' <<< "$updater"; echo $?)"
+
+check "updatefog.sh offers rc in its help" \
+    "$(grep -q 'stable|patches|beta|rc' <<< "$updater"; echo $?)"
+
+check "installfog.sh --channel accepts rc" \
+    "$(sed 's/#.*//' "$root/bin/installfog.sh" | grep -qi 'stable, patches, beta, rc'; echo $?)"
+
+printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$pass" "$fail"
+[[ $fail -eq 0 ]]

--- a/tests/rc-channel-resolution.test.sh
+++ b/tests/rc-channel-resolution.test.sh
@@ -101,10 +101,19 @@ publish() {
 # ---------------------------------------------------------------------------
 publish stable
 publish working-1.6
+# A branch whose LAST PATH SEGMENT starts with rc-, which is not a release
+# candidate. ls-remote matches a pattern against the tail of a ref at slash
+# boundaries, so a bare `rc-*` pattern matches this and rcBranch used to offer
+# it as the current RC -- confirmed against origin, where it returned
+# feat/rc-update-channel. Published FIRST so it is the only candidate here and
+# stays in the way for every assertion below.
+publish feat/rc-update-channel
 
 out=$(channelToBranch rc); st=$?
 check "rc with no release candidate returns 2, not 1" \
     "$([[ $st -eq 2 ]]; echo $?)"
+check "a feat/rc-* branch is not mistaken for a release candidate" \
+    "$([[ -z $(rcBranch) ]]; echo $?)"
 check "and prints nothing to stand in for a branch name" \
     "$([[ -z $out ]]; echo $?)"
 
@@ -140,6 +149,9 @@ check "the newest of several is chosen" \
 # version sort does not.
 publish rc-1.6.10
 check "rc-1.6.10 beats rc-1.6.2 (version order, not lexical)" \
+    "$([[ $(channelToBranch rc) == rc-1.6.10 ]]; echo $?)"
+
+check "and it does not outrank a real one once one exists" \
     "$([[ $(channelToBranch rc) == rc-1.6.10 ]]; echo $?)"
 
 publish rc-1.5.99

--- a/tests/update-channel-vocabulary.test.sh
+++ b/tests/update-channel-vocabulary.test.sh
@@ -179,10 +179,15 @@ for br in stable dev-branch working-1.6; do
     fi
 done
 
-# The two labels with no update channel. Pinned so that a later attempt to give
-# them one has to come here and think about it, rather than silently inventing a
-# fourth spelling of an existing channel.
-for pair in "rc:Release Candidate" "feature:Feature"; do
+# feature is the only label left with no update channel. Still pinned so that a
+# later attempt to give it one has to come here and think about it, rather than
+# silently inventing a second spelling of an existing channel.
+#
+# rc was in this loop and is not any more -- it HAS a channel now (see
+# channelToBranch in lib/common/functions.sh for why the old reasoning was
+# retired). What it does not have is a title-case-derived label, so it is
+# pinned as explicit pairs below instead of going through the F loop.
+for pair in "feature:Feature"; do
     arm="${pair%%:*}"; want="${pair#*:}"
     got=$(labelForArm "$arm")
     [[ $got == "$want" ]] && ok "F. $arm labels '$want'" \
@@ -191,6 +196,28 @@ for pair in "rc:Release Candidate" "feature:Feature"; do
         && bad "F. $arm has no update channel" "branchToChannel returned one" \
         || ok "F. $arm correctly has no update channel"
 done
+
+# rc, the deliberate exception to "the label is the channel's title-case form".
+# Asserted as literal pairs, in both directions, so the exception stays exactly
+# one word wide and cannot quietly become a second name for something else.
+got=$(labelForArm rc)
+[[ $got == "Release Candidate" ]] && ok "F. rc labels 'Release Candidate'" \
+    || bad "F. rc labels 'Release Candidate'" "got '$got'"
+
+got=$(branchToChannel "rc-1.6.0")
+[[ $got == rc ]] && ok "F. an rc-* branch maps to the rc channel" \
+    || bad "F. an rc-* branch maps to the rc channel" "got '$got'"
+
+got=$(normalizeChannel rc)
+[[ $got == rc ]] && ok "F. rc is its own canonical spelling" \
+    || bad "F. rc is its own canonical spelling" "got '$got'"
+
+# The distinction that keeps two different failures apart: a channel FOG does
+# not know is exit 1; a channel it knows but cannot resolve right now -- no
+# release candidate published -- is exit 2. Callers say different things.
+channelToBranch nonsense >/dev/null 2>&1; st=$?
+[[ $st -eq 1 ]] && ok "F. an unknown channel exits 1" \
+    || bad "F. an unknown channel exits 1" "got exit $st"
 
 # --- F2. the same thing EXECUTED, where the checkout allows it ------------
 # Belt and braces for a full local clone: proves the parse above describes what


### PR DESCRIPTION
Stacked on #1584.

Prerequisite for the 1.5 back-port of `updatefog.sh`: the channel a 1.5 server crossing to 1.6 will actually pass is `rc`.

## Reversing a documented decision, deliberately

`rc-*` branches had a `FOG_CHANNEL` label and **no** update channel, on the stated reasoning that *"nobody tracks a release candidate as a standing preference."* That turned out to be wrong about who is tracking one — a 1.5 server moving to 1.6 wants the release candidate, not the beta branch, and "track the current RC until it becomes stable" is exactly a standing preference.

`tests/update-channel-vocabulary.test.sh` pinned this on purpose:

> *"Pinned so that a later attempt to give them one has to come here and think about it."*

So the reasoning is retired in the comment rather than the decision quietly reversed, and the test's rc arm is replaced with explicit assertions rather than deleted.

## rc is a query, not a constant

The other three channels name a branch that always exists. `rc-*` is a family whose members come and go, so `channelToBranch` asks the remote. Two consequences that aren't obvious at the call site:

**It can legitimately resolve to nothing.** No `rc-*` branch is published on origin today — an ordinary state, not an error, and it must not read like a misspelled channel. `channelToBranch` now returns **2** for "known channel, nothing to point at" and keeps **1** for "no such channel":

```
 * No release candidate is currently published, so the rc channel
 | has nothing to check out. This is normal between releases.
 |
 | Track the beta line instead with --channel beta, or pass a
 | specific branch with --branch.
```

**"Current" is the highest version, not the newest commit.** Three reasons, in increasing order of how much they settle it:

1. A lexical sort puts `rc-1.6.2` above `rc-1.6.10` — backwards for any series running past nine.
2. A date sort would follow a late fix pushed to a superseded RC.
3. The answer has to come from `git ls-remote`, which **reports no commit dates at all**. `bin/bootstrap.sh` must resolve this before it has a clone to run `for-each-ref` against, so a date-based answer could not be shared with it.

## The one vocabulary exception

`rc` is the only label that is not its channel's title-case form — the stored value is the abbreviation, the label spells it out. Deliberate, not drift: "Release Candidate" is already in released version strings and nobody reads it as naming something other than `rc`. The pair is pinned literally in the vocabulary test instead of derived, so the exception stays exactly one word wide.

## Tests

`tests/rc-channel-resolution.test.sh` (18 checks) runs the resolution against a local bare repository standing in for origin — git required, no network. It covers the nothing-published case, the 1-vs-2 exit distinction, and that the three constant channels are unaffected.

The assertion the design turns on — `rc-1.6.10` beating `rc-1.6.2`, plus a stale `rc-1.5.99` pushed *last* not winning — was confirmed to fail against a lexical sort before being kept.

## Fixed after review

`rcBranch` asked the remote for `rc-*`. `ls-remote` matches a pattern against the **tail** of each ref at slash boundaries, so that also matches `refs/heads/feat/rc-update-channel` — and run against origin it did exactly that, offering a feature branch as the current release candidate. An admin on `--channel rc` would have been checked out onto it.

The pattern is now `refs/heads/rc-*`, and the extracted name is re-checked with a `sed` that rejects a further slash.

The test could not see this: its fixture had no branch shaped like the one that broke it. It now publishes `feat/rc-update-channel` **first**, so the decoy is in the way of every assertion below it. Three arms go red against the old pattern — confirmed by putting it back.


## Note

There is no `rc-*` branch on origin, so `--channel rc` currently takes the "nothing published" path on a real server. That is the correct behaviour and the tests cover it, but it does mean the happy path can only be exercised against a real RC once one exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtZHpyWZWDPSxePdTViGZy

