### PR TITLE
Let the pre-commit hook exit 0 when an optional tool is missing (GH-1581, dev-branch)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -88,3 +88,17 @@ psrfix
 # push instead.
 #
 # Ported from working-1.6 (GH-1510), where the bug was diagnosed.
+
+# GH-1581: the hook's exit status is the status of the last command, which was
+# psrfix -- and psrfix returns 1 when php-cs-fixer is not installed, via
+# require_tools. So a machine without the optional tools printed "the commit
+# will proceed WITHOUT those changes" and then blocked the commit, with git
+# exiting 1 and saying nothing.
+#
+# Every step above is deliberately advisory: require_tools exists so a missing
+# formatter is a skip, not a failure, and CI regenerates all of it. Nothing in
+# this hook is a gate. Say so explicitly rather than leaving the status to
+# whichever helper happens to run last -- post-commit already ends this way.
+#
+# Ported from working-1.6, where it was diagnosed and fixed first.
+exit 0


### PR DESCRIPTION
The same defect as #1582, on `dev-branch`. **Draft.**

`.githooks/pre-commit` ends on a call to `psrfix` followed by a comment block, so the hook's exit status is `psrfix`'s. `psrfix` goes through `require_tools`, which returns 1 when `php-cs-fixer` is not installed — so the hook prints

```
pre-commit: SKIPPING PSR2 formatting -- not installed: php-cs-fixer
pre-commit: the commit will proceed WITHOUT those changes; CI regenerates them.
```

and then **blocks the commit**. `git commit` exits 1 with no message of its own, which reads as git failing rather than a hook rejecting.

Nothing in this hook is a gate — `require_tools` exists precisely so a missing formatter or gettext is a *skip*, and CI regenerates every artifact it would have written. `post-commit` already ends with `exit 0`; `pre-commit` was the one missing the guard.

Without this, a contributor without both `gettext` and `php-cs-fixer` cannot commit to this branch at all, and the workaround they reach for is `--no-verify`, which also skips the checks the hook is actually there to run.

### Verifying

```bash
bash .githooks/pre-commit; echo $?   # 0 after this change, 1 before
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtZHpyWZWDPSxePdTViGZy
