### PR TITLE
Add bin/bootstrap.sh, and one distro-name map instead of three (GH-1006)

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -1,0 +1,363 @@
+#!/bin/bash
+#
+#  FOG is a computer imaging solution.
+#  Copyright (C) 2007  Chuck Syperski & Jian Zhang
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#    any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# GH-1006. Gets FOG onto a machine that has nothing on it yet:
+#
+#   curl -fsSL https://raw.githubusercontent.com/FOGProject/fogproject/working-1.6/bin/bootstrap.sh | bash
+#
+# Installs git, clones the repository, checks out the branch for the requested
+# channel, and runs installfog.sh. Nothing else -- once the clone exists,
+# installfog.sh and bin/updatefog.sh own everything that happens after.
+#
+# WHY THIS FILE DUPLICATES detectOSFamily() AND THE CHANNEL MAP
+#
+# It has to be self-contained. It runs BEFORE there is a clone, so it cannot
+# source lib/common/functions.sh -- the file does not exist on the machine yet,
+# and fetching 300+ KB of installer over HTTP to reach twelve lines of
+# /etc/os-release parsing would be worse than copying the twelve lines.
+#
+# The original design for this script called for extracting the detection into
+# functions.sh "so bootstrap.sh and installfog.sh share one implementation".
+# That is not achievable in the pre-clone half and pretending otherwise would
+# have produced a script that could not run. The extraction was worth doing on
+# its own merits and was done -- installfog.sh and lib/common/input.sh now both
+# call detectOSFamily() instead of carrying a copy each -- but this file is not
+# one of its callers. tests/detect-os-family.test.sh runs BOTH copies over the
+# same distro names and fails if they ever disagree, which is the honest way to
+# hold two implementations together when one of them cannot import the other.
+#
+# NO `set -e`, matching every other script in this repository. Failures are
+# handled where they happen, so a partial failure can say what it was.
+#
+# Exit codes match installfog.sh's where the failure is the same one:
+#   1 not root        2 not Linux       3 bad argument
+#   4 unsupported distribution          5 could not install git
+#   6 clone or checkout failed          7 no terminal for an interactive install
+
+version="1.0.0"
+
+usage() {
+    echo -e "Usage: curl -fsSL <url>/bootstrap.sh | bash -s -- [options]"
+    echo -e "       $0 [options]\n"
+    echo -e "\t-h -? --help\t\tDisplay this info"
+    echo -e "\t      --channel\t\tWhich line to install: stable, patches, beta"
+    echo -e "\t              \t\tor rc. Defaults to stable"
+    echo -e "\t      --branch\t\tCheck out a literal branch or tag instead of a"
+    echo -e "\t              \t\tchannel, for testing a PR or feature branch"
+    echo -e "\t      --git-path\tWhere to clone to. Defaults to /root/fogproject"
+    echo -e "\t-y    --yes\t\tRun the installer unattended (-Y). Without it the"
+    echo -e "\t              \t\tinstaller runs interactively, which is what a"
+    echo -e "\t              \t\tfirst install wants. Pass it from Ansible/cloud-init"
+    echo -e "\n\tThis script only gets FOG onto the machine. Afterwards,"
+    echo -e "\tbin/updatefog.sh moves it between channels and bin/installfog.sh"
+    echo -e "\tdoes everything else."
+    exit 0
+}
+
+fail() {
+    echo
+    echo " * $1"
+    shift
+    while [[ $# -gt 1 ]]; do
+        echo " | $1"
+        shift
+    done
+    echo
+    exit "$1"
+}
+
+repo="https://github.com/FOGProject/fogproject.git"
+gitpath="/root/fogproject"
+channel="stable"
+branch=""
+autoYes=""
+
+# Hand-rolled rather than getopt(1), because getopt is part of util-linux and
+# this script runs before any package has been installed. On a minimal image it
+# is usually there and occasionally is not, and a bootstrap that dies parsing
+# its own arguments is the worst possible first impression.
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h | -\? | --help)
+            usage
+            ;;
+        --channel)
+            [[ -n $2 ]] || fail "--channel requires a value" 3
+            channel="$2"
+            shift 2
+            ;;
+        --branch)
+            [[ -n $2 ]] || fail "--branch requires a value" 3
+            branch="$2"
+            shift 2
+            ;;
+        --git-path)
+            [[ -n $2 && $2 == /* ]] || fail "--git-path requires an absolute path" 3
+            gitpath="${2%/}"
+            shift 2
+            ;;
+        -y | --yes)
+            autoYes=1
+            shift
+            ;;
+        *)
+            fail "Unknown option: $1" "Run with --help for the list." 3
+            ;;
+    esac
+done
+
+if [[ ! $EUID -eq 0 ]]; then
+    # Same message and same exit code as installfog.sh's own root check. No
+    # auto-elevation: piping a script from the internet into a shell that then
+    # reaches for sudo by itself is precisely the shape nobody should get used
+    # to trusting.
+    echo "FOG Installation must be run as root user"
+    exit 1
+fi
+
+[[ -z $OS ]] && OS=$(uname -s)
+if [[ ! $(echo "$OS" | tr [:upper:] [:lower:]) =~ "linux" ]]; then
+    echo "We do not currently support Installation on non-Linux Operating Systems"
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Which distro family, and therefore which package manager.
+#
+# A copy of detectOSFamily() from lib/common/functions.sh -- see the note at the
+# top of this file for why it cannot be the same copy, and
+# tests/detect-os-family.test.sh for what keeps the two honest.
+# ---------------------------------------------------------------------------
+detectOSFamily() {
+    if [[ -f /etc/os-release ]]; then
+        [[ -z $linuxReleaseName ]] && linuxReleaseName=$(sed -n 's/^NAME=\(.*\)/\1/p' /etc/os-release | tr -d '"')
+        [[ -z $OSVersion ]] && OSVersion=$(sed -n 's/^VERSION_ID=\([^.]*\).*/\1/p' /etc/os-release | tr -d '"')
+    elif [[ -f /etc/redhat-release ]]; then
+        [[ -z $linuxReleaseName ]] && linuxReleaseName=$(cat /etc/redhat-release | awk '{print $1}')
+        [[ -z $OSVersion ]] && OSVersion=$(cat /etc/redhat-release | sed s/.*release\ // | sed s/\ .*// | awk -F. '{print $1}')
+    elif [[ -f /etc/debian_version ]]; then
+        [[ -z $linuxReleaseName ]] && linuxReleaseName='Debian'
+        [[ -z $OSVersion ]] && OSVersion=$(cat /etc/debian_version)
+    fi
+    linuxReleaseName_lower=$(echo "$linuxReleaseName" | tr [:upper:] [:lower:])
+    osfamily=""
+    case $linuxReleaseName_lower in
+        *fedora*|*red*hat*|*centos*|*mageia*|*alma*|*rocky*)
+            osfamily="redhat"
+            ;;
+        *ubuntu*|*bian*|*mint*)
+            osfamily="debian"
+            ;;
+        *alpine*)
+            osfamily="alpine"
+            ;;
+        *arch*|*manjaro*)
+            osfamily="arch"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# The channel map, likewise a copy -- of channelToBranch()/normalizeChannel()
+# in lib/common/functions.sh. The retired stable/staging/dev spellings are
+# honoured here exactly as they are there, silently and forever: an admin who
+# pastes a command from an older forum post should get a working install, not a
+# lecture about vocabulary.
+#
+# Note what `dev` means. It is the retired spelling of BETA, not of dev-branch,
+# despite a branch by that name existing -- see normalizeChannel's comment.
+# ---------------------------------------------------------------------------
+normalizeChannel() {
+    case "$1" in
+        stable) echo "stable" ;;
+        patches|staging) echo "patches" ;;
+        beta|dev) echo "beta" ;;
+        rc) echo "rc" ;;
+        *) return 1 ;;
+    esac
+}
+
+# Asked of the remote with ls-remote, which needs no clone -- the reason the
+# rc channel is resolved by version order rather than commit date at all, since
+# the remote ref advertisement carries no dates. -v:refname so rc-1.6.10 beats
+# rc-1.6.2.
+rcBranch() {
+    local ref
+    ref=$(git ls-remote --heads --sort=-v:refname "$repo" 'rc-*' 2>/dev/null | head -n1) || return 1
+    [[ -n $ref ]] || return 1
+    ref="${ref##*refs/heads/}"
+    [[ -n $ref ]] || return 1
+    echo "$ref"
+}
+
+channelToBranch() {
+    case "$(normalizeChannel "$1")" in
+        stable) echo "stable" ;;
+        patches) echo "dev-branch" ;;
+        beta) echo "working-1.6" ;;
+        rc) rcBranch || return 2 ;;
+        *) return 1 ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Refuse an unsupported distribution UP FRONT.
+#
+# The alternative -- install git, clone, and let installfog.sh discover it --
+# leaves a machine with packages and a checkout it cannot use, and tells the
+# person about it several minutes later.
+# ---------------------------------------------------------------------------
+if ! detectOSFamily; then
+    fail "FOG does not support this distribution: ${linuxReleaseName:-unknown}" \
+         "Supported: Red Hat family (RHEL, CentOS, Rocky, Alma, Fedora, Mageia)," \
+         "Debian family (Debian, Ubuntu, Mint), Alpine, and Arch (incl. Manjaro)." \
+         4
+fi
+
+installGit() {
+    command -v git >/dev/null 2>&1 && return 0
+    echo " * Installing git (${osfamily})"
+    case $osfamily in
+        debian)
+            apt-get -yq update
+            apt-get -yq install git
+            ;;
+        redhat)
+            # dnf where it exists, yum where it does not -- the same fallback
+            # installfog.sh uses for its own package work on this family.
+            if command -v dnf >/dev/null 2>&1; then
+                dnf -y install git
+            else
+                yum -y install git
+            fi
+            ;;
+        alpine)
+            apk add --no-cache git
+            ;;
+        arch)
+            pacman -Sy --noconfirm git
+            ;;
+    esac
+    command -v git >/dev/null 2>&1
+}
+
+if ! installGit; then
+    fail "Could not install git with this system's package manager." \
+         "Install it by hand and run this again." 5
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve the branch before touching the disk, so a bad channel costs nothing.
+# ---------------------------------------------------------------------------
+# Whether the branch was resolved FROM a channel, which is what decides if
+# --channel gets forwarded. $branch is non-empty either way by the time the
+# installer runs, so it cannot answer this itself.
+fromChannel=0
+if [[ -z $branch ]]; then
+    fromChannel=1
+    branch=$(channelToBranch "$channel")
+    case $? in
+        0) ;;
+        2)
+            fail "No release candidate is currently published, so the rc channel" \
+                 "has nothing to install. This is normal between releases." \
+                 "" \
+                 "Install the beta line instead with --channel beta." 3
+            ;;
+        *)
+            fail "Unknown channel: ${channel}" \
+                 "Expected stable, patches, beta or rc." \
+                 "The retired names staging and dev are also accepted, and mean" \
+                 "patches and beta respectively." 3
+            ;;
+    esac
+fi
+
+# ---------------------------------------------------------------------------
+# Clone, or leave an existing checkout alone.
+#
+# Idempotent by refusing to be clever: if there is already a .git here, this
+# script's job is done and it has no business resetting, pulling, or deleting
+# somebody's working tree. bin/updatefog.sh is the thing that moves an existing
+# checkout between channels, and it knows how to do it safely.
+# ---------------------------------------------------------------------------
+if [[ -d ${gitpath}/.git ]]; then
+    echo " * ${gitpath} is already a git checkout -- not cloning over it."
+    echo " | To move an existing install to another channel, use:"
+    echo " |   cd ${gitpath}/bin && ./updatefog.sh --channel ${channel}"
+    echo
+else
+    if [[ -e $gitpath && -n $(ls -A "$gitpath" 2>/dev/null) ]]; then
+        fail "${gitpath} exists and is not empty, but is not a git checkout." \
+             "Move it aside, or choose another path with --git-path." 6
+    fi
+    echo " * Cloning FOG into ${gitpath}"
+    git clone "$repo" "$gitpath" || fail "git clone failed." 6
+fi
+
+echo " * Checking out ${branch}"
+git -C "$gitpath" checkout "$branch" || fail "Could not check out ${branch}." \
+    "If this is a channel, the branch may have been renamed; if you passed" \
+    "--branch, check the name." 6
+
+# ---------------------------------------------------------------------------
+# Hand over to the installer.
+#
+# < /dev/tty, and this is the whole reason it is here: under
+# `curl ... | bash`, this script's stdin IS THE PIPE. Every read in
+# installfog.sh would take the remaining bytes of this file, or EOF, and answer
+# its own prompts with them. Reattaching the terminal is what makes an
+# interactive install possible at all from a one-liner.
+#
+# With no terminal and no --yes, this REFUSES rather than quietly falling back
+# to -Y. An unattended install of imaging software, as root, on a machine
+# nobody is watching, is not something to start because a tty happened to be
+# missing -- it is something to ask for.
+# ---------------------------------------------------------------------------
+# Forwarded only when a channel was actually chosen. --branch is a one-off for
+# testing a PR, exactly as it is in updatefog.sh: it must not leave the server
+# recording a channel it is not on.
+channelArgs=()
+[[ $fromChannel -eq 1 ]] && channelArgs=(--channel "$channel")
+
+if [[ -n $autoYes ]]; then
+    echo " * Starting the installer unattended"
+    (cd "${gitpath}/bin" && bash installfog.sh -Y "${channelArgs[@]}")
+    exit $?
+fi
+
+# Tested by OPENING it, not by stat'ing it. /dev/tty exists in plenty of
+# contexts where opening it fails with ENXIO -- a container started without a
+# tty is the common one -- and `[[ -r ]]` cannot tell those apart.
+if ! (exec < /dev/tty) 2>/dev/null; then
+    fail "No terminal is available, so the installer cannot run interactively." \
+         "This happens when the one-liner runs from cloud-init, CI, or a" \
+         "container with no tty attached." \
+         "" \
+         "Re-run with --yes for an unattended install:" \
+         "  curl -fsSL <url>/bootstrap.sh | bash -s -- --channel ${channel} --yes" 7
+fi
+
+echo " * Starting the installer"
+echo
+(cd "${gitpath}/bin" && bash installfog.sh "${channelArgs[@]}" < /dev/tty)
+exit $?

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -63,7 +63,7 @@ usage() {
     echo -e "\t-y    --yes\t\tRun the installer unattended (-Y). Without it the"
     echo -e "\t              \t\tinstaller runs interactively, which is what a"
     echo -e "\t              \t\tfirst install wants. Pass it from Ansible/cloud-init"
-    echo -e "\n\tThis script only gets FOG onto the machine. Afterwards,"
+    echo -e "\n\tThis script only gets FOG onto the machine. Afterward,"
     echo -e "\tbin/updatefog.sh moves it between channels and bin/installfog.sh"
     echo -e "\tdoes everything else."
     exit 0
@@ -179,7 +179,7 @@ detectOSFamily() {
 # ---------------------------------------------------------------------------
 # The channel map, likewise a copy -- of channelToBranch()/normalizeChannel()
 # in lib/common/functions.sh. The retired stable/staging/dev spellings are
-# honoured here exactly as they are there, silently and forever: an admin who
+# honored here exactly as they are there, silently and forever: an admin who
 # pastes a command from an older forum post should get a working install, not a
 # lecture about vocabulary.
 #

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -200,11 +200,18 @@ normalizeChannel() {
 # rc channel is resolved by version order rather than commit date at all, since
 # the remote ref advertisement carries no dates. -v:refname so rc-1.6.10 beats
 # rc-1.6.2.
+# refs/heads/rc-*, NOT a bare rc-*. ls-remote matches a pattern against the
+# TAIL of each ref at slash boundaries, so `rc-*` also matches
+# refs/heads/feat/rc-update-channel -- a feature branch, offered to an admin as
+# the current release candidate. Anchoring at refs/heads/ makes "rc-" mean the
+# start of the branch name rather than the start of its last path segment, and
+# the sed re-checks that on the way out: matching rules are not the place to
+# rely on one layer alone when the answer decides what gets checked out.
 rcBranch() {
     local ref
-    ref=$(git ls-remote --heads --sort=-v:refname "$repo" 'rc-*' 2>/dev/null | head -n1) || return 1
-    [[ -n $ref ]] || return 1
-    ref="${ref##*refs/heads/}"
+    ref=$(git ls-remote --heads --sort=-v:refname "$repo" 'refs/heads/rc-*' 2>/dev/null \
+        | sed -n 's#^[0-9a-f]\{7,\}[[:space:]]\{1,\}refs/heads/\(rc-[^/]\{1,\}\)$#\1#p' \
+        | head -n1) || return 1
     [[ -n $ref ]] || return 1
     echo "$ref"
 }

--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -716,18 +716,20 @@ while :; do
 done
 
 
-if [[ -f /etc/os-release ]]; then
-    [[ -z $linuxReleaseName ]] && linuxReleaseName=$(sed -n 's/^NAME=\(.*\)/\1/p' /etc/os-release | tr -d '"')
-    [[ -z $OSVersion ]] && OSVersion=$(sed -n 's/^VERSION_ID=\([^.]*\).*/\1/p' /etc/os-release | tr -d '"')
-elif [[ -f /etc/redhat-release ]]; then
-    [[ -z $linuxReleaseName ]] && linuxReleaseName=$(cat /etc/redhat-release | awk '{print $1}')
-    [[ -z $OSVersion ]] && OSVersion=$(cat /etc/redhat-release | sed s/.*release\ // | sed s/\ .*// | awk -F. '{print $1}')
-elif [[ -f /etc/debian_version ]]; then
-    [[ -z $linuxReleaseName ]] && linuxReleaseName='Debian'
-    [[ -z $OSVersion ]] && OSVersion=$(cat /etc/debian_version)
-fi
-
-linuxReleaseName_lower=$(echo "$linuxReleaseName" | tr [:upper:] [:lower:])
+# This parse used to be inline here, and the family map it feeds used to be
+# inline in lib/common/input.sh -- two halves of one question, neither able to
+# see the other, and already drifted: input.sh knew *mageia* and this did not.
+# Both now come from detectOSFamily(), which bin/bootstrap.sh's own copy is
+# kept in step with by tests/detect-os-family.test.sh.
+#
+# Called directly, never as $(...): it sets linuxReleaseName, OSVersion,
+# linuxReleaseName_lower and osfamily as globals, and a subshell would lose
+# all four.
+#
+# Its non-zero return is deliberately ignored. An unrecognized distro was never
+# fatal here -- input.sh suggests Redhat and the admin corrects it at the
+# prompt -- and making it fatal now would refuse installs that work today.
+detectOSFamily
 listPackages
 
 echo "Installing LSB_Release as needed"

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -225,6 +225,59 @@ offerRevert() {
     echo
     return 0
 }
+# Which of FOG's four packaging families this box belongs to, so a caller can
+# pick a package manager instead of hardcoding one.
+#
+# Sets linuxReleaseName / OSVersion / linuxReleaseName_lower -- the same three
+# globals installfog.sh has always derived at this point in its flow -- plus
+# $osfamily. Each is guarded with [[ -z ]] like the values it replaces, so a
+# caller that has already set them (a test, an override) is left alone.
+#
+# MUST be called directly, never as $(detectOSFamily): command substitution
+# runs it in a subshell and every one of those globals is lost.
+#
+# The patterns are lib/common/input.sh's, which were the more complete of the
+# two copies -- installfog.sh's inline block did not know *mageia*. That is the
+# drift this exists to end: the distro-name parse lived in installfog.sh, the
+# family map lived in input.sh, and neither could see the other.
+#
+# Returns 1 with $osfamily empty for a distro matching none of the four. It
+# does NOT fall back to redhat the way input.sh's suggestion does, and the
+# difference is deliberate: there, redhat is a pre-filled answer to a prompt a
+# person can correct; here it would be a guess about which package-manager
+# binary actually exists, made by something with nobody watching.
+detectOSFamily() {
+    if [[ -f /etc/os-release ]]; then
+        [[ -z $linuxReleaseName ]] && linuxReleaseName=$(sed -n 's/^NAME=\(.*\)/\1/p' /etc/os-release | tr -d '"')
+        [[ -z $OSVersion ]] && OSVersion=$(sed -n 's/^VERSION_ID=\([^.]*\).*/\1/p' /etc/os-release | tr -d '"')
+    elif [[ -f /etc/redhat-release ]]; then
+        [[ -z $linuxReleaseName ]] && linuxReleaseName=$(cat /etc/redhat-release | awk '{print $1}')
+        [[ -z $OSVersion ]] && OSVersion=$(cat /etc/redhat-release | sed s/.*release\ // | sed s/\ .*// | awk -F. '{print $1}')
+    elif [[ -f /etc/debian_version ]]; then
+        [[ -z $linuxReleaseName ]] && linuxReleaseName='Debian'
+        [[ -z $OSVersion ]] && OSVersion=$(cat /etc/debian_version)
+    fi
+    linuxReleaseName_lower=$(echo "$linuxReleaseName" | tr [:upper:] [:lower:])
+    osfamily=""
+    case $linuxReleaseName_lower in
+        *fedora*|*red*hat*|*centos*|*mageia*|*alma*|*rocky*)
+            osfamily="redhat"
+            ;;
+        *ubuntu*|*bian*|*mint*)
+            osfamily="debian"
+            ;;
+        *alpine*)
+            osfamily="alpine"
+            ;;
+        *arch*|*manjaro*)
+            osfamily="arch"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+    return 0
+}
 backupReports() {
     dots "Backing up user reports"
     [[ ! -d ../rpttmp/ ]] && mkdir ../rpttmp/ >>$error_log

--- a/lib/common/input.sh
+++ b/lib/common/input.sh
@@ -14,22 +14,26 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 if [[ $guessdefaults == 1 ]]; then
-    case $linuxReleaseName_lower in
-        *fedora*|*red*hat*|*centos*|*mageia*|*alma*|*rocky*)
-            strSuggestedOS=1
-            ;;
-        *ubuntu*|*bian*|*mint*)
-            strSuggestedOS=2
-            ;;
-        *alpine*)
-            strSuggestedOS=3
-            ;;
-        *arch*|*manjaro*)
-            strSuggestedOS=4
-            ;;
-        *)
-            strSuggestedOS=1
-            ;;
+    # The distro-name patterns that used to be spelled out here now live in
+    # detectOSFamily() (lib/common/functions.sh), which installfog.sh has
+    # already run by the time this file is sourced. Re-run only if something
+    # reached here without it: the function is idempotent and [[ -z ]]-guarded,
+    # so a second call costs nothing, and an unset $osfamily would otherwise
+    # fall to the default below and suggest Redhat on a Debian box.
+    [[ -z $osfamily ]] && detectOSFamily
+    # osid numbering is GH-447's: 3 meant Arch on FOG 1.5 and means Alpine now,
+    # with Arch renumbered to 4. See displayOSChoices().
+    case $osfamily in
+        redhat) strSuggestedOS=1 ;;
+        debian) strSuggestedOS=2 ;;
+        alpine) strSuggestedOS=3 ;;
+        arch)   strSuggestedOS=4 ;;
+        # Unchanged: a distro matching none of the four still SUGGESTS Redhat.
+        # detectOSFamily deliberately refuses to make that guess and this
+        # deliberately does, because they are different questions -- this is a
+        # pre-filled answer to a prompt a person can correct, not a claim about
+        # which package-manager binary exists on the box.
+        *)      strSuggestedOS=1 ;;
     esac
     allinterfaces=($(getAllNetworkInterfaces))
     strSuggestedInterface=${allinterfaces[0]}

--- a/tests/bootstrap-installer.test.sh
+++ b/tests/bootstrap-installer.test.sh
@@ -1,0 +1,321 @@
+#!/bin/bash
+#
+# The one-liner bootstrap does the irreducible pre-clone work, and no more.
+#
+#   tests/bootstrap-installer.test.sh
+#
+# GH-1006. bin/bootstrap.sh is fetched over HTTP and piped into bash as root on
+# a machine with nothing on it, which makes almost every interesting case here
+# a REFUSAL: the wrong distro, no terminal, a directory that is not ours. A
+# bootstrap that guesses in any of those is worse than one that stops.
+#
+# The two that matter most:
+#
+#   * An unsupported distribution is refused BEFORE git is installed. The
+#     alternative leaves a machine carrying packages and a checkout it cannot
+#     use, and says so several minutes later.
+#
+#   * No terminal and no --yes is a refusal, not a silent fall back to -Y.
+#     Under `curl ... | bash` the script's stdin is the pipe, so the installer
+#     has to be handed /dev/tty or it answers its own prompts with the
+#     remaining bytes of this file. Where there is no tty to hand it, starting
+#     an unattended root install of imaging software on a machine nobody is
+#     watching is not a reasonable default.
+#
+# Nothing here runs as root, installs a package, or reaches the network. The
+# root check is neutered in a COPY of the script, the package managers and git
+# are stubs on PATH, and the distro is chosen by pre-setting linuxReleaseName,
+# which detectOSFamily is [[ -z ]]-guarded to respect.
+#
+# OS=Linux is exported for the same reason: bootstrap.sh does
+# `[[ -z $OS ]] && OS=$(uname -s)`, and on a developer's machine uname may not
+# say Linux at all -- this suite runs under Git Bash on Windows in at least one
+# place. The override uses the guard the script already provides rather than
+# patching the check out, so the check itself stays exercised: the unmodified
+# script is run WITHOUT the override further down to prove it still refuses.
+#
+# Usage: bash tests/bootstrap-installer.test.sh
+# Exit status 0 = pass, 1 = fail.
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+bootstrap="$root/bin/bootstrap.sh"
+
+pass=0
+fail=0
+
+check() {
+    if [[ $2 -eq 0 ]]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        printf '  FAIL  %s\n' "$1"
+    fi
+}
+
+if [[ ! -r $bootstrap ]]; then
+    echo "FAIL: cannot read $bootstrap" >&2
+    exit 1
+fi
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# ---------------------------------------------------------------------------
+# The real script, unmodified. Everything before the root check is reachable
+# without being root, which is most of the argument handling.
+# ---------------------------------------------------------------------------
+bash "$bootstrap" --help >/dev/null 2>&1
+check "--help exits 0" "$?"
+
+check "--help works before the root check, so a user can read it" \
+    "$(bash "$bootstrap" --help 2>&1 | grep -q -- '--channel'; echo $?)"
+
+bash "$bootstrap" >/dev/null 2>&1
+check "a non-root run exits 1, like installfog.sh" \
+    "$([[ $? -eq 1 ]]; echo $?)"
+
+check "and says the same thing installfog.sh says" \
+    "$(bash "$bootstrap" 2>&1 | grep -q 'must be run as root user'; echo $?)"
+
+for bad in "--nonsense" "--channel" "--branch" "--git-path relative/path"; do
+    bash "$bootstrap" $bad >/dev/null 2>&1
+    check "bad argument '${bad}' exits 3" "$([[ $? -eq 3 ]]; echo $?)"
+done
+
+# ---------------------------------------------------------------------------
+# A copy with the root gate removed, so the rest of the flow is reachable.
+# Nothing else is changed -- the point is to exercise the real logic.
+# ---------------------------------------------------------------------------
+sut="$work/bootstrap.sh"
+sed 's/^if \[\[ ! \$EUID -eq 0 \]\]; then$/if false; then/' "$bootstrap" > "$sut"
+if ! grep -q 'if false; then' "$sut"; then
+    echo "FAIL: could not neuter the root check -- it changed shape." >&2
+    echo "  Point this test at the new one; do not delete the assertions." >&2
+    exit 1
+fi
+
+# --- stubs ----------------------------------------------------------------
+# Two directories on purpose. installGit() returns early when git is already
+# on PATH, so the "which package manager" cases have to run with a PATH that
+# does NOT have the git stub in it -- otherwise they assert nothing, which is
+# how they first passed for the wrong reason.
+pmstubs="$work/pm"      # package managers only
+stubs="$work/stubs"     # package managers + git
+mkdir -p "$pmstubs" "$stubs"
+calls="$work/calls.log"
+
+for tool in apt-get dnf yum pacman apk; do
+    cat > "$pmstubs/$tool" <<EOF
+#!/bin/bash
+echo "$tool \$*" >> "\$CALLS"
+exit 0
+EOF
+    chmod +x "$pmstubs/$tool"
+    cp "$pmstubs/$tool" "$stubs/$tool"
+done
+
+# git: records what it was asked, and makes `clone` produce a checkout that
+# looks real enough for the next step to act on.
+cat > "$stubs/git" <<'EOF'
+#!/bin/bash
+echo "git $*" >> "$CALLS"
+case "$1" in
+    clone)
+        mkdir -p "$3/.git" "$3/bin"
+        cat > "$3/bin/installfog.sh" <<'INNER'
+#!/bin/bash
+echo "installfog $*" >> "$CALLS"
+exit 0
+INNER
+        chmod +x "$3/bin/installfog.sh"
+        ;;
+    ls-remote)
+        # No release candidate published, which is origin's real state.
+        exit 0
+        ;;
+esac
+exit 0
+EOF
+chmod +x "$stubs/git"
+
+# Every invocation goes through here so the environment is set the same way
+# each time. EXPORTED, not prefixed: a `VAR=x func` prefix sets the variable
+# for the function, not for the `bash` child it starts, so the script would
+# never see it.
+run() {
+    local distro="$1" version="$2"
+    shift 2
+    ( export PATH="$stubs:$PATH" CALLS="$calls" OS="Linux"
+      export linuxReleaseName="$distro" OSVersion="$version"
+      unset osfamily
+      cd "$work" && bash "$sut" "$@" )
+}
+
+# The same, on a machine that does not have git yet -- which is the machine
+# this script exists for.
+runNoGit() {
+    local distro="$1" version="$2"
+    shift 2
+    ( export PATH="$pmstubs:/usr/bin:/bin" CALLS="$calls" OS="Linux"
+      export linuxReleaseName="$distro" OSVersion="$version"
+      unset osfamily
+      cd "$work" && bash "$sut" "$@" )
+}
+
+# ---------------------------------------------------------------------------
+# An unsupported distribution is refused, and refused EARLY.
+# ---------------------------------------------------------------------------
+: > "$calls"
+out=$(run "Void Linux" 1 --git-path "$work/void" 2>&1)
+st=$?
+check "an unsupported distribution exits 4" "$([[ $st -eq 4 ]]; echo $?)"
+check "it names the distribution it refused" \
+    "$(grep -q 'Void Linux' <<< "$out"; echo $?)"
+check "it lists what IS supported" \
+    "$(grep -qi 'Alpine' <<< "$out" && grep -qi 'Debian' <<< "$out"; echo $?)"
+check "nothing was installed before the refusal" \
+    "$([[ ! -s $calls ]]; echo $?)"
+check "and nothing was cloned" \
+    "$([[ ! -d $work/void ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# Each family reaches for its own package manager.
+# ---------------------------------------------------------------------------
+declare -A wanted=( [Ubuntu]=apt-get [Debian]=apt-get ["Rocky Linux"]=dnf ["Alpine Linux"]=apk ["Arch Linux"]=pacman )
+for name in Ubuntu Debian "Rocky Linux" "Alpine Linux" "Arch Linux"; do
+    : > "$calls"
+    dir="$work/fam-${name// /_}"
+    runNoGit "$name" 1 --git-path "$dir" --yes >/dev/null 2>&1
+    check "${name} installs git with ${wanted[$name]}" \
+        "$(grep -q "^${wanted[$name]} " "$calls"; echo $?)"
+done
+
+# dnf-before-yum is the fallback installfog.sh already uses on this family.
+: > "$calls"
+nodnf="$work/nodnf"
+mkdir -p "$nodnf"
+cp "$pmstubs/yum" "$nodnf/"
+( export PATH="$nodnf:/usr/bin:/bin" CALLS="$calls" OS="Linux"
+  unset osfamily
+  export linuxReleaseName="CentOS Linux" OSVersion=9
+  cd "$work" && bash "$sut" --git-path "$work/yumbox" --yes ) >/dev/null 2>&1
+check "a Red Hat box without dnf falls back to yum" \
+    "$(grep -q '^yum ' "$calls"; echo $?)"
+
+# ---------------------------------------------------------------------------
+# Channels resolve to branches, and rc says something true when there is none.
+# ---------------------------------------------------------------------------
+for pair in "stable:stable" "patches:dev-branch" "beta:working-1.6" "dev:working-1.6" "staging:dev-branch"; do
+    ch="${pair%%:*}"; want="${pair#*:}"
+    : > "$calls"
+    run Ubuntu 22 --git-path "$work/ch-$ch" --channel "$ch" --yes >/dev/null 2>&1
+    check "--channel ${ch} checks out ${want}" \
+        "$(grep -q "^git -C .* checkout ${want}$" "$calls"; echo $?)"
+done
+
+: > "$calls"
+out=$(run Ubuntu 22 --git-path "$work/rc" --channel rc --yes 2>&1)
+check "--channel rc with none published says so, rather than 'unknown channel'" \
+    "$(grep -qi 'No release candidate is currently published' <<< "$out"; echo $?)"
+check "and does not clone anything" \
+    "$([[ ! -d $work/rc ]]; echo $?)"
+
+: > "$calls"
+out=$(run Ubuntu 22 --git-path "$work/bogus" --channel nonsense --yes 2>&1)
+check "an unknown channel is a different message" \
+    "$(grep -qi 'Unknown channel' <<< "$out"; echo $?)"
+check "which still names the retired spellings" \
+    "$(grep -qi 'staging and dev' <<< "$out"; echo $?)"
+
+# --branch is a one-off and must NOT record a channel.
+: > "$calls"
+run Ubuntu 22 --git-path "$work/br" --branch some-pr-branch --yes >/dev/null 2>&1
+check "--branch checks out the literal branch" \
+    "$(grep -q 'checkout some-pr-branch$' "$calls"; echo $?)"
+check "--branch does not forward --channel to the installer" \
+    "$(! grep -q 'installfog.*--channel' "$calls"; echo $?)"
+
+# The other half of the same rule, on its own run so it reads its own log.
+: > "$calls"
+run Ubuntu 22 --git-path "$work/fwd" --channel beta --yes >/dev/null 2>&1
+check "a channel run DOES forward --channel to the installer" \
+    "$(grep -q 'installfog.*--channel beta' "$calls"; echo $?)"
+
+# ---------------------------------------------------------------------------
+# Idempotence: an existing checkout is never cloned over or reset.
+# ---------------------------------------------------------------------------
+existing="$work/existing"
+mkdir -p "$existing/.git" "$existing/bin"
+echo "mine" > "$existing/precious"
+cat > "$existing/bin/installfog.sh" <<'EOF'
+#!/bin/bash
+echo "installfog $*" >> "$CALLS"
+EOF
+: > "$calls"
+out=$(run Ubuntu 22 --git-path "$existing" --channel beta --yes 2>&1)
+check "an existing checkout is not cloned over" \
+    "$(! grep -q '^git clone' "$calls"; echo $?)"
+check "a file in it survives" \
+    "$([[ $(cat "$existing/precious") == mine ]]; echo $?)"
+check "nothing is reset --hard" \
+    "$(! grep -q 'reset --hard' "$calls"; echo $?)"
+check "it points the admin at updatefog.sh instead" \
+    "$(grep -q 'updatefog.sh' <<< "$out"; echo $?)"
+
+# A non-empty directory that is NOT a checkout is refused rather than merged.
+notours="$work/notours"
+mkdir -p "$notours"
+echo x > "$notours/somefile"
+run Ubuntu 22 --git-path "$notours" --yes >/dev/null 2>&1
+check "a non-empty directory that is not a checkout exits 6" \
+    "$([[ $? -eq 6 ]]; echo $?)"
+check "and is left alone" \
+    "$([[ -f $notours/somefile && ! -d $notours/.git ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# The tty rule. This test process has no controlling terminal, which is
+# exactly the cloud-init/CI case.
+# ---------------------------------------------------------------------------
+: > "$calls"
+out=$(run Ubuntu 22 --git-path "$work/notty" --channel beta < /dev/null 2>&1)
+st=$?
+if [[ $st -eq 7 ]]; then
+    ok=0
+else
+    # A tty IS available in some local shells; the refusal cannot be observed
+    # there, and reporting a pass would be a lie either way.
+    ok=$( (exec < /dev/tty) 2>/dev/null && echo 0 || echo 1 )
+    [[ $ok -eq 0 ]] && echo "  SKIP  no-tty refusal (this shell has a usable /dev/tty)"
+fi
+check "no tty and no --yes exits 7 rather than installing unattended" "$ok"
+
+if [[ $st -eq 7 ]]; then
+    check "it tells the user to pass --yes" \
+        "$(grep -q -- '--yes' <<< "$out"; echo $?)"
+    check "it does not start the installer" \
+        "$(! grep -q '^installfog' "$calls"; echo $?)"
+    # The clone is fine to have happened -- the machine is further along and
+    # nothing is lost. What must not happen is an install nobody asked for.
+    check "the refusal comes after the clone, not instead of it" \
+        "$(grep -q '^git clone' "$calls"; echo $?)"
+fi
+
+# --yes installs unattended, which is the whole point of the flag.
+: > "$calls"
+run Ubuntu 22 --git-path "$work/yes" --channel beta --yes >/dev/null 2>&1
+check "--yes runs the installer" \
+    "$(grep -q '^installfog' "$calls"; echo $?)"
+check "--yes passes -Y" \
+    "$(grep -q '^installfog.*-Y' "$calls"; echo $?)"
+
+# ---------------------------------------------------------------------------
+# It must not grow into an installer.
+# ---------------------------------------------------------------------------
+body=$(sed 's/#.*//' "$bootstrap")
+check "bootstrap does not source anything from the repo" \
+    "$(! grep -qE '^\s*\.\s+\.\./lib|^\s*source\s' <<< "$body"; echo $?)"
+check "bootstrap does not write .fogsettings" \
+    "$(! grep -q 'fogsettings' <<< "$body"; echo $?)"
+
+printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$pass" "$fail"
+[[ $fail -eq 0 ]]

--- a/tests/bootstrap-installer.test.sh
+++ b/tests/bootstrap-installer.test.sh
@@ -95,14 +95,31 @@ if ! grep -q 'if false; then' "$sut"; then
 fi
 
 # --- stubs ----------------------------------------------------------------
-# Two directories on purpose. installGit() returns early when git is already
+# Three directories on purpose. installGit() returns early when git is already
 # on PATH, so the "which package manager" cases have to run with a PATH that
-# does NOT have the git stub in it -- otherwise they assert nothing, which is
-# how they first passed for the wrong reason.
+# reaches NO git at all -- not the stub, and not the real one in /usr/bin
+# either. Naming /usr/bin in that PATH is what made these six assertions pass
+# vacuously: every machine that runs this suite, developer box and CI runner
+# alike, already has git, so installGit() returned at its first line and no
+# package manager was ever reached.
+#
+# Hence $sandbox: symlinks to the tools bootstrap.sh actually calls, git
+# deliberately absent, and nothing else on PATH. A tool added to the script
+# later fails here loudly rather than silently falling back to the host.
 pmstubs="$work/pm"      # package managers only
 stubs="$work/stubs"     # package managers + git
-mkdir -p "$pmstubs" "$stubs"
+sandbox="$work/nogit"   # host tools, minus git
+mkdir -p "$pmstubs" "$stubs" "$sandbox"
 calls="$work/calls.log"
+
+# bash included: `bash "$sut"` is resolved with the PATH set for the run.
+for tool in bash awk cat cut date env grep head ls mkdir rm sed sort stat tr tty uname which; do
+    src=$(command -v "$tool" 2>/dev/null) || {
+        echo "FAIL: $tool is not on PATH; the sandbox cannot be built." >&2
+        exit 1
+    }
+    ln -sf "$src" "$sandbox/$tool"
+done
 
 for tool in apt-get dnf yum pacman apk; do
     cat > "$pmstubs/$tool" <<EOF
@@ -156,7 +173,7 @@ run() {
 runNoGit() {
     local distro="$1" version="$2"
     shift 2
-    ( export PATH="$pmstubs:/usr/bin:/bin" CALLS="$calls" OS="Linux"
+    ( export PATH="$pmstubs:$sandbox" CALLS="$calls" OS="Linux"
       export linuxReleaseName="$distro" OSVersion="$version"
       unset osfamily
       cd "$work" && bash "$sut" "$@" )
@@ -186,8 +203,11 @@ for name in Ubuntu Debian "Rocky Linux" "Alpine Linux" "Arch Linux"; do
     : > "$calls"
     dir="$work/fam-${name// /_}"
     runNoGit "$name" 1 --git-path "$dir" --yes >/dev/null 2>&1
+    # Asked to install GIT, not merely invoked: the debian arm runs
+    # `apt-get -yq update` first, so a bare "^apt-get " matches even when the
+    # install line is gone.
     check "${name} installs git with ${wanted[$name]}" \
-        "$(grep -q "^${wanted[$name]} " "$calls"; echo $?)"
+        "$(grep -qE "^${wanted[$name]} .*(^| )git( |$)" "$calls"; echo $?)"
 done
 
 # dnf-before-yum is the fallback installfog.sh already uses on this family.
@@ -195,12 +215,12 @@ done
 nodnf="$work/nodnf"
 mkdir -p "$nodnf"
 cp "$pmstubs/yum" "$nodnf/"
-( export PATH="$nodnf:/usr/bin:/bin" CALLS="$calls" OS="Linux"
+( export PATH="$nodnf:$sandbox" CALLS="$calls" OS="Linux"
   unset osfamily
   export linuxReleaseName="CentOS Linux" OSVersion=9
   cd "$work" && bash "$sut" --git-path "$work/yumbox" --yes ) >/dev/null 2>&1
 check "a Red Hat box without dnf falls back to yum" \
-    "$(grep -q '^yum ' "$calls"; echo $?)"
+    "$(grep -qE '^yum .*(^| )git( |$)' "$calls"; echo $?)"
 
 # ---------------------------------------------------------------------------
 # Channels resolve to branches, and rc says something true when there is none.

--- a/tests/bootstrap-installer.test.sh
+++ b/tests/bootstrap-installer.test.sh
@@ -329,6 +329,51 @@ check "--yes passes -Y" \
     "$(grep -q '^installfog.*-Y' "$calls"; echo $?)"
 
 # ---------------------------------------------------------------------------
+# bootstrap.sh's own rcBranch, against a real remote.
+#
+# Everything above runs with a git STUB whose ls-remote answers nothing, so it
+# cannot see what this catches: a bare `rc-*` pattern matches the TAIL of a ref
+# at slash boundaries, and so picks up refs/heads/feat/rc-anything. This is the
+# second copy of a function lib/common/functions.sh also carries -- the copy
+# bootstrap.sh has to carry, because it runs before there is a clone -- and the
+# two diverging silently is the exact hazard this file exists to police.
+# tests/rc-channel-resolution.test.sh pins the functions.sh copy the same way.
+# ---------------------------------------------------------------------------
+rcfn=$(awk '/^rcBranch\(\) \{/ { grab = 1 } grab { print } grab && /^\}/ { exit }' "$bootstrap")
+if ! grep -q '^rcBranch() {' <<< "$rcfn"; then
+    echo "FAIL: could not find rcBranch() in bin/bootstrap.sh." >&2
+    echo "  If it moved or was renamed, point this test at it -- do not" >&2
+    echo "  delete the assertions." >&2
+    exit 1
+fi
+eval "$rcfn"
+
+rcremote="$work/rc.git"
+rcseed="$work/rcseed"
+git init -q --bare "$rcremote"
+git init -q "$rcseed"
+git -C "$rcseed" config user.email t@example.invalid
+git -C "$rcseed" config user.name t
+echo x > "$rcseed/f"
+git -C "$rcseed" add f && git -C "$rcseed" commit -qm seed
+rcpublish() {
+    git -C "$rcseed" branch -f "$1" >/dev/null 2>&1
+    git -C "$rcseed" push -q "$rcremote" "$1" >/dev/null 2>&1
+}
+repo="$rcremote"
+
+rcpublish feat/rc-update-channel
+check "a feat/rc-* branch is not offered as a release candidate" \
+    "$([[ -z $(rcBranch) ]]; echo $?)"
+check "and rcBranch reports nothing published" \
+    "$(! rcBranch >/dev/null 2>&1; echo $?)"
+
+rcpublish rc-1.6.2
+rcpublish rc-1.6.10
+check "rc-1.6.10 beats rc-1.6.2 and the decoy" \
+    "$([[ $(rcBranch) == rc-1.6.10 ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
 # It must not grow into an installer.
 # ---------------------------------------------------------------------------
 body=$(sed 's/#.*//' "$bootstrap")

--- a/tests/detect-os-family.test.sh
+++ b/tests/detect-os-family.test.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+#
+# One distro-name map, wherever it is spelled.
+#
+#   tests/detect-os-family.test.sh
+#
+# Mapping a distro name to one of FOG's four packaging families used to be
+# written out three times: the /etc/os-release parse inline in
+# bin/installfog.sh, the family map inline in lib/common/input.sh, and -- with
+# bin/bootstrap.sh -- a third that has to exist because bootstrap runs before
+# there is a clone to source anything from.
+#
+# The first two had already drifted. input.sh knew *mageia*; installfog.sh's
+# copy did not. Nothing failed: a Mageia box simply took a different path
+# through the two halves of the same question.
+#
+# Two of the three are now one function. The third cannot be -- see the header
+# of bin/bootstrap.sh -- so this file is what holds it honest: both copies are
+# run over the same list of distro names and must answer identically, every
+# name, every time.
+#
+# It also pins the family -> osid mapping, because that renumbering is the part
+# with a trap in it. GH-447 moved Arch from 3 to 4 so Alpine could take 3, so
+# getting the family right and the number wrong installs the wrong distro's
+# package set.
+#
+# No root, no network, no FOG install.
+#
+# Usage: bash tests/detect-os-family.test.sh
+# Exit status 0 = pass, 1 = fail.
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+functions="$root/lib/common/functions.sh"
+bootstrap="$root/bin/bootstrap.sh"
+inputsh="$root/lib/common/input.sh"
+
+pass=0
+fail=0
+
+check() {
+    if [[ $2 -eq 0 ]]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        printf '  FAIL  %s\n' "$1"
+    fi
+}
+
+for f in "$functions" "$bootstrap" "$inputsh"; do
+    if [[ ! -r $f ]]; then
+        echo "FAIL: cannot read $f" >&2
+        exit 1
+    fi
+done
+
+lift() {
+    awk -v fn="$2" '
+        $0 ~ "^" fn "\\(\\) \\{" { grab = 1 }
+        grab { print }
+        grab && /^\}/ { exit }
+    ' "$1"
+}
+
+libcopy=$(lift "$functions" detectOSFamily)
+bootcopy=$(lift "$bootstrap" detectOSFamily)
+
+for pair in "lib/common/functions.sh:$libcopy" "bin/bootstrap.sh:$bootcopy"; do
+    where="${pair%%:*}"
+    if ! grep -q 'osfamily=' <<< "${pair#*:}"; then
+        echo "FAIL: could not find detectOSFamily() in ${where}." >&2
+        echo "  If it moved or was renamed, point this test at it -- do not" >&2
+        echo "  delete the assertions." >&2
+        exit 1
+    fi
+done
+
+# Every name FOG claims to recognize, plus the shapes that must NOT match.
+# Kept as one list so both copies are asked exactly the same questions.
+cases="
+Fedora+Linux:redhat
+Red+Hat+Enterprise+Linux:redhat
+CentOS+Linux:redhat
+CentOS+Stream:redhat
+Rocky+Linux:redhat
+AlmaLinux:redhat
+Mageia:redhat
+Debian+GNU/Linux:debian
+Ubuntu:debian
+Linux+Mint:debian
+Alpine+Linux:alpine
+Arch+Linux:arch
+Manjaro+Linux:arch
+Gentoo:
+openSUSE+Leap:
+Slackware:
+Void+Linux:
+"
+
+runcopy() {
+    # A subshell per case: the function sets four globals and the whole point
+    # is that each name is answered from a clean slate.
+    local body="$1" name="$2"
+    (
+        eval "$body"
+        unset linuxReleaseName OSVersion linuxReleaseName_lower osfamily
+        linuxReleaseName="$name"
+        OSVersion="1"
+        detectOSFamily
+        printf '%s|%s' "$?" "$osfamily"
+    )
+}
+
+for case_ in $cases; do
+    name="${case_%%:*}"
+    name="${name//+/ }"
+    want="${case_#*:}"
+
+    libout=$(runcopy "$libcopy" "$name")
+    bootout=$(runcopy "$bootcopy" "$name")
+
+    libst="${libout%%|*}"; libfam="${libout#*|}"
+
+    if [[ -n $want ]]; then
+        check "functions.sh: ${name} -> ${want}" \
+            "$([[ $libfam == "$want" && $libst -eq 0 ]]; echo $?)"
+    else
+        # An unrecognized distro must return non-zero AND leave osfamily empty.
+        # Returning 1 while still setting a family would let a caller that
+        # ignores the status install the wrong package manager's packages.
+        check "functions.sh: ${name} is refused, with no family guessed" \
+            "$([[ $libst -ne 0 && -z $libfam ]]; echo $?)"
+    fi
+
+    # The drift guard. Not "bootstrap is also right" -- "bootstrap says the
+    # same thing", status included, so a change to one that is not made to the
+    # other fails here rather than on somebody's server.
+    check "both copies agree on ${name}" \
+        "$([[ $libout == "$bootout" ]]; echo $?)"
+done
+
+# ---------------------------------------------------------------------------
+# The copies are meant to be identical, not merely equivalent. Comparing them
+# textually catches a divergence in a name this test does not happen to list.
+# ---------------------------------------------------------------------------
+strip() { sed 's/#.*//' <<< "$1" | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//' | grep -v '^$'; }
+check "the two detectOSFamily bodies are textually identical" \
+    "$(diff <(strip "$libcopy") <(strip "$bootcopy") >/dev/null; echo $?)"
+
+# ---------------------------------------------------------------------------
+# family -> osid, where GH-447's renumbering lives.
+# ---------------------------------------------------------------------------
+suggest=$(sed -n '/if \[\[ $guessdefaults == 1 \]\]; then/,/esac/p' "$inputsh")
+
+for pair in redhat:1 debian:2 alpine:3 arch:4; do
+    fam="${pair%%:*}"; want="${pair#*:}"
+    got=$(sed 's/#.*//' <<< "$suggest" | grep -oE "^[[:space:]]*${fam}\)[[:space:]]*strSuggestedOS=[0-9]+" | grep -oE '[0-9]+$')
+    check "input.sh maps ${fam} to osid ${want}" \
+        "$([[ $got == "$want" ]]; echo $?)"
+done
+
+# Alpine is 3 and Arch is 4, not the other way round. Stated separately from
+# the loop because reversing exactly this pair is the mistake GH-447 was, and a
+# loop that is edited wholesale would not notice.
+check "alpine is 3 and arch is 4 (GH-447 renumbering, not FOG 1.5's)" \
+    "$(sed 's/#.*//' <<< "$suggest" | grep -qE 'alpine\)[[:space:]]*strSuggestedOS=3' \
+        && sed 's/#.*//' <<< "$suggest" | grep -qE 'arch\)[[:space:]]*strSuggestedOS=4'; echo $?)"
+
+# An unknown distro still SUGGESTS redhat here, even though detectOSFamily
+# refuses to guess one. Different questions: this is a pre-filled answer to a
+# prompt a person can correct, that one is a claim about which package-manager
+# binary exists. Pinned so the asymmetry is not "tidied up" in either direction.
+check "input.sh still defaults an unknown distro to osid 1" \
+    "$(sed 's/#.*//' <<< "$suggest" | grep -qE '\*\)[[:space:]]*strSuggestedOS=1'; echo $?)"
+
+# ---------------------------------------------------------------------------
+# And that the callers actually call it, rather than keeping their own copy.
+# ---------------------------------------------------------------------------
+check "installfog.sh calls detectOSFamily instead of parsing os-release itself" \
+    "$(sed 's/#.*//' "$root/bin/installfog.sh" | grep -qE '^detectOSFamily$' \
+        && ! sed 's/#.*//' "$root/bin/installfog.sh" | grep -q '/etc/redhat-release'; echo $?)"
+
+check "input.sh no longer carries its own distro-name patterns" \
+    "$(! sed 's/#.*//' "$inputsh" | grep -q 'mageia'; echo $?)"
+
+# Never as $(detectOSFamily): the globals would be set in a subshell and lost.
+# Comments stripped -- functions.sh's own docstring warns against exactly this
+# spelling, and that warning is worth keeping.
+check "no caller invokes it in a command substitution" \
+    "$(! cat "$root"/bin/*.sh "$root"/lib/common/*.sh | sed 's/#.*//' | grep -q '[$](detectOSFamily'; echo $?)"
+
+printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$pass" "$fail"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
Closes #1006. Stacked on #1585.

```
curl -fsSL https://raw.githubusercontent.com/FOGProject/fogproject/working-1.6/bin/bootstrap.sh | bash -s -- --channel beta
```

Installs git, clones, checks out the branch for the channel, runs `installfog.sh`. Nothing else — once the clone exists, `installfog.sh` and `updatefog.sh` own everything after.

## The issue's central design claim doesn't hold

#1006 asks to extract the OS detection into `functions.sh` *"so `bootstrap.sh` and `installfog.sh` share one implementation instead of duplicating it."*

**That half is not achievable.** `bootstrap.sh` runs *before there is a clone*. It cannot source a file that is not on the machine yet, and fetching 300+ KB of installer over HTTP to reach twelve lines of `/etc/os-release` parsing would be worse than copying the twelve lines.

The extraction was worth doing anyway — for a reason the issue doesn't give. The parse was inline in `installfog.sh`, the family map it feeds was inline in `input.sh`, and **they had already drifted**: `input.sh` knew `*mageia*` and `installfog.sh` did not. Nothing failed; a Mageia box just took a different path through the two halves of one question. Both now call `detectOSFamily()`.

`bootstrap.sh` carries the third copy it has to carry, and `tests/detect-os-family.test.sh` runs **both copies over the same distro names**, comparing their answers *and* their bodies. That's the honest way to hold two implementations together when one cannot import the other — and it immediately earned its keep: it caught a mangled `sed` back-reference in the `functions.sh` copy that would have left `linuxReleaseName` empty on every `/etc/os-release` system.

## Correcting myself on Alpine

I earlier claimed FOG couldn't install on Alpine and that `apk` should be dropped. That was read off `dev-branch`, which predates `lib/alpine/` and GH-447's renumbering of `osid` 3 from Arch to Alpine. **Four families**, `apk` included. `input.sh`'s family→osid map is pinned by test, because getting the family right and the number wrong installs another distro's package set.

## Refusals

Most of what a script piped into a root shell should be good at:

- **Unsupported distribution → exit 4, before git is installed.** The alternative leaves a machine carrying packages and a checkout it cannot use, and says so several minutes later.
- **No tty and no `--yes` → exit 7.** Under `curl | bash` this script's stdin *is the pipe*, so `installfog.sh` is handed `< /dev/tty` — without that, its prompts read the remaining bytes of this file and answer themselves. Where there's no tty to hand it, an unattended root install of imaging software on a machine nobody is watching is not a reasonable default. The tty is tested by **opening** it, not `[[ -r ]]`: `/dev/tty` exists in plenty of contexts where opening it fails with ENXIO.
- **An existing checkout is never cloned over, reset, or pulled.** It says its job is done and points at `updatefog.sh`. A non-empty directory that is *not* a checkout is refused rather than merged into.

## Smaller decisions

Arguments are parsed by hand rather than with `getopt(1)`, which is part of util-linux and may not be installed yet — a bootstrap that dies parsing its own arguments is the worst first impression available. Channel handling is the same vocabulary as everywhere else, retired `stable`/`staging`/`dev` spellings honoured silently, and `--branch` stays a one-off that does not record a channel.

## Tests

`tests/bootstrap-installer.test.sh` (45 checks) and `tests/detect-os-family.test.sh` (44). No root, no packages, no network — the root check is neutered in a *copy*, package managers and git are stubs on PATH, and the distro is chosen by pre-setting `linuxReleaseName`, which `detectOSFamily` is `[[ -z ]]`-guarded to respect.

## Fixed after review

**`rcBranch` resolved a feature branch as the release candidate.** The same defect as in `lib/common/functions.sh` (see #1585): a bare `rc-*` pattern matches the tail of a ref at slash boundaries, so `ls-remote` returns `refs/heads/feat/rc-update-channel`. Both copies are now anchored at `refs/heads/rc-*` and re-check the extracted name.

Nothing in this file's 45 checks could catch it — every one of them runs against a git stub whose `ls-remote` answers nothing. `rcBranch` is now lifted out of `bootstrap.sh` and run against a real bare repository carrying the decoy, matching how `rc-channel-resolution.test.sh` pins the other copy.

**Six assertions were passing vacuously.** The "installs git with `<pm>`" arms ran with `PATH="$pmstubs:/usr/bin:/bin"`, which reaches the real `/usr/bin/git`; `installGit()` returns at its first line when git is present, so no package manager was ever invoked. They failed on every machine, CI and developer box alike. They now run against a sandbox of symlinks to the tools `bootstrap.sh` actually calls, git deliberately absent — and the assertions were tightened from `"^apt-get "` (which the preceding `apt-get -yq update` satisfies) to requiring git to have been asked for.

All three fixes were confirmed to go red against the code they gate.


## `detectOSFamily()` arrived on `working-1.6` ahead of this PR

Worth stating plainly rather than leaving someone to find it in a blame. While splitting the `rcBranch` fix across #1585 and this PR, the whole of `lib/common/functions.sh` was copied from this branch onto #1585's instead of just the `rcBranch` hunk. `detectOSFamily()` rode along, so commit `3fe4d166a` added it to `working-1.6` under a message that only describes the rc fix.

Nothing is broken by it: on `working-1.6` today the function is defined and never called, `functions.sh` still parses, and no behavior changed. This PR is the other half — it adds the two call sites (`installfog.sh`, `lib/common/input.sh`) and `tests/detect-os-family.test.sh`, which is what holds it in step with `bootstrap.sh`'s copy. Merging this closes the gap; the function is otherwise untested dead code on the branch.


## Left alone deliberately

The `case $linuxReleaseName_lower` block that installs `lsb-release` in `installfog.sh` is a **third** copy of the family patterns and is *not* rewired. It encodes per-distro package names and a dnf→yum fallback rather than just a family, and folding it in would newly attempt `dnf install redhat-lsb-core` on Mageia — unverified. Worth a follow-up, not worth risking here.

## Needs a real server

Fresh minimal Debian/Ubuntu, RHEL/Rocky, Arch and Alpine: git installs, the repo clones, the branch checks out, and the installer launches interactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtZHpyWZWDPSxePdTViGZy


