### PR TITLE
Add bin/updatefog.sh for the 1.5 -> 1.6 crossing, and retire fogupdater.sh

### DIFF
--- a/bin/updatefog.sh
+++ b/bin/updatefog.sh
@@ -169,11 +169,19 @@ normalizeChannel() {
 # Asked of the remote, by version order. -v:refname so rc-1.6.10 beats
 # rc-1.6.2; the remote advertises no commit dates, so a "newest" answer could
 # not be date-based even if that were preferable.
+#
+# refs/heads/rc-*, NOT a bare rc-*. ls-remote matches a pattern against the
+# TAIL of each ref at slash boundaries, so `rc-*` also matches
+# refs/heads/feat/rc-anything -- and against origin it does. That would put a
+# 1.5 server onto a feature branch while telling its admin it was the current
+# release candidate, on the one channel this whole script recommends. The sed
+# re-checks the extracted name for a further slash: two layers, because the
+# answer decides what a major upgrade checks out.
 rcBranch() {
     local ref
-    ref=$(git ls-remote --heads --sort=-v:refname "$repo" 'rc-*' 2>/dev/null | head -n1) || return 1
-    [[ -n $ref ]] || return 1
-    ref="${ref##*refs/heads/}"
+    ref=$(git ls-remote --heads --sort=-v:refname "$repo" 'refs/heads/rc-*' 2>/dev/null \
+        | sed -n 's#^[0-9a-f]\{7,\}[[:space:]]\{1,\}refs/heads/\(rc-[^/]\{1,\}\)$#\1#p' \
+        | head -n1) || return 1
     [[ -n $ref ]] || return 1
     echo "$ref"
 }

--- a/bin/updatefog.sh
+++ b/bin/updatefog.sh
@@ -1,0 +1,331 @@
+#!/bin/bash
+#
+#  FOG is a computer imaging solution.
+#  Copyright (C) 2007  Chuck Syperski & Jian Zhang
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#    any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Moves this 1.5 server's checkout onto another FOG line and runs the installer
+# it finds there. Its reason to exist is the 1.5 -> 1.6 crossing, and the
+# channel most people will pass is rc.
+#
+# WHY THIS IS STANDALONE, AND WILL STAY THAT WAY
+#
+# The 1.6 line has a bin/updatefog.sh that shares a channel map, a set of
+# managed .fogsettings keys and a pile of helper functions with the rest of the
+# installer. None of that exists on 1.5, and back-porting it would mean surgery
+# on lib/common/functions.sh on a line that is heading for end of life -- every
+# edit of which risks the 1.5 installs it is supposed to help.
+#
+# So this file sources nothing, and duplicates the small amount it needs. It
+# WILL diverge from the 1.6 implementation, and that is fine: this branch is
+# terminal and does not track 1.6's future. What matters is that it can carry
+# a server across, once.
+#
+# THE HAZARD THIS SCRIPT IS BUILT AROUND
+#
+# It replaces itself. Checking out 1.6 rewrites bin/updatefog.sh underneath a
+# bash process that is still reading it -- bash reads a script incrementally
+# and seeks by byte offset, so a file that changes length mid-run makes it
+# resume in the middle of a different line. The failure is silent, arbitrary,
+# and happens after the checkout has already succeeded.
+#
+# So the first thing this does is copy itself somewhere git will not touch and
+# re-exec from there. Everything after the re-exec is running from a file
+# nothing is going to rewrite. See relaunchFromCopy().
+#
+# Exit codes:
+#   1 not root, or no install found     3 bad argument
+#   6 git failed                        7 no terminal for an interactive install
+
+bindir=$(dirname $(readlink -f "$BASH_SOURCE"))
+cd "$bindir"
+workingdir=$(pwd)
+
+usage() {
+    echo -e "Usage: $0 [-h?y] [--channel rc|beta|stable|patches] [--branch <name>]"
+    echo -e "\t-h -? --help\t\tDisplay this info"
+    echo -e "\t      --channel\tWhich line to move this server to:"
+    echo -e "\t               \t\t  rc      the current 1.6 release candidate"
+    echo -e "\t               \t\t  beta    the 1.6 development line"
+    echo -e "\t               \t\t  stable  the 1.5 stable line (where you are)"
+    echo -e "\t               \t\t  patches the 1.5 patches line"
+    echo -e "\t               \t\tDefaults to rc"
+    echo -e "\t      --branch\tCheck out a literal branch instead of a channel"
+    echo -e "\t-y    --yes\t\tSkip the confirmation AND run the installer"
+    echo -e "\t               \t\tunattended. NOT recommended for the crossing to"
+    echo -e "\t               \t\t1.6 -- that upgrade asks questions 1.5 never did"
+    echo -e "\n\tGoing from 1.5 to 1.6 is a MAJOR upgrade. Take a backup first."
+    echo -e "\tThe 1.6 tree carries bin/revertfog.sh, which puts a server back on"
+    echo -e "\tits pre-upgrade 1.5 database and web tree from the dump the"
+    echo -e "\tinstaller takes. That dump is the only supported way back."
+    exit 0
+}
+
+fail() {
+    echo
+    echo " * $1"
+    shift
+    while [[ $# -gt 1 ]]; do
+        echo " | $1"
+        shift
+    done
+    echo
+    exit "$1"
+}
+
+# ---------------------------------------------------------------------------
+# Re-exec from a copy, before anything can rewrite this file. See the header.
+#
+# FOG_UPDATE_RELAUNCHED marks the copy so it does not do this again. The copy
+# is removed on exit by the trap below, not here -- it is the file currently
+# being read.
+# ---------------------------------------------------------------------------
+relaunchFromCopy() {
+    local copy
+    copy=$(mktemp -t fog-updatefog.XXXXXX) || return 1
+    cat "$0" > "$copy" || { rm -f "$copy"; return 1; }
+    chmod +x "$copy"
+    FOG_UPDATE_RELAUNCHED=1 FOG_UPDATE_ORIGIN="$workingdir" \
+        FOG_UPDATE_COPY="$copy" exec bash "$copy" "$@"
+}
+
+
+# Kept before the option loop consumes them: the relaunch below re-execs with
+# the ORIGINAL arguments, and by then "$@" has been shifted empty.
+origArgs=("$@")
+
+repo="https://github.com/FOGProject/fogproject.git"
+channel="rc"
+branch=""
+autoYes=""
+sgitpath=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h | -\? | --help) usage ;;
+        --channel)
+            [[ -n $2 ]] || fail "--channel requires a value" 3
+            channel="$2"; shift 2 ;;
+        --branch)
+            [[ -n $2 ]] || fail "--branch requires a value" 3
+            branch="$2"; shift 2 ;;
+        --git-path)
+            [[ -n $2 && $2 == /* ]] || fail "--git-path requires an absolute path" 3
+            sgitpath="${2%/}"; shift 2 ;;
+        -y | --yes) autoYes=1; shift ;;
+        *) fail "Unknown option: $1" "Run with --help for the list." 3 ;;
+    esac
+done
+
+# Parsing comes first so --help works for anyone, and a typo is answered
+# before the user is told to go and find root.
+if [[ ! $EUID -eq 0 ]]; then
+    echo "FOG updates must be run as root user"
+    exit 1
+fi
+
+if [[ -z $FOG_UPDATE_RELAUNCHED ]]; then
+    relaunchFromCopy "${origArgs[@]}" || fail "Could not copy this script to a temporary location." \
+        "The update has to run from a copy, because checking out another branch" \
+        "rewrites this file while bash is still reading it." 1
+fi
+[[ -n $FOG_UPDATE_COPY ]] && trap 'rm -f "$FOG_UPDATE_COPY"' EXIT
+# After the re-exec, $bindir is the temp directory. The checkout is where the
+# ORIGINAL copy lived.
+workingdir="${FOG_UPDATE_ORIGIN:-$workingdir}"
+gitpath=$(cd "$workingdir/.." && pwd)
+[[ -n $sgitpath ]] && gitpath="$sgitpath"
+
+# ---------------------------------------------------------------------------
+# The 1.6 channel vocabulary, copied. Retired spellings honoured exactly as
+# lib/common/functions.sh on working-1.6 honours them -- an admin pasting a
+# command from an older forum post should get a working upgrade.
+#
+# Note `dev` means BETA, not dev-branch, despite a branch by that name. That
+# is the 1.6 vocabulary and this must not invent a different one.
+# ---------------------------------------------------------------------------
+normalizeChannel() {
+    case "$1" in
+        stable) echo "stable" ;;
+        patches|staging) echo "patches" ;;
+        beta|dev) echo "beta" ;;
+        rc) echo "rc" ;;
+        *) return 1 ;;
+    esac
+}
+
+# Asked of the remote, by version order. -v:refname so rc-1.6.10 beats
+# rc-1.6.2; the remote advertises no commit dates, so a "newest" answer could
+# not be date-based even if that were preferable.
+rcBranch() {
+    local ref
+    ref=$(git ls-remote --heads --sort=-v:refname "$repo" 'rc-*' 2>/dev/null | head -n1) || return 1
+    [[ -n $ref ]] || return 1
+    ref="${ref##*refs/heads/}"
+    [[ -n $ref ]] || return 1
+    echo "$ref"
+}
+
+channelToBranch() {
+    case "$(normalizeChannel "$1")" in
+        stable) echo "stable" ;;
+        patches) echo "dev-branch" ;;
+        beta) echo "working-1.6" ;;
+        rc) rcBranch || return 2 ;;
+        *) return 1 ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Find the install. 1.5 has no fog_git_path, so the checkout is simply where
+# this script lives -- which is what the pre-relaunch $workingdir recorded.
+# ---------------------------------------------------------------------------
+[[ -z $fogprogramdir && -r /etc/fog/fog.conf ]] && . /etc/fog/fog.conf
+[[ -z $fogprogramdir ]] && fogprogramdir="/opt/fog"
+fogprogramdir="${fogprogramdir%/}"
+
+if [[ ! -r "$fogprogramdir/.fogsettings" ]]; then
+    fail "No existing FOG install found at ${fogprogramdir} (.fogsettings missing)." \
+         "This updates an EXISTING install. For a new one, run installfog.sh." 1
+fi
+
+if [[ ! -d "${gitpath}/.git" ]]; then
+    fail "${gitpath} is not a git checkout." \
+         "This server was installed from a tarball or a copied directory, so" \
+         "there is no branch to move. Use the bootstrap installer instead --" \
+         "it clones a checkout and runs the installer over this install, which" \
+         "finds the existing server through /etc/fog/fog.conf:" \
+         "" \
+         "  curl -fsSL https://raw.githubusercontent.com/FOGProject/fogproject/working-1.6/bin/bootstrap.sh | bash -s -- --channel ${channel}" 1
+fi
+
+if [[ -z $branch ]]; then
+    branch=$(channelToBranch "$channel")
+    case $? in
+        0) ;;
+        2) fail "No release candidate is currently published, so the rc channel" \
+                "has nothing to check out. This is normal between releases." \
+                "" \
+                "Use --channel beta for the 1.6 development line, or wait." 3 ;;
+        *) fail "Unknown channel: ${channel}" \
+                "Expected rc, beta, stable or patches. The retired names staging" \
+                "and dev are also accepted, and mean patches and beta." 3 ;;
+    esac
+fi
+
+# ---------------------------------------------------------------------------
+# Say what this is before doing it. A 1.5 -> 1.6 move is not an update.
+# ---------------------------------------------------------------------------
+currentBranch=$(git -C "$gitpath" rev-parse --abbrev-ref HEAD 2>/dev/null)
+currentCommit=$(git -C "$gitpath" rev-parse HEAD 2>/dev/null)
+
+echo " * FOG Update"
+echo "   Checkout: ${gitpath}"
+echo "   Now on:   ${currentBranch:-unknown}"
+echo "   Moving to: ${branch}"
+echo
+
+crossing=0
+case $branch in
+    working-1.6|rc-*) [[ $currentBranch != working-1.6 && $currentBranch != rc-* ]] && crossing=1 ;;
+esac
+
+if [[ $crossing -eq 1 ]]; then
+    echo " * This is a MAJOR upgrade, 1.5 to 1.6, not a patch."
+    echo " |"
+    echo " | The database schema is migrated forward and the web tree is"
+    echo " | replaced. The 1.6 installer takes a database dump before it starts,"
+    echo " | and the 1.6 tree carries bin/revertfog.sh, which uses that dump to"
+    echo " | put the server back. That dump is the ONLY supported way back --"
+    echo " | there is no down-migration and there will not be one."
+    echo " |"
+    echo " | Take your own backup as well, and read"
+    echo " | docs/SUPPORTED_CUSTOMIZATIONS.md in the 1.6 tree afterwards."
+    echo
+fi
+
+if [[ -z $autoYes ]]; then
+    echo -n " * Continue? (Y/N) "
+    read confirmGo
+    case $confirmGo in
+        [Yy] | [Yy][Ee][Ss]) ;;
+        *) echo " * Canceled."; exit 0 ;;
+    esac
+fi
+
+# ---------------------------------------------------------------------------
+# Move the checkout. Safe to do now: this process is running from the copy.
+# ---------------------------------------------------------------------------
+echo " * Fetching"
+git -C "$gitpath" fetch --all || fail "git fetch failed." 6
+echo " * Checking out ${branch}"
+git -C "$gitpath" checkout "$branch" || fail "Could not check out ${branch}." 6
+git -C "$gitpath" reset --hard "origin/${branch}" || fail "Could not reset to origin/${branch}." 6
+
+if [[ ! -x "${gitpath}/bin/installfog.sh" && ! -f "${gitpath}/bin/installfog.sh" ]]; then
+    fail "${branch} has no bin/installfog.sh." \
+         "Nothing has been installed. To go back:" \
+         "  git -C ${gitpath} reset --hard ${currentCommit}" 6
+fi
+
+# ---------------------------------------------------------------------------
+# Hand over to the installer that is now on disk -- which for a crossing is
+# 1.6's, not the one this script shipped beside.
+#
+# INTERACTIVE unless --yes. This is the case the whole file exists for, and it
+# is exactly the case where -Y is wrong: the 1.6 installer asks about settings
+# 1.5's .fogsettings has never held, and unattended it takes a default for each
+# of them without saying so.
+# ---------------------------------------------------------------------------
+if [[ -n $autoYes ]]; then
+    echo " * Starting the installer unattended"
+    (cd "${gitpath}/bin" && bash installfog.sh -Y)
+    installStatus=$?
+else
+    if ! (exec < /dev/tty) 2>/dev/null; then
+        fail "No terminal is available, so the installer cannot run interactively." \
+             "The checkout has already been moved to ${branch}; only the install" \
+             "did not start. Re-run this from a terminal, or with --yes." \
+             "" \
+             "To put the checkout back:" \
+             "  git -C ${gitpath} reset --hard ${currentCommit}" 7
+    fi
+    echo " * Starting the installer"
+    echo
+    (cd "${gitpath}/bin" && bash installfog.sh < /dev/tty)
+    installStatus=$?
+fi
+
+if [[ $installStatus -eq 0 ]]; then
+    echo
+    echo " * Update completed successfully."
+    [[ $crossing -eq 1 ]] && echo " * This server is now on FOG 1.6. From here, use its own bin/updatefog.sh."
+    exit 0
+fi
+
+echo
+echo " * installfog.sh failed (exit ${installStatus})."
+echo " | Nothing has been reverted. To put the checkout back where it was:"
+echo " |"
+echo " |     git -C ${gitpath} reset --hard ${currentCommit}"
+echo " |     cd ${gitpath}/bin && ./installfog.sh"
+echo " |"
+if [[ $crossing -eq 1 ]]; then
+    echo " | If the database was already migrated, the checkout alone is not"
+    echo " | enough -- use bin/revertfog.sh from the 1.6 tree, which restores the"
+    echo " | pre-upgrade dump as well."
+    echo " |"
+fi
+exit "$installStatus"

--- a/tests/fogupdater-update-source.test.sh
+++ b/tests/fogupdater-update-source.test.sh
@@ -1,285 +1,129 @@
 #!/bin/bash
 #
-# Guards GHSA-qp3r-8mwm-vg6h and the dead-update-source bug class.
+# utils/FOGUpdater/fogupdater.sh is retired, and stays retired.
 #
 #   tests/fogupdater-update-source.test.sh
 #
-# utils/FOGUpdater/fogupdater.sh downloads a tarball and runs its installer
-# unattended as root. Whatever answers those requests becomes the FOG server,
-# so the transport is not a detail of the download -- it IS the authentication.
-# The advisory found three things wrong with it at once:
+# This file used to assert the details of how that utility fetched things --
+# https only, held through redirects, --fail, the payload identified before it
+# was executed. All of that came out of GHSA-qp3r-8mwm-vg6h, where the
+# combination of --no-check-certificate, plain-HTTP SourceForge mirrors and an
+# unverified payload meant whatever answered the request became the FOG server,
+# unattended, as root.
 #
-#   1. Both fetches passed --no-check-certificate. Fixed separately, in
-#      aa3d699b1; tests/installer-tls-verification.test.sh owns that assertion
-#      and this file does not duplicate it.
-#   2. The default stable mirrors were four plain-HTTP SourceForge URLs, so on
-#      the default path there was no TLS to verify in the first place. An
-#      on-path attacker substituted the tarball and got root.
-#   3. Nothing about the payload was checked before it was extracted and run.
+# The utility is now a message and an exit. Those assertions have nothing left
+# to describe, and deleting them would have quietly given up the guarantee they
+# encoded. So they are replaced by the strongest form of the same statement:
+# THIS FILE FETCHES NOTHING AND RUNS NOTHING. A fetcher that does not exist
+# cannot be talked into fetching over cleartext.
 #
-# Removing --no-check-certificate does not close 2 on its own. "https in the
-# default string" and "the bytes arrived over TLS" are different statements,
-# and two things separate them: $updatemirrors is read from .fogsettings, so an
-# admin (or anything that can write that file) can put the http:// mirror back;
-# and github.com REDIRECTS the archive endpoint to codeload.github.com, so the
-# scheme that matters is the one at the end of the chain, not the one typed.
-# curl's --proto '=https' --proto-redir '=https' are what make those one
-# statement, which is why they are pinned here per call site rather than once.
+# That also makes the file the tripwire for its own return. Anyone who
+# reintroduces a download here -- rather than adding one to bin/updatefog.sh,
+# where a checkout is fetched by git and can be diffed and reset -- fails this
+# and has to come and read why it was retired.
 #
-# The SourceForge half is not only a security fix. SourceForge has carried no
-# FOG release since fog_1.4.4, so the stable path had been fetching a 404 page
-# for years -- and without --fail, curl/wget write that page to the destination
-# and report success, handing it to `tar`. That is the same failure shape as
-# fetch-plugins.sh printing its success line after every operation failed
-# (#1337): the exit status described the transfer, not the outcome.
+# Why it was retired, in one line each:
+#   * It could not reach 1.6 at all. Its Beta arm resolved working-1.6 and then
+#     read that branch's version from a 1.5-only path, so every crossing died
+#     on a 404. GH-1587.
+#   * It ran `installfog.sh -y`, which is the wrong default for an upgrade that
+#     meets settings the old .fogsettings has never held.
 #
-# The channel assertions guard a different destructive default. FOG_CHANNEL on
-# a 1.6 server reads "Beta"; the old script had only stable and dev, resolved
-# stable to a 1.5.x version, reported "you are not running the latest", and
-# installed 1.5 over a 1.6 server. A channel with no branch this can derive
-# must therefore stop, not fall through to stable.
-#
-# What this checks and what it does not: it asserts on the SOURCE for the shape
-# of the calls and for the order of the payload check against the install, and
-# it EXECUTES the branch-selection block and requireHttps/fetch for real. It
-# does not install FOG, need root, or need the internet -- the one live curl
-# goes to 192.0.2.1 (TEST-NET-1, RFC 5737), which must never be routed, and it
-# is expected to fail before any connection is attempted because the scheme is
-# rejected locally.
-#
+# Usage: bash tests/fogupdater-update-source.test.sh
 # Exit status 0 = pass, 1 = fail.
 
-cd "$(dirname "$0")/.." || exit 1
-UPD="utils/FOGUpdater/fogupdater.sh"
-[[ -r $UPD ]] || { echo "cannot read $UPD -- run this from the repository"; exit 1; }
+REPO="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+UPD="$REPO/utils/FOGUpdater/fogupdater.sh"
 
 PASS=0
 FAIL=0
-ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
 
-# Comments are stripped before every source assertion. This file's own prose
-# names http:// and sourceforge repeatedly, and so does the reasoning block at
-# the top of the script -- a gate its own documentation satisfies is not a gate.
-joined() {
-    sed -e :a -e '/\\$/N; s/\\\n//; ta' "$1" | grep -vE '^[[:space:]]*#'
-}
-
-# body <function-name> <file> -- the text of one shell function, comments kept
-# (callers strip when they need to). Every function in this file opens
-# "name() {" and closes on a bare brace in column one.
-body() {
-    awk -v fn="$1" '
-        $0 ~ "^" fn "\\(\\) \\{" { inside = 1 }
-        inside { print }
-        inside && /^}/ { exit }
-    ' "$2"
-}
-
-echo "1. the update source is https, and stays https"
-
-if joined "$UPD" | grep -qiE 'sourceforge|freeghost'; then
-    bad "$UPD still names a SourceForge mirror -- no release has been published there since fog_1.4.4"
-else
-    ok "no SourceForge mirror remains"
-fi
-
-# Any http:// literal at all, not just in the mirror default. The four mirrors
-# were one string; the next one will not be.
-if joined "$UPD" | grep -qE 'http://'; then
-    bad "$UPD contains a cleartext http:// URL"
-else
-    ok "no cleartext URL in the source"
-fi
-
-# Per call site, not once for the file. A second fetch helper added later
-# without the flags is exactly how --no-check-certificate spread in the first
-# place: by copying a neighbouring call that had it.
-curls=0
-unpinned=0
-while IFS= read -r line; do
-    [[ -n $line ]] || continue
-    curls=$((curls + 1))
-    if ! printf '%s\n' "$line" | grep -q -- "--proto '=https'" \
-        || ! printf '%s\n' "$line" | grep -q -- "--proto-redir '=https'"; then
-        unpinned=$((unpinned + 1))
-        printf '        unpinned: %s\n' "$(printf '%s' "$line" | sed 's/^ *//;s/  */ /g' | cut -c1-96)"
-    fi
-done < <(joined "$UPD" | grep -E '(^|[^-[:alnum:]_])curl[[:space:]]')
-
-if [[ $curls -eq 0 ]]; then
-    bad "no curl invocation found in $UPD -- this gate has stopped checking anything"
-elif [[ $unpinned -eq 0 ]]; then
-    ok "all $curls curl invocation(s) pin the scheme through redirects"
-else
-    bad "$unpinned curl invocation(s) do not pin --proto/--proto-redir to https"
-fi
-
-if joined "$UPD" | grep -E '(^|[^-[:alnum:]_])curl[[:space:]]' | grep -q -- '--fail'; then
-    ok "the download fails on an HTTP error instead of saving the error page"
-else
-    bad "$UPD does not pass --fail -- a 404 body lands in the tarball and reads as a successful download"
-fi
-
-echo
-echo "2. requireHttps refuses cleartext at runtime, not just by default"
-
-if grep -q '^requireHttps() {' "$UPD"; then
-    ok "requireHttps() is defined"
-else
-    bad "requireHttps() is gone -- an http:// \$updatemirrors from .fogsettings has nothing to stop it"
-fi
-
-# Both fetch call sites must be preceded by the check. Pinned by counting: one
-# for the version lookup, one inside the mirror loop.
-guards=$(joined "$UPD" | grep -cE '^[[:space:]]*requireHttps[[:space:]]+"')
-if [[ $guards -ge 2 ]]; then
-    ok "both fetch call sites are guarded ($guards requireHttps calls)"
-else
-    bad "only $guards requireHttps call(s) -- the version lookup and the download each need one"
-fi
-
-# Behavioral. handleError is stubbed to report rather than exit, so a
-# requireHttps that silently returns is distinguishable from one that objects.
-(
-    handleError() { echo "REFUSED"; return 0; }
-    eval "$(body requireHttps "$UPD")"
-    good=$(requireHttps "https://github.com/FOGProject/fogproject" 2>&1)
-    bad_=$(requireHttps "http://internap.dl.sourceforge.net/sourceforge/freeghost/" 2>&1)
-    [[ -z $good && $bad_ == *REFUSED* ]] && exit 0
+if [[ ! -r $UPD ]]; then
+    echo "FAIL: cannot read $UPD" >&2
+    echo "  The file is kept deliberately, so an existing cron entry gets a" >&2
+    echo "  message rather than 'No such file or directory'." >&2
     exit 1
-)
-if [[ $? -eq 0 ]]; then
-    ok "requireHttps passes https and refuses http"
-else
-    bad "requireHttps does not discriminate on scheme"
 fi
 
-# Behavioral, and the one that proves the flags are doing the work rather than
-# merely being present: curl itself must refuse the scheme.
-#
-# The exit STATUS is what is asserted, not merely that it failed. 192.0.2.1 is
-# TEST-NET-1 and unroutable, so a fetch() with --proto removed also fails --
-# on a connect timeout -- and "it failed" would pass for the wrong reason,
-# fifteen seconds later. curl exit 1 is CURLE_UNSUPPORTED_PROTOCOL: the URL was
-# rejected locally, before any socket. 7/28 would be the connect failing.
-(
-    eval "$(body fetch "$UPD")"
-    fetch "http://192.0.2.1/fog.tar.gz" /dev/null >/dev/null 2>&1
-    [[ $? -eq 1 ]] && exit 0
-    exit 1
-)
-if [[ $? -eq 0 ]]; then
-    ok "fetch() rejects an http:// URL on the scheme, before connecting"
-else
-    bad "fetch() did not refuse a cleartext URL outright"
-fi
+# What is left after removing the two things that are TEXT rather than code:
+# comments, and the heredoc the retirement message is printed from. The message
+# quotes the bootstrap one-liner, curl and all, because that is the instruction
+# a tarball install needs -- and a check that could not tell a printed command
+# from an executed one would either fail on the advice or have to stop looking
+# for curl at all. Both are worse than knowing the difference.
+body=$(sed 's/#.*//' "$UPD" | awk '
+    /<<[[:space:]]*.?EOF.?[[:space:]]*$/ { inhere = 1; next }
+    inhere && /^EOF$/                    { inhere = 0; next }
+    inhere                               { next }
+    { print }
+')
 
-echo
-echo "3. the tracked branch follows the installed channel"
-
-# The selection block, executed for real against each channel. Stubs make the
-# two exits observable: handleError prints and returns, so a fall-through to
-# stable is visible as a branch value where a refusal was required.
-select_branch() (
-    channel="$1"; trunk="$2"; updatebranch="$3"; branch=""
-    handleError() { echo "REFUSED" >&2; return 0; }
-    eval "$(joined "$UPD" | awk '
-        /^if \[\[ -n \$updatebranch \]\]; then/ { inside = 1 }
-        inside { print }
-        inside && /^fi$/ { exit }
-    ')"
-    echo "$branch"
-)
-
-check_branch() {
-    local got
-    got=$(select_branch "$1" "$2" "$3" 2>/dev/null)
-    if [[ $got == "$4" ]]; then
-        ok "channel='$1' trunk='$2' updatebranch='$3' -> ${4:-<refused>}"
+# --- it fetches nothing ----------------------------------------------------
+for tool in curl wget; do
+    if grep -qE "(^|[^-[:alnum:]_])${tool}([[:space:]]|$)" <<< "$body"; then
+        bad "$tool appears in a retired utility -- it must not fetch anything"
     else
-        bad "channel='$1' trunk='$2' updatebranch='$3' -> '$got', expected '${4:-<refused>}'"
+        ok "no $tool"
     fi
-}
+done
 
-check_branch "Patches" ""  ""              "stable"
-check_branch "Patches" "1" ""              "dev-branch"
-check_branch "Beta"    ""  ""              "working-1.6"
-# The one that used to install 1.5 over a 1.6 server: $trunk must not drag a
-# beta install onto the 1.5 patch line either.
-check_branch "Beta"    "1" ""              "working-1.6"
-check_branch "Patches" ""  "my-branch"     "my-branch"
-# No branch is derivable for these, so they must stop. A non-empty $branch here
-# means a release candidate would be overwritten with whatever stable is.
-check_branch "Release Candidate" "" ""     ""
-check_branch "Feature"           "" ""     ""
-
-echo
-echo "4. the payload is identified before it is executed"
-
-# Order first: a version check that runs after installfog.sh has already been
-# invoked is decoration.
-#
-# The call site is matched whole, not just by name. `if false && ! verifyPayload
-# ...` keeps the call, keeps it above the installer, and never runs it -- so a
-# grep for the function name passes on a check that has been switched off. The
-# anchored pattern makes any added condition a visible failure rather than a
-# line that still looks right.
-guard='^if ! verifyPayload "\$extractdir" "\$latest"; then$'
-verify_line=$(joined "$UPD" | grep -nE "$guard" | head -1 | cut -d: -f1)
-install_line=$(joined "$UPD" | grep -n '\./installfog\.sh' | head -1 | cut -d: -f1)
-if [[ -z $verify_line ]]; then
-    bad "the verifyPayload guard is missing or has grown a condition -- it may no longer run"
-elif [[ -n $install_line && $verify_line -lt $install_line ]]; then
-    ok "the payload is verified before ./installfog.sh is invoked"
-else
-    bad "the payload is verified after ./installfog.sh has already run"
-fi
-
-# Then behavior, because the line-order check above cannot tell a check that
-# FIRES from one that has been made unreachable -- `if false && ...` satisfies
-# it, and so does a verifyPayload that returns 0 unconditionally. This runs the
-# decision against three real trees: the version we asked for, a different
-# version, and an archive that unpacked to nothing.
-verify_case() {
-    local dir="$1" expect="$2" want="$3" got
-    (
-        eval "$(body verifyPayload "$UPD")"
-        verifyPayload "$dir" "$expect" 2>/dev/null
-    )
-    got=$?
-    if [[ $got -eq $want ]]; then
-        ok "verifyPayload: $4"
+for pattern in 'https\?://' 'updatemirrors' 'versionurl'; do
+    if grep -qE "$pattern" <<< "$body"; then
+        bad "'$pattern' appears outside a comment -- this file resolves no URLs"
     else
-        bad "verifyPayload: $4 -- returned $got, expected $want"
+        ok "no live '$pattern'"
     fi
-}
+done
 
-tmp=$(mktemp -d) || { echo "cannot create a temp directory"; exit 1; }
-trap 'rm -rf "$tmp"' EXIT
-mkdir -p "$tmp/good/packages/web/lib/fog" "$tmp/wrong/packages/web/lib/fog" "$tmp/empty"
-printf "        define('FOG_VERSION', '1.6.0-beta.4108');\n" > "$tmp/good/packages/web/lib/fog/system.class.php"
-printf "        define('FOG_VERSION', '1.5.10.2254');\n"     > "$tmp/wrong/packages/web/lib/fog/system.class.php"
+# --- and runs nothing ------------------------------------------------------
+for pattern in 'tar[[:space:]]' 'installfog\.sh' '\bexec\b' 'eval[[:space:]]'; do
+    if grep -qE "$pattern" <<< "$body"; then
+        bad "'$pattern' appears outside a comment -- this file executes nothing"
+    else
+        ok "no live '$pattern'"
+    fi
+done
 
-verify_case "$tmp/good"  "1.6.0-beta.4108" 0 "accepts the version it resolved"
-verify_case "$tmp/wrong" "1.6.0-beta.4108" 1 "refuses a package built from another branch"
-verify_case "$tmp/empty" "1.6.0-beta.4108" 1 "refuses a tree with no system.class.php"
-
-# The extraction directory is emptied first. Untarring over a previous run left
-# files that upstream had deleted in the tree that then got installed.
-if joined "$UPD" | grep -qE '^rm -rf "\$extractdir"'; then
-    ok "the extraction directory is emptied before the tarball is unpacked"
+# It sources nothing either. lib/common/utils.sh pulls in the whole installer
+# library, and a retired file has no business having it in scope.
+if grep -qE '^[[:space:]]*(\.|source)[[:space:]]' <<< "$body"; then
+    bad "the retired utility still sources something"
 else
-    bad "the tarball is unpacked over whatever a previous run left behind"
+    ok "it sources nothing"
 fi
 
-# errorStat reports through $error_log, which only bin/installfog.sh sets.
-# Reached from a utility its failure arm runs `tail -n 5` with no file
-# argument, so tail reads stdin and the update hangs instead of reporting.
-if joined "$UPD" | grep -qE '(^|[^[:alnum:]_])errorStat[[:space:]]'; then
-    bad "$UPD calls errorStat -- with \$error_log unset its failure arm hangs on tail reading stdin"
+# --- it says where to go instead -------------------------------------------
+# The point of keeping the file at all. A cron entry that has been running for
+# years should produce an instruction, not a silence.
+if grep -q 'updatefog.sh' "$UPD"; then
+    ok "it points at bin/updatefog.sh for a git checkout"
 else
-    ok "failures are reported through handleError, not errorStat"
+    bad "it does not say what to use instead for a git checkout"
+fi
+
+if grep -q 'bootstrap.sh' "$UPD"; then
+    ok "it points at the bootstrap installer for a tarball install"
+else
+    bad "it leaves tarball installs -- the ones it used to serve -- with nowhere to go"
+fi
+
+if grep -qi 'retired' "$UPD"; then
+    ok "it says it is retired"
+else
+    bad "it does not say it is retired"
+fi
+
+# --- and fails, rather than looking like it worked -------------------------
+# A cron entry checks exit status. Printing advice and exiting 0 would report
+# a successful update forever.
+bash "$UPD" >/dev/null 2>&1
+st=$?
+if [[ $st -ne 0 ]]; then
+    ok "it exits non-zero, so a cron entry reports a failure rather than a success"
+else
+    bad "it exits 0 -- a scheduled update would silently report success forever"
 fi
 
 echo

--- a/tests/updatefog-1-5-crossing.test.sh
+++ b/tests/updatefog-1-5-crossing.test.sh
@@ -1,0 +1,307 @@
+#!/bin/bash
+#
+# bin/updatefog.sh carries a 1.5 server across to 1.6, without reading itself
+# out from under its own feet.
+#
+#   tests/updatefog-1-5-crossing.test.sh
+#
+# THE ASSERTION THIS FILE EXISTS FOR
+#
+# The script replaces itself. Checking out 1.6 rewrites bin/updatefog.sh while
+# bash is still reading it, and bash reads a script incrementally, seeking by
+# byte offset -- so a file that changes length mid-run makes it resume in the
+# middle of a different line. The failure is silent, arbitrary, and happens
+# AFTER the checkout has already succeeded, which is the worst possible moment:
+# the server's code has moved and the process driving the upgrade is now
+# executing fragments.
+#
+# The guard is to copy itself somewhere git will not touch and re-exec from
+# there before going anywhere near git. That is cheap, and it is the kind of
+# thing that gets "simplified" out by someone who has not hit it -- so it is
+# asserted here by actually rewriting the original mid-run and checking the
+# process was unaffected, not by grepping for the function.
+#
+# Everything else here is a refusal. This script runs as root on somebody's
+# working imaging server and moves it to a different major version; nearly
+# every interesting case is one where it should decline.
+#
+# No root, no network, no FOG install: the root check is neutered in a copy,
+# git and the installer are stubs on PATH.
+#
+# Usage: bash tests/updatefog-1-5-crossing.test.sh
+# Exit status 0 = pass, 1 = fail.
+
+REPO="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="$REPO/bin/updatefog.sh"
+
+PASS=0
+FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+check() { if [[ $2 -eq 0 ]]; then ok "$1"; else bad "$1"; fi; }
+
+if [[ ! -r $SRC ]]; then
+    echo "FAIL: cannot read $SRC" >&2
+    exit 1
+fi
+if ! command -v git >/dev/null 2>&1; then
+    echo "SKIP: git is not installed" >&2
+    exit 0
+fi
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# --- unmodified, before the root check ------------------------------------
+bash "$SRC" --help >/dev/null 2>&1
+check "--help exits 0 without root" "$?"
+check "--help names the rc channel, which is the one most people will use" \
+    "$(bash "$SRC" --help 2>&1 | grep -q 'rc '; echo $?)"
+check "--help warns that 1.5 -> 1.6 is a major upgrade" \
+    "$(bash "$SRC" --help 2>&1 | grep -qi 'MAJOR upgrade'; echo $?)"
+check "--help points at revertfog.sh as the way back" \
+    "$(bash "$SRC" --help 2>&1 | grep -q 'revertfog.sh'; echo $?)"
+
+bash "$SRC" >/dev/null 2>&1
+check "a non-root run exits 1" "$([[ $? -eq 1 ]]; echo $?)"
+bash "$SRC" --nonsense >/dev/null 2>&1
+check "a bad argument exits 3, and does so before asking for root" \
+    "$([[ $? -eq 3 ]]; echo $?)"
+
+# --- a copy with the root gate removed ------------------------------------
+sut="$work/updatefog.sh"
+sed 's/^if \[\[ ! \$EUID -eq 0 \]\]; then$/if false; then/' "$SRC" > "$sut"
+if ! grep -q 'if false; then' "$sut"; then
+    echo "FAIL: could not neuter the root check -- it changed shape." >&2
+    exit 1
+fi
+chmod +x "$sut"
+
+stubs="$work/stubs"
+mkdir -p "$stubs"
+calls="$work/calls.log"
+
+cat > "$stubs/git" <<'EOF'
+#!/bin/bash
+echo "git $*" >> "$CALLS"
+case "$2$1" in
+    *rev-parse*)
+        case "$*" in
+            *--abbrev-ref*) echo "stable" ;;
+            *) echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" ;;
+        esac
+        ;;
+    *ls-remote*) : ;;
+esac
+[[ $* == *ls-remote* ]] && exit 0
+exit 0
+EOF
+chmod +x "$stubs/git"
+
+# A fake 1.5 install: a checkout with a bin/, and a .fogsettings to find.
+mkinstall() {
+    local dir="$1"
+    mkdir -p "$dir/.git" "$dir/bin" "$work/opt"
+    cat > "$dir/bin/installfog.sh" <<'EOF'
+#!/bin/bash
+echo "installfog $*" >> "$CALLS"
+exit ${FAKE_INSTALL_STATUS:-0}
+EOF
+    chmod +x "$dir/bin/installfog.sh"
+    : > "$work/opt/.fogsettings"
+}
+
+run() {
+    ( export PATH="$stubs:$PATH" CALLS="$calls" fogprogramdir="$work/opt"
+      cd "$work" && bash "$sut" "$@" )
+}
+
+# ---------------------------------------------------------------------------
+# THE SELF-REWRITE GUARD, exercised for real.
+#
+# A stub git whose `checkout` truncates the ORIGINAL script to nothing --
+# which is what a real checkout does to it in miniature. Without the re-exec
+# the running process is reading that file and cannot survive it.
+# ---------------------------------------------------------------------------
+victimdir="$work/victim"
+mkinstall "$victimdir"
+cp "$sut" "$victimdir/bin/updatefog.sh"
+
+cat > "$stubs/git" <<'EOF'
+#!/bin/bash
+echo "git $*" >> "$CALLS"
+for a in "$@"; do
+    if [[ $a == checkout ]]; then
+        # What a real branch change does to this file, at its most brutal.
+        : > "$VICTIM/bin/updatefog.sh"
+    fi
+done
+case "$*" in
+    *--abbrev-ref*) echo "stable" ;;
+    *rev-parse*)    echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" ;;
+esac
+exit 0
+EOF
+chmod +x "$stubs/git"
+
+: > "$calls"
+out=$( export PATH="$stubs:$PATH" CALLS="$calls" VICTIM="$victimdir" \
+              fogprogramdir="$work/opt" FAKE_INSTALL_STATUS=0
+       cd "$victimdir/bin" && bash ./updatefog.sh --channel beta --yes 2>&1 )
+st=$?
+
+check "it survives its own file being emptied mid-run" \
+    "$([[ $st -eq 0 ]]; echo $?)"
+check "and still reached the installer afterwards" \
+    "$(grep -q '^installfog' "$calls"; echo $?)"
+check "and reported success rather than a fragment of itself" \
+    "$(grep -q 'completed successfully' <<< "$out"; echo $?)"
+check "the original really was emptied, so the test proved something" \
+    "$([[ ! -s $victimdir/bin/updatefog.sh ]]; echo $?)"
+check "no temporary copy is left behind" \
+    "$([[ $(ls /tmp/fog-updatefog.* 2>/dev/null | wc -l) -eq 0 ]]; echo $?)"
+
+# Restore the ordinary stub for the rest.
+cat > "$stubs/git" <<'EOF'
+#!/bin/bash
+echo "git $*" >> "$CALLS"
+case "$*" in
+    *--abbrev-ref*) echo "stable" ;;
+    *rev-parse*)    echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" ;;
+esac
+exit 0
+EOF
+chmod +x "$stubs/git"
+
+# ---------------------------------------------------------------------------
+# Refusals.
+# ---------------------------------------------------------------------------
+nogit="$work/nogit"
+mkdir -p "$nogit/bin"
+: > "$work/opt/.fogsettings"
+out=$(run --git-path "$nogit" --yes 2>&1)
+check "a tarball install (no .git) is refused, exit 1" \
+    "$([[ $? -eq 1 ]]; echo $?)"
+check "and is sent to the bootstrap installer, which can upgrade it in place" \
+    "$(grep -q 'bootstrap.sh' <<< "$out"; echo $?)"
+
+rm -f "$work/opt/.fogsettings"
+d="$work/noinstall"; mkinstall "$d"; rm -f "$work/opt/.fogsettings"
+out=$(run --git-path "$d" --yes 2>&1)
+check "no .fogsettings means no install to update, exit 1" \
+    "$([[ $? -eq 1 ]]; echo $?)"
+: > "$work/opt/.fogsettings"
+
+d="$work/badchan"; mkinstall "$d"
+out=$(run --git-path "$d" --channel nonsense --yes 2>&1)
+check "an unknown channel exits 3" "$([[ $? -eq 3 ]]; echo $?)"
+check "and names the retired spellings, which still work" \
+    "$(grep -qi 'staging' <<< "$out"; echo $?)"
+
+d="$work/rc"; mkinstall "$d"
+out=$(run --git-path "$d" --channel rc --yes 2>&1)
+check "rc with nothing published says so, rather than 'unknown channel'" \
+    "$(grep -qi 'No release candidate is currently published' <<< "$out"; echo $?)"
+
+# ---------------------------------------------------------------------------
+# The crossing is announced, and the vocabulary matches 1.6's.
+# ---------------------------------------------------------------------------
+d="$work/crossing"; mkinstall "$d"
+: > "$calls"
+out=$(run --git-path "$d" --channel beta --yes 2>&1)
+check "moving from stable to working-1.6 is announced as a MAJOR upgrade" \
+    "$(grep -qi 'MAJOR upgrade' <<< "$out"; echo $?)"
+check "it names revertfog.sh as the only supported way back" \
+    "$(grep -q 'revertfog.sh' <<< "$out"; echo $?)"
+check "it checks out working-1.6" \
+    "$(grep -q 'checkout working-1.6' "$calls"; echo $?)"
+
+for pair in "beta:working-1.6" "dev:working-1.6" "patches:dev-branch" "staging:dev-branch" "stable:stable"; do
+    ch="${pair%%:*}"; want="${pair#*:}"
+    d="$work/v-$ch"; mkinstall "$d"
+    : > "$calls"
+    run --git-path "$d" --channel "$ch" --yes >/dev/null 2>&1
+    check "--channel ${ch} checks out ${want}, matching 1.6's vocabulary" \
+        "$(grep -q "checkout ${want}\$" "$calls"; echo $?)"
+done
+
+# ---------------------------------------------------------------------------
+# Interactive by default; -Y only on request. This is the whole reason the
+# retired fogupdater.sh was not simply fixed in place.
+# ---------------------------------------------------------------------------
+d="$work/yes"; mkinstall "$d"
+: > "$calls"
+run --git-path "$d" --channel beta --yes >/dev/null 2>&1
+check "--yes runs the installer with -Y" \
+    "$(grep -q '^installfog.*-Y' "$calls"; echo $?)"
+
+# Asserted in whichever environment this happens to run in. Both branches check
+# the same requirement -- never unattended unless asked -- because whether
+# /dev/tty can be opened is a property of the test runner, not of the script,
+# and a check that only worked on a headless runner would go quietly vacuous on
+# a developer's terminal.
+d="$work/interactive"; mkinstall "$d"
+: > "$calls"
+out=$(run --git-path "$d" --channel beta < /dev/null 2>&1)
+st=$?
+
+# The invariant, either way: no -Y. That is the whole difference from the
+# retired fogupdater.sh, which ended in `./installfog.sh -y`.
+check "without --yes the installer is never given -Y" \
+    "$(! grep -q '^installfog.*-Y' "$calls"; echo $?)"
+
+if [[ $st -eq 7 ]]; then
+    ok "with no terminal available it refuses (exit 7) rather than going unattended"
+    check "and tells the user how to put the checkout back" \
+        "$(grep -q 'reset --hard' <<< "$out"; echo $?)"
+    check "and does not start the installer at all" \
+        "$(! grep -q '^installfog' "$calls"; echo $?)"
+else
+    # A terminal was available, so the run reached the confirmation prompt --
+    # and its stdin is /dev/null, so `read` got EOF. An unanswerable prompt
+    # must CANCEL. Treating EOF as consent would mean a cron entry that lost
+    # its terminal silently upgrading a server across a major version.
+    ok "with a terminal available it reaches the confirmation prompt"
+    check "an unanswered confirmation cancels instead of proceeding" \
+        "$(grep -qi 'Canceled' <<< "$out"; echo $?)"
+    check "and the installer is never started" \
+        "$(! grep -q '^installfog' "$calls"; echo $?)"
+    check "and the checkout is not moved either" \
+        "$(! grep -q 'checkout' "$calls"; echo $?)"
+    # The refusal still has to EXIST, or a headless run would silently go
+    # unattended. Checked in the source, since it cannot be reached here.
+    check "the no-terminal refusal is still present in the script" \
+        "$(sed 's/#.*//' "$SRC" | grep -q 'exec < /dev/tty'; echo $?)"
+fi
+
+# ---------------------------------------------------------------------------
+# It reverts nothing, and says so.
+# ---------------------------------------------------------------------------
+d="$work/failing"; mkinstall "$d"
+: > "$calls"
+out=$( export PATH="$stubs:$PATH" CALLS="$calls" fogprogramdir="$work/opt" FAKE_INSTALL_STATUS=9
+       cd "$work" && bash "$sut" --git-path "$d" --channel beta --yes 2>&1 )
+check "a failed install propagates the installer's exit status" \
+    "$([[ $? -eq 9 ]]; echo $?)"
+check "it does not reset the checkout itself" \
+    "$(! grep -q 'reset --hard aaaa' "$calls"; echo $?)"
+check "it names the commit to reset to instead" \
+    "$(grep -q 'reset --hard aaaaaaaa' <<< "$out"; echo $?)"
+check "and mentions revertfog.sh, because the database may already have moved" \
+    "$(grep -q 'revertfog.sh' <<< "$out"; echo $?)"
+
+# ---------------------------------------------------------------------------
+# It stays standalone. The moment it sources the installer library it stops
+# being portable to a branch that does not have the same one.
+# ---------------------------------------------------------------------------
+body=$(sed 's/#.*//' "$SRC")
+check "it sources nothing" \
+    "$(! grep -qE '^[[:space:]]*(\.|source)[[:space:]]+\.\./lib' <<< "$body"; echo $?)"
+
+echo
+if [[ $FAIL -eq 0 ]]; then
+    echo "PASS ($PASS assertions)"
+    exit 0
+fi
+echo "FAIL ($FAIL of $((PASS + FAIL)) assertions)"
+exit 1

--- a/tests/updatefog-1-5-crossing.test.sh
+++ b/tests/updatefog-1-5-crossing.test.sh
@@ -291,6 +291,50 @@ check "and mentions revertfog.sh, because the database may already have moved" \
     "$(grep -q 'revertfog.sh' <<< "$out"; echo $?)"
 
 # ---------------------------------------------------------------------------
+# rcBranch, against a REAL remote.
+#
+# Everything above runs with a git stub whose ls-remote exits 0 saying nothing,
+# so none of it can see what this catches: a bare `rc-*` pattern matches the
+# TAIL of a ref at slash boundaries, so ls-remote also returns
+# refs/heads/feat/rc-anything. That would send a 1.5 server across to a feature
+# branch on --channel rc -- the very channel this script recommends for the
+# crossing -- while reporting it as the current release candidate.
+# ---------------------------------------------------------------------------
+rcfn=$(awk '/^rcBranch\(\) \{/ { grab = 1 } grab { print } grab && /^\}/ { exit }' "$SRC")
+if ! grep -q '^rcBranch() {' <<< "$rcfn"; then
+    echo "FAIL: could not find rcBranch() in bin/updatefog.sh." >&2
+    echo "  If it moved or was renamed, point this test at it -- do not" >&2
+    echo "  delete the assertions." >&2
+    exit 1
+fi
+eval "$rcfn"
+
+rcremote="$work/rc.git"
+rcseed="$work/rcseed"
+git init -q --bare "$rcremote"
+git init -q "$rcseed"
+git -C "$rcseed" config user.email t@example.invalid
+git -C "$rcseed" config user.name t
+echo x > "$rcseed/f"
+git -C "$rcseed" add f && git -C "$rcseed" commit -qm seed
+rcpublish() {
+    git -C "$rcseed" branch -f "$1" >/dev/null 2>&1
+    git -C "$rcseed" push -q "$rcremote" "$1" >/dev/null 2>&1
+}
+repo="$rcremote"
+
+rcpublish feat/rc-update-channel
+check "a feat/rc-* branch is not offered as a release candidate" \
+    "$([[ -z $(rcBranch) ]]; echo $?)"
+check "and rcBranch reports nothing published" \
+    "$(! rcBranch >/dev/null 2>&1; echo $?)"
+
+rcpublish rc-1.6.2
+rcpublish rc-1.6.10
+check "rc-1.6.10 beats rc-1.6.2 and the decoy (version order, not lexical)" \
+    "$([[ $(rcBranch) == rc-1.6.10 ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
 # It stays standalone. The moment it sources the installer library it stops
 # being portable to a branch that does not have the same one.
 # ---------------------------------------------------------------------------

--- a/utils/FOGUpdater/fogupdater.sh
+++ b/utils/FOGUpdater/fogupdater.sh
@@ -1,193 +1,60 @@
 #!/bin/bash
-# GH-314: resolve against this script's own location, not the caller's cwd.
-. "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/../../lib/common/utils.sh"
 #
-# GHSA-qp3r-8mwm-vg6h -- this utility downloads a tarball and runs its
-# installer unattended as root, so whatever answers these requests becomes the
-# FOG server. Three things follow from that and none of them are optional:
+# RETIRED. This utility no longer updates anything.
 #
-#   1. Every fetch verifies TLS. No -k, no --insecure, no
-#      --no-check-certificate. tests/installer-tls-verification.test.sh pins
-#      this file specifically.
-#   2. Every URL is https and stays https through redirects. github.com
-#      redirects the archive endpoint to codeload.github.com, so "the URL I
-#      typed is https" is not the same statement as "the bytes arrived over
-#      TLS" -- curl's --proto/--proto-redir make it one, and they refuse a
-#      cleartext $updatemirrors override set in .fogsettings rather than
-#      merely not defaulting to one.
-#   3. Nothing is executed until the payload has been identified. There is no
-#      release signature to check -- FOG does not sign releases today, and
-#      GitHub publishes no checksum for branch archives -- so the trust root
-#      here is verified TLS to github.com and nothing else. The version
-#      re-check below is therefore NOT a security control; it refuses a
-#      payload whose FOG_VERSION is not the one we resolved, which catches a
-#      stale tarball left in $downloaddir, a truncated download, and the
-#      branch moving between the version check and the fetch.
+# It downloaded a branch tarball from GitHub, extracted it, and ran the
+# installer inside it unattended as root. Three things retired it:
 #
-# The plain-HTTP SourceForge mirror list this used to default to is gone for a
-# second reason as well: SourceForge has carried no release since fog_1.4.4, so
-# the stable path had been downloading a 404 page for years.
+#   1. It could not do the job people most need from a 1.5 updater. Its Beta
+#      arm mapped to working-1.6 and then resolved that branch's version from
+#      packages/web/lib/fog/system.class.php -- a path 1.6 does not have, since
+#      it moved to packages/web/src/Base/System.php. The fetch 404'd, the
+#      version came back empty, and every 1.5 -> 1.6 attempt died reporting a
+#      version lookup failure. verifyPayload() read the same missing path, so
+#      fixing one half would only have moved the failure a few lines down.
+#      GH-1587.
 #
-[[ -z $downloaddir ]] && downloaddir="/opt"
-downloaddir="${downloaddir%/}"
-echo " ***************************************************************"
-echo " *                         ** Notice **                        *"
-echo " ***************************************************************"
-echo " *                                                             *"
-echo " * Your FOG server may go offline during this upgrade process! *"
-echo " *                                                             *"
-echo " ***************************************************************"
-# The installer this ends up running writes to /opt, the web root, the database
-# and the service manager. Refuse up front rather than half way through.
-[[ $EUID -ne 0 ]] && handleError " * This utility must be run as root" 1
-# requireHttps <url> -- abort unless the URL is https.
+#   2. It ran `installfog.sh -y`. Unattended is defensible for a 1.5.x point
+#      update, where .fogsettings already holds every answer. It is the wrong
+#      default for a crossing to 1.6, which meets settings that file has never
+#      held and takes a default for each of them without saying so.
 #
-# curl's --proto '=https' already refuses anything else, so this is not what
-# makes the guarantee; it is what makes the failure legible. Without it an
-# http:// mirror in .fogsettings surfaces as "curl exit 1" with no clue which
-# of the fetches objected or why.
+#   3. Its trust root was verified TLS to github.com and nothing else --
+#      correctly documented as such after GHSA-qp3r-8mwm-vg6h, but it means a
+#      tarball is strictly weaker than a git checkout, which at least records
+#      what it fetched and can be diffed and reset.
 #
-# Called as a plain statement, never inside $( ), because handleError exits and
-# an exit inside a command substitution kills only the subshell.
-requireHttps() {
-    [[ $1 == https://* ]] && return 0
-    handleError " * Refusing to update over an unverified transport: $1" 8
-}
-# fetch <url> <destination|-> -- one verified download.
+# The file is kept, rather than deleted, so an existing cron entry or a script
+# that calls it gets this message instead of "No such file or directory" --
+# and so tests/fogupdater-update-source.test.sh can keep asserting that it
+# never fetches or executes anything again. That assertion is the GHSA
+# guarantee in its strongest possible form.
 #
-# curl rather than wget because --proto/--proto-redir have no wget equivalent:
-# they pin the scheme for the whole redirect chain, which is what actually
-# holds guarantee 2 above. curl is a FOG_packages entry on every supported
-# distro, so it is as available here as wget was.
-#
-# --fail matters as much as verification does. Without it an HTTP error page is
-# written to the destination and reported as a successful download, which is
-# how the dead SourceForge mirrors used to hand `tar` an HTML 404.
-fetch() {
-    curl --silent --show-error --fail --location \
-        --proto '=https' --proto-redir '=https' \
-        --connect-timeout 15 --speed-time 30 --speed-limit 1024 \
-        --output "$2" "$1"
-}
-# Which branch this server tracks.
-#
-# $updatebranch (.fogsettings or the environment) wins, then the installed
-# FOG_CHANNEL, then the legacy $trunk switch. FOG_CHANNEL cannot tell stable
-# from dev-branch -- .githooks/lib/fog-version.sh stamps both "Patches" -- so
-# $trunk still selects between those two exactly as it did before. What
-# FOG_CHANNEL is needed for is the case that used to be actively destructive:
-# on a 1.6 server the stable path resolved a 1.5.x version, called it "not up
-# to date", and installed 1.5 over the top. "Release Candidate" and "Feature"
-# have no branch this can derive, so they stop rather than guess -- same
-# reason, one step further out.
-#
-# On a 1.5 server there is no FOG_CHANNEL to read: system.class.php defines
-# only FOG_VERSION, so $channel comes back empty and the stable arm takes it,
-# which is the right answer here. The channel arms are kept identical to the
-# 1.6 copy deliberately -- this file is maintained as one script on both lines,
-# and the Beta arm is what stops a 1.5 updater left behind on an upgraded box
-# from pulling the server back down to 1.5.
-channel=$(awk -F\' /"define\('FOG_CHANNEL'[,](.*)"/'{print $4}' "$configpath" | tr -d '[[:space:]]')
-if [[ -n $updatebranch ]]; then
-    branch="$updatebranch"
-elif [[ $channel == Beta ]]; then
-    branch="working-1.6"
-elif [[ -n $trunk ]]; then
-    branch="dev-branch"
-elif [[ -z $channel || $channel == Patches ]]; then
-    branch="stable"
-else
-    handleError " * Unrecognized release channel '$channel' -- set updatebranch in .fogsettings to choose what to track" 9
-fi
-echo " * Update channel: ${channel:-unknown} (tracking branch $branch)"
-# The version of a branch is the FOG_VERSION its own system.class.php defines,
-# read with the same awk utils.sh uses on the installed copy -- so "latest" and
-# "running" are the same number produced the same way. This replaces the POST
-# to fogproject.org/version/index.php, which returned JSON for stable and dev
-# only: it had no answer for the beta channel, and it was a second service that
-# had to be kept in step with the branches by hand.
-versionurl="https://raw.githubusercontent.com/FOGProject/fogproject/${branch}/packages/web/lib/fog/system.class.php"
-requireHttps "$versionurl"
-dots "Checking latest version"
-latest=$(fetch "$versionurl" - 2>/dev/null | awk -F\' /"define\('FOG_VERSION'[,](.*)"/'{print $4}' | tr -d '[[:space:]]')
-if [[ -z $latest ]]; then
-    echo "Failed"
-    handleError " * Could not determine the latest FOG version for branch $branch" 1
-fi
-echo "Done"
-echo " * Latest FOG Version: $latest"
-[[ $version == $latest ]] && handleError " * You are already up to date!" 0
-echo "   You are not running the latest $branch version"
-echo " * Preparing to upgrade"
-echo " * Attempting to download $branch to $downloaddir"
-# $updatemirrors keeps working for anyone mirroring internally: each entry is a
-# base URL that "$branch.tar.gz" is appended to, and each is held to the same
-# https requirement as the default. The default is GitHub's branch archive,
-# which is where FOG releases live now.
-[[ -z $updatemirrors ]] && updatemirrors="https://github.com/FOGProject/fogproject/archive/refs/heads"
-fileplace="$downloaddir/fog_${latest}.tar.gz"
-downloaded=""
-for url in $updatemirrors; do
-    echo " * Trying mirror $url"
-    requireHttps "${url%/}/${branch}.tar.gz"
-    dots "Attempting Download"
-    if fetch "${url%/}/${branch}.tar.gz" "$fileplace" >/dev/null 2>&1; then
-        echo "Done"
-        downloaded=1
-        break
-    fi
-    echo "Failed"
-done
-[[ -z $downloaded ]] && handleError "   Failed to download current file" 5
-echo
-echo
-echo " * Extracting package $fileplace"
-echo
-echo
-dots "Extracting"
-# A fresh directory every time. The old code untarred over whatever was already
-# there, so a previous run's tree survived and files deleted upstream were
-# still present in the thing that then got installed.
-extractdir="$downloaddir/fog_${latest}"
-rm -rf "$extractdir" >/dev/null 2>&1
-mkdir -p "$extractdir" >/dev/null 2>&1
-# --strip-components=1 drops the archive's own top-level directory, whose name
-# differs per source (fog_1.5.10/ from SourceForge, fogproject-<branch>/ from
-# GitHub). Stripping it fixes the path to the installer here instead of
-# guessing it from the archive, which is what the old
-# `cd $downloaddir/fog_$latest/*/bin` glob was doing -- and it retires the
-# unset $extract that made the stable path untar straight into $downloaddir.
-# Not errorStat: it reports through $error_log, which only installfog.sh ever
-# sets. Reached from a utility, its failure arm runs `tail -n 5` with no file
-# argument, so tail reads stdin and a failed extraction hangs the update
-# instead of reporting it.
-if ! tar -xzf "$fileplace" -C "$extractdir" --strip-components=1 >/dev/null 2>&1; then
-    echo "Failed"
-    handleError " * Could not extract $fileplace" 4
-fi
-echo "Done"
-echo
-# Identify what was actually unpacked before running it. See note 3 at the top:
-# this is a correctness check, not a signature check.
-#
-# A function rather than four inline lines so a test can run the decision
-# itself. Asserting on the ORDER of the lines cannot tell a check that fires
-# from one that has been made unreachable -- and a guard that falls through
-# returns normally, which reads as success, is a defect this tree has met
-# repeatedly (#1215/#1216).
-verifyPayload() {
-    local dir="$1" expect="$2" unpacked=""
-    unpacked=$(awk -F\' /"define\('FOG_VERSION'[,](.*)"/'{print $4}' "$dir/packages/web/lib/fog/system.class.php" 2>/dev/null | tr -d '[[:space:]]')
-    [[ $unpacked == $expect ]] && return 0
-    echo " * Downloaded package reports version '${unpacked:-none}', expected '$expect'" >&2
-    return 1
-}
-dots "Verifying package"
-if ! verifyPayload "$extractdir" "$latest"; then
-    echo "Failed"
-    handleError " * Refusing to install a package that is not the version resolved for $branch" 6
-fi
-echo "Done"
-[[ ! -x $extractdir/bin/installfog.sh ]] && handleError " * No installer found in $extractdir" 7
-cd "$extractdir/bin" || handleError " * Could not enter $extractdir/bin" 7
-./installfog.sh -y
+# Deliberately sources nothing. Its whole job is to print and exit.
+
+cat <<'EOF'
+
+ * utils/FOGUpdater/fogupdater.sh has been retired and does nothing.
+
+   It could not update a 1.5 server to 1.6 (GH-1587), and it ran the installer
+   unattended, which is the wrong default for that upgrade.
+
+   If this server is a git checkout -- the documented way to install FOG --
+   use the updater beside the installer instead:
+
+       cd <your fogproject checkout>/bin
+       ./updatefog.sh --channel rc      # the current 1.6 release candidate
+       ./updatefog.sh --help            # the other channels
+
+   If it is NOT a git checkout, clone one and run its installer over this
+   install. It finds the existing server through /etc/fog/fog.conf and
+   upgrades it in place:
+
+       curl -fsSL https://raw.githubusercontent.com/FOGProject/fogproject/working-1.6/bin/bootstrap.sh | bash -s -- --channel rc
+
+   Going from 1.5 to 1.6 is a major upgrade. Take a backup first. The 1.6 tree
+   carries bin/revertfog.sh, which restores the pre-upgrade database dump the
+   installer takes; that dump is the only supported way back.
+
+EOF
+exit 1


### PR DESCRIPTION
#1588 has merged, so this targets `dev-branch` directly. Companion to the 1.6 stack (#1583 → #1586) — **merge that stack first**: the retirement message points at `bootstrap.sh --channel rc` on `working-1.6`, which only exists once #1585 and #1586 land. Supersedes #1587 by retirement rather than repair.

## There was no working path from 1.5 to 1.6

`utils/FOGUpdater/fogupdater.sh` *looked* like one — it has a Beta arm mapping to `working-1.6`. **That arm has never worked.** It resolves a branch's version from `packages/web/lib/fog/system.class.php`, a path 1.6 does not have (it moved to `packages/web/src/Base/System.php`). The fetch 404s, the version comes back empty, and every crossing dies on *"Could not determine the latest FOG version for branch working-1.6"*. `verifyPayload()` reads the same missing path, so fixing one half only moves the failure a few lines down. (#1587)

It also ends in `./installfog.sh -y`. Unattended is fine for a 1.5.x point update where `.fogsettings` already holds every answer; it's the wrong default for a crossing that meets settings that file has **never** held and takes a default for each of them silently.

So it's **retired rather than repaired**, and `bin/updatefog.sh` replaces it — git-based, beside the installer, matching where 1.6 already keeps its updater. That also leaves the server a git checkout, so 1.6's own `updatefog.sh` works immediately afterwards. A tarball extraction does not.

## The hazard this script is built around

**It replaces itself.** Checking out 1.6 rewrites `bin/updatefog.sh` while bash is still reading it — and bash reads a script incrementally, seeking by byte offset, so a file that changes length mid-run resumes in the middle of a different line. Silent, arbitrary, and it happens *after* the checkout has succeeded: the code has moved and the process driving the upgrade is executing fragments.

So the first thing it does is copy itself out of the checkout and re-exec. The test proves this by **emptying the original mid-run** and asserting the process finished anyway — not by grepping for the function. This is exactly the kind of guard that gets "simplified" out by someone who has not hit it.

> The same hazard exists in `working-1.6`'s `bin/updatefog.sh` and is being fixed there too.

## Everything else is a refusal

- A tarball install (no `.git`) → sent to the bootstrap one-liner, which clones and upgrades in place via `/etc/fog/fog.conf`.
- An unknown channel is kept distinct from a known channel with nothing published (`rc` between releases).
- No terminal and no `--yes` → exit 7 rather than going unattended.
- An **unanswered** confirmation cancels rather than being read as consent — a cron entry that lost its terminal must not silently cross a major version.

The crossing is announced as a major upgrade and points at `bin/revertfog.sh`, which restores the pre-upgrade dump — the only supported way back. A failed install reverts nothing and names the commit to reset to instead.

## Standalone by design

1.5 has none of the channel map, managed `.fogsettings` keys, or helper functions the 1.6 updater shares with its installer, and back-porting them would mean surgery on `lib/common/functions.sh` on a line heading for EOL. It **will** diverge from the 1.6 implementation, and that's fine — this line is terminal. The channel vocabulary is copied verbatim, retired `staging`/`dev` spellings included, so the two never disagree about what a channel name means.

## The retirement

`fogupdater.sh` is kept as a message rather than deleted, so an existing cron entry gets an instruction instead of `No such file or directory` — and exits **non-zero**, so a scheduled run reports a failure rather than success forever.

Its test is **repurposed, not removed**. It now asserts the file fetches nothing and executes nothing, which is the GHSA-qp3r-8mwm-vg6h guarantee in its strongest possible form: a fetcher that does not exist cannot be talked into fetching over cleartext. It's also the tripwire for anyone reintroducing a download there. Confirmed to fail the moment a `curl -k` is added back.

## Fixed after review

**`rcBranch` resolved a feature branch as the release candidate.** `ls-remote` matches a pattern against the **tail** of each ref at slash boundaries, so the bare `rc-*` pattern also matched `refs/heads/feat/rc-update-channel` — confirmed against origin. On `--channel rc`, which is the channel this script recommends for the crossing, a 1.5 server would have been checked out onto a feature branch and told it was the current release candidate.

The pattern is now `refs/heads/rc-*`, and the extracted name is re-checked with a `sed` that rejects a further slash.

No assertion here could have caught it: every other one runs against a git stub whose `ls-remote` exits 0 saying nothing. `rcBranch` is now lifted out and run against a real bare repository carrying the decoy — 40 assertions, up from 37 — and was confirmed to go red against the old pattern. The same defect and the same fix landed in #1585 and #1586.


## Test status

`tests/updatefog-1-5-crossing.test.sh` — 37 assertions. `tests/fogupdater-update-source.test.sh` — 14. Both pass; no root, no network, no FOG install.

`sh tests/run-all.sh` reports **13 failures both before and after** this change — the identical set, all pre-existing on a clean `dev-branch` checkout (9 PHP tests plus `generated-config-mode`, `installer-tls-verification`, `node-registration-reports-truthfully`, `secureboot-mok-enrolment-message`). Passing count goes 34 → 35, the one new file.

## Needs a real server

The crossing itself: a real 1.5 install moving onto an RC of 1.6, with the 1.6 installer running against a 1.5 database and web tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtZHpyWZWDPSxePdTViGZy

