### PR TITLE
ADR 0038: a group grants snapins and printers; it copies nothing

### DIFF
--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -1,0 +1,759 @@
+# A group grants snapins and printers; it copies nothing
+
+## Status
+
+proposed. No code has been written for it, and this ADR deliberately proposes
+none in this pass. The sizing, the evidence behind every claim, and the
+questions that need a lab to settle are in
+[`docs/development/group-split.md`](../development/group-split.md).
+
+Amends [ADR 0001](0001-group-association-state.md) rather than superseding it:
+0001's tri-state derivation is still how the group page reports *member* state
+after this change, but its opening sentence — "a group owns no associations of
+its own" — stops being true for snapins and printers, which is the whole point.
+
+## Context
+
+`Group::addSnapin()` writes one `snapinAssoc` row per member host
+(`packages/web/src/Items/Group.php:236`). `addPrinter()` (`:136`),
+`setSnapinOrder()` (`:316`), `setDisp()` (`:401`), `setAlo()` (`:436`),
+`addImage()` (`:501`) and `setAD()` (`:1100`) are the same shape: read
+`$this->get('hosts')`, write to each one. Every one of them is a **bulk write
+onto the hosts that existed at the moment the button was pressed**.
+
+Nothing records that the write happened, so nothing can replay it. Add a host
+to the group afterward and it gets nothing. Remove a host and it keeps
+everything. Membership is rendered as a declarative statement — a checkbox that
+says "all member hosts have this" — and behaves as a historical one.
+
+`GROUP_SHARED_STATE.md` is the current design honestly described, and reading
+it is the clearest statement of the problem: the group page has had to build a
+whole vocabulary (`All`/`Some`/`None`, `Hosts: (varies)`, Has/Missing
+drill-downs) whose only job is to reconstruct, after the fact, what the group
+would have looked like if it had ever owned anything.
+
+### The field evidence
+
+The `persistentgroups` plugin is this defect worked around in SQL. Its manager
+returns a `CREATE TRIGGER` for an `AFTER INSERT ON groupMembers`
+(`persistentgroups/src/Managers/PersistentGroupsManager.php:36`). On every new
+member it finds a **template host whose `hostName` equals the group's
+`groupName`** (`:44`) and copies that host's settings onto the new member.
+
+Two things about that are worth stating plainly before anything else:
+
+- The coupling between a group and its template is **string equality between
+  two unrelated tables**. There is no key, no constraint, and no UI that shows
+  the relationship exists. Renaming either object silently detaches it.
+- Its column list is not a design. It is thirteen columns somebody added one at
+  a time because each one caused real pain:
+
+      hostImage, hostBuilding, hostUseAD, hostADDomain, hostADOU, hostADUser,
+      hostADPass, hostProductKey, hostPrinterLevel, hostKernelArgs,
+      hostExitBios, hostExitEfi, hostEnforce
+
+That empirical list is the better specification of "what a group is expected to
+push", and this ADR uses it in preference to one derived from reading `Group`'s
+methods. Where the two disagree is Decision 2.
+
+The trigger also copies four **association** tables the column list does not
+mention — `locationAssoc` (`:58`), `printerAssoc` (`:63`), `snapinAssoc`
+(`:69`) and `moduleStatusByHost` (`:92`) — and, having copied the snapins, it
+**creates a snapin job and runs them** (`:78`, `:86`). So on a server with this
+plugin, adding a host to a group is not only a configuration change: it starts
+work on the machine.
+
+## Decision
+
+### 1. A group's contents split by lifetime, not by data type
+
+Two halves, and the line between them is **whether the thing is a value the
+host holds or an item the host is granted**.
+
+**Imperative half — the thirteen columns above.** These are columns on the
+`hosts` row. A host has exactly one image, one product key, one set of kernel
+arguments. There is no coherent meaning to "this host is granted an image by
+two groups". The group is only ever a *selection mechanism* for writing them,
+and the write is legitimately one-shot. This half **leaves the group entirely**
+and becomes mass edit driven from the host list (Decision 8).
+
+**Declarative half — snapins and printers.** These are set membership. A host
+can hold any number, from any number of sources, and the union is meaningful.
+These **stay with the group**, in new group-owned association tables, and are
+**evaluated, never copied**.
+
+The test that separates them is not "is it a column or a row". `hostPrinterLevel`
+is a column and belongs to the imperative half; `moduleStatusByHost` is a row
+and also belongs to the imperative half (Decision 3). The test is whether two
+sources granting the same thing can be combined without one of them losing.
+
+### 2. Where the empirical list and the group page disagree
+
+Both directions matter, and the disagreements are the interesting part.
+
+| Column | persistentgroups trigger | Group page today | After this ADR |
+|---|---|---|---|
+| `hostImage` | copies | `groupImage` tab, `addImage()`, always clobbers | mass edit |
+| `hostBuilding` | copies | **nothing writes it** | **dropped — see below** |
+| `hostUseAD` | copies | AD tab, tri-state select | mass edit |
+| `hostADDomain` / `ADOU` / `ADUser` | copies | AD tab, no-clobber | mass edit |
+| `hostADPass` | copies | AD tab, 32-asterisk sentinel | mass edit, set-only |
+| `hostProductKey` | copies | General tab, no-clobber | mass edit |
+| `hostPrinterLevel` | copies | Printers tab (`GroupManagement.php:1093`) | mass edit |
+| `hostKernelArgs` | copies | General tab, no-clobber | mass edit |
+| `hostExitBios` / `hostExitEfi` | copies | General tab, no-clobber | mass edit |
+| `hostEnforce` | copies | its own tri-state tab (`:1519`) | mass edit |
+| `hostKernel` / `hostDevice` / `hostInit` | **does not copy** | General tab | mass edit |
+| auto-logout | **does not copy** | `setAlo()`, replaces all rows | mass edit |
+| screen resolution | **does not copy** | `setDisp()`, replaces all rows | mass edit |
+| modules | copies (`msState` and all) | Modules tab, tri-state | mass edit (Decision 3) |
+| location / OU | copies `locationAssoc` | plugin group hooks | mass edit, plugin field (Decision 9) |
+| snapins | copies **and tasks them** | Snapins tab | **group-owned** |
+| printers | copies including `paIsDefault` | Printers tab | **group-owned** |
+
+Two findings out of that table are load-bearing.
+
+**`hostBuilding` is dead and the trigger copies it.** `building` is declared in
+both `Host` and `Group`'s field maps (`Host.php:50`, `Group.php:49`) and is
+**written by nothing** — no page, no JS, no report, no service. Its only other
+appearance in the tree is as an always-hidden column in the host export table
+(`fog.host.export.js:8`, `visible: false`). It is in the trigger's list because
+somebody added it when it meant something. It is not in the mass edit form, and
+saying so here is cheaper than somebody re-deriving the same list from the same
+plugin in two years.
+
+**The group page covers more than the trigger, and better.** Kernel, primary
+disk, init, auto-logout and screen resolution are all pushable from the group
+page and are all absent from the trigger. So "cover the persistentgroups list"
+is a floor, not a ceiling: mass edit must cover the **union**, or retiring
+either mechanism is a regression. That union is what Decision 8 sizes against.
+
+### 3. Modules go to the imperative half, and this is the one place ADR 0001's asymmetry pays off
+
+ADR 0001 established that a module counts as "had" only when
+`moduleStatusByHost.msState = 1`, because a module carries an enabled/disabled
+state that snapins and printers do not.
+
+That state is exactly why modules cannot join the declarative half. A group
+granting a module and a second group granting the same module *disabled* is a
+contradiction with no correct resolution — and unlike a snapin, where the union
+is obviously right, both readings of a module conflict are defensible. So
+modules stay a per-host value that a bulk edit writes, which is what they
+already are.
+
+ADR 0001's closing sentence anticipated the opposite migration ("if snapins or
+printers ever gain a per-host enabled/disabled state, they should converge on
+the module rule"). This decision takes the other fork and the reason is the
+same fact: an item with a tri-state cannot be rolled up.
+
+### 4. Snapins resolve at task creation, and the snapshot already exists
+
+The resolved, ordered snapin list is computed **when a task is created** and
+written onto the task. A task then records what was decided. A group edited
+while a task is in flight does not change that task. **Re-tasking is the only
+way to pick up a change, and the documentation must say so in those words**,
+because every admin will assume live evaluation and be wrong.
+
+This is far less new machinery than it sounds, and that is the point:
+`snapinTasks` **is already the snapshot**. It carries `stSnapinID` and
+`stSequence` per row under `UNIQUE (stJobID, stSnapinID)`
+(`packages/web/commons/schema-expected.php:813`), and
+`Group::_createSnapinTasking()` already materializes an ordered list into it
+(`Group.php:1060-1070`). Nothing about the task side changes. What changes is
+only where the list it materializes comes from.
+
+### 5. Printers resolve live, at the client's request
+
+There is no task to hang a snapshot on. `fog-client` reconciles desired state
+on a schedule against `service/Printers.php`, and a removal has to reach the
+machine, so the list must be computed on each request.
+
+### 6. Order is explicit, and a rename must never change it
+
+The resolved order for a host is:
+
+1. **Host-direct snapins**, by `saSequence`, then by `saID`.
+2. **Group-granted snapins**, groups ordered by an explicit integer order
+   column on the group, then `groupName`, then `groupID`; within a group, by
+   the group association's own sequence column.
+
+The `saID` tiebreak at step 1 is not decoration. `snapinAssoc.saSequence`
+defaults to `0` and `Host::loadSnapins()` orders by sequence alone
+(`Host.php:660`), so any two rows that both sit at 0 — which is every row
+`Group::addSnapin()` ever wrote before `appendSnapinSequence()` numbered them,
+and every row the persistentgroups trigger writes today — are returned in
+whatever order the engine chose. That is a real nondeterminism in the current
+code and the resolver fixes it in passing.
+
+**Not name alone, at any level.** Renaming a group must not silently reorder
+what runs on a thousand machines. The explicit order column is what makes
+ordering a decision an admin made rather than a side effect of alphabetising.
+
+`groupName` is the second key rather than the first because an install that
+never sets an order column needs *some* stable answer, and alphabetical is the
+one an admin can predict. `groupID` is third. **If `groupName` really is
+UNIQUE, the `groupID` tiebreak is unreachable by construction — keep it
+anyway**, because it costs one clause and it is the difference between a
+resolver that is deterministic and a resolver that is deterministic as long as
+an index nobody re-checks is still there. The manifest declares
+`UNIQUE KEY groupName (groupName)` and `Route::$nonUniqueNameClasses` does not
+list `group` (`Route.php:677`), so the code already believes it. Whether a real
+upgraded 1.5 database agrees is unverified here and is UNKNOWN-1 in the
+proposal — `roles.rName` is the precedent for the manifest and the disk
+disagreeing, and schema step 401 exists because of it.
+
+### 7. Deduplication takes the host's position
+
+A snapin reached both directly and through a group appears **once**, at its
+host-direct position. Rationale: the host-direct row is the one an admin
+deliberately placed in an order, and a group grant should not be able to move
+it. The dedupe happens in the resolver, not by leaning on
+`UNIQUE (stJobID, stSnapinID)` — `insertBatch()` upserts, so a duplicate
+reaching the insert would silently overwrite the sequence rather than being
+rejected.
+
+Default printer follows the same precedence: a host-direct default wins;
+otherwise the default from the first group in the Decision 6 order that names
+one.
+
+### 8. One resolver, and it takes a set of hosts
+
+The ordered list for a host comes from **one function**. Task creation, the
+client's printer request, and any UI preview all call it. Three sorts in three
+files drift, and the symptom is a preview that does not match what runs — which
+is unfalsifiable from a bug report and miserable to diagnose.
+
+The precedent is `SiteScope::_inScopeSelect()` (`Auth/SiteScope.php:436`),
+whose docblock states the identical reasoning for the identical reason: "Two
+copies of a membership rule in two dialects is the failure this codebase
+already documents elsewhere: when they drift nothing fails, the boundary simply
+stops matching in one of the two places."
+
+**The signature takes a set of host ids, not one host.** This is a hard
+constraint, not a convenience. GH-707 was exactly this: the "all snapins" path
+queried `snapinAssoc` once per member host inside a loop, a thousand round
+trips for a thousand-host group, and the fix was to read the association table
+once and index by host (`Group.php:975-991`). A resolver whose natural unit is
+one host reintroduces that the first time a group task uses it. So:
+
+```
+resolveSnapins(array $hostIDs): array   // hostID => ordered [snapinID, ...]
+resolvePrinters(array $hostIDs): array  // hostID => ['printers' => [...], 'default' => id|null]
+```
+
+The single-host client path calls it with a one-element array. The group task
+path calls it with the whole membership. Neither gets its own sort.
+
+Proposed home: a new autoload-only bucket `FOG\Assign\`. The bucket is not
+load-bearing — `FOG\Util\` would do — but `Auth/SiteScope.php` is the model for
+"a non-model class that owns one rule", and putting it in `Items/` next to the
+ORM models would misdescribe it.
+
+### 9. The printer resolver must not be able to fail quietly
+
+Under printer level `ar` ("FOG Handles all printers",
+`Client/PrinterClient.php:44`) the resolved list is **authoritative in both
+directions**: the client removes printers that are not on it. A resolver that
+errs by returning nothing does not fail to add a printer — it strips printers
+from every machine that polls, one machine at a time, for as long as nobody
+notices.
+
+Today's endpoint conflates the two cases, and it does so under the same key.
+A host with no printers gets `['error' => 'np', 'printers' => []]`
+(`PrinterClient.php:72`); an exception anywhere in `json()` is caught by
+`FOGClient::__construct()` and becomes `['error' => <message>]` with **no
+`printers` key at all** (`FOGClient.php:234`). So the failure shape is already
+the safe one — a response with no `printers` key — and the success-but-empty
+shape is already distinguished by carrying `printers` explicitly. What is wrong
+is only that both are spelled `error`, which invites a client to branch on the
+wrong thing.
+
+So:
+
+- **The resolver throws on failure. It never returns an empty list to mean
+  failure.** A caught exception yields a body with no `printers` key, which no
+  correct client may read as "remove everything".
+- **"This host has no printers" stops being an `error`.** It becomes an
+  ordinary success carrying `printers: []` and an explicit flag. `error` is
+  reserved for "I could not answer".
+- **The mode gate stays and is documented as the blast radius.** Only `ar`
+  removes. Under `a` FOG manages only the printers it added, and under `0`
+  nothing. That narrows the danger but does not remove it, and it is a client-
+  side behaviour this repository cannot verify — see UNKNOWN-4.
+
+Every one of these is the same shape as `inScopeWhere()`'s tri-state return
+(`SiteScope.php:498`), where the docblock spells out that the *falsy* value is
+the permissive one "on purpose" so that a caller writing the natural
+`if (!$x) { skip }` skips only the case where skipping is correct. The printer
+resolver has the same obligation and the opposite polarity: there is no falsy
+return that is safe to skip on, so it does not have one.
+
+### 10. Mass edit lands before anything is removed from the group page
+
+Sequencing is a decision, not a project-management detail, so it is recorded
+here: **the group page keeps every imperative tab it has today until the host
+list version is shipped and proven.** There is no release in which the only way
+to set an image on many hosts at once has been deleted.
+
+The order is: mass edit ships → the group page's imperative tabs are marked
+deprecated in the UI and the docs → they are removed in a later release. The
+declarative work (snapins, printers moving to group ownership) is independent
+of that sequence and can land in parallel.
+
+### 11. Three states per field, out of band
+
+A mass edit form that posts every field is a form that overwrites everything
+the admin did not touch. Every field needs three states — **leave alone**, **set
+to this value**, **clear** — and this is the single requirement most likely to
+be got wrong, because the wrong version looks identical until somebody's images
+are gone.
+
+The codebase already has both a right answer and a wrong one, side by side.
+
+- **Right:** the AD join state and `hostEnforce` use an explicit tri-state
+  `<select>` — *No change / Enable on all / Disable on all*
+  (`GroupManagement.php:1405`, `:1519`). The state is a separate control from
+  the value.
+- **Wrong, and it must not be carried over:** every text field uses an **in-band
+  sentinel** — blank means leave alone, the literal string `NULL`
+  (case-insensitive) means clear (`GroupManagement.php:746-753`, `:863-870`).
+
+The sentinel is rejected for three reasons, in increasing order of weight.
+It is undiscoverable — nothing in the form says the word `NULL` is magic. It
+cannot express "clear" for a control that has no text box, which is why image,
+building and printer level had to be special-cased in the first place. And it
+has no escape: a value that is legitimately the string `NULL` cannot be set.
+
+So the mass edit form pairs **every** field with an explicit action, and the
+value control is disabled unless the action is *set*. This is more markup than
+the group page has and it is the correct amount.
+
+**Mixed values are shown, never resolved.** Forty hosts with six images must
+render as *(varies)*, not as one of the six. The machinery exists:
+`_uniformHostValues()` (`GroupManagement.php:264`) computes
+`COUNT(DISTINCT ...)` and `MIN(...)` per column in **one** query over the whole
+selection, and `_sharedValueText()` (`:327`) renders `(varies)` /
+`(empty on all)` / `<value> (all)`. It is parameterised by a column map and
+keyed off a host id list, so it ports to a selection with no change to its
+shape.
+
+**The AD password is set-only and never displayed.** Not the 32-asterisk
+placeholder — that renders a fake value into a form and then pattern-matches it
+back out (`GroupManagement.php:878`), which works but teaches the wrong lesson
+and has to be re-remembered at every call site. The mass edit form renders an
+**empty** password input whose action defaults to *leave alone*; typing into it
+selects *set*. There is no read path. `ADPass` is a credential under
+`Redaction::CREDENTIAL_PATTERN` (`Auth/Redaction.php:94`) and so is
+`productKey` — both are redacted in the audit trail, and neither should be
+displayed by a form that is editing four hundred of them at once.
+
+### 12. One bulk edit is one audit row, and the batching follows from that
+
+**ADR 0021 Decision 11 already decided this, and it decided it against this
+exact example** — "the prompt asked how a group edit over 400 hosts where 397
+land should be represented". Restating it rather than re-deciding it:
+
+- **One authorized action is one header.** Always. `affectedCount` records how
+  many rows the statement touched. No per-object headers — that is the
+  `save()`-as-seam mistake arriving by another door.
+- Genuine partial success exists only on iterating paths that call `save()` per
+  object. There the header stays one row, `outcome` becomes `partial`, and
+  `affectedCount` records the successes.
+
+Applied here, and this is what decides the batching:
+
+- **The imperative half is one statement and is already atomic.**
+  `FOGManagerController::perform_update()` builds one
+  `UPDATE hosts SET ... WHERE hostID IN (...)`
+  (`Base/FOGManagerController.php:1963`). Four hundred hosts is one statement,
+  not four hundred, so "a 400-row loop that times out" is not a risk this path
+  has. It succeeds or fails whole. **One audit header, `outcome = allowed`,
+  `affectedCount` = the row count, and — per ADR 0021 Decision 5 — no
+  `auditChange` rows, because a bulk update has no before/after.** That gap is
+  named in ADR 0021 and the docs must repeat it rather than let it read as a
+  bug.
+- **Association writes chunk at 500 and are not transactional.**
+  `insertBatch()` does `array_chunk($values, 500)` and issues one statement per
+  chunk (`FOGManagerController.php:1854`), and **there is no transaction
+  support anywhere in the DB layer** — no `beginTransaction`, `commit` or
+  `rollBack` in `Db/PDODB.php` or any base class. So a multi-chunk write can
+  partially succeed today.
+
+  **The answer is not to add transactions; it is that the split removes the
+  volume.** Once a group owns its snapins, granting ten snapins to a
+  four-hundred-host group writes **ten rows**, not four thousand. It is one
+  chunk. The partial-failure question stops being reachable for the declarative
+  half rather than being solved.
+
+- Therefore: **all-or-nothing where the database gives it for free, partial
+  with a report where it does not.** Nothing new is introduced to manufacture
+  atomicity, and the one path that can still partially land (a mass edit that
+  writes both host columns and associations in one submission) reports which
+  hosts succeeded. If that reporting turns out to be the expensive part, the
+  cheaper answer is to refuse the mixed submission, not to fake a transaction.
+
+**Authorization is all-or-nothing and already is.** `deployMultiPost()` calls
+`Authorization::requirePageObjectScopeMass('host', $hosts)` with the comment
+"Airtight: one id outside the caller's site scope denies the whole request
+rather than quietly tasking the rest" (`HostManagement.php:4633`). Mass edit
+takes the same gate for the same reason. Note that this call is a per-id loop
+(`Authorization.php:2274`) that dispatches an `OBJECT_SCOPE_CHECK` hook per id
+— a known cost at 400 hosts, pre-existing, measured in UNKNOWN-5 rather than
+assumed.
+
+### 13. Plugin fields participate, or the ABI has a hole with a name
+
+`location` and `ou` each ship two near-identical hook files —
+`AddLocationHost`/`AddLocationGroup`, `AddOUHost`/`AddOUGroup`, 317/282 and
+318/277 lines. The group copy exists **only** to set one value across many
+hosts at once: `AddOUGroup::groupOUPost()` deletes every member's
+`ouAssociation` row and re-inserts one per host
+(`ou/src/Hooks/AddOUGroup.php:176`). That is mass edit, reimplemented per
+plugin, carrying the same membership defect — and it is worse than core's,
+because it *always* clobbers. It cannot express "leave alone" at all, so the
+no-clobber convention core adopted for its own group fields was never extended
+to the plugins beside them.
+
+So **the mass edit form takes plugin-contributed fields with the same
+three-state semantics as core ones**, through a hook pair modelled on the
+existing `HOST_ADD_FIELDS` / `HOST_EDIT_SUCCESS` shape that both plugins
+already register against (`AddOUHost.php:60-63`):
+
+- `HOST_MASSEDIT_FIELDS` — contribute controls. A plugin supplies a field key,
+  a label, a value control, and a mixed-value hint computed over the selection.
+  The three-state action control is rendered by core, not by the plugin, so a
+  plugin cannot accidentally ship a two-state field.
+- `HOST_MASSEDIT_APPLY` — receives the host id list and the **resolved**
+  actions for the plugin's own keys, already reduced to *leave alone* / *set
+  value* / *clear*. A plugin never parses the sentinel, because there is no
+  sentinel.
+
+**The gap this names, precisely.** The ABI already has a bulk **read** seam and
+a bulk **delete** seam and no bulk **edit** seam. `API_MASSDATA_MAPPING`
+(`Route.php:3188`, `:4785`) lets a plugin decorate a list result for a whole
+page of rows; `DELETEMASS_API` (`Route.php:8722`) lets it participate in a
+cascading delete over a set. Between them sits the operation neither covers —
+changing a value across a set — and there is nothing. Every editing extension
+point a plugin has (`HOST_ADD_FIELDS`, `HOST_EDIT_SUCCESS`, `GROUP_ADD_FIELDS`,
+`GROUP_EDIT_SUCCESS`) is a per-object edit with a loop behind it.
+
+That hole is why `AddOUGroup` exists as a separate file from `AddOUHost` at
+all: there was no other way to say "set this across many". Naming the gap is
+half the decision; `HOST_MASSEDIT_*` is the other half, and it is the shape the
+two neighbouring seams already imply.
+
+Two consequences follow, and the second is a genuine open scope question:
+
+- `AddLocationGroup.php` and `AddOUGroup.php` become redundant — roughly 560
+  lines across two plugins — as does the group-side half of any third-party
+  plugin that copied the pattern.
+- **Removing them is follow-up work in `fog-plugins`, not part of this.** The
+  core change is additive: `HOST_MASSEDIT_*` can ship while the group hooks
+  still work. Deleting them is a separate PR against `fog-plugins` gated on
+  Decision 10's sequencing — the group page's own imperative tabs and the
+  plugins' group tabs are the same deprecation and should be removed in the
+  same release, or the group page ends up with an OU tab and no image tab,
+  which is worse than either end state.
+
+### 14. Retiring persistentgroups means dropping a trigger, not deleting a directory
+
+Once the split lands the plugin compensates for a defect that no longer exists.
+Retirement is not `rm -rf`, for a reason that is specific and serious.
+
+**A server that installed it has a live trigger in its database, and removing
+the plugin does not drop it.** Bundled plugins are fetched into
+`packages/web/lib/plugins` (`lib/common/functions.sh:3143`), which is inside
+`$webdirdest` and is `rm -rf`'d by `configureHttpd()` on every upgrade. So
+deleting the plugin from `fog-plugins` does remove the code. It does not touch
+the trigger. The trigger keeps copying template-host settings onto every new
+group member, forever, silently, long after the plugin that created it is gone
+— and unlike the stale `site` plugins row that schema 399 cleaned up, this one
+is **active rather than cosmetic**.
+
+So an upgrade step must `DROP TRIGGER IF EXISTS \`persistentGroups\`` and
+retire the `plugins` row, **on schema 399's evidence gate pattern**: read table
+facts a 1.5-origin database can actually carry, not a column whose value
+depends on which branch counted the steps. Step 399's own comment is the
+argument — step 334 tried to retire the `site` row by reading
+`plugins.pLocation`, which is a rename of `pAnon3`, which 1.5 never wrote, so
+the gate matched the empty string on every upgraded row and the DELETE was
+unreachable. A step runs once and cannot be corrected in place.
+
+Here the evidence is easier than it was for `site`, because the trigger is
+itself the fact:
+
+```sql
+SELECT COUNT(*) FROM information_schema.TRIGGERS
+WHERE TRIGGER_SCHEMA = DATABASE() AND TRIGGER_NAME = 'persistentGroups';
+```
+
+`TRIGGER_SCHEMA = DATABASE()` and not a literal, which is also the fix for a
+latent bug in the plugin: its own location-copy branch tests
+`table_schema = 'fog'` hardcoded (`PersistentGroupsManager.php:56`), so on any
+server whose database is not named `fog` that branch has silently never run.
+
+The step drops the trigger unconditionally (`IF EXISTS` makes it a no-op on a
+server that never installed the plugin) and deletes the `plugins` row only when
+the trigger was actually there or the row names a plugin whose code no longer
+ships.
+
+**One risk that the drop alone does not close.** The external plugin root
+`/opt/fog/plugins` is "never touched" by the installer
+(`lib/common/functions.sh:2250`, ADR 0009). An admin who copied
+`persistentgroups` there keeps the files across the upgrade, and the plugin's
+`install()` re-creates the trigger on demand. Dropping a trigger is not
+idempotent against a re-install. The cheap mitigation is for core to refuse to
+install a plugin on a retirement list; the alternative is to accept it and say
+so in the release notes. Either is defensible; silently doing neither is not.
+
+### 15. The trigger has been copying a domain password between hosts, and retirement says so
+
+`hostADPass` is in the copied column list (`PersistentGroupsManager.php:48`).
+On every server running this plugin, adding a host to a group has copied the
+template host's Active Directory join password onto it — in the database, below
+the PHP layer, with no audit row, since the plugin shipped.
+
+**This belongs in the release notes for the retirement, in plain language, and
+not only in a changelog line.** The reasoning is the project's own: `Redaction`
+exists because two credential leaks landed in one week and both had an opt-in
+registry somebody forgot to add to (`Auth/Redaction.php:28-38`). A mechanism
+that has been propagating a domain credential for a decade is not a smaller
+version of that; it is a larger one, and the only reason it does not appear in
+the audit trail is that it never went through PHP.
+
+What the note should say, and its limits: the password was copied **between
+hosts within one FOG server's database**, from a host the admin designated by
+naming it after the group. It was not transmitted anywhere new and it was
+already readable to anything that could read the `hosts` table. The reason to
+say it out loud anyway is that an admin who is rotating a domain join account
+needs to know that the credential propagated to hosts they never edited, and
+nothing in the UI would have told them. This is a **notification**, not an
+advisory; whether it warrants more than that is the maintainer's call and is
+flagged as such rather than decided here.
+
+### 16. Groups, not tags
+
+Both are many-to-many sets of hosts, so the data model does not discriminate.
+The real difference is editing direction and semantics, and both readings
+deserve stating.
+
+**The reading that favours tags.** Group membership is edited from the group
+side. "Add 40 hosts to 3 groups" is three trips through Group Management;
+"apply 3 tags to 40 hosts" is one selection and one action. After this ADR
+groups get *heavier* — they own snapins, printers, an order column and a
+resolution semantics — and a heavy object is a poor fit for "label these forty
+machines ex-lab-B". People will make forty tags and will not make forty groups.
+That last observation is true and is the strongest argument on this side.
+
+**The reading that wins.** The complaint is entirely about **editing
+direction**, and editing direction is a UI affordance, not an entity.
+
+1. The host list **already has** "Add to group" on the same selection gate
+   (`fog.host.list.js:2`, `:394`). The tag workflow half-exists. What is
+   missing is *remove from group* and *apply several at once* — which is an
+   extension of one existing modal, not a new object.
+2. "Groups get heavy" cuts the other way once you ask what heavy means. A group
+   with no snapins and no printers **is** a tag: one row in `groups`, N rows in
+   `groupMembers`, zero behaviour. The weight is opt-in and its default is
+   nothing. Forty label-groups cost forty rows.
+3. **A second entity doubles the semantics, not just the storage.** The day
+   tags exist, somebody asks whether a tag can carry a snapin. If no, tags and
+   groups differ only by a rule invisible in the UI, and every admin will pick
+   the wrong one half the time. If yes, there are two group systems and
+   Decision 8's single resolver has to merge them.
+4. The bill for a second entity is measurable, because absorbing the `site`
+   plugin paid it recently: `Route::$validClasses` (52 entries,
+   `Route.php:562`), `$nonUniqueNameClasses`, the `deletemass` cascade case,
+   `SiteScope::$_nodes`, the permission registry, FK declarations under ADR
+   0031, a page class, five JS files under `management/js/fog/`, saved-filter
+   targets, and the API description. None of that is hard; all of it is real.
+
+**Decision: no tag entity. Build bulk group-membership editing from the host
+list** — add to several groups, remove from several groups, in one action on
+the existing selection gate — and get the tag workflow with one entity.
+
+**What this costs, stated rather than hidden.** "Group" is a bad name for a
+label, and admins will keep asking for tags because the word is wrong, not
+because the model is. The partial mitigation is to make weightlessness visible:
+the group list gets a column showing whether a group grants anything, so
+label-groups read as labels at a glance. That is a mitigation, not an answer,
+and if the asks keep coming after 1.6 the honest response is to revisit this
+decision with usage data rather than to have pre-built the entity.
+
+### 17. No exclusion mechanism, and the loss is real
+
+Under rollup there is no way to say "this host gets the group's snapins except
+S2". Today that is expressible, because everything is a direct row: remove the
+row and it is gone.
+
+**Decision: no exclusion mechanism in this work. "Make another group" is the
+answer, and the capability loss goes in the release notes as a loss.**
+
+Why not build one:
+
+- **Negatives do not compose.** Two groups grant S; one of them excludes this
+  host. Does the host get S? Both answers are defensible and neither is
+  guessable from the UI, which is the CSS-specificity failure mode: a rule
+  system where the answer requires reading the rules rather than looking at the
+  screen.
+- The workaround got cheaper with this change, not more expensive. Before, a
+  second group meant a second bulk copy onto every member. After, a group is a
+  row and a membership list.
+- An exclusion is a third source in the Decision 6 order, and the resolver's
+  value is that its order is short enough to state in one sentence.
+
+Why it is nevertheless a real loss, and asymmetric: **the capability exists
+today by accident** — it is a side effect of the copy semantics being broken in
+the first place — and it disappears the moment the semantics are fixed. An
+admin who has been using "remove the row from the one host" as an exception
+mechanism will find it stops working, and the failure is silent: the snapin
+comes back on the next resolve.
+
+The mitigation that is in scope: the host's snapin tab shows group-granted
+snapins as read-only rows **naming the granting group**, beside the removable
+host-direct ones. The admin sees why the row will not go away and where to go
+to change it. That does not restore the capability; it stops the loss being
+mysterious.
+
+### 18. Existing associations are not migrated, and nothing guesses their provenance
+
+Every upgraded server carries `snapinAssoc` and `printerAssoc` rows that were
+copied from a group years ago. **Nothing distinguishes "chosen directly for
+this host" from "copied from a group in 2019"** — `snapinAssoc` is
+`(saID, saHostID, saSnapinID, saSequence)` and `printerAssoc` is
+`(paID, paHostID, paPrinterID, paIsDefault, paAnon1..5)`
+(`schema-expected.php:760`, `:582`). There is no timestamp, no creator, no
+source.
+
+**Decision: no backfill. Existing direct rows stay direct rows, which is what
+they literally are.**
+
+What that means concretely, and it is less alarming than it sounds:
+
+- On upgrade, every group owns **zero** snapins and **zero** printers, because
+  no group ever did. Every host keeps every row it has. **Behaviour is
+  unchanged for every existing host and every existing group.**
+- The new removal semantics apply to what is granted after the upgrade. Take a
+  host out of a group and the old copied rows stay — which is **exactly what
+  happens today**, so it is not a regression. It is the new promise not
+  reaching back, which is a different and much smaller thing.
+
+**Rejected: infer group ownership from what members currently share.** This is
+the `CONVERT_TZ` sweep that `docs/development/utc-storage-boundary.md` §2.1
+rejects, in a different table. A snapin held by all forty members might be a
+group push or might be forty deliberate choices, and the data cannot tell. The
+inference is unfalsifiable, and the destructive version — create the group row
+*and* delete the host rows — silently removes a snapin from a host that chose
+it directly, the moment that host leaves the group. The non-destructive version
+(create group rows, keep host rows) is a no-op under Decision 7's dedupe and so
+buys nothing but clutter.
+
+**Rejected: a boundary that gates the semantics**, on the model of the UTC
+document's `seBoundary`. It would let the resolver treat pre-upgrade direct
+rows as group-derived and remove them on membership change — but deciding that
+a legacy row *came from* a group is the same unknowable inference, just
+deferred to read time. The UTC boundary works because the question there is
+"how should this value be *interpreted*", and interpretation can be
+conditional. Here the question is "what did the admin *mean*", and there is no
+conditional form of that.
+
+**What replaces a migration: an opt-in, previewable reconciliation the admin
+performs.** A tool on the group page that says *"every member of this group
+holds snapin X directly — promote it to a group snapin and remove the 40 direct
+rows?"*, with the count and the host list shown before anything is written. The
+admin asserts the intent; the software does not guess it. It is reversible —
+re-pushing from the host list restores direct rows — and it is testable, which
+a silent sweep is not. It is also **not required for correctness**, so it can
+ship after the split rather than blocking it.
+
+**Optional, and only for labelling:** a one-row watermark table recording
+`MAX(saID)` and `MAX(paID)` at upgrade, so the UI can mark a direct row as
+"pre-1.6". `saID` and `paID` are `AUTO_INCREMENT`, so a watermark orders
+creation without a timestamp column. Its one caveat is that InnoDB's
+auto-increment counter is not guaranteed monotonic across every restore and
+server-restart path, so an id below the watermark is *evidence* of a legacy row
+and not proof — which is fine for a label and would not be fine for a
+semantics gate, which is the second reason the boundary is not one.
+
+## Consequences
+
+- **`persistentgroups` becomes unnecessary**, and its retirement is a schema
+  step rather than a deletion. The trigger's side effect of *running* snapins
+  on a newly added host has no equivalent in the new model, deliberately:
+  granting a snapin is not tasking it.
+- **Roughly 560 lines across two bundled plugins become redundant**
+  (`AddLocationGroup`, `AddOUGroup`), plus the group-side half of any
+  third-party plugin that copied the pattern. Removing them is separate work in
+  `fog-plugins`, sequenced with Decision 10.
+- **Storage for the declarative half drops by a factor of the membership.** Ten
+  snapins on a four-hundred-host group is ten rows instead of four thousand,
+  and the change to a group's snapins is one write instead of four thousand.
+- **A group edited mid-run does not change a task in flight, and people will be
+  surprised.** This is the documentation obligation in Decision 4 and it is the
+  most likely support question this change generates.
+- **ADR 0001 becomes half-true and stays in force.** Its tri-state derivation
+  is still how the group page reports member state for modules; its premise
+  that a group owns nothing is no longer true for snapins and printers. The
+  file gets an amendment note rather than a rewrite, because the module
+  asymmetry it argues for is what Decision 3 relies on.
+- **`GROUP_SHARED_STATE.md` becomes the mass edit document.** Most of it
+  survives the move — the no-clobber convention becomes the three-state
+  convention (Decision 11), the `Hosts: (varies)` hint becomes the selection
+  hint — and the sections describing snapins and printers as derived coverage
+  are replaced rather than edited.
+- **One new ABI surface (`HOST_MASSEDIT_*`) with no deprecation window
+  required.** ADR 0017 records that "there is no shipped 1.6 plugin ABI", so
+  this is free before 1.6.0 and expensive after it. That is an argument about
+  *when*, and it is made in the proposal.
+
+## Alternatives considered
+
+**Keep the copy semantics and fix the symptom — re-push a group's settings when
+a host joins.** This is the persistentgroups design with the string-equality
+coupling replaced by something sane, and it is the smallest change that closes
+the reported bug. Rejected because it does not close the *other* half: removal
+still does nothing, a host taken out of a group keeps everything, and the
+group's state is still unknowable from the group's own rows. It would also make
+the group page's tri-state derivation permanent, which is a lot of machinery
+whose only job is to compensate for the model.
+
+**Move everything to the group, including the imperative columns.** Uniform and
+tempting. Rejected because a host has one `hostImage`, and two groups granting
+different images has no correct answer — the resolver would need a conflict
+policy for exactly the fields where a conflict is a configuration error rather
+than a union. Decision 1's test exists to keep those fields out.
+
+**Copy on join, evaluate on read — both.** Rejected as the worst of the two: it
+has the copy's staleness *and* the resolver's indirection, and when they
+disagree there is no way to say which is right.
+
+**Give `snapinAssoc` a provenance column and migrate.** A `saSourceGroupID`
+would make removal semantics work on existing data. Rejected because the column
+can only be populated by the inference Decision 18 rejects — there is no
+provenance to record retroactively, only a guess to write down, and writing a
+guess into a column makes it look like a fact.
+
+**Build the exclusion mechanism now, before anyone asks.** Rejected per
+Decision 17; the composition rule is the problem, not the storage.
+
+**Build tags.** Rejected per Decision 16, with the counter-argument recorded
+rather than dismissed.
+
+## The claim that would hurt most if it is false
+
+**That `snapinTasks` is already a sufficient snapshot** (Decision 4).
+
+Everything about the snapin half is sized on the assumption that task creation
+already materializes an ordered per-host list into a table that the running
+task reads, so the change is only to the source of that list. If the client or
+`service/snapins.checkin.php` re-reads `snapinAssoc` at run time for anything
+beyond the task rows — a re-resolve, a "has this host still got this snapin"
+check, a fallback when the job is missing — then a group edited mid-run *does*
+change a task in flight, Decision 4 is a lie, and the snapin half needs a
+genuine snapshot table rather than a redirected read.
+
+It is checkable in an afternoon and it is UNKNOWN-2 in the proposal. Nothing
+else here is load-bearing in the same way: if `groupName` turns out not to be
+unique the resolver's third tiebreak starts earning its keep, which is why it
+is there; if the trigger's duplicate-key behaviour is different from the
+inference, the retirement step is unchanged.

--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -810,8 +810,46 @@ requiring `group.create` means anyone who may label hosts may also create
 groups. The membership editor should require `group.create` only when
 `groups_new[]` is non-empty, and something narrower otherwise.
 
-That is an **access-control change**, so it is named here and left open rather
-than decided in passing.
+**Decided: `group.create` only when `groups_new[]` is non-empty; membership
+editing behind `group.edit`.**
+
+`group.edit`, and not a new `group.assign`, because the permission registry has
+a **fixed action vocabulary per node** — `coreRegistry()` declares
+`'group' => ['view', 'create', 'edit', 'delete', 'task']`
+(`Authorization.php:496`) and permissions are `<node>.<action>` strings (ADR
+0005). A sixth action for one endpoint would be the first node in the registry
+with a bespoke verb, and the thing it describes is not bespoke: **adding a host
+to a group is editing the group.** The membership rows are the group's.
+
+It also avoids an upgrade regression a new permission would create. Every
+existing role would lack `group.assign` on the day it shipped, so bulk
+membership editing would stop working for everyone holding `group.edit` until
+an admin went round the roles — a silent loss of a capability people already
+have, to gain a distinction nobody asked for.
+
+`host.edit` was the other candidate and is rejected: it would let anyone who
+can rename a host also rewrite what every group contains, which is the wider
+grant, not the narrower one.
+
+So the endpoint checks two permissions rather than one, and which it needs
+depends on the request body:
+
+| Request | Requires |
+|---|---|
+| add/remove existing hosts to/from existing groups | `group.edit` |
+| the same, plus `groups_new[]` naming a group that does not exist | `group.edit` **and** `group.create` |
+
+That is a **narrowing** for the common case — today's endpoint demands
+`group.create` for all of it — so a role holding `group.edit` but not
+`group.create` gains bulk membership editing it could not previously reach,
+and no role loses anything. Both checks are inside the handler rather than in
+`SUB_OVERRIDES`, because the answer depends on the body and a route-level
+override can only name one permission; that is the same reasoning
+`savedfilters` records for its own `null` entry (`Authorization.php:289`).
+
+The existing `SUB_OVERRIDES['host']['savegroup'] => 'group.create'` entry stays
+as the floor until the handler is split, so nothing is loosened before the
+narrower check exists to replace it.
 
 **5. The group list shows what a group grants.**
 

--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -250,6 +250,19 @@ resolvePrinters(array $hostIDs): array  // hostID => ['printers' => [...], 'defa
 The single-host client path calls it with a one-element array. The group task
 path calls it with the whole membership. Neither gets its own sort.
 
+**It reads the association tables directly, not through their managers.**
+`FOGController::buildQuery()` walks `$databaseFieldClassRelationships`
+*transitively* and folds any fourth-element filter into the WHERE rather than
+the ON, so every query whose class chain reaches `Host` picks up
+`` AND `hostMAC`.`hmPrimary` = '1' `` from `Host`'s own
+`MACAddressAssociation` declaration — which turns the LEFT JOIN into an
+effective inner one and **silently drops every host with no primary MAC**.
+Measured on the 1.5 lab: a membership lookup returned 95 where the raw
+`COUNT(*)` on the association table was 1000. There is no flag that suppresses
+it; the fix used elsewhere (PR #1233) was to read the association table
+directly. A resolver that silently omits hosts is a printer resolver that
+strips their printers, so this is not a performance note.
+
 Proposed home: a new autoload-only bucket `FOG\Assign\`. The bucket is not
 load-bearing — `FOG\Util\` would do — but `Auth/SiteScope.php` is the model for
 "a non-model class that owns one rule", and putting it in `Items/` next to the
@@ -621,23 +634,53 @@ filterable.**
 
 Not a comma-joined string. Chips, because the unit an admin acts on is one
 label and they need to see at a glance which of several a host carries. The
-column does not exist today (`HostManagement.php:114-169` enumerates the
-header set) and, more to the point, **the grid has no per-column search UI at
-all** — its own comment says so, and says sorting is the substitute
-(`HostManagement.php:150-153`). So "filterable" is a genuinely new capability
-on this grid, not a column definition.
+column does not exist today — `HostManagement.php:114-169` enumerates the
+header set and there is no groups entry.
 
-The mechanism it should use already exists and is documented with its reasoning:
-the site boundary is pushed into the list query as a subquery ANDed into the row
-query, the filter count *and* the total count, precisely because `complex()`
-applies the `LIMIT` before any row-level filtering and a post-filter therefore
-returns empty pages and lying counts (`Route.php:3149-3172`). A group filter has
-exactly that shape — `hostID IN (SELECT gmHostID FROM groupMembers WHERE
-gmGroupID IN (...))` — and must be applied the same way, never by filtering the
-returned page.
+**The filtering framework already exists, and the constraint is that it is
+column-backed.** Every grid gets a **Filter** button (SearchBuilder) and a
+**Column search** header row, server-parsed in
+`FOGManagerController::filter()` — #1471/#1476/#1477, on this branch. The host
+list opts into nothing; `fog.filters.js` is generic and it gets both for free.
+(The comment at `HostManagement.php:150-153` still says "this grid has no
+per-column search UI". It is stale, it predates that work, and it should be
+corrected when this column lands — it is exactly the kind of comment that gets
+read as current.)
 
-The rendering half is cheap and also already has its mechanism: `relColumn()`
-takes a `prime` callback that receives every row on the page at once
+What that framework cannot do is the thing this requirement needs.
+`_sbCriterion()` resolves a criterion to `` `$column['db']` `` and returns
+empty when a column has no `db`, or carries `removeFromQuery` or `nosearch`
+(`FOGManagerController.php:1050-1082`); the type comes from
+`searchBuilderType()` → `columnType()`, which reads the schema manifest for a
+**real column of a real table** (`FOGBase.php:5733`). A groups column has no
+backing scalar on `hosts`. It is a relationship, and the filter path has never
+had to express one.
+
+So requirement 1 is not "build filtering" and it is not "add a column". It is
+**teach the existing filter path its first relationship column**: the column
+contract grows an optional SQL form — a subquery expression `_sbCriterion()`
+uses in place of `` `db` `` — plus a `searchBuilderType()` answer for it. That
+is a change to a shared helper every grid runs through, so it is plan-first work
+in its own right and it sets the pattern every later relationship filter will
+copy.
+
+Two constraints on that expression, both already learned here:
+
+- **It goes into the query, not onto the page.** `complex()` applies the
+  `LIMIT` before any row-level filtering, which is why the site boundary is
+  passed as a subquery ANDed into the row query, the filter count *and* the
+  total count (`Route.php:3149-3172`). A post-filter returns empty first pages
+  and counts describing rows the caller cannot see. A groups filter is the same
+  shape — `hostID IN (SELECT gmHostID FROM groupMembers WHERE gmGroupID IN
+  (...))` — and inherits the same rule.
+- **Every binding it emits must be named by the clause it emits.** `sqlexec()`
+  binds every entry of `$bindings` to all three of `complex()`'s queries, so an
+  unreferenced binding makes PDO refuse the statement and the whole list answers
+  HTTP 406. That shipped once already, in `_sbDate()`, and broke exactly the two
+  conditions the feature existed for. Bind inside the branch that names it.
+
+The rendering half is cheap and already has its mechanism: `relColumn()` takes
+a `prime` callback that receives every row on the page at once
 (`Route.php:7667`), so the chips cost one extra query per page rather than one
 per host.
 
@@ -847,11 +890,13 @@ semantics gate, which is the second reason the boundary is not one.
   required.** ADR 0017 records that "there is no shipped 1.6 plugin ABI", so
   this is free before 1.6.0 and expensive after it. That is an argument about
   *when*, and it is made in the proposal.
-- **The host list grows its first per-column filter.** Decision 16a's groups
-  column is the first thing on that grid anyone can filter *by* rather than
-  sort by, and the mechanism it establishes — a subquery ANDed into the row
-  query and both counts, on `scopedObjectWhere()`'s pattern — is the one every
-  later filterable association column should reuse.
+- **The filter path gains its first relationship column.** Everything it
+  filters today is a real column of a real table, resolved through
+  `$column['db']` and typed from the schema manifest. Decision 16a's groups
+  column is the first that is neither, so the column contract grows an optional
+  SQL form — and that is a change to a helper every grid runs through, whose
+  shape every later relationship filter will copy. It is the one piece of this
+  ADR that is plan-first work on its own account.
 - **`saveGroup()` gets a CSRF check and an object-scope bound.** Both are
   pre-existing gaps this ADR does not create; it promotes the endpoint, which
   is why closing them is inside the work rather than beside it.

--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -7,6 +7,14 @@ none in this pass. The sizing, the evidence behind every claim, and the
 questions that need a lab to settle are in
 [`docs/development/group-split.md`](../development/group-split.md).
 
+**Verified against the lab 2026-09-01** (1.6 server, `10.255.20.1`): Decision 4
+holds — `snapinTasks` is already a sufficient snapshot, proven in both
+directions, so the snapin half needs no new table. Decision 9 was **revised**
+after reading the shipped `fog-client` (0.13.0): the failure path is already
+fail-safe at both ends, and the real rule is narrower than the first draft's.
+Decision 16a's two named gaps on `saveGroup()` are **confirmed real**. Evidence
+and the remaining open items are in the proposal's §5.
+
 **Decision 16 (groups become the tag concept, presented as tags) is the
 maintainer's decision, not a derivation.** It is recorded with its argument and
 with the rejected alternative stated in full. Decision 16a's five presentation
@@ -277,30 +285,66 @@ errs by returning nothing does not fail to add a printer — it strips printers
 from every machine that polls, one machine at a time, for as long as nobody
 notices.
 
-Today's endpoint conflates the two cases, and it does so under the same key.
-A host with no printers gets `['error' => 'np', 'printers' => []]`
-(`PrinterClient.php:72`); an exception anywhere in `json()` is caught by
-`FOGClient::__construct()` and becomes `['error' => <message>]` with **no
-`printers` key at all** (`FOGClient.php:234`). So the failure shape is already
-the safe one — a response with no `printers` key — and the success-but-empty
-shape is already distinguished by carrying `printers` explicitly. What is wrong
-is only that both are spelled `error`, which invites a client to branch on the
-wrong thing.
+Today's endpoint conflates the two cases under one key. A host with no printers
+gets `['error' => 'np', 'printers' => []]` (`PrinterClient.php:72`); an
+exception anywhere in `json()` is caught by `FOGClient::__construct()` and
+becomes `['error' => <message>]` with **no `printers` key at all**
+(`FOGClient.php:234`).
 
-So:
+**The shipped client was read rather than assumed** — `fog-client` `master` @
+`610ad5f` (0.13.0), `Modules/PrinterManager/PrinterManager.cs:60-121` — and it
+changes what this decision has to say.
+
+```csharp
+if (data.Error && data.ReturnCode.Equals("np", StringComparison.OrdinalIgnoreCase))
+{
+    RemoveExtraPrinters(new List<Printer>(), msg, installedPrinters);   // remove-all
+    return;
+}
+if (data.Error) return;                                    // <-- the fail-safe
+if (!data.Encrypted) { ...; return; }
+RemoveExtraPrinters(msg.Printers, msg, installedPrinters);
+```
+
+**The fleet-wide strip this decision was written to prevent cannot happen with
+this client.** A thrown resolver produces `data.Error` with a `ReturnCode` that
+is the exception text, and `if (data.Error) return;` fires before anything
+touches a printer. The server's failure shape and the client's failure handling
+were already aligned; nobody had written down that they were.
+
+So the rules stand, and one of them stands for a different reason than the
+first draft of this ADR gave:
 
 - **The resolver throws on failure. It never returns an empty list to mean
-  failure.** A caught exception yields a body with no `printers` key, which no
-  correct client may read as "remove everything".
-- **"This host has no printers" stops being an `error`.** It becomes an
-  ordinary success carrying `printers: []` and an explicit flag. `error` is
-  reserved for "I could not answer".
-- **The mode gate stays and is documented as the blast radius.** Only `ar`
-  removes. Under `a` FOG manages only the printers it added, and under `0`
-  nothing. That narrows the danger but does not remove it, and it is a client-
-  side behaviour this repository cannot verify — see UNKNOWN-4.
+  failure.** Not "or printers get stripped today" — this client will not. The
+  real rule is sharper: **never let a failure be spelled `np`.** That one
+  string, matched case-insensitively against `ReturnCode`, is the *only*
+  removal-on-empty trigger in the client, and it is indistinguishable from the
+  legitimate empty case. A resolver that fails and happens to report `np` does
+  strip the fleet. Everything else is caught.
+- **"This host has no printers" stops being an `error`** and becomes an
+  ordinary success carrying `printers: []` with an explicit flag. Traced
+  through the client, this is safe: no error means `data.Error` is false, the
+  encryption guard passes, and `RemoveExtraPrinters([], …)` removes the same
+  set under `ar`. **Safe by that trace, not by design** — see the risk section
+  at the end of the proposal. It changes one thing on the wire: the `np` branch
+  sits *above* the `!data.Encrypted` guard, so today the empty-case removal
+  happens on an unencrypted response and afterwards it would not. That is an
+  improvement and it is a behaviour change; it goes in the release notes, and
+  the safest shipping order keeps `np` alongside the new field for a release.
+- **The mode gate stays and is documented as the blast radius, which is wider
+  than "the printers FOG added".** Under `ar`, `RemoveExtraPrinters` removes
+  **every installed printer** not in the resolved list, FOG's or not. Under `a`
+  it removes only names present in `AllPrinters` — the server's entire printer
+  catalogue, sent on every response — so mode `a`'s notion of "FOG-managed" is
+  *inferred fresh from the catalogue each time* and is not persisted client
+  side. A change to what the catalogue contains is therefore a change to what
+  mode `a` removes.
+- **One behaviour remains unobserved.** The above is source-verified and has
+  not been watched happen: no mode-`ar` host with steady printers was available
+  (UNKNOWN-4). The printer resolver should not ship on the reading alone.
 
-Every one of these is the same shape as `inScopeWhere()`'s tri-state return
+The first of these is the same shape as `inScopeWhere()`'s tri-state return
 (`SiteScope.php:498`), where the docblock spells out that the *falsy* value is
 the permissive one "on purpose" so that a caller writing the natural
 `if (!$x) { skip }` skips only the case where skipping is correct. The printer
@@ -748,8 +792,26 @@ skips the first one's validation is the wrong thing to promote.
 Both are pre-existing and neither is created by this ADR. They are named here
 because this decision promotes that endpoint from a convenience to the main
 way membership is edited, and promoting an unbounded, un-CSRF'd write is not
-something to discover afterward. Confirmation procedure in the proposal
-(UNKNOWN-6) — this is a code reading, not an observed request.
+something to discover afterward.
+
+**Both confirmed on the lab, 2026-09-01** (proposal §5, UNKNOWN-6): the CSRF-
+less POST returned `202` where the same shape to `deployMulti` returned `403`,
+and a site1-scoped user added a host from another site, where `deployMulti`
+refused the same id.
+
+**And a third thing the code reading had missed, which is a decision rather
+than a fix.** `saveGroup`'s required permission is **`group.create`**, not
+`host.edit` — `Authorization::SUB_OVERRIDES['host']['savegroup']`
+(`Authorization.php:157`) overrides what `_subToAction()` would derive. That is
+correct for the endpoint as it exists, because it can mint groups from
+`groups_new[]`. It is **wrong for the endpoint this decision asks for**: adding
+forty existing hosts to three existing groups is not a group creation, and
+requiring `group.create` means anyone who may label hosts may also create
+groups. The membership editor should require `group.create` only when
+`groups_new[]` is non-empty, and something narrower otherwise.
+
+That is an **access-control change**, so it is named here and left open rather
+than decided in passing.
 
 **5. The group list shows what a group grants.**
 

--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -2,8 +2,22 @@
 
 ## Status
 
-proposed. No code has been written for it, and this ADR deliberately proposes
-none in this pass. The sizing, the evidence behind every claim, and the
+**accepted** 2026-09-01. No code has been written for it yet — this ADR
+deliberately proposed none in the pass that produced it — and **the whole
+change targets 1.6.0**, not a 1.6.0/1.6.x split.
+
+The proposal's own earlier recommendation was to split it across two releases,
+and the maintainer overturned that with an argument this ADR records because it
+is the better one: there is no RC yet, and the items used to justify deferring
+the declarative half were exactly the ones no amount of pre-RC review can
+settle. An RC exists to surface what neither code review nor a lab can see, so
+holding work back from it to avoid shipping findable bugs inverts its purpose.
+What makes that safe here rather than merely faster is specific — the shipped
+client is fail-safe at both ends of the printer path (Decision 9), so an RC
+exposes a wrong printer list rather than a stripped fleet, and Decision 18
+migrates nothing, so an RC-stage rethink strands no data. Build order and its
+constraints are in the proposal's §2.5; Decision 10's sequencing is unchanged
+and becomes a merge-order constraint rather than a release boundary. The sizing, the evidence behind every claim, and the
 questions that need a lab to settle are in
 [`docs/development/group-split.md`](../development/group-split.md).
 

--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -7,6 +7,12 @@ none in this pass. The sizing, the evidence behind every claim, and the
 questions that need a lab to settle are in
 [`docs/development/group-split.md`](../development/group-split.md).
 
+**Decision 16 (groups become the tag concept, presented as tags) is the
+maintainer's decision, not a derivation.** It is recorded with its argument and
+with the rejected alternative stated in full. Decision 16a's five presentation
+requirements are **binding parts of that decision**, not follow-up work: the
+decision is only correct if a group is cheap to apply in bulk.
+
 Amends [ADR 0001](0001-group-association-state.md) rather than superseding it:
 0001's tri-state derivation is still how the group page reports *member* state
 after this change, but its opening sentence — "a group owns no associations of
@@ -531,54 +537,190 @@ nothing in the UI would have told them. This is a **notification**, not an
 advisory; whether it warrants more than that is the maintainer's call and is
 flagged as such rather than decided here.
 
-### 16. Groups, not tags
+### 16. Groups become the tag concept, and are presented as tags
 
-Both are many-to-many sets of hosts, so the data model does not discriminate.
-The real difference is editing direction and semantics, and both readings
-deserve stating.
+No new entity. **A group is the tag**, and the UI presents it as one.
 
-**The reading that favours tags.** Group membership is edited from the group
-side. "Add 40 hosts to 3 groups" is three trips through Group Management;
-"apply 3 tags to 40 hosts" is one selection and one action. After this ADR
-groups get *heavier* — they own snapins, printers, an order column and a
-resolution semantics — and a heavy object is a poor fit for "label these forty
-machines ex-lab-B". People will make forty tags and will not make forty groups.
-That last observation is true and is the strongest argument on this side.
+**The argument is the schema.** A tag is a set of hosts you filter and select
+by. That is precisely what group membership already is, and `groupMembers` says
+so in three columns:
 
-**The reading that wins.** The complaint is entirely about **editing
-direction**, and editing direction is a UI affordance, not an entity.
+```sql
+CREATE TABLE `groupMembers` (
+  `gmID` int(11) NOT NULL AUTO_INCREMENT,
+  `gmHostID` int(11) NOT NULL,
+  `gmGroupID` int(11) NOT NULL,
+  PRIMARY KEY (`gmID`),
+  UNIQUE KEY (`gmHostID`,`gmGroupID`), ...
+)
+```
 
-1. The host list **already has** "Add to group" on the same selection gate
-   (`fog.host.list.js:2`, `:394`). The tag workflow half-exists. What is
-   missing is *remove from group* and *apply several at once* — which is an
-   extension of one existing modal, not a new object.
-2. "Groups get heavy" cuts the other way once you ask what heavy means. A group
-   with no snapins and no printers **is** a tag: one row in `groups`, N rows in
-   `groupMembers`, zero behaviour. The weight is opt-in and its default is
-   nothing. Forty label-groups cost forty rows.
+A plain many-to-many join with **no attributes at all** — no ordering, no
+state, no metadata. That is a labelling table and nothing else. Everything
+heavier was hung off it later, and hung off it *because it was the only place
+to hang things*: a group was the only object in FOG that meant "these hosts",
+so every feature needing "these hosts" grew a group tab, and each one wrote its
+result onto the member rows because the group had nowhere of its own to keep
+it. That accumulation is the defect this ADR is about.
+
+So the split takes a group **back toward what its schema always looked like**.
+Adding a second overlapping set-of-hosts concept alongside it would be solving a
+**presentation gap with a data model** — introducing an entity, its tables, its
+routes, its permissions and its scope rules to fix the fact that one existing
+entity is edited from the wrong side and rendered in a dropdown.
+
+**Rejected: a separate `tags` entity.** Stated rather than omitted, because the
+case for it is not weak.
+
+The case: group membership is edited from the group side, so "add 40 hosts to 3
+groups" is three trips through Group Management, while "apply 3 tags to 40
+hosts" is one selection and one action. And after this ADR groups get *heavier*
+— they own snapins, printers, an order column and a resolution semantics — and
+a heavy object is a poor fit for "label these forty machines ex-lab-B". People
+will make forty tags and will not make forty groups. That last observation is
+true and is the strongest thing on that side.
+
+Why it loses anyway:
+
+1. **The complaint is editing direction and rendering, and neither is an
+   entity.** Both are fixable on the object that already exists, and Decision
+   16a makes fixing them binding.
+2. **Weight is opt-in and its floor is zero.** A group with no snapins and no
+   printers *is* a tag: one row in `groups`, N rows in `groupMembers`, no
+   behaviour. Forty label-groups cost forty rows. The heaviness people will
+   feel is the dropdown, not the schema.
 3. **A second entity doubles the semantics, not just the storage.** The day
-   tags exist, somebody asks whether a tag can carry a snapin. If no, tags and
-   groups differ only by a rule invisible in the UI, and every admin will pick
-   the wrong one half the time. If yes, there are two group systems and
-   Decision 8's single resolver has to merge them.
-4. The bill for a second entity is measurable, because absorbing the `site`
-   plugin paid it recently: `Route::$validClasses` (52 entries,
-   `Route.php:562`), `$nonUniqueNameClasses`, the `deletemass` cascade case,
-   `SiteScope::$_nodes`, the permission registry, FK declarations under ADR
-   0031, a page class, five JS files under `management/js/fog/`, saved-filter
-   targets, and the API description. None of that is hard; all of it is real.
+   tags exist somebody asks whether a tag can carry a snapin. If no, tags and
+   groups differ only by a rule invisible in the UI and every admin picks wrong
+   half the time. If yes, there are two group systems and Decision 8's single
+   resolver has to merge them — which is the same drift failure Decision 8
+   exists to prevent, reintroduced at the entity level.
+4. **The bill is measurable**, because absorbing the `site` plugin paid it
+   recently: `Route::$validClasses`, `$nonUniqueNameClasses`, the `deletemass`
+   cascade case, `SiteScope::$_nodes`, the permission registry, FK declarations
+   under ADR 0031, a page class, five JS files, saved-filter targets and the
+   API description. None of it is hard; all of it is real; and none of it moves
+   a host into a group any faster.
 
-**Decision: no tag entity. Build bulk group-membership editing from the host
-list** — add to several groups, remove from several groups, in one action on
-the existing selection gate — and get the tag workflow with one entity.
+**Rejected: do nothing and let people use groups as they are.** This is what
+happens today, and what happens today is that people do not use groups for
+labelling, because applying one to forty hosts is unpleasant enough that they
+keep the information somewhere else. That is the gap tags were being reached
+for. Deciding against tags without closing it decides nothing.
 
-**What this costs, stated rather than hidden.** "Group" is a bad name for a
-label, and admins will keep asking for tags because the word is wrong, not
-because the model is. The partial mitigation is to make weightlessness visible:
-the group list gets a column showing whether a group grants anything, so
-label-groups read as labels at a glance. That is a mitigation, not an answer,
-and if the asks keep coming after 1.6 the honest response is to revisit this
-decision with usage data rather than to have pre-built the entity.
+### 16a. What "presented as tags" requires — binding, not follow-up
+
+These are part of this decision. A group that is correct but unpleasant to
+apply in bulk fails at the thing this decision exists to enable, and the
+failure mode is specific: people keep not using groups for labelling, and the
+gap that tags were reached for comes straight back with the split having made
+groups *heavier* in the meantime.
+
+**1. The host list carries a groups column, rendered as chips, and it is
+filterable.**
+
+Not a comma-joined string. Chips, because the unit an admin acts on is one
+label and they need to see at a glance which of several a host carries. The
+column does not exist today (`HostManagement.php:114-169` enumerates the
+header set) and, more to the point, **the grid has no per-column search UI at
+all** — its own comment says so, and says sorting is the substitute
+(`HostManagement.php:150-153`). So "filterable" is a genuinely new capability
+on this grid, not a column definition.
+
+The mechanism it should use already exists and is documented with its reasoning:
+the site boundary is pushed into the list query as a subquery ANDed into the row
+query, the filter count *and* the total count, precisely because `complex()`
+applies the `LIMIT` before any row-level filtering and a post-filter therefore
+returns empty pages and lying counts (`Route.php:3149-3172`). A group filter has
+exactly that shape — `hostID IN (SELECT gmHostID FROM groupMembers WHERE
+gmGroupID IN (...))` — and must be applied the same way, never by filtering the
+returned page.
+
+The rendering half is cheap and also already has its mechanism: `relColumn()`
+takes a `prime` callback that receives every row on the page at once
+(`Route.php:7667`), so the chips cost one extra query per page rather than one
+per host.
+
+**2. Membership is editable from the host side, in bulk, both directions.**
+
+Add **and remove**, over the list selection, on the same gate as Queue Task /
+Add to Group / Delete. Today membership is add-only from the list and otherwise
+only editable from the group side, which is the whole "three trips through
+Group Management" complaint. Remove is not a nicety: a label you can apply and
+cannot retract is not a label, and its absence is why the current modal reads
+as a group operation rather than a tagging one.
+
+**3. It has to *feel* lightweight, and that is a requirement with a test.**
+
+Chips, typeahead, and create-on-the-fly from the list. Nobody minds twenty
+tags; everybody minds twenty groups in a dropdown. The test this requirement
+has to pass: **applying three labels to forty hosts is one selection and one
+action** — the same sentence that was the argument for tags. If the
+implementation cannot pass that sentence, it has not satisfied this decision.
+
+Two thirds of this already exists and is easy to miss: the list's Add to Group
+modal is already a select2 with `tags: true`, `tokenSeparators`, ajax typeahead
+against `/group/names/`, and a `createTag` handler that badges an unmatched
+term `(new)` (`fog.host.list.js:29-90`). What is missing is remove, multi-group
+clarity, and requirement 4.
+
+**4. Create-and-associate goes through the shared path, not a second one.**
+
+The host **edit** page already does this properly:
+`$.registerCreateAndAssociate('host-group', hostGroupsTable)`
+(`fog.host.edit.js:617`). The helper (`fog.common.js:1761`) POSTs the created
+id to the association tab's own update URL — its docblock is explicit that this
+is "the same call *Add selected* makes, so this is not a second write path" —
+and it is already used by eleven tabs across host, group and site.
+
+The **list** modal does not use it. It posts `groups[]` and `groups_new[]` to
+`sub=saveGroup`, which creates a group from a raw string with
+`->set('name', $group)->addHost($hosts)->save()` and no name-collision check
+(`HostManagement.php:4115-4123`) — where the group page's own rename path does
+check, via `getManager()->exists()` (`GroupManagement.php:733`). So there are
+already two creation paths and the newer one is the looser one.
+
+Reuse the shared helper. This is not tidiness: the list modal is about to
+become the *primary* surface for membership, and a second write path that
+skips the first one's validation is the wrong thing to promote.
+
+**Two defects on that path must be fixed as part of this, not after it.**
+`saveGroup()` (`HostManagement.php:4083`) is a state-changing POST handler and:
+
+- **It performs no CSRF check.** `FOGPageManager` calls `checkAuthAndCSRF()`
+  centrally only when the resolved method takes an `Ajax` or `Post` suffix
+  (`FOGPageManager.php:178-189`); the handler is named `saveGroup`, there is no
+  `saveGroupPost`, and the handler does not call it itself — it is absent from
+  all seven `checkAuthAndCSRF()` call sites in the file. Page *permission* is
+  still checked, because `requirePagePermission()` runs unconditionally on
+  every dispatch (`FOGPageManager.php:195`); CSRF is the gap.
+- **It does not bound the posted host ids to the caller's object scope.**
+  `deployMultiPost()` calls `requirePageObjectScopeMass('host', $hosts)` on the
+  identical shape of input, with the comment "Airtight: one id outside the
+  caller's site scope denies the whole request rather than quietly tasking the
+  rest" (`HostManagement.php:4633`). `saveGroup()` has no equivalent. The
+  central `requirePageObjectScope()` is passed the URL `$id`, of which a
+  list-level action has none.
+
+Both are pre-existing and neither is created by this ADR. They are named here
+because this decision promotes that endpoint from a convenience to the main
+way membership is edited, and promoting an unbounded, un-CSRF'd write is not
+something to discover afterward. Confirmation procedure in the proposal
+(UNKNOWN-6) — this is a code reading, not an observed request.
+
+**5. The group list shows what a group grants.**
+
+A column saying whether a group carries snapins or printers, so a label-group
+reads as a label at a glance and a heavy group reads as heavy. This is the
+cheapest half of making one entity serve both jobs legibly, and without it the
+Group Management list is forty rows that all look identically consequential.
+
+**What this decision costs, stated rather than hidden.** "Group" remains a bad
+name for a label. The model is right and the word is wrong, and no amount of
+chips fixes a noun. If the requests for tags continue after 1.6 with all five
+requirements shipped, that is evidence about the *word*, and the answer is
+renaming or aliasing the concept in the UI — not building the second entity
+this decision rejected.
 
 ### 17. No exclusion mechanism, and the loss is real
 
@@ -705,6 +847,22 @@ semantics gate, which is the second reason the boundary is not one.
   required.** ADR 0017 records that "there is no shipped 1.6 plugin ABI", so
   this is free before 1.6.0 and expensive after it. That is an argument about
   *when*, and it is made in the proposal.
+- **The host list grows its first per-column filter.** Decision 16a's groups
+  column is the first thing on that grid anyone can filter *by* rather than
+  sort by, and the mechanism it establishes — a subquery ANDed into the row
+  query and both counts, on `scopedObjectWhere()`'s pattern — is the one every
+  later filterable association column should reuse.
+- **`saveGroup()` gets a CSRF check and an object-scope bound.** Both are
+  pre-existing gaps this ADR does not create; it promotes the endpoint, which
+  is why closing them is inside the work rather than beside it.
+- **There will be exactly one create-and-associate path for host↔group.** The
+  list modal stops creating groups from raw strings and joins the eleven tabs
+  already using `$.registerCreateAndAssociate()`.
+- **The presentation requirements are not a follow-up and a release that ships
+  the split without them has not delivered this decision.** Decision 16 is only
+  correct if a group is cheap to apply in bulk; the model change alone makes
+  groups heavier and leaves the labelling gap exactly where it was, which is
+  the outcome that made a `tags` entity look necessary in the first place.
 
 ## Alternatives considered
 
@@ -736,8 +894,16 @@ guess into a column makes it look like a fact.
 **Build the exclusion mechanism now, before anyone asks.** Rejected per
 Decision 17; the composition rule is the problem, not the storage.
 
-**Build tags.** Rejected per Decision 16, with the counter-argument recorded
-rather than dismissed.
+**Build a `tags` entity.** Rejected per Decision 16: `groupMembers` is already
+an attribute-free many-to-many labelling table, so a second set-of-hosts
+concept would be solving a presentation gap with a data model. The
+counter-argument is recorded there rather than dismissed, along with what the
+decision costs.
+
+**Decide against tags and stop there.** Rejected as deciding nothing. The
+labelling gap is real and is what made tags look necessary; Decision 16a is the
+half of the decision that closes it, which is why those requirements are
+binding rather than a follow-up.
 
 ## The claim that would hurt most if it is false
 
@@ -752,7 +918,7 @@ check, a fallback when the job is missing — then a group edited mid-run *does*
 change a task in flight, Decision 4 is a lie, and the snapin half needs a
 genuine snapshot table rather than a redirected read.
 
-It is checkable in an afternoon and it is UNKNOWN-2 in the proposal. Nothing
+It is one grep and a three-step lab test — UNKNOWN-2 in the proposal. Nothing
 else here is load-bearing in the same way: if `groupName` turns out not to be
 unique the resolver's third tiebreak starts earning its keep, which is why it
 is there; if the trigger's duplicate-key behaviour is different from the

--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -24,8 +24,16 @@ the proposal had listed (the template subquery's missing `LIMIT` is unreachable
 while `hosts.hostName` is UNIQUE) and sharpened another (the `'fog'` literal is
 a cross-database read, not merely a mis-scoped one).
 
-Evidence and the remaining open items — UNKNOWN-1 and UNKNOWN-5, neither
-blocking — are in the proposal's §5.
+**UNKNOWN-1 is also closed**, read-only against the 1.5-origin install on the
+same box (schema 278, 2079 hosts) as well as 1.6: `groups.groupName` and
+`hosts.hostName` both carry single-column UNIQUE indexes, and both are created
+by schema step 161 rather than only by the manifest. So Decision 6's
+`groupName` tiebreak is safe on upgraded databases, and the retirement step
+needs no index repair.
+
+**UNKNOWN-5** — the cost of the per-id scope check at 400 hosts — is the only
+open item, and it blocks nothing; it decides whether the mass edit needs a
+set-based authorization path. Evidence for all of it is in the proposal's §5.
 
 **Decision 16 (groups become the tag concept, presented as tags) is the
 maintainer's decision, not a derivation.** It is recorded with its argument and

--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -12,8 +12,20 @@ holds — `snapinTasks` is already a sufficient snapshot, proven in both
 directions, so the snapin half needs no new table. Decision 9 was **revised**
 after reading the shipped `fog-client` (0.13.0): the failure path is already
 fail-safe at both ends, and the real rule is narrower than the first draft's.
-Decision 16a's two named gaps on `saveGroup()` are **confirmed real**. Evidence
-and the remaining open items are in the proposal's §5.
+Decision 16a's two named gaps on `saveGroup()` are **confirmed real**, and the
+permission split in 16a.6 is now decided rather than flagged.
+
+Decision 14's retirement case was tested separately, in a throwaway container
+cloned from the live database rather than against the lab: the trigger's
+duplicate-key failures are **fatal to the membership insert**, and the module
+arm is reachable for **98.8% of hosts**, which moves the plugin from "fragile"
+to "substantially non-functional on 1.6 data". The same run refuted one hazard
+the proposal had listed (the template subquery's missing `LIMIT` is unreachable
+while `hosts.hostName` is UNIQUE) and sharpened another (the `'fog'` literal is
+a cross-database read, not merely a mis-scoped one).
+
+Evidence and the remaining open items — UNKNOWN-1 and UNKNOWN-5, neither
+blocking — are in the proposal's §5.
 
 **Decision 16 (groups become the tag concept, presented as tags) is the
 maintainer's decision, not a derivation.** It is recorded with its argument and
@@ -551,9 +563,36 @@ WHERE TRIGGER_SCHEMA = DATABASE() AND TRIGGER_NAME = 'persistentGroups';
 ```
 
 `TRIGGER_SCHEMA = DATABASE()` and not a literal, which is also the fix for a
-latent bug in the plugin: its own location-copy branch tests
-`table_schema = 'fog'` hardcoded (`PersistentGroupsManager.php:56`), so on any
-server whose database is not named `fog` that branch has silently never run.
+real bug in the plugin: its own location-copy branch tests
+`table_schema = 'fog'` hardcoded (`PersistentGroupsManager.php:56`), and
+`information_schema.tables` is **server-global**. So the guard asks about
+whatever database on that server happens to be named `fog`, and the
+unqualified `INSERT INTO locationAssoc` two lines later writes to the
+trigger's *own* database — it tests one database and writes to another.
+Verified in an isolated container 2026-09-01, both directions reachable on a
+box hosting two FOG databases.
+
+**What the retirement note has to reckon with: on 1.6 data the plugin is
+substantially non-functional, not merely fragile.** The `printerAssoc` and
+`moduleStatusByHost` copies carry no `ON DUPLICATE KEY UPDATE`, so a collision
+raises 1062 inside an `AFTER INSERT` trigger and rolls back the
+`INSERT INTO groupMembers` that fired it — the host is not added at all.
+Reproduced in a clone of the live 1.6 database:
+`ERROR 1062 (23000): Duplicate entry '9002-1' for key 'paHostID'` and
+`... '9004-1' for key 'msHostID'`, `groupMembers` empty afterwards in both
+cases.
+
+The module arm is the one that matters, because **85 of 86 hosts (98.8%) on
+that database carry `moduleStatusByHost` rows**. For a group using the template
+convention, adding almost any host fails. Two limits on how far that
+generalises: it only fires for groups that *have* a template host, and it says
+nothing about how often 1.5-era databases populated `moduleStatusByHost` — so
+this is evidence the plugin does not work now, not that it never worked.
+
+That changes the register of the release note. It is not "we removed a
+workaround you were relying on"; it is closer to "we removed a workaround that
+had been failing your group additions with a database error, and the feature it
+was faking is now in core."
 
 The step drops the trigger unconditionally (`IF EXISTS` makes it a no-op on a
 server that never installed the plugin) and deletes the `plugins` row only when
@@ -583,6 +622,16 @@ registry somebody forgot to add to (`Auth/Redaction.php:28-38`). A mechanism
 that has been propagating a domain credential for a decade is not a smaller
 version of that; it is a larger one, and the only reason it does not appear in
 the audit trail is that it never went through PHP.
+
+**Refinement from the reproduction, and it narrows the affected set without
+weakening the case.** The `hosts` column UPDATE is the trigger's *first*
+statement, and a later collision rolls it back with everything else. So the
+password propagated on **clean** adds only — hosts that shared no printer and
+no module override with the template. On the lab clone that is a small
+fraction of adds today; on the 1.5-era databases where this plugin was
+actually used it may have been most of them. The admin cannot tell which from
+the UI, which is exactly why the note is needed: the affected set is
+unknowable from the outside and is not "every host in the group".
 
 What the note should say, and its limits: the password was copied **between
 hosts within one FOG server's database**, from a host the admin designated by

--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -363,18 +363,18 @@ first draft of this ADR gave:
   set under `ar`. **Safe by that trace, not by design** — see the risk section
   at the end of the proposal. It changes one thing on the wire: the `np` branch
   sits *above* the `!data.Encrypted` guard, so today the empty-case removal
-  happens on an unencrypted response and afterwards it would not. That is an
-  improvement and it is a behaviour change; it goes in the release notes, and
+  happens on an unencrypted response and afterward it would not. That is an
+  improvement and it is a behavior change; it goes in the release notes, and
   the safest shipping order keeps `np` alongside the new field for a release.
 - **The mode gate stays and is documented as the blast radius, which is wider
   than "the printers FOG added".** Under `ar`, `RemoveExtraPrinters` removes
   **every installed printer** not in the resolved list, FOG's or not. Under `a`
   it removes only names present in `AllPrinters` — the server's entire printer
-  catalogue, sent on every response — so mode `a`'s notion of "FOG-managed" is
-  *inferred fresh from the catalogue each time* and is not persisted client
-  side. A change to what the catalogue contains is therefore a change to what
+  catalog, sent on every response — so mode `a`'s notion of "FOG-managed" is
+  *inferred fresh from the catalog each time* and is not persisted client
+  side. A change to what the catalog contains is therefore a change to what
   mode `a` removes.
-- **One behaviour remains unobserved.** The above is source-verified and has
+- **One behavior remains unobserved.** The above is source-verified and has
   not been watched happen: no mode-`ar` host with steady printers was available
   (UNKNOWN-4). The printer resolver should not ship on the reading alone.
 
@@ -512,7 +512,7 @@ no-clobber convention core adopted for its own group fields was never extended
 to the plugins beside them.
 
 So **the mass edit form takes plugin-contributed fields with the same
-three-state semantics as core ones**, through a hook pair modelled on the
+three-state semantics as core ones**, through a hook pair modeled on the
 existing `HOST_ADD_FIELDS` / `HOST_EDIT_SUCCESS` shape that both plugins
 already register against (`AddOUHost.php:60-63`):
 
@@ -537,7 +537,7 @@ point a plugin has (`HOST_ADD_FIELDS`, `HOST_EDIT_SUCCESS`, `GROUP_ADD_FIELDS`,
 That hole is why `AddOUGroup` exists as a separate file from `AddOUHost` at
 all: there was no other way to say "set this across many". Naming the gap is
 half the decision; `HOST_MASSEDIT_*` is the other half, and it is the shape the
-two neighbouring seams already imply.
+two neighboring seams already imply.
 
 Two consequences follow, and the second is a genuine open scope question:
 
@@ -601,7 +601,7 @@ raises 1062 inside an `AFTER INSERT` trigger and rolls back the
 `INSERT INTO groupMembers` that fired it — the host is not added at all.
 Reproduced in a clone of the live 1.6 database:
 `ERROR 1062 (23000): Duplicate entry '9002-1' for key 'paHostID'` and
-`... '9004-1' for key 'msHostID'`, `groupMembers` empty afterwards in both
+`... '9004-1' for key 'msHostID'`, `groupMembers` empty afterward in both
 cases.
 
 The module arm is the one that matters, because **85 of 86 hosts (98.8%) on
@@ -684,7 +684,7 @@ CREATE TABLE `groupMembers` (
 ```
 
 A plain many-to-many join with **no attributes at all** — no ordering, no
-state, no metadata. That is a labelling table and nothing else. Everything
+state, no metadata. That is a labeling table and nothing else. Everything
 heavier was hung off it later, and hung off it *because it was the only place
 to hang things*: a group was the only object in FOG that meant "these hosts",
 so every feature needing "these hosts" grew a group tab, and each one wrote its
@@ -715,7 +715,7 @@ Why it loses anyway:
    16a makes fixing them binding.
 2. **Weight is opt-in and its floor is zero.** A group with no snapins and no
    printers *is* a tag: one row in `groups`, N rows in `groupMembers`, no
-   behaviour. Forty label-groups cost forty rows. The heaviness people will
+   behavior. Forty label-groups cost forty rows. The heaviness people will
    feel is the dropdown, not the schema.
 3. **A second entity doubles the semantics, not just the storage.** The day
    tags exist somebody asks whether a tag can carry a snapin. If no, tags and
@@ -732,7 +732,7 @@ Why it loses anyway:
 
 **Rejected: do nothing and let people use groups as they are.** This is what
 happens today, and what happens today is that people do not use groups for
-labelling, because applying one to forty hosts is unpleasant enough that they
+labeling, because applying one to forty hosts is unpleasant enough that they
 keep the information somewhere else. That is the gap tags were being reached
 for. Deciding against tags without closing it decides nothing.
 
@@ -740,7 +740,7 @@ for. Deciding against tags without closing it decides nothing.
 
 These are part of this decision. A group that is correct but unpleasant to
 apply in bulk fails at the thing this decision exists to enable, and the
-failure mode is specific: people keep not using groups for labelling, and the
+failure mode is specific: people keep not using groups for labeling, and the
 gap that tags were reached for comes straight back with the split having made
 groups *heavier* in the meantime.
 
@@ -987,7 +987,7 @@ they literally are.**
 What that means concretely, and it is less alarming than it sounds:
 
 - On upgrade, every group owns **zero** snapins and **zero** printers, because
-  no group ever did. Every host keeps every row it has. **Behaviour is
+  no group ever did. Every host keeps every row it has. **Behavior is
   unchanged for every existing host and every existing group.**
 - The new removal semantics apply to what is granted after the upgrade. Take a
   host out of a group and the old copied rows stay — which is **exactly what
@@ -1022,7 +1022,7 @@ re-pushing from the host list restores direct rows — and it is testable, which
 a silent sweep is not. It is also **not required for correctness**, so it can
 ship after the split rather than blocking it.
 
-**Optional, and only for labelling:** a one-row watermark table recording
+**Optional, and only for labeling:** a one-row watermark table recording
 `MAX(saID)` and `MAX(paID)` at upgrade, so the UI can mark a direct row as
 "pre-1.6". `saID` and `paID` are `AUTO_INCREMENT`, so a watermark orders
 creation without a timestamp column. Its one caveat is that InnoDB's
@@ -1077,7 +1077,7 @@ semantics gate, which is the second reason the boundary is not one.
 - **The presentation requirements are not a follow-up and a release that ships
   the split without them has not delivered this decision.** Decision 16 is only
   correct if a group is cheap to apply in bulk; the model change alone makes
-  groups heavier and leaves the labelling gap exactly where it was, which is
+  groups heavier and leaves the labeling gap exactly where it was, which is
   the outcome that made a `tags` entity look necessary in the first place.
 
 ## Alternatives considered
@@ -1111,13 +1111,13 @@ guess into a column makes it look like a fact.
 Decision 17; the composition rule is the problem, not the storage.
 
 **Build a `tags` entity.** Rejected per Decision 16: `groupMembers` is already
-an attribute-free many-to-many labelling table, so a second set-of-hosts
+an attribute-free many-to-many labeling table, so a second set-of-hosts
 concept would be solving a presentation gap with a data model. The
 counter-argument is recorded there rather than dismissed, along with what the
 decision costs.
 
 **Decide against tags and stop there.** Rejected as deciding nothing. The
-labelling gap is real and is what made tags look necessary; Decision 16a is the
+labeling gap is real and is what made tags look necessary; Decision 16a is the
 half of the decision that closes it, which is why those requirements are
 binding rather than a follow-up.
 
@@ -1137,5 +1137,5 @@ genuine snapshot table rather than a redirected read.
 It is one grep and a three-step lab test — UNKNOWN-2 in the proposal. Nothing
 else here is load-bearing in the same way: if `groupName` turns out not to be
 unique the resolver's third tiebreak starts earning its keep, which is why it
-is there; if the trigger's duplicate-key behaviour is different from the
+is there; if the trigger's duplicate-key behavior is different from the
 inference, the retirement step is unchanged.

--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -111,7 +111,7 @@ has the clause.
 
 Reproduced 2026-09-01 in an isolated container against a clone of the live 1.6
 database — `ERROR 1062 (23000): Duplicate entry '9002-1' for key 'paHostID'`
-and `... '9004-1' for key 'msHostID'`, with `groupMembers` empty afterwards in
+and `... '9004-1' for key 'msHostID'`, with `groupMembers` empty afterward in
 both cases. Full results, including the 98.8% prevalence figure that makes the
 module arm the dominant one, in §5.1 (UNKNOWN-3).
 
@@ -141,7 +141,7 @@ Confirmed 2026-09-01 in a second isolated container holding only `fogtest`: the
 branch was skipped, the membership insert succeeded, and the template's own
 `locationAssoc` row was left alone. The *first* attempt was a false negative —
 `fog` and `fogtest` coexisted in one container and the branch ran from inside
-`fogtest`, which is what exposed the server-global behaviour.
+`fogtest`, which is what exposed the server-global behavior.
 
 **VERIFIED — every snapin task the trigger creates ties at sequence 0.** Line
 86 names four columns and `stSequence` is not among them; the column defaults
@@ -265,7 +265,7 @@ sed -n '36,50p' packages/web/src/Client/PrinterClient.php
 ```
 
 Three modes: `0` no management, `a` FOG-managed only, `ar` FOG handles all
-printers. Only `ar` implies removal. Whether the shipped `fog-client` honours
+printers. Only `ar` implies removal. Whether the shipped `fog-client` honors
 that is UNKNOWN-4 — it is a different repository and not readable from here.
 
 ### 1.7 The snapshot that already exists
@@ -336,7 +336,7 @@ STORED word". That comment is **stale**: it predates #1471/#1476/#1477
 (2026-08-29), which added a SearchBuilder **Filter** button and a **Column
 search** header row to every grid, server-parsed in
 `FOGManagerController::filter()`. All of it is on this branch. The first draft
-quoted the comment as evidence of current behaviour instead of grepping for the
+quoted the comment as evidence of current behavior instead of grepping for the
 mechanism — the comment should be corrected when the groups column lands.
 
 ```
@@ -591,7 +591,7 @@ what is reversible.
 | 403 | `groupPrinterAssoc` (`gpaGroupID`, `gpaPrinterID`, `gpaIsDefault`) + FKs | yes, same |
 | 404 | `groups.groupOrder INT NOT NULL DEFAULT 0` + index | yes |
 | 405 | `DROP TRIGGER IF EXISTS persistentGroups` + retire the `plugins` row | **no** — a dropped trigger cannot be un-dropped, only recreated from the plugin source |
-| 406 | *(optional, labelling only)* watermark row: `MAX(saID)`, `MAX(paID)` | yes |
+| 406 | *(optional, labeling only)* watermark row: `MAX(saID)`, `MAX(paID)` | yes |
 
 **Four required steps, one optional, and exactly one of them is irreversible.**
 Step 405 is the only step that touches existing state at all; 402–404 are pure
@@ -636,7 +636,7 @@ the list modal has select2 chips, typeahead and create-on-the-fly today
 (§1.9). The filter framework is built too — what 16a.1 needs is the column
 contract extended to express a relationship, which is server-side work on a
 shared helper rather than UI work. **Remove** (16a.2) is the one genuinely
-absent piece of behaviour. The rest is reuse and two security fixes.
+absent piece of behavior. The rest is reuse and two security fixes.
 
 ### 2.3 Plugin files
 
@@ -699,10 +699,10 @@ change:**
 - **Nothing is migrated** (Decision 18). The upgrade is additive schema steps
   plus one `DROP TRIGGER`, so an RC finding a design problem does not leave
   anyone with un-migrated data.
-- **Behaviour for existing hosts and groups is unchanged on upgrade**, which is
+- **Behavior for existing hosts and groups is unchanged on upgrade**, which is
   what makes the blast radius of an RC-stage discovery small.
 - **The ABI argument only ever pointed this way.** `HOST_MASSEDIT_*` is free
-  before 1.6.0 ships and needs a deprecation window afterwards (§1.10).
+  before 1.6.0 ships and needs a deprecation window afterward (§1.10).
 
 **What does not change: Decision 10's ordering constraint.** The mass edit must
 land, and be proven, *before* anything is removed from the group page. Within
@@ -738,7 +738,7 @@ and is the only unit that removes anything.
 - **Docs ship with C, not after it.** Decision 4 promises that re-tasking is
   the only way to pick up a snapin change and that "the docs must say so
   plainly". That sentence is load-bearing for support, so it lands in the same
-  unit as the behaviour it describes — `GROUP_SHARED_STATE.md` rewritten as the
+  unit as the behavior it describes — `GROUP_SHARED_STATE.md` rewritten as the
   mass edit document, the ADR 0001 amendment note, and the release note
   covering both the re-tasking semantics and Decision 15's credential
   propagation.
@@ -809,7 +809,7 @@ is the one the design removes. Introducing transactions to the DB layer for it
 would be a much larger change with its own failure modes.
 
 **Build a `tags` entity.** Rejected in ADR 0038 Decision 16: `groupMembers` is
-already an attribute-free many-to-many labelling table
+already an attribute-free many-to-many labeling table
 (`gmID, gmHostID, gmGroupID`, §1.1), so a second set-of-hosts concept solves a
 presentation gap with a data model. The cost of the entity is measurable from
 the `site` plugin's absorption: `$validClasses`, the deletemass cascade,
@@ -819,7 +819,7 @@ description — and none of it moves a host into a group any faster.
 **Ship the split and treat the presentation work as a follow-up.** Rejected,
 and this is the one rejection that is a scheduling decision rather than a
 design one. Decision 16 is only correct if a group is cheap to apply in bulk;
-the split alone makes groups *heavier* and leaves the labelling gap untouched,
+the split alone makes groups *heavier* and leaves the labeling gap untouched,
 which reproduces the state that made tags look necessary. §2.5 puts all of
 Decision 16a in 1.6.0 for that reason.
 
@@ -949,7 +949,7 @@ checkin path. `SnapinClient::json()` drives entirely off
 and `SnapinTask::getSnapin()` is `new Snapin($this->get('snapinID'))` — the
 stored `stSnapinID` off the task row.
 
-*Behaviour*, on throwaway host `te-u2-test` (id 228, deleted afterwards):
+*Behavior*, on throwaway host `te-u2-test` (id 228, deleted afterward):
 
 | Case | Setup | Result |
 |---|---|---|
@@ -985,7 +985,7 @@ sed -n '1,200p' packages/web/service/snapins.checkin.php
 sed -n '1,200p' packages/web/service/snapinlisting.php
 ```
 
-Then, on the lab, the behavioural test that settles it regardless of what the
+Then, on the lab, the behavioral test that settles it regardless of what the
 code reading suggests:
 
 1. Host H, snapins A and B associated. Create a snapin job.
@@ -1003,7 +1003,7 @@ Repeat with the addition case (add C after job creation, see whether C runs).
 ### UNKNOWN-3 — does the trigger break `add host to group`? — **VERIFIED, and worse than inferred**
 
 **Answered 2026-09-01 in an isolated podman MariaDB 11 container cloned from
-the live 1.6 database, torn down afterwards. The trigger was installed verbatim
+the live 1.6 database, torn down afterward. The trigger was installed verbatim
 from `PersistentGroupsManager::triggerSql()`. No live database was written to.**
 
 **A. Printer collision — VERIFIED.**
@@ -1013,7 +1013,7 @@ INSERT INTO groupMembers (gmHostID, gmGroupID) VALUES (9002, 9001);
 ERROR 1062 (23000): Duplicate entry '9002-1' for key 'paHostID'
 ```
 
-`groupMembers` afterwards: **empty**. The whole INSERT rolled back, membership
+`groupMembers` afterward: **empty**. The whole INSERT rolled back, membership
 included — the row is not created, so the failure is total rather than partial.
 
 **B. Module collision — VERIFIED, and it is the one that matters.**
@@ -1194,11 +1194,11 @@ printer**, not merely the ones FOG added — `managedPrinters` is empty and the
 empty case behaving as intended, and it is worth knowing how wide it is.
 
 **3. Under mode `a`, "FOG-managed" is inferred fresh from each response's
-`AllPrinters`** — the server's entire printer catalogue, from
+`AllPrinters`** — the server's entire printer catalog, from
 `Route::getIds('printer', [], 'name')` (`PrinterClient.php:60`) — and is **not**
 persisted client-side. `_configuredPrinters` is in-memory per service run and
 means "already configured this pass", not identity. So under `a` the client
-removes a printer only if it is in FOG's catalogue, absent from the resolved
+removes a printer only if it is in FOG's catalog, absent from the resolved
 list, and currently installed.
 
 #### 🔴 The consequence that changes a decision
@@ -1220,7 +1220,7 @@ Decision 9 was rewritten for them:
   branch removes every installed printer — the same outcome. One real
   difference: the `np` branch sits **above** the `!data.Encrypted` guard, so
   today the empty-case removal happens even on an unencrypted response, and
-  after the change it would not. That is an improvement, but it is a behaviour
+  after the change it would not. That is an improvement, but it is a behavior
   change on the wire and belongs in the release notes rather than being
   discovered.
 
@@ -1228,7 +1228,7 @@ Decision 9 was rewritten for them:
 required state — `telliottwin11` (host 105) is offline (`lastcheckin`
 2026-08-30) and its `printerLevel` is empty (mode `0`, not `ar`). Standing one
 up was out of scope for the verification run. So items 1–3 are source-verified
-and unobserved; the behavioural confirmation remains open and is cheap once a
+and unobserved; the behavioral confirmation remains open and is cheap once a
 mode-`ar` host with two steady printers exists.
 
 <details>
@@ -1244,7 +1244,7 @@ the response and answer three questions.
 3. Under mode `a`, what exactly counts as "FOG-managed"? Is it tracked
    client-side, or inferred from the current response?
 
-Behavioural test, on a lab host with mode `ar` and two printers:
+Behavioral test, on a lab host with mode `ar` and two printers:
 
 ```
 # 1. Confirm steady state: both printers present after a poll.
@@ -1310,7 +1310,7 @@ The reasoning, because the obvious alternatives are both worse:
   (`Authorization.php:496`) declares a *fixed* action vocabulary per node —
   `'group' => ['view', 'create', 'edit', 'delete', 'task']`. A bespoke sixth
   verb would be the registry's first, and worse, it would **regress the
-  upgrade**: every role that exists today would lack it, so labelling would
+  upgrade**: every role that exists today would lack it, so labeling would
   stop working for everyone on upgrade until an admin edited every role.
 - **`host.edit` is the wider grant, not the narrower one.** It carries the
   whole imperative half — image, AD credentials, kernel args — which is exactly
@@ -1421,7 +1421,7 @@ the change is safe, because a no-error response carrying `printers: []` reaches
   failure is printers that never disappear, which nobody reports for months.
 - **The `!data.Encrypted` guard sitting below the `np` branch.** Today the
   empty-case removal happens even on an unencrypted response; after the change
-  it would not. That is the right direction, and it is still a behaviour change
+  it would not. That is the right direction, and it is still a behavior change
   on a path nobody is watching.
 
 It is checkable the same way the rest of UNKNOWN-4 was — on one mode-`ar` host

--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -287,21 +287,75 @@ table as it found it, and schema step 401 exists to repair it. Query in §5.
 
 Evidence for ADR 0038 Decision 16a, whose five requirements are binding.
 
-**VERIFIED — there is no groups column on the host list, and the grid has no
-per-column search UI of any kind.** The header set is enumerated in one place,
-and its own comment says sorting is the substitute for filtering.
+**VERIFIED — there is no groups column on the host list.**
 
 ```
 sed -n '105,170p' packages/web/src/Pages/HostManagement.php
 grep -n 'data-col' packages/web/src/Pages/HostManagement.php
 ```
 
-> "Sorting is the filter here -- this grid has no per-column search UI, so the
-> global box matches the STORED word" — `HostManagement.php:150-153`
+**CORRECTED — the grid DOES have per-column filtering, and an earlier draft of
+this document said it did not.** The comment at `HostManagement.php:150-153`
+reads "this grid has no per-column search UI, so the global box matches the
+STORED word". That comment is **stale**: it predates #1471/#1476/#1477
+(2026-08-29), which added a SearchBuilder **Filter** button and a **Column
+search** header row to every grid, server-parsed in
+`FOGManagerController::filter()`. All of it is on this branch. The first draft
+quoted the comment as evidence of current behaviour instead of grepping for the
+mechanism — the comment should be corrected when the groups column lands.
 
-So requirement 1's "filterable" is a **new capability on this grid**, not a
-column definition. That is the honest sizing and it is the requirement most
-likely to be under-scoped.
+```
+git grep -l 'SearchBuilder\|_searchtypes\|_sbCriterion' -- packages/web
+grep -n 'function filter\|_sbCriterion\|_searchtypes' packages/web/src/Base/FOGManagerController.php
+#   755 filter()   1050 _sbCriterion()   1513 '_searchtypes'
+grep -n -i filter packages/web/management/js/fog/host/fog.host.list.js   # no output
+```
+
+The host list opts into nothing — `fog.filters.js` is generic and the grid gets
+both controls for free.
+
+**VERIFIED — and this is the actual constraint: the filter path is
+column-backed by construction.** `_sbCriterion()` returns empty unless the
+column carries a `db`, and builds `` `$column['db']` `` directly; the type comes
+from `searchBuilderType()` → `columnType()`, which reads the schema manifest for
+a real column of a real table.
+
+```
+sed -n '1050,1082p' packages/web/src/Base/FOGManagerController.php
+sed -n '5733,5756p' packages/web/src/Base/FOGBase.php
+```
+
+A groups column has no backing scalar on `hosts`. So requirement 16a.1 is
+neither "build filtering" nor "add a column": it is **teaching the shared filter
+path its first relationship column**, by growing the column contract an optional
+subquery form that `_sbCriterion()` uses in place of `` `db` ``. Smaller than
+the first draft implied on the UI side, and a change to a helper every grid runs
+through on the server side.
+
+Two constraints on that expression, both already paid for here:
+
+**VERIFIED — it must go into the query, not onto the page.** `complex()` applies
+the `LIMIT` before any row-level filtering, which is why the site boundary is
+passed as a subquery ANDed into the row query, the filter count *and* the total
+count. Post-filtering gave empty first pages and counts describing rows the user
+could not see.
+
+```
+sed -n '3149,3178p' packages/web/src/Router/Route.php
+```
+
+**VERIFIED — every binding must be named by the clause that emits it.**
+`sqlexec()` binds every entry of `$bindings` to all three of `complex()`'s
+queries, so an unreferenced binding makes PDO refuse the statement and the list
+answers HTTP 406. That shipped once in `_sbDate()` and broke Before/After — the
+two conditions the feature existed for — while `=` and `between` worked. Bind
+inside the branch that names it, and gate on "no binding left unnamed" rather
+than on string-comparing substituted SQL, which is what missed it.
+
+```
+grep -n '_sbDate' packages/web/src/Base/FOGManagerController.php   # :1238
+ls tests/searchbuilder-filter-clause.test.php
+```
 
 **VERIFIED — the grid is server-side, so a filter must be SQL.**
 
@@ -309,22 +363,6 @@ likely to be under-scoped.
 sed -n '298,310p' packages/web/management/js/fog/host/fog.host.list.js
 # processing: true, serverSide: true, POST ?node=host&sub=list
 ```
-
-**VERIFIED — the mechanism for a query-level filter already exists and is
-documented with the trap it avoids.** The site boundary is passed to
-`complex()` as a subquery ANDed into the row query, the filter count and the
-total count, because the `LIMIT` is applied before any row-level filtering:
-post-filtering returned empty first pages and counts describing rows the user
-could not see.
-
-```
-sed -n '3149,3178p' packages/web/src/Router/Route.php
-grep -n 'scopedObjectWhere' packages/web/src/Auth/Authorization.php
-```
-
-A groups filter is the same shape — `hostID IN (SELECT gmHostID FROM
-groupMembers WHERE gmGroupID IN (...))` — and inherits the same rule: into the
-query, never onto the page.
 
 **VERIFIED — rendering chips is cheap, because the column table already has a
 per-page batch loader.** `relColumn()` takes a `prime` callback handed every row
@@ -547,7 +585,7 @@ grep -rl "printerassociation\|PrinterAssociation" packages/web/src packages/web/
 | Mass edit form + apply | `Pages/HostManagement.php`, `js/fog/host/fog.host.list.js` | 2, plus `_uniformHostValues()` lifted to a shared home |
 | Bulk group-membership editing | same 2 files | extends the existing `#addToGroupModal` |
 | `HOST_MASSEDIT_*` hooks | `Pages/HostManagement.php` + `docs/plugin-development.md` | 2 |
-| **Groups column + filter** (Dec 16a.1) | `Router/Route.php` (column + `prime` + filter subquery), `Pages/HostManagement.php` (header), `js/fog/host/fog.host.list.js` (chips, filter control) | 3, and the filter is the first of its kind on this grid |
+| **Groups column + filter** (Dec 16a.1) | `Router/Route.php` (column + `prime` + the subquery form), `Base/FOGManagerController.php` (`_sbCriterion`/`searchBuilderType` accept it), `Pages/HostManagement.php` (header + the stale comment), `tests/searchbuilder-filter-clause.test.php` | 4; the shared-helper change is plan-first on its own account |
 | **Bulk add/remove + shared create path** (Dec 16a.2–4) | `Pages/HostManagement.php` (`saveGroup` rewritten: remove, CSRF, scope), `js/fog/host/fog.host.list.js` | 2 |
 | **Group list "grants" column** (Dec 16a.5) | `Pages/GroupManagement.php` | 1 |
 | Retirement step | `commons/schema.php` | 1 |
@@ -560,9 +598,10 @@ are `GroupManagement.php` (3532 lines, 8 tabs), `HostManagement.php` (5256) and
 
 Requirement 16a.3 ("it has to feel lightweight") is mostly **already built**:
 the list modal has select2 chips, typeahead and create-on-the-fly today
-(§1.9). What is genuinely new is the **filter** (16a.1) — no per-column
-filtering exists on this grid at all — and **remove** (16a.2). Those two are
-the presentation work; the rest is reuse and two security fixes.
+(§1.9). The filter framework is built too — what 16a.1 needs is the column
+contract extended to express a relationship, which is server-side work on a
+shared helper rather than UI work. **Remove** (16a.2) is the one genuinely
+absent piece of behaviour. The rest is reuse and two security fixes.
 
 ### 2.3 Plugin files
 
@@ -653,7 +692,7 @@ earlier release, the removals in the later one.
 
 ---
 
-## 3. The five things most likely to be built wrong
+## 3. The six things most likely to be built wrong
 
 Recorded here rather than in the ADR because they are implementation hazards,
 not decisions.
@@ -661,21 +700,30 @@ not decisions.
 1. **A resolver whose natural unit is one host.** GH-707 was exactly this
    (§1.7). The signature takes an array of host ids or it will be a thousand
    round trips the first time a group task calls it.
-2. **A mass edit form that posts every field.** The three-state control is not
+2. **A resolver that reads membership through a manager.**
+   `FOGController::buildQuery()` walks `$databaseFieldClassRelationships`
+   transitively and folds a fourth-element filter into the WHERE, not the ON,
+   so any query chaining through `Host` picks up
+   `` AND `hostMAC`.`hmPrimary` = '1' `` and silently drops every host with no
+   primary MAC — 95 rows returned where the raw `COUNT(*)` was 1000, measured on
+   the 1.5 lab. No flag suppresses it; read the association table directly (the
+   fix used in PR #1233). A resolver that silently omits hosts is a printer
+   resolver that strips their printers.
+3. **A mass edit form that posts every field.** The three-state control is not
    a nicety; a form without it silently overwrites every field the admin did
    not touch, and it looks correct in every test where the admin touched
    everything.
-3. **A printer resolver that returns `[]` on failure.** Under mode `ar` that is
+4. **A printer resolver that returns `[]` on failure.** Under mode `ar` that is
    a fleet-wide printer removal, delivered one machine at a time as they poll.
    The resolver throws; §1.6 shows the endpoint already turns a throw into a
    body with no `printers` key.
-4. **A groups filter applied to the returned page instead of the query.**
-   `complex()` applies the `LIMIT` before any row filtering, so a post-filter
-   gives empty first pages and counts that describe rows the caller cannot see.
-   That trap is already documented at `Route.php:3149-3172`, where the site
-   boundary hit it; the groups filter is the same shape and must go into the
-   query, the filter count and the total count.
-5. **A second create-and-associate path for host↔group.** There are already two
+5. **A groups filter applied to the returned page instead of the query**, or
+   one that binds a parameter its clause does not name. Both already happened
+   here: the first to the site boundary (`Route.php:3149-3172` records it), the
+   second to `_sbDate()`, which answered HTTP 406 on exactly the two conditions
+   the feature existed for. Into the query, into all three counts, and bind
+   inside the branch that names it.
+6. **A second create-and-associate path for host↔group.** There are already two
    (§1.9) and the newer one skips the name-collision check. The list modal
    should use `$.registerCreateAndAssociate()` like the other eleven tabs, not
    grow a third.
@@ -789,6 +837,18 @@ the snapin half needs a real snapshot table plus a service-path change.
 Repeat with the addition case (add C after job creation, see whether C runs).
 
 ### UNKNOWN-3 — does the trigger break `add host to group`?
+
+**🔴 Run this on the isolated lab database only, never on a lab server whose
+hosts are real.** The trigger under test does not merely copy columns: it
+creates a `snapinJobs` row and `snapinTasks` rows for the host being added
+(`PersistentGroupsManager.php:75-89`), so firing it on a live-ish box **queues
+software to run on that machine** at its next check-in. The fixture host must be
+a throwaway that nothing polls.
+
+Same discipline as any lab fixture: assert the discriminators you are borrowing
+are unoccupied before creating anything, and clean up at the START of the run as
+well as the end — a run that errors inside the trigger leaves its rows behind.
+"Empty of my rows" is not "empty".
 
 ```sql
 -- Setup: a group G, a host T named exactly like G, and a host H that already

--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -13,6 +13,10 @@ names the claim that would hurt most if it turned out to be false.
 Repository state: `working-1.6` at `4729701`. Plugins at `fog-plugins`
 `ec101b3`.
 
+**Update 2026-09-01:** UNKNOWN-2, UNKNOWN-4 and UNKNOWN-6 were run against the
+1.6 lab (`10.255.20.1`) and are recorded in §5 with their evidence. One of them
+changed a decision — see UNKNOWN-4 and ADR 0038 Decision 9.
+
 ---
 
 ## 1. What is actually there today
@@ -616,21 +620,29 @@ absent piece of behaviour. The rest is reuse and two security fixes.
 Nothing in §2.1–§2.3 can be signed off from a cloud session. The lab-gated
 items, in the order they block work:
 
-1. **UNKNOWN-2** (snapshot sufficiency) — blocks the snapin half's whole design.
-   Cheapest to answer, answer it first.
+**Closed 2026-09-01** against the 1.6 lab: **UNKNOWN-2** (VERIFIED — the task
+is the authority, no new snapshot table needed), **UNKNOWN-4** (VERIFIED from
+`fog-client` source; the live poll cycle is still unobserved), **UNKNOWN-6**
+(VERIFIED — both gaps real).
+
+Still open:
+
+1. **The printer wire contract is now the top risk**, and it is not a question
+   about the server. `error: 'np'` is load-bearing in the shipped client
+   (UNKNOWN-4), so any change to the empty-case spelling is a client-visible
+   change. Confirm the trace on a real mode-`ar` host before shipping the
+   printer resolver — that is the one piece UNKNOWN-4 could not observe.
 2. **UNKNOWN-1** (`groupName` uniqueness on real upgraded databases) — does not
    block; determines whether step 404 also needs an index repair like 401.
 3. **UNKNOWN-3** (trigger duplicate-key behaviour) — does not block the
    retirement; determines how the release note describes what admins have been
-   hitting.
-4. **UNKNOWN-4** (client removal semantics under each mode) — blocks shipping
-   the printer resolver, because it decides the blast radius of a resolver bug.
-5. **UNKNOWN-5** (mass authorization cost at 400 hosts) — does not block;
+   hitting. **Isolated lab database only** — see the warning on that section.
+4. **UNKNOWN-5** (mass authorization cost at 400 hosts) — does not block;
    determines whether the mass edit needs a set-based scope check.
-6. **UNKNOWN-6** (`saveGroup()`'s CSRF and scope gaps) — does not block, but
-   both are on the endpoint ADR 0038 Decision 16a promotes to primary. Cheap:
-   two requests.
-7. **A migration rehearsal** on a 1.5-origin dump, per
+5. **The `group.create` question** raised by UNKNOWN-6: membership editing
+   should not require the permission to mint groups. An access-control change,
+   so it is a decision rather than a test.
+6. **A migration rehearsal** on a 1.5-origin dump, per
    `docs/development/upgrade-rehearsal.md`, for step 405.
 
 ### 2.5 1.6.0 or 1.6.x
@@ -808,10 +820,45 @@ If (c) returns rows, the trigger's template subquery (`:44`) returns more than
 one row and **every** `INSERT INTO groupMembers` on this server errors — worth
 knowing before writing the release note.
 
-### UNKNOWN-2 — is `snapinTasks` a sufficient snapshot? *(answer this first)*
+### UNKNOWN-2 — is `snapinTasks` a sufficient snapshot? — **VERIFIED, closed**
 
-This is §6. The question: does anything read `snapinAssoc` **after** a snapin
-job has been created, for that job?
+**Answered 2026-09-01 on the 1.6 lab (`10.255.20.1`). The task is the
+authority; `snapinTasks` is a sufficient snapshot. ADR 0038 Decision 4 holds
+and needs no new table.**
+
+Both halves agree.
+
+*Code:* zero reads of `snapinAssoc` / `snapinAssociation` anywhere in the
+checkin path. `SnapinClient::json()` drives entirely off
+`Route::getList('snapintask', ['jobID' => ..., 'stateID' => queued/progress])`,
+and `SnapinTask::getSnapin()` is `new Snapin($this->get('snapinID'))` — the
+stored `stSnapinID` off the task row.
+
+*Behaviour*, on throwaway host `te-u2-test` (id 228, deleted afterwards):
+
+| Case | Setup | Result |
+|---|---|---|
+| **Removal** | job 26 with tasks for snapins A and B; **deleted B from `snapinAssoc` before checkin** | both task 67 (A) and task 68 (B) went Queued → Checked-In on the same `stCheckinDate`. **B still ran.** |
+| **Addition** | job 27 with a task for A only; **added snapin C to `snapinAssoc` after job creation** | task 69 (A) advanced; **no task row ever existed for C.** C was never served. |
+
+Method note, because it matters for anyone repeating this: the JSON body is not
+readable without a full RSA/AES client emulator — `SnapinClient`'s
+`requestClientInfo` branch runs inside `FOGClient::__construct()` and PHP
+discards a constructor's return value, so real clients get their answer through
+the encrypted `#!enkey=` path in `sendData()`. The test therefore reads the
+**database side-effects** of the checkin call, before and after. The task-state
+transitions happen inside the same loop that builds the response, so they are
+direct evidence of what would have been served rather than a proxy for it.
+
+**Consequence for the docs:** "a group edited mid-run does not change a task in
+flight" is true *today*, undocumented, and becomes a promise the split makes
+explicit. Re-tasking really is the only way to pick up a change.
+
+<details>
+<summary>Original procedure, kept for the record</summary>
+
+The question: does anything read `snapinAssoc` **after** a snapin job has been
+created, for that job?
 
 ```bash
 # Every read of the association table on the running-task side.
@@ -835,6 +882,8 @@ association table is re-read at run time, Decision 4 is false as written, and
 the snapin half needs a real snapshot table plus a service-path change.
 
 Repeat with the addition case (add C after job creation, see whether C runs).
+
+</details>
 
 ### UNKNOWN-3 — does the trigger break `add host to group`?
 
@@ -880,10 +929,93 @@ WHERE gm.gmHostID <> t.hostID
 GROUP BY g.groupID;
 ```
 
-### UNKNOWN-4 — what does the client actually do with the printer list?
+### UNKNOWN-4 — what does the client do with the printer list? — **VERIFIED from source; live poll COULDN'T-TEST**
 
-**Blocks shipping the printer resolver.** Not answerable from this repository —
-`fog-client` is a separate codebase.
+**Answered 2026-09-01. `fog-client` is checked out locally at
+`/home/telliott/fog-client`, `master` @ `610ad5f` (Release 0.13.0), so this was
+read rather than inferred.** `Modules/PrinterManager/PrinterManager.cs:60-121`:
+
+```csharp
+if (msg.Mode == "0") return;
+var installedPrinters = _instance.GetPrinters();
+
+if (data.Error && data.ReturnCode.Equals("np", StringComparison.OrdinalIgnoreCase))
+{
+    RemoveExtraPrinters(new List<Printer>(), msg, installedPrinters);   // remove-all
+    return;
+}
+if (data.Error) return;                                    // <-- fail-safe
+if (!data.Encrypted) { Log.Error(Name, "Response was not encrypted"); return; }
+RemoveExtraPrinters(msg.Printers, msg, installedPrinters);
+```
+
+and
+
+```csharp
+private void RemoveExtraPrinters(List<Printer> newPrinters, ... ) {
+    var managedPrinters = newPrinters.Where(p => p != null).Select(p => p.Name).ToList();
+    if (!msg.Mode.Equals("ar", StringComparison.OrdinalIgnoreCase))
+        foreach (var name in msg.AllPrinters.Where(n => !managedPrinters.Contains(n)
+                                                     && installedPrinters.Contains(n)))
+            CleanPrinter(name, true);
+    else
+        foreach (var name in installedPrinters.Where(n => !managedPrinters.Contains(n)))
+            _instance.Remove(name);
+}
+```
+
+**1. A response with no `printers` key (the exception shape), under `ar`:
+printers are NOT removed.** `if (data.Error) return;` fires before anything
+touches them. The fleet-wide-strip scenario the design was written against
+**cannot happen with the shipped client** — the failure path is already safe at
+both ends. (It is safe by that guard alone: `RemoveExtraPrinters(null, …)` would
+throw on `.Where`, so nothing downstream is defending it.)
+
+**2. `{"error":"np","printers":[]}` under `ar` removes EVERY installed
+printer**, not merely the ones FOG added — `managedPrinters` is empty and the
+`ar` branch removes every name in `installedPrinters`. That is the legitimate
+empty case behaving as intended, and it is worth knowing how wide it is.
+
+**3. Under mode `a`, "FOG-managed" is inferred fresh from each response's
+`AllPrinters`** — the server's entire printer catalogue, from
+`Route::getIds('printer', [], 'name')` (`PrinterClient.php:60`) — and is **not**
+persisted client-side. `_configuredPrinters` is in-memory per service run and
+means "already configured this pass", not identity. So under `a` the client
+removes a printer only if it is in FOG's catalogue, absent from the resolved
+list, and currently installed.
+
+#### 🔴 The consequence that changes a decision
+
+**`error: 'np'` is a load-bearing wire contract, not an accident of spelling.**
+It is the *only* string that triggers removal-on-empty, matched
+case-insensitively against `ReturnCode`. Two things follow, and ADR 0038
+Decision 9 was rewritten for them:
+
+- **The rule "never return an empty list on failure" is still right, but its
+  justification changes.** It is not "or printers get stripped today" — this
+  client will not. It is: *never let a failure be spelled `np`*, because that
+  one string is indistinguishable from the legitimate empty case, and because a
+  less careful client (or a future one) has no other signal.
+- **Re-spelling the empty case is safe with this client, but only by
+  coincidence, and the trace has to be checked rather than assumed.** Sending
+  `{printers: [], mode: 'ar'}` with no `error` leaves `data.Error` false, passes
+  the encryption check, and reaches `RemoveExtraPrinters([], …)`, whose `ar`
+  branch removes every installed printer — the same outcome. One real
+  difference: the `np` branch sits **above** the `!data.Encrypted` guard, so
+  today the empty-case removal happens even on an unencrypted response, and
+  after the change it would not. That is an improvement, but it is a behaviour
+  change on the wire and belongs in the release notes rather than being
+  discovered.
+
+**COULDN'T-TEST: the live poll cycle.** No Windows fog-client host is in the
+required state — `telliottwin11` (host 105) is offline (`lastcheckin`
+2026-08-30) and its `printerLevel` is empty (mode `0`, not `ar`). Standing one
+up was out of scope for the verification run. So items 1–3 are source-verified
+and unobserved; the behavioural confirmation remains open and is cheap once a
+mode-`ar` host with two steady printers exists.
+
+<details>
+<summary>Original procedure, kept for the record</summary>
 
 Read side, in the `fog-client` source: find the printer module's handling of
 the response and answer three questions.
@@ -906,7 +1038,9 @@ Behavioural test, on a lab host with mode `ar` and two printers:
 
 Step 3's answer is the blast radius. If a thrown resolver strips printers today,
 that is a **pre-existing** bug worth its own fix regardless of this work, and
-the resolver must not be shipped until it is fixed.
+the resolver must not be shipped until it is fixed. *(Answered: it does not.)*
+
+</details>
 
 ### UNKNOWN-5 — what does the per-id scope check cost at 400 hosts?
 
@@ -923,10 +1057,43 @@ use `SiteScope::allInScopeIDs()` once and diff, which is the set-based answer
 the class already provides — and it is a pre-existing improvement to the Queue
 Task path, not new work this creates.
 
-### UNKNOWN-6 — is `saveGroup()` really unprotected?
+### UNKNOWN-6 — is `saveGroup()` really unprotected? — **VERIFIED, both gaps**
 
-Code reading says yes (§1.9). Confirm with requests rather than trusting the
-reading, because dispatch has paths this session did not trace.
+**Answered 2026-09-01 on the 1.6 lab. Both gaps are real, both confirmed with
+requests against controls.**
+
+| Test | `saveGroup` | Control (`deployMulti`) |
+|---|---|---|
+| **CSRF** — admin session, no `X-CSRF-Token`, no `_csrf` | `202 {"msg":"Successfully added hosts to the provided groups!"}` | `403 Forbidden (invalid CSRF token)` |
+| **Object scope** — site1-scoped user, `hosts[]=1` (a host outside site1) | `202`, host joined the group | `403 {"error":"You do not have permission to perform this action."}` |
+
+The controls matter: they are the same request shape to a `*Post`-suffixed
+handler, so the difference is the missing gate and not something about the
+session or the user.
+
+**A detail the code reading missed, and it has a design consequence.**
+`saveGroup`'s required permission is **`group.create`**, not `host.edit` —
+`Authorization::SUB_OVERRIDES['host']['savegroup'] => 'group.create'`
+(`Authorization.php:157`), which overrides what `_subToAction()` would derive.
+The verification run had to grant the Technician role to its throwaway user to
+get past the permission gate at all before object scope could be reached.
+
+That is right for the endpoint as it exists, because the endpoint can create
+groups from `groups_new[]`. It is **wrong for the endpoint ADR 0038 Decision
+16a is asking for**: adding forty existing hosts to three existing groups is
+not a group *creation*, and requiring `group.create` for it means an operator
+who may label hosts must also be able to mint groups. Splitting that —
+`group.create` only when `groups_new[]` is non-empty, membership editing behind
+something narrower — is an **access-control change** and is flagged here rather
+than decided.
+
+Fixtures created and removed, verified back to baseline: host 228 and its
+`snapinJobs` / `snapinTasks` / `snapinAssoc` / `tasks` rows; groups
+`te_csrf_throwaway_grp` and `te_scopetest_throwaway_grp`; user `te_scopetest`
+(id 123) with its role and site assignments. No standing lab fixtures touched.
+
+<details>
+<summary>Original procedure, kept for the record</summary>
 
 **CSRF.** Logged in as an admin in a browser, from a page on another origin (or
 with `curl` reusing the session cookie and **omitting** both the
@@ -958,7 +1125,9 @@ the control that shows the difference is the missing
 
 If either comes back protected, find what protects it before removing anything
 — a gap that is not there does not need fixing, and the reading was wrong about
-where enforcement lives.
+where enforcement lives. *(Answered: both gaps are real.)*
+
+</details>
 
 ### The retirement rehearsal
 
@@ -986,30 +1155,44 @@ the plugin, where step 405 must be a clean no-op.
 
 ## 6. The claim that would hurt most if it is false
 
-**That `snapinTasks` already constitutes the snapshot** — §1.7, ADR 0038
-Decision 4.
+**Superseded 2026-09-01.** The original answer was that `snapinTasks` already
+constitutes the snapshot. **It does** — UNKNOWN-2 is VERIFIED in both
+directions on the lab, so the snapin half is sized correctly, needs no new
+table and no schema step, and Decision 4's documentation promise is true rather
+than aspirational.
 
-The snapin half is sized on it. If task creation already materializes an
-ordered per-host list into a table the running task reads, then "snapshot at
-task creation" costs one changed data source in `_createSnapinTasking()` and
-nothing else: no new table, no schema step, no service-path change, and the
-promise that a group edited mid-run does not affect a task in flight is already
-true and merely undocumented.
+The risk has moved to the printers, and it is narrower and more specific than
+the one it replaces:
 
-If it is false — if `service/snapins.checkin.php` or the client re-reads
-`snapinAssoc` for a running job, as a re-resolve or a validity check or a
-fallback when the job row is missing — then three things follow at once. The
-snapin half needs a genuine snapshot table and a schema step it does not
-currently have. Decision 4's documentation promise is a lie that would ship in
-the release notes. And a group edited mid-run *does* change a task in flight
-today, which is a live bug independent of any of this and probably the reason
-somebody would file it.
+**That the printer wire contract can be changed server-side alone.**
 
-It is the cheapest UNKNOWN to close (one grep and one three-step lab test,
-§5/UNKNOWN-2) and the one with the largest downstream cost, so it should be
-closed before any code is written.
+ADR 0038 Decision 9 re-spells the empty case so that `error` means "I could not
+answer" and nothing else. UNKNOWN-4 shows the shipped client
+(`fog-client` 0.13.0) removes printers on exactly one signal —
+`data.Error && ReturnCode == "np"` — and that reading the trace end to end says
+the change is safe, because a no-error response carrying `printers: []` reaches
+`RemoveExtraPrinters([], …)` and removes the same set.
 
-Second place, and only because its consequence is narrower rather than smaller:
-**UNKNOWN-4**. If the shipped client removes printers on a response it should
-have treated as an error, then that is true *today*, and the printer half of
-this work cannot ship until it is not.
+**Safe by that trace, not by design.** Two things would make it false:
+
+- **A deployed client older than the one that was read.** The trace covers
+  `master @ 610ad5f`. Any client whose removal path requires the `np` sentinel
+  rather than falling through to the general branch would simply stop removing
+  printers under `ar` — silently, because nothing errors and nothing logs. The
+  failure is printers that never disappear, which nobody reports for months.
+- **The `!data.Encrypted` guard sitting below the `np` branch.** Today the
+  empty-case removal happens even on an unencrypted response; after the change
+  it would not. That is the right direction, and it is still a behaviour change
+  on a path nobody is watching.
+
+It is checkable the same way the rest of UNKNOWN-4 was — on one mode-`ar` host
+with two steady printers, induce the empty case both ways and see whether the
+printers go. Until that is observed, the honest position is that Decision 9's
+re-spelling is *reasoned* safe and not *shown* safe, and it should not ship
+without either the observation or keeping `np` alongside the new field for a
+release.
+
+Second place: **UNKNOWN-1**, and only because its consequence is cheap. If a
+real upgraded database turns out not to have a UNIQUE index on `groupName`, the
+resolver's `groupID` tiebreak stops being dead code and starts earning its
+keep — which is exactly why Decision 6 keeps it.

--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -13,9 +13,13 @@ names the claim that would hurt most if it turned out to be false.
 Repository state: `working-1.6` at `4729701`. Plugins at `fog-plugins`
 `ec101b3`.
 
-**Update 2026-09-01:** UNKNOWN-2, UNKNOWN-4 and UNKNOWN-6 were run against the
-1.6 lab (`10.255.20.1`) and are recorded in §5 with their evidence. One of them
-changed a decision — see UNKNOWN-4 and ADR 0038 Decision 9.
+**Update 2026-09-01:** UNKNOWN-2, UNKNOWN-3, UNKNOWN-4 and UNKNOWN-6 were run
+and are recorded in §5 with their evidence — UNKNOWN-3 in a throwaway container
+cloned from the live database, the rest against the 1.6 lab (`10.255.20.1`).
+Two changed a decision: UNKNOWN-4 (ADR 0038 Decision 9) and UNKNOWN-6 (Decision
+16a.6, the permission split). UNKNOWN-3 refuted one hazard this document
+claimed and made another materially worse. **UNKNOWN-1** and **UNKNOWN-5**
+remain open; neither blocks.
 
 ---
 
@@ -78,15 +82,15 @@ sed -n '30,100p' <fog-plugins>/persistentgroups/src/Managers/PersistentGroupsMan
 
 | Line | What | Note |
 |---|---|---|
-| 44 | template = host whose `hostName` = the group's `groupName` | scalar subquery, **no `LIMIT`** |
+| 44 | template = host whose `hostName` = the group's `groupName` | scalar subquery, no `LIMIT` — **unreachable, see below** |
 | 46–54 | copies the 13 `hosts` columns | the empirical list |
 | 56 | `information_schema` probe for `locationAssoc` | **`table_schema = 'fog'` hardcoded** |
 | 58–60 | copies `locationAssoc` | no `ON DUPLICATE KEY` |
-| 63–65 | copies `printerAssoc` incl. `paIsDefault` | **no `ON DUPLICATE KEY`** |
+| 63–65 | copies `printerAssoc` incl. `paIsDefault` | **no `ON DUPLICATE KEY` — proven fatal** |
 | 69–72 | copies `snapinAssoc` | has `ON DUPLICATE KEY`; **never sets `saSequence`** |
 | 75–83 | finds or creates a `snapinJobs` row | **adding a host runs snapins on it** |
 | 86–89 | inserts `snapinTasks` | **never sets `stSequence`** |
-| 92–94 | copies `moduleStatusByHost` incl. `msState` | **no `ON DUPLICATE KEY`** |
+| 92–94 | copies `moduleStatusByHost` incl. `msState` | **no `ON DUPLICATE KEY` — proven fatal, and reachable for 98.8% of hosts** |
 
 **VERIFIED — `printerAssoc` and `moduleStatusByHost` both carry composite
 UNIQUE keys.**
@@ -97,27 +101,51 @@ foreach (["printerAssoc","moduleStatusByHost","snapinAssoc"] as $t)
   echo $m["tables"][$t]["create"], "\n\n";' | grep -o 'UNIQUE KEY [^,]*'
 ```
 
-**INFERRED — adding a host to a group fails outright if that host already
+**VERIFIED — adding a host to a group fails outright if that host already
 shares any printer, or any module override, with the template host.** The
 copies at lines 63 and 92 carry no `ON DUPLICATE KEY UPDATE`, so a duplicate
 raises error 1062 inside an `AFTER INSERT` trigger, which rolls back the
 `INSERT INTO groupMembers` that fired it. The snapin copy is immune because it
-has the clause. Reproduction in §5.1 (UNKNOWN-3) — this is a mechanism argument
-from MySQL semantics, not something observed.
+has the clause.
 
-**VERIFIED — the location branch has silently never run on a server whose
-database is not named `fog`.** Line 56 tests `table_schema = 'fog'` as a
-literal. The core equivalent, schema step 399, uses
-`TABLE_SCHEMA = DATABASE()`.
+Reproduced 2026-09-01 in an isolated container against a clone of the live 1.6
+database — `ERROR 1062 (23000): Duplicate entry '9002-1' for key 'paHostID'`
+and `... '9004-1' for key 'msHostID'`, with `groupMembers` empty afterwards in
+both cases. Full results, including the 98.8% prevalence figure that makes the
+module arm the dominant one, in §5.1 (UNKNOWN-3).
+
+**VERIFIED — the location branch asks about one database and then writes to a
+different one.** Line 56 tests `table_schema = 'fog'` as a literal, and
+`information_schema.tables` is **server-global** — so the guard is answered by
+whatever database on that server happens to be named `fog`, while the
+`INSERT INTO locationAssoc` two lines later is unqualified and resolves to the
+trigger's *own* database. The core equivalent, schema step 399, uses
+`TABLE_SCHEMA = DATABASE()`, which is the correct form.
+
+Both failure directions are reachable, and neither is hypothetical on a box
+hosting two FOG databases — this machine has `fog` and `fog-1.5` side by side:
+
+- No database named `fog` on the server → the branch never runs, and location
+  associations are silently not copied even though the table exists.
+- A `fog` database exists but the *trigger's* database is an older schema
+  without `locationAssoc` → the guard passes and the INSERT fails with 1146,
+  taking the membership row with it.
 
 ```
 grep -n "table_schema" <fog-plugins>/persistentgroups/src/Managers/PersistentGroupsManager.php
 grep -n 'TABLE_SCHEMA. = DATABASE()' packages/web/commons/schema.php
 ```
 
-**INFERRED — every snapin task the trigger creates ties at sequence 0.** Line
+Confirmed 2026-09-01 in a second isolated container holding only `fogtest`: the
+branch was skipped, the membership insert succeeded, and the template's own
+`locationAssoc` row was left alone. The *first* attempt was a false negative —
+`fog` and `fogtest` coexisted in one container and the branch ran from inside
+`fogtest`, which is what exposed the server-global behaviour.
+
+**VERIFIED — every snapin task the trigger creates ties at sequence 0.** Line
 86 names four columns and `stSequence` is not among them; the column defaults
-to `0` and `snapinTasks` is read in sequence order. So on a plugin-managed
+to `0` and `snapinTasks` is read in sequence order. Observed in the lab clone:
+`stID=70, stJobID=28, stSnapinID=1, stSequence=0`. So on a plugin-managed
 server the snapin run order for a newly added host is whatever the engine
 returns.
 
@@ -590,12 +618,12 @@ grep -rl "printerassociation\|PrinterAssociation" packages/web/src packages/web/
 | Bulk group-membership editing | same 2 files | extends the existing `#addToGroupModal` |
 | `HOST_MASSEDIT_*` hooks | `Pages/HostManagement.php` + `docs/plugin-development.md` | 2 |
 | **Groups column + filter** (Dec 16a.1) | `Router/Route.php` (column + `prime` + the subquery form), `Base/FOGManagerController.php` (`_sbCriterion`/`searchBuilderType` accept it), `Pages/HostManagement.php` (header + the stale comment), `tests/searchbuilder-filter-clause.test.php` | 4; the shared-helper change is plan-first on its own account |
-| **Bulk add/remove + shared create path** (Dec 16a.2–4) | `Pages/HostManagement.php` (`saveGroup` rewritten: remove, CSRF, scope), `js/fog/host/fog.host.list.js` | 2 |
+| **Bulk add/remove + shared create path** (Dec 16a.2–4) | `Pages/HostManagement.php` (`saveGroup` rewritten: remove, CSRF, scope, and the `group.create` → `group.edit` split), `Auth/Authorization.php` (`SUB_OVERRIDES`), `js/fog/host/fog.host.list.js` | 3; the permission change is **access-control**, so it lands as its own reviewed commit |
 | **Group list "grants" column** (Dec 16a.5) | `Pages/GroupManagement.php` | 1 |
 | Retirement step | `commons/schema.php` | 1 |
 | Docs | `GROUP_SHARED_STATE.md` rewritten as the mass edit doc; ADR 0001 amendment note; release notes | 3 |
 
-**Roughly 22 core files touched, 7 new** — the presentation work overlaps
+**Roughly 23 core files touched, 7 new** — the presentation work overlaps
 almost entirely with files the rest of the change already opens. The heavy ones
 are `GroupManagement.php` (3532 lines, 8 tabs), `HostManagement.php` (5256) and
 `Route.php`.
@@ -621,9 +649,11 @@ Nothing in §2.1–§2.3 can be signed off from a cloud session. The lab-gated
 items, in the order they block work:
 
 **Closed 2026-09-01** against the 1.6 lab: **UNKNOWN-2** (VERIFIED — the task
-is the authority, no new snapshot table needed), **UNKNOWN-4** (VERIFIED from
-`fog-client` source; the live poll cycle is still unobserved), **UNKNOWN-6**
-(VERIFIED — both gaps real).
+is the authority, no new snapshot table needed), **UNKNOWN-3** (VERIFIED in an
+isolated container — both collisions are fatal, and the module arm is reachable
+for 98.8% of hosts), **UNKNOWN-4** (VERIFIED from `fog-client` source; the live
+poll cycle is still unobserved), **UNKNOWN-6** (VERIFIED — both gaps real, and
+the permission split is now decided rather than flagged).
 
 Still open:
 
@@ -632,17 +662,14 @@ Still open:
    (UNKNOWN-4), so any change to the empty-case spelling is a client-visible
    change. Confirm the trace on a real mode-`ar` host before shipping the
    printer resolver — that is the one piece UNKNOWN-4 could not observe.
-2. **UNKNOWN-1** (`groupName` uniqueness on real upgraded databases) — does not
-   block; determines whether step 404 also needs an index repair like 401.
-3. **UNKNOWN-3** (trigger duplicate-key behaviour) — does not block the
-   retirement; determines how the release note describes what admins have been
-   hitting. **Isolated lab database only** — see the warning on that section.
-4. **UNKNOWN-5** (mass authorization cost at 400 hosts) — does not block;
+2. **UNKNOWN-1** (`groupName` *and* `hostName` uniqueness on real upgraded
+   databases) — does not block; determines whether step 404 also needs an index
+   repair like 401. Grew after UNKNOWN-3: neither index is created by a
+   numbered step on 1.6, so both reach a 1.5-origin database only through the
+   manifest reconciler.
+3. **UNKNOWN-5** (mass authorization cost at 400 hosts) — does not block;
    determines whether the mass edit needs a set-based scope check.
-5. **The `group.create` question** raised by UNKNOWN-6: membership editing
-   should not require the permission to mint groups. An access-control change,
-   so it is a decision rather than a test.
-6. **A migration rehearsal** on a 1.5-origin dump, per
+4. **A migration rehearsal** on a 1.5-origin dump, per
    `docs/development/upgrade-rehearsal.md`, for step 405.
 
 ### 2.5 1.6.0 or 1.6.x
@@ -682,9 +709,9 @@ The honest read, with the argument on both sides.
 - **1.6.0:** the `HOST_MASSEDIT_*` hooks and the mass edit form; **all five of
   Decision 16a's presentation requirements** (groups column + filter, bulk
   add/remove from the host side, the shared create-and-associate path with
-  `saveGroup()`'s CSRF and scope gaps closed, the group list's "grants"
-  column); schema step 405 (the trigger drop) and the `persistentgroups`
-  deletion. None of these depends on the resolver, all of them are additive,
+  `saveGroup()`'s CSRF and scope gaps closed and its permission narrowed from
+  `group.create` to `group.edit`, the group list's "grants" column); schema
+  step 405 (the trigger drop) and the `persistentgroups` deletion. None of these depends on the resolver, all of them are additive,
   and the ABI half genuinely gets harder after 1.6.0.
 
   **16a is in the earlier release deliberately, and it is the half that must
@@ -820,6 +847,26 @@ If (c) returns rows, the trigger's template subquery (`:44`) returns more than
 one row and **every** `INSERT INTO groupMembers` on this server errors — worth
 knowing before writing the release note.
 
+**Partially answered 2026-09-01, and (c) is now the more interesting half.**
+On a clone of the live 1.6 database, `hosts` carries `UNIQUE KEY hostName
+(hostName)`, so (c) is empty and the missing-`LIMIT` hazard is unreachable
+*there* (UNKNOWN-3 case E).
+
+But **no numbered schema step adds that index on 1.6.** Step 161 calls
+`Schema::dropDuplicateData(DATABASE_NAME, ['hosts', ['hostName']])`, and
+`dropDuplicateData`'s third parameter `$indexNeeded` defaults to `false` — it
+deletes duplicate rows and creates nothing. The UNIQUE therefore comes from the
+manifest via `SchemaReconciler`, which is precisely the `roles.rName` shape.
+
+```
+grep -n -A25 'function dropDuplicateData' packages/web/src/Items/Schema.php
+sed -n '2405,2425p' packages/web/commons/schema.php
+```
+
+So this question now covers **both** `groups.groupName` and `hosts.hostName`,
+and on a 1.5-origin database both are open. One real 1.6 database is one
+sample, not a guarantee.
+
 ### UNKNOWN-2 — is `snapinTasks` a sufficient snapshot? — **VERIFIED, closed**
 
 **Answered 2026-09-01 on the 1.6 lab (`10.255.20.1`). The task is the
@@ -885,7 +932,113 @@ Repeat with the addition case (add C after job creation, see whether C runs).
 
 </details>
 
-### UNKNOWN-3 — does the trigger break `add host to group`?
+### UNKNOWN-3 — does the trigger break `add host to group`? — **VERIFIED, and worse than inferred**
+
+**Answered 2026-09-01 in an isolated podman MariaDB 11 container cloned from
+the live 1.6 database, torn down afterwards. The trigger was installed verbatim
+from `PersistentGroupsManager::triggerSql()`. No live database was written to.**
+
+**A. Printer collision — VERIFIED.**
+
+```
+INSERT INTO groupMembers (gmHostID, gmGroupID) VALUES (9002, 9001);
+ERROR 1062 (23000): Duplicate entry '9002-1' for key 'paHostID'
+```
+
+`groupMembers` afterwards: **empty**. The whole INSERT rolled back, membership
+included — the row is not created, so the failure is total rather than partial.
+
+**B. Module collision — VERIFIED, and it is the one that matters.**
+
+```
+ERROR 1062 (23000): Duplicate entry '9004-1' for key 'msHostID'
+```
+
+**85 of 86 hosts (98.8%) in the cloned database carry at least one
+`moduleStatusByHost` row.** So on this data shape B is not an edge case: adding
+almost *any* host to a template-backed group fails. The printer collision needs
+a shared printer; the module collision needs only a host that has ever had its
+modules touched, which is nearly all of them.
+
+That reframes the plugin's status. It is not "a workaround that is fragile" —
+on a 1.6 database with this row distribution it is **substantially
+non-functional for its own use case**, and has been failing silently at the
+`INSERT` rather than doing anything visible.
+
+*Careful about how far that generalises.* It only fires for groups that use the
+template convention (a host named exactly like the group); groups without one
+skip the whole `IF` block and insert normally. And it says nothing about how
+often 1.5-era databases populated `moduleStatusByHost`, so it is not evidence
+that the plugin never worked — only that it does not work now, here.
+
+**C. Control, no collision — VERIFIED on every count.** Membership row created;
+`hostImage`, `hostKernelArgs` and `hostADPass` copied H←T exactly; a
+`snapinJobs` row created (`sjID=28`); `snapinTasks` row created. This is what
+proves A and B are about the collision rather than a generally broken trigger.
+
+It also pins the ordering that matters for the credential question: the `hosts`
+column UPDATE is the trigger's *first* statement, and the rollback takes it with
+everything else. So `hostADPass` propagates on **clean** adds only — see the
+refinement to ADR 0038 Decision 15.
+
+**D. `stSequence` — VERIFIED.** `stID=70, stJobID=28, stSnapinID=1,
+stSequence=0`. Trigger-created snapin tasks land at 0 and their run order is
+whatever the engine returns.
+
+**E. Duplicate host names — REFUTED as reachable (on 1.6).** `hosts.hostName`
+carries `UNIQUE KEY hostName (hostName)`, confirmed by `SHOW INDEX` on the
+cloned live database; a second host with the template's name is refused with
+1062 before the trigger is involved. So the scalar subquery's missing `LIMIT`
+(line 44) cannot be reached.
+
+**Caveat, and it moves E into UNKNOWN-1 rather than closing it.** That index is
+**not added by any schema step**. Step 161 calls
+`Schema::dropDuplicateData(DATABASE_NAME, ['hosts', ['hostName']])` with
+`$indexNeeded` defaulting to false, so it deletes duplicates and creates
+nothing; the UNIQUE comes from the manifest via `SchemaReconciler`. That is
+exactly the `roles.rName` shape schema step 401 exists to repair. Verified
+present on one real 1.6 database — not proven for a 1.5-origin one.
+
+```
+grep -n -A25 'function dropDuplicateData' packages/web/src/Items/Schema.php
+sed -n '2414,2427p' packages/web/commons/schema.php
+```
+
+**F. The hardcoded `'fog'` literal — VERIFIED, and the real bug is sharper than
+this document claimed.**
+
+The first attempt gave a **false negative** worth recording: with `fog` and
+`fogtest` both present on the same server, the branch ran even from inside
+`fogtest`, because **`information_schema.tables` is server-global**. A second,
+isolated container holding only `fogtest` confirmed the intended result —
+membership insert succeeded, the template's own `locationAssoc` row survived,
+and H got no row.
+
+So this document's earlier phrasing ("silently never runs on a server whose
+database is not named `fog`") was wrong. The condition is **"no database *on
+that server* is named `fog`"**, and that makes the guard worse than a
+mis-scoped test:
+
+> **It checks for the table's existence in one database and then writes to a
+> different one.** `SET @myDBTest = (SELECT count(table_name) ... WHERE
+> table_schema = 'fog' ...)` is answered by whatever database is called `fog`;
+> the `INSERT INTO locationAssoc` that follows is unqualified and resolves to
+> the *trigger's own* database.
+
+Both directions are reachable on a box that hosts two FOG databases — which is
+not hypothetical, since this machine has `fog` and `fog-1.5` side by side. A
+1.5 install whose own schema lacks `locationAssoc` would pass the guard on the
+strength of the 1.6 database's table and then fail the INSERT with 1146.
+
+**G. Prevalence on the live 1.6 lab — read-only, no writes.** The collision
+query returned **0 rows**. Exactly one group (`test`, groupID 1) has a
+`groupName` matching a `hostName`, so the template convention is in use on that
+box — but that template host has no `printerAssoc` rows, so collision A is not
+currently reachable there. "Zero" here means "not reachable on this box today",
+not "does not happen".
+
+<details>
+<summary>Original procedure, kept for the record</summary>
 
 **🔴 Run this on the isolated lab database only, never on a lab server whose
 hosts are real.** The trigger under test does not merely copy columns: it
@@ -928,6 +1081,8 @@ JOIN `printerAssoc` pa2 ON pa2.paPrinterID = pa1.paPrinterID
 WHERE gm.gmHostID <> t.hostID
 GROUP BY g.groupID;
 ```
+
+</details>
 
 ### UNKNOWN-4 — what does the client do with the printer list? — **VERIFIED from source; live poll COULDN'T-TEST**
 
@@ -1082,10 +1237,32 @@ That is right for the endpoint as it exists, because the endpoint can create
 groups from `groups_new[]`. It is **wrong for the endpoint ADR 0038 Decision
 16a is asking for**: adding forty existing hosts to three existing groups is
 not a group *creation*, and requiring `group.create` for it means an operator
-who may label hosts must also be able to mint groups. Splitting that —
-`group.create` only when `groups_new[]` is non-empty, membership editing behind
-something narrower — is an **access-control change** and is flagged here rather
-than decided.
+who may label hosts must also be able to mint groups.
+
+**Decided (ADR 0038 Decision 16a.6): `group.edit` for membership,
+`group.create` only when `groups_new[]` is non-empty.**
+
+The reasoning, because the obvious alternatives are both worse:
+
+- **A new `group.assign` verb is not available.** `Authorization::coreRegistry()`
+  (`Authorization.php:496`) declares a *fixed* action vocabulary per node —
+  `'group' => ['view', 'create', 'edit', 'delete', 'task']`. A bespoke sixth
+  verb would be the registry's first, and worse, it would **regress the
+  upgrade**: every role that exists today would lack it, so labelling would
+  stop working for everyone on upgrade until an admin edited every role.
+- **`host.edit` is the wider grant, not the narrower one.** It carries the
+  whole imperative half — image, AD credentials, kernel args — which is exactly
+  what Decision 1 is separating membership *from*. Gating a label behind the
+  permission to rewrite a host's AD password inverts the point of the split.
+- **`group.edit` already exists on every role that can manage groups**, and it
+  is the right shape: membership is an edit to a group. It is strictly narrower
+  than the `group.create` in force today, so the change only ever *removes*
+  reach — no role gains anything, and no upgrade step is needed.
+
+This is an access-control change, so it is called out explicitly rather than
+folded into the mass-edit work: the same permission split must land on the
+rewritten `saveGroup` **and** on the host-side bulk add/remove that Decision
+16a.2 introduces, or the narrower gate is bypassable through the new endpoint.
 
 Fixtures created and removed, verified back to baseline: host 228 and its
 `snapinJobs` / `snapinTasks` / `snapinAssoc` / `tasks` rows; groups

--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -283,7 +283,129 @@ git show origin/stable:packages/web/commons/schema.php | grep -n -B2 -A2 'ADD UN
 UNIQUE, the accesscontrol plugin never created it, native RBAC adopted the
 table as it found it, and schema step 401 exists to repair it. Query in §5.
 
-### 1.9 Plugin duplication
+### 1.9 The host list, and what "presented as tags" actually costs
+
+Evidence for ADR 0038 Decision 16a, whose five requirements are binding.
+
+**VERIFIED — there is no groups column on the host list, and the grid has no
+per-column search UI of any kind.** The header set is enumerated in one place,
+and its own comment says sorting is the substitute for filtering.
+
+```
+sed -n '105,170p' packages/web/src/Pages/HostManagement.php
+grep -n 'data-col' packages/web/src/Pages/HostManagement.php
+```
+
+> "Sorting is the filter here -- this grid has no per-column search UI, so the
+> global box matches the STORED word" — `HostManagement.php:150-153`
+
+So requirement 1's "filterable" is a **new capability on this grid**, not a
+column definition. That is the honest sizing and it is the requirement most
+likely to be under-scoped.
+
+**VERIFIED — the grid is server-side, so a filter must be SQL.**
+
+```
+sed -n '298,310p' packages/web/management/js/fog/host/fog.host.list.js
+# processing: true, serverSide: true, POST ?node=host&sub=list
+```
+
+**VERIFIED — the mechanism for a query-level filter already exists and is
+documented with the trap it avoids.** The site boundary is passed to
+`complex()` as a subquery ANDed into the row query, the filter count and the
+total count, because the `LIMIT` is applied before any row-level filtering:
+post-filtering returned empty first pages and counts describing rows the user
+could not see.
+
+```
+sed -n '3149,3178p' packages/web/src/Router/Route.php
+grep -n 'scopedObjectWhere' packages/web/src/Auth/Authorization.php
+```
+
+A groups filter is the same shape — `hostID IN (SELECT gmHostID FROM
+groupMembers WHERE gmGroupID IN (...))` — and inherits the same rule: into the
+query, never onto the page.
+
+**VERIFIED — rendering chips is cheap, because the column table already has a
+per-page batch loader.** `relColumn()` takes a `prime` callback handed every row
+on the page at once.
+
+```
+sed -n '7660,7690p' packages/web/src/Router/Route.php
+```
+
+One extra query per page, not per host.
+
+**VERIFIED — the list's Add to Group modal already has typeahead, chips and
+create-on-the-fly.** This is easy to miss and it changes what requirement 3
+costs: select2 with `tags: true`, `tokenSeparators: [',', ' ']`, ajax against
+`/group/names/name=%term%`, and a `createTag` handler that badges an unmatched
+term `(new)`.
+
+```
+sed -n '29,120p' packages/web/management/js/fog/host/fog.host.list.js
+```
+
+**What it does not have: remove.** The modal is add-only, and `saveGroup()`
+only ever calls `addHost()`. A label you can apply and cannot retract is not a
+label — requirement 2.
+
+**VERIFIED — the list modal is a second create-and-associate path, and the
+looser one.** The shared helper POSTs the created id to the association tab's
+own update URL and its docblock says so explicitly ("this is not a second write
+path"); it is used by eleven tabs, including `host-group` on the host **edit**
+page.
+
+```
+grep -rn 'registerCreateAndAssociate' packages/web/management/js/   # 11 call sites
+sed -n '1752,1790p' packages/web/management/js/fog/fog.common.js    # the helper
+sed -n '617p'       packages/web/management/js/fog/host/fog.host.edit.js
+```
+
+The list modal instead posts `groups[]` / `groups_new[]` to `sub=saveGroup`,
+which builds a group from a raw string:
+
+```
+sed -n '4083,4141p' packages/web/src/Pages/HostManagement.php
+```
+
+`->set('name', $group)->addHost($hosts)->save()` — **no name-collision check**,
+where the group page's own rename path does check via
+`getManager()->exists()` (`GroupManagement.php:733`).
+
+**VERIFIED by code reading — `saveGroup()` performs no CSRF check.**
+`FOGPageManager` calls `checkAuthAndCSRF()` centrally only when the resolved
+method takes an `Ajax`/`Post` suffix; the handler is `saveGroup`, there is no
+`saveGroupPost`, and it does not call it itself.
+
+```
+sed -n '176,208p' packages/web/src/Base/FOGPageManager.php    # central gate
+grep -c 'function saveGroupPost' packages/web/src/Pages/HostManagement.php   # 0
+grep -n 'checkAuthAndCSRF' packages/web/src/Pages/HostManagement.php
+# 1643 1983 2251 2922 3730 4606 4919 -- saveGroup() is at 4083, not among them
+grep -n -A30 'function requireForStateChanging' packages/web/src/Auth/CSRF.php
+```
+
+`CSRF::requireForStateChanging()` is reached from exactly two places
+(`FOGBase::checkAuthAndCSRF()` and `Route.php:901`), so there is no third,
+global enforcement. Page **permission** is unaffected —
+`requirePagePermission()` runs on every dispatch (`FOGPageManager.php:195`).
+
+**VERIFIED — `saveGroup()` does not bound the posted host ids to the caller's
+object scope**, where `deployMultiPost()` does on identical input.
+
+```
+grep -n 'requirePageObjectScopeMass' packages/web/src/Pages/HostManagement.php  # 4633 only
+```
+
+The central `requirePageObjectScope()` is passed the URL `$id`
+(`FOGPageManager.php:203`), and a list-level action has none.
+
+Both gaps are pre-existing. They are in scope because ADR 0038 Decision 16a
+promotes this endpoint from a convenience to the primary membership surface.
+Confirm both with a request, not a reading — UNKNOWN-6.
+
+### 1.10 Plugin duplication
 
 **VERIFIED — two plugins each ship a host hook and a near-identical group hook
 whose only job is to write one value across many hosts.**
@@ -327,7 +449,7 @@ grep -n 'no shipped 1.6 plugin ABI' docs/adr/0017-hook-dispatch-contract.md
 This is the strongest single argument for putting `HOST_MASSEDIT_*` in **1.6.0**
 rather than 1.6.x.
 
-### 1.10 Where the plugin code lives, and what an upgrade removes
+### 1.11 Where the plugin code lives, and what an upgrade removes
 
 **VERIFIED — bundled plugins are fetched into the web tree, which is
 `rm -rf`'d on upgrade; the external plugin root is not.**
@@ -346,7 +468,7 @@ trigger.** `DROP TRIGGER` appears only in the plugin's own `uninstall()` and
 grep -n 'DROP TRIGGER' <fog-plugins>/persistentgroups/src/Managers/PersistentGroupsManager.php
 ```
 
-### 1.11 The retirement precedent
+### 1.12 The retirement precedent
 
 **VERIFIED — schema step 399 is the pattern, and its comment is the argument
 for why the gate must read table facts.**
@@ -362,7 +484,7 @@ grep -n '^// [0-9]\+$' packages/web/commons/schema.php | tail -3      # 399, 400
 grep -c '^// [0-9]\+$' packages/web/commons/schema.php                # 360 numbered comments in file
 ```
 
-### 1.12 Audit
+### 1.13 Audit
 
 **VERIFIED — ADR 0021 Decision 11 already answers the 400-host question,
 against this exact example.** One header, `affectedCount`, `outcome` allowed or
@@ -425,11 +547,22 @@ grep -rl "printerassociation\|PrinterAssociation" packages/web/src packages/web/
 | Mass edit form + apply | `Pages/HostManagement.php`, `js/fog/host/fog.host.list.js` | 2, plus `_uniformHostValues()` lifted to a shared home |
 | Bulk group-membership editing | same 2 files | extends the existing `#addToGroupModal` |
 | `HOST_MASSEDIT_*` hooks | `Pages/HostManagement.php` + `docs/plugin-development.md` | 2 |
+| **Groups column + filter** (Dec 16a.1) | `Router/Route.php` (column + `prime` + filter subquery), `Pages/HostManagement.php` (header), `js/fog/host/fog.host.list.js` (chips, filter control) | 3, and the filter is the first of its kind on this grid |
+| **Bulk add/remove + shared create path** (Dec 16a.2–4) | `Pages/HostManagement.php` (`saveGroup` rewritten: remove, CSRF, scope), `js/fog/host/fog.host.list.js` | 2 |
+| **Group list "grants" column** (Dec 16a.5) | `Pages/GroupManagement.php` | 1 |
 | Retirement step | `commons/schema.php` | 1 |
 | Docs | `GROUP_SHARED_STATE.md` rewritten as the mass edit doc; ADR 0001 amendment note; release notes | 3 |
 
-**Roughly 20 core files touched, 7 new.** The heavy ones are
-`GroupManagement.php` (3532 lines, 8 tabs) and `HostManagement.php` (5256).
+**Roughly 22 core files touched, 7 new** — the presentation work overlaps
+almost entirely with files the rest of the change already opens. The heavy ones
+are `GroupManagement.php` (3532 lines, 8 tabs), `HostManagement.php` (5256) and
+`Route.php`.
+
+Requirement 16a.3 ("it has to feel lightweight") is mostly **already built**:
+the list modal has select2 chips, typeahead and create-on-the-fly today
+(§1.9). What is genuinely new is the **filter** (16a.1) — no per-column
+filtering exists on this grid at all — and **remove** (16a.2). Those two are
+the presentation work; the rest is reuse and two security fixes.
 
 ### 2.3 Plugin files
 
@@ -455,7 +588,10 @@ items, in the order they block work:
    the printer resolver, because it decides the blast radius of a resolver bug.
 5. **UNKNOWN-5** (mass authorization cost at 400 hosts) — does not block;
    determines whether the mass edit needs a set-based scope check.
-6. **A migration rehearsal** on a 1.5-origin dump, per
+6. **UNKNOWN-6** (`saveGroup()`'s CSRF and scope gaps) — does not block, but
+   both are on the endpoint ADR 0038 Decision 16a promotes to primary. Cheap:
+   two requests.
+7. **A migration rehearsal** on a 1.5-origin dump, per
    `docs/development/upgrade-rehearsal.md`, for step 405.
 
 ### 2.5 1.6.0 or 1.6.x
@@ -464,7 +600,7 @@ The honest read, with the argument on both sides.
 
 **What argues for 1.6.0:**
 
-- **The plugin ABI is unshipped** (§1.9). `HOST_MASSEDIT_*` costs nothing now
+- **The plugin ABI is unshipped** (§1.10). `HOST_MASSEDIT_*` costs nothing now
   and needs a deprecation window after 1.6.0 ships. This is the strongest
   argument and it is not about the group split at all — it is about the hook.
 - **There is no destructive migration** (Decision 18). The upgrade is four
@@ -492,10 +628,21 @@ The honest read, with the argument on both sides.
 
 **Recommendation, and it is a split rather than a single answer:**
 
-- **1.6.0:** the `HOST_MASSEDIT_*` hooks and the mass edit form; the bulk
-  group-membership editor; schema step 405 (the trigger drop) and the
-  `persistentgroups` deletion. None of these depends on the resolver, all of
-  them are additive, and the ABI half genuinely gets harder after 1.6.0.
+- **1.6.0:** the `HOST_MASSEDIT_*` hooks and the mass edit form; **all five of
+  Decision 16a's presentation requirements** (groups column + filter, bulk
+  add/remove from the host side, the shared create-and-associate path with
+  `saveGroup()`'s CSRF and scope gaps closed, the group list's "grants"
+  column); schema step 405 (the trigger drop) and the `persistentgroups`
+  deletion. None of these depends on the resolver, all of them are additive,
+  and the ABI half genuinely gets harder after 1.6.0.
+
+  **16a is in the earlier release deliberately, and it is the half that must
+  not slip.** It is the part of Decision 16 that closes the labelling gap, and
+  the failure mode of shipping the split without it is specific: groups become
+  heavier while staying just as unpleasant to apply, which is the exact state
+  that made a `tags` entity look necessary. Landing 16a first also means the
+  presentation improvement stands on its own even if the declarative split
+  slips further — it is useful against today's groups, unchanged.
 - **1.6.x:** the declarative split itself — steps 402–404, the resolver, the
   group page rework, and the removal of the group page's imperative tabs. It
   depends on two UNKNOWNs that need a lab, and Decision 10's sequencing already
@@ -506,7 +653,7 @@ earlier release, the removals in the later one.
 
 ---
 
-## 3. The three things most likely to be built wrong
+## 3. The five things most likely to be built wrong
 
 Recorded here rather than in the ADR because they are implementation hazards,
 not decisions.
@@ -522,6 +669,16 @@ not decisions.
    a fleet-wide printer removal, delivered one machine at a time as they poll.
    The resolver throws; §1.6 shows the endpoint already turns a throw into a
    body with no `printers` key.
+4. **A groups filter applied to the returned page instead of the query.**
+   `complex()` applies the `LIMIT` before any row filtering, so a post-filter
+   gives empty first pages and counts that describe rows the caller cannot see.
+   That trap is already documented at `Route.php:3149-3172`, where the site
+   boundary hit it; the groups filter is the same shape and must go into the
+   query, the filter count and the total count.
+5. **A second create-and-associate path for host↔group.** There are already two
+   (§1.9) and the newer one skips the name-collision check. The list modal
+   should use `$.registerCreateAndAssociate()` like the other eleven tabs, not
+   grow a third.
 
 ---
 
@@ -546,13 +703,23 @@ reduces the declarative half to one chunk, so the case that needs a transaction
 is the one the design removes. Introducing transactions to the DB layer for it
 would be a much larger change with its own failure modes.
 
-**Build a `tags` entity.** Rejected in ADR 0038 Decision 16. The cost is
-measurable from the `site` plugin's absorption: `$validClasses`, the deletemass
-cascade, `SiteScope::$_nodes`, permissions, FKs, a page, five JS files, the API
-description.
+**Build a `tags` entity.** Rejected in ADR 0038 Decision 16: `groupMembers` is
+already an attribute-free many-to-many labelling table
+(`gmID, gmHostID, gmGroupID`, §1.1), so a second set-of-hosts concept solves a
+presentation gap with a data model. The cost of the entity is measurable from
+the `site` plugin's absorption: `$validClasses`, the deletemass cascade,
+`SiteScope::$_nodes`, permissions, FKs, a page, five JS files, the API
+description — and none of it moves a host into a group any faster.
+
+**Ship the split and treat the presentation work as a follow-up.** Rejected,
+and this is the one rejection that is a scheduling decision rather than a
+design one. Decision 16 is only correct if a group is cheap to apply in bulk;
+the split alone makes groups *heavier* and leaves the labelling gap untouched,
+which reproduces the state that made tags look necessary. §2.5 puts all of
+Decision 16a in 1.6.0 for that reason.
 
 **Retire `persistentgroups` by deleting the directory.** Rejected: the trigger
-outlives the code (§1.10), and it is active rather than cosmetic.
+outlives the code (§1.11), and it is active rather than cosmetic.
 
 **Gate the rollup semantics on a provenance boundary.** Rejected: deciding a
 legacy row came from a group is the same unknowable inference as backfilling
@@ -695,6 +862,43 @@ time for one `deployMultiPost` of 400 hosts. If it is material, the fix is to
 use `SiteScope::allInScopeIDs()` once and diff, which is the set-based answer
 the class already provides — and it is a pre-existing improvement to the Queue
 Task path, not new work this creates.
+
+### UNKNOWN-6 — is `saveGroup()` really unprotected?
+
+Code reading says yes (§1.9). Confirm with requests rather than trusting the
+reading, because dispatch has paths this session did not trace.
+
+**CSRF.** Logged in as an admin in a browser, from a page on another origin (or
+with `curl` reusing the session cookie and **omitting** both the
+`X-CSRF-Token` header and a `_csrf` body field):
+
+```
+curl -i -b "<session cookie>" \
+  -X POST '<server>/management/index.php?node=host&sub=saveGroup' \
+  --data 'hosts[]=<id>&groups[]=<groupID>'
+```
+
+Expected if the reading is right: `202` and the host is added. Expected if
+something else enforces CSRF: `403 Forbidden (invalid CSRF token)`. Compare
+against the same request to `sub=deployMulti` (a `*Post` handler), which must
+give the 403.
+
+**Object scope.** As a user restricted to site A, with host `H` in site B:
+
+```
+curl -i -b "<cookie for the restricted user>" \
+  -X POST '<server>/management/index.php?node=host&sub=saveGroup' \
+  --data 'hosts[]=<H>&groups[]=<a group the user can see>'
+```
+
+Expected if the reading is right: the request succeeds and `H` joins the group.
+The same ids sent to `sub=deployMultiPost` must be refused with 403, which is
+the control that shows the difference is the missing
+`requirePageObjectScopeMass()` call and not something about the user.
+
+If either comes back protected, find what protects it before removing anything
+— a gap that is not there does not need fixing, and the reading was wrong about
+where enforcement lives.
 
 ### The retirement rehearsal
 

--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -672,62 +672,80 @@ Still open:
 3. **A migration rehearsal** on a 1.5-origin dump, per
    `docs/development/upgrade-rehearsal.md`, for step 405.
 
-### 2.5 1.6.0 or 1.6.x
+### 2.5 Release targeting — **decided: all of it in 1.6.0**
 
-The honest read, with the argument on both sides.
+**Decision (maintainer, 2026-09-01): the whole change targets 1.6.0.** The
+sequencing below is kept, because the ordering constraints are real, but the
+release boundary that used to sit in the middle of it is gone.
 
-**What argues for 1.6.0:**
+**The reasoning, recorded because it overturns this section's own earlier
+recommendation.** There is no RC yet. An RC exists to surface the bugs that
+neither code review nor a lab can see, and the two items this document had used
+to justify deferring the declarative half were both *unobservable* items —
+UNKNOWN-2 and UNKNOWN-4. Both are now closed, and the residue of UNKNOWN-4 (the
+live poll cycle on a real mode-`ar` host) is precisely the kind of thing an RC
+observes and a pre-RC hold does not. Holding work back from the RC to avoid
+shipping bugs the RC is designed to find inverts what the RC is for.
 
-- **The plugin ABI is unshipped** (§1.10). `HOST_MASSEDIT_*` costs nothing now
-  and needs a deprecation window after 1.6.0 ships. This is the strongest
-  argument and it is not about the group split at all — it is about the hook.
-- **There is no destructive migration** (Decision 18). The upgrade is four
-  additive schema steps plus one `DROP TRIGGER`. The usual reason to hold a
-  model change for a point release — "we cannot un-migrate the data" — does not
-  apply, because no data is migrated.
-- **The trigger is active on real servers right now** and every day it runs it
-  copies a domain password between hosts (Decision 15). Step 405 is worth
-  shipping on its own schedule.
-- Behaviour for every existing host and group is unchanged on upgrade, which is
-  what makes the risk profile a point-release profile even though the model
-  change is a major one.
+**Why that is safe rather than merely faster, and it is specific to this
+change:**
 
-**What argues for 1.6.x:**
+- **The client is fail-safe at both ends** (§5, UNKNOWN-4, verified in
+  `fog-client` 0.13.0). A resolver error surfaces as `data.Error`, and the
+  client returns without touching printers; the empty case has its own explicit
+  `np` spelling. So the worst an RC exposes is a *wrong printer list*, not a
+  stripped fleet. That was the one failure mode that genuinely argued for
+  holding, and the client already bounds it.
+- **Nothing is migrated** (Decision 18). The upgrade is additive schema steps
+  plus one `DROP TRIGGER`, so an RC finding a design problem does not leave
+  anyone with un-migrated data.
+- **Behaviour for existing hosts and groups is unchanged on upgrade**, which is
+  what makes the blast radius of an RC-stage discovery small.
+- **The ABI argument only ever pointed this way.** `HOST_MASSEDIT_*` is free
+  before 1.6.0 ships and needs a deprecation window afterwards (§1.10).
 
-- **UNKNOWN-2 is unanswered.** If `snapinTasks` is not a sufficient snapshot,
-  the snapin half needs a real snapshot table and the sizing above is wrong by
-  a schema step and a service-path change.
-- **UNKNOWN-4 is unanswered**, and the failure mode is printers being stripped
-  from a fleet. That is not a bug you ship to find out about.
-- The mass edit form is the largest single piece and it is the one with no
-  existing equivalent to fall back on. Decision 10 forbids removing the group
-  tabs before it is proven, so a half-landed release is *safe* but is also two
-  ways to do the same thing.
+**What does not change: Decision 10's ordering constraint.** The mass edit must
+land, and be proven, *before* anything is removed from the group page. Within
+one release that is a merge-order constraint rather than a release-boundary
+one, and it is honored by the build order below.
 
-**Recommendation, and it is a split rather than a single answer:**
+**The build order, and why it is grouped this way.** The binding constraints
+are Decision 10 (mass edit before removals), the resolver preceding the group
+page rework, and — pragmatically — file ownership, because
+`HostManagement.php` (5256 lines), `GroupManagement.php` (3532) and
+`Route.php` are touched by most of the work and concurrent PRs against them
+serialize through conflicts anyway.
 
-- **1.6.0:** the `HOST_MASSEDIT_*` hooks and the mass edit form; **all five of
-  Decision 16a's presentation requirements** (groups column + filter, bulk
-  add/remove from the host side, the shared create-and-associate path with
-  `saveGroup()`'s CSRF and scope gaps closed and its permission narrowed from
-  `group.create` to `group.edit`, the group list's "grants" column); schema
-  step 405 (the trigger drop) and the `persistentgroups` deletion. None of these depends on the resolver, all of them are additive,
-  and the ABI half genuinely gets harder after 1.6.0.
+| # | Unit | Owns | Gated by |
+|---|---|---|---|
+| A | Step 405 + `persistentgroups` deletion | `commons/schema.php`, `schema-expected.php`, `fog-plugins` | nothing; rehearsed on the 1.5-origin dump first |
+| B | `saveGroup` security + permission split | `Auth/Authorization.php`, the one method | nothing; these are live bugs today (§5, UNKNOWN-6) |
+| C | Resolver + mass edit + `HOST_MASSEDIT_*` | new `src/` classes, `Pages/HostManagement.php`, `docs/plugin-development.md` | B (same method) |
+| D | Presentation: groups column + filter, bulk add/remove, group list "grants" | `Router/Route.php`, `Base/FOGManagerController.php`, `Pages/HostManagement.php`, JS | C |
+| E | Group page rework + removal of the imperative tabs | `Pages/GroupManagement.php`, JS | **C proven** (Decision 10), D |
 
-  **16a is in the earlier release deliberately, and it is the half that must
-  not slip.** It is the part of Decision 16 that closes the labelling gap, and
-  the failure mode of shipping the split without it is specific: groups become
-  heavier while staying just as unpleasant to apply, which is the exact state
-  that made a `tags` entity look necessary. Landing 16a first also means the
-  presentation improvement stands on its own even if the declarative split
-  slips further — it is useful against today's groups, unchanged.
-- **1.6.x:** the declarative split itself — steps 402–404, the resolver, the
-  group page rework, and the removal of the group page's imperative tabs. It
-  depends on two UNKNOWNs that need a lab, and Decision 10's sequencing already
-  says the removals come a release later than the replacement.
+A and B are independent of everything and of each other, so they go first and
+in parallel. C is the bulk and unblocks both D and E. E is last by Decision 10
+and is the only unit that removes anything.
 
-That ordering also satisfies Decision 10 by construction: mass edit is in the
-earlier release, the removals in the later one.
+**Two things inside that order need calling out rather than discovering.**
+
+- **D's filter work touches a shared helper.** Teaching `_sbCriterion()` /
+  `searchBuilderType()` to express a *relationship* column is a change to
+  something every grid depends on, so it gets a written design before it gets
+  code, and `tests/searchbuilder-filter-clause.test.php` is the existing gate
+  it has to keep green.
+- **Docs ship with C, not after it.** Decision 4 promises that re-tasking is
+  the only way to pick up a snapin change and that "the docs must say so
+  plainly". That sentence is load-bearing for support, so it lands in the same
+  unit as the behaviour it describes — `GROUP_SHARED_STATE.md` rewritten as the
+  mass edit document, the ADR 0001 amendment note, and the release note
+  covering both the re-tasking semantics and Decision 15's credential
+  propagation.
+
+**UNKNOWN-5** (per-id scope check cost at 400 hosts) is measured inside C,
+where the mass edit's authorization path is being written, rather than as a
+prerequisite to it.
 
 ---
 

--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -13,13 +13,14 @@ names the claim that would hurt most if it turned out to be false.
 Repository state: `working-1.6` at `4729701`. Plugins at `fog-plugins`
 `ec101b3`.
 
-**Update 2026-09-01:** UNKNOWN-2, UNKNOWN-3, UNKNOWN-4 and UNKNOWN-6 were run
-and are recorded in §5 with their evidence — UNKNOWN-3 in a throwaway container
-cloned from the live database, the rest against the 1.6 lab (`10.255.20.1`).
-Two changed a decision: UNKNOWN-4 (ADR 0038 Decision 9) and UNKNOWN-6 (Decision
-16a.6, the permission split). UNKNOWN-3 refuted one hazard this document
-claimed and made another materially worse. **UNKNOWN-1** and **UNKNOWN-5**
-remain open; neither blocks.
+**Update 2026-09-01:** UNKNOWN-1, -2, -3, -4 and -6 were run and are recorded
+in §5 with their evidence — UNKNOWN-3 in a throwaway container cloned from the
+live database, UNKNOWN-1 read-only against both installs on this box, the rest
+against the 1.6 lab (`10.255.20.1`). Two changed a decision: UNKNOWN-4 (ADR
+0038 Decision 9) and UNKNOWN-6 (Decision 16a.6, the permission split).
+UNKNOWN-3 refuted one hazard this document claimed and made another materially
+worse; UNKNOWN-1 then removed a schema step the earlier write-up had wrongly
+added. **UNKNOWN-5** is the only one left open, and it blocks nothing.
 
 ---
 
@@ -310,10 +311,12 @@ sed -n '677,690p' packages/web/src/Router/Route.php
 git show origin/stable:packages/web/commons/schema.php | grep -n -B2 -A2 'ADD UNIQUE ( .groupName. )'
 ```
 
-**UNKNOWN-1 — whether a real upgraded 1.5-origin database actually has it.**
-`roles.rName` is the precedent for exactly this gap: the manifest declared it
-UNIQUE, the accesscontrol plugin never created it, native RBAC adopted the
-table as it found it, and schema step 401 exists to repair it. Query in §5.
+**VERIFIED on a real upgraded database — UNKNOWN-1 is closed.** The
+`roles.rName` precedent was the worry (manifest declares UNIQUE, nothing
+creates it, step 401 repairs it), and it does not apply: step 161's
+`dropDuplicateData()` creates the index as well as removing duplicates, so
+every database past 161 has it. Confirmed on the 1.5-origin install at schema
+278 with 2079 hosts and on the live 1.6 one. Details in §5.
 
 ### 1.9 The host list, and what "presented as tags" actually costs
 
@@ -648,12 +651,14 @@ absent piece of behaviour. The rest is reuse and two security fixes.
 Nothing in §2.1–§2.3 can be signed off from a cloud session. The lab-gated
 items, in the order they block work:
 
-**Closed 2026-09-01** against the 1.6 lab: **UNKNOWN-2** (VERIFIED — the task
-is the authority, no new snapshot table needed), **UNKNOWN-3** (VERIFIED in an
-isolated container — both collisions are fatal, and the module arm is reachable
-for 98.8% of hosts), **UNKNOWN-4** (VERIFIED from `fog-client` source; the live
-poll cycle is still unobserved), **UNKNOWN-6** (VERIFIED — both gaps real, and
-the permission split is now decided rather than flagged).
+**Closed 2026-09-01:** **UNKNOWN-1** (VERIFIED read-only on the 1.5-origin
+install at schema 278 *and* the live 1.6 one — both indexes present, both
+created by schema step 161, no repair needed), **UNKNOWN-2** (VERIFIED — the
+task is the authority, no new snapshot table needed), **UNKNOWN-3** (VERIFIED
+in an isolated container — both collisions are fatal, and the module arm is
+reachable for 98.8% of hosts), **UNKNOWN-4** (VERIFIED from `fog-client`
+source; the live poll cycle is still unobserved), **UNKNOWN-6** (VERIFIED —
+both gaps real, and the permission split is now decided rather than flagged).
 
 Still open:
 
@@ -662,14 +667,9 @@ Still open:
    (UNKNOWN-4), so any change to the empty-case spelling is a client-visible
    change. Confirm the trace on a real mode-`ar` host before shipping the
    printer resolver — that is the one piece UNKNOWN-4 could not observe.
-2. **UNKNOWN-1** (`groupName` *and* `hostName` uniqueness on real upgraded
-   databases) — does not block; determines whether step 404 also needs an index
-   repair like 401. Grew after UNKNOWN-3: neither index is created by a
-   numbered step on 1.6, so both reach a 1.5-origin database only through the
-   manifest reconciler.
-3. **UNKNOWN-5** (mass authorization cost at 400 hosts) — does not block;
+2. **UNKNOWN-5** (mass authorization cost at 400 hosts) — does not block;
    determines whether the mass edit needs a set-based scope check.
-4. **A migration rehearsal** on a 1.5-origin dump, per
+3. **A migration rehearsal** on a 1.5-origin dump, per
    `docs/development/upgrade-rehearsal.md`, for step 405.
 
 ### 2.5 1.6.0 or 1.6.x
@@ -847,25 +847,75 @@ If (c) returns rows, the trigger's template subquery (`:44`) returns more than
 one row and **every** `INSERT INTO groupMembers` on this server errors — worth
 knowing before writing the release note.
 
-**Partially answered 2026-09-01, and (c) is now the more interesting half.**
-On a clone of the live 1.6 database, `hosts` carries `UNIQUE KEY hostName
-(hostName)`, so (c) is empty and the missing-`LIMIT` hazard is unreachable
-*there* (UNKNOWN-3 case E).
+**ANSWERED 2026-09-01 — CLOSED. Both indexes are present, both are created by
+a numbered schema step, and there is no index repair for step 404 to do.**
 
-But **no numbered schema step adds that index on 1.6.** Step 161 calls
-`Schema::dropDuplicateData(DATABASE_NAME, ['hosts', ['hostName']])`, and
-`dropDuplicateData`'s third parameter `$indexNeeded` defaults to `false` — it
-deletes duplicate rows and creates nothing. The UNIQUE therefore comes from the
-manifest via `SchemaReconciler`, which is precisely the `roles.rName` shape.
+Run against the real 1.5-origin install on this box (`/var/www/html/fog-1.5`,
+schema **278**, **2079 hosts**) and against the live 1.6 install
+(`/var/www/html/fog`, schema 401, 86 hosts), read-only:
 
 ```
-grep -n -A25 'function dropDuplicateData' packages/web/src/Items/Schema.php
-sed -n '2405,2425p' packages/web/commons/schema.php
+php ~/scripts/background_scripts/check_group_host_unique_indexes.php /var/www/html/fog-1.5
+php ~/scripts/background_scripts/check_group_host_unique_indexes.php /var/www/html/fog
 ```
 
-So this question now covers **both** `groups.groupName` and `hosts.hostName`,
-and on a 1.5-origin database both are open. One real 1.6 database is one
-sample, not a guarantee.
+| | 1.5-origin (278, 2079 hosts) | 1.6 (401, 86 hosts) |
+|---|---|---|
+| `groups.groupName` single-column UNIQUE | **yes** (`groupName`, `groupName_2`) | **yes** (same two) |
+| duplicate `groupName` values | 0 | 0 |
+| `hosts.hostName` single-column UNIQUE | **yes** (`hostName`) | **yes** (`hostName`) |
+| duplicate `hostName` values | 0 of 2079 | 0 of 86 |
+
+**Correction to what this document said earlier, because it was wrong and it
+pointed at unnecessary work.** It claimed no numbered step creates these
+indexes and that the UNIQUE reaches a database only through
+`SchemaReconciler` — the `roles.rName` shape. That is not what
+`dropDuplicateData()` does. Its `$indexNeeded` parameter only chooses the
+*form* of the index clause; the `ADD UNIQUE` is unconditional and sits outside
+that branch:
+
+```php
+// packages/web/src/Items/Schema.php — the ALTER is outside the if
+if ($indexNeeded) { $ending = sprintf('INDEX (`%s`)', ...); }
+else              { $ending = sprintf('(`%s`)', ...); }
+...
+'ALTER TABLE `%s`.`_%s` ADD UNIQUE %s'
+```
+
+It builds a shadow `_hosts` **with** the UNIQUE, `INSERT IGNORE`s the rows in
+(which is how the duplicates get dropped), and renames it over the original. So
+step 161's `dropDuplicateData(DATABASE_NAME, ['hosts', ['hostName']])` both
+removes duplicates *and* creates the index. 1.5 does the same, from identical
+code in `lib/fog/schema.class.php`.
+
+```
+sed -n '92,155p' packages/web/src/Items/Schema.php
+git show origin/stable:packages/web/lib/fog/schema.class.php | sed -n '92,150p'
+```
+
+The observed index names corroborate the mechanism rather than just the
+outcome. Both databases carry **two** unique indexes on `groupName` —
+`groupName` from `dropDuplicateData`'s shadow-table `ADD UNIQUE`, and
+`groupName_2` from 1.5's separate explicit
+`ALTER TABLE groups ADD UNIQUE (groupName)`. `hosts` has only one, because only
+the `dropDuplicateData` path ever creates it. That is the fingerprint of the
+mechanism above and not of a reconciler.
+
+**Consequences:**
+
+- **Step 404 needs no index repair.** The `roles.rName` parallel does not hold;
+  drop it from the plan.
+- **UNKNOWN-3 case E is refuted generally, not only on 1.6.** The trigger's
+  template subquery (`:44`, no `LIMIT`) is unreachable on any database that has
+  reached schema 161, which is every supported one.
+- **`groupName` is a safe order tiebreak** (ADR 0038 Decision 6), on upgraded
+  databases as well as fresh ones.
+
+Remaining limit, stated rather than papered over: the 1.5 box has **0 rows in
+`groups`**, so its zero-duplicates result for `groupName` is vacuous. The
+*index* presence is what was in question and that is proven on both; the
+duplicate check is only load-bearing for `hosts`, where 2079 rows is a real
+sample.
 
 ### UNKNOWN-2 — is `snapinTasks` a sufficient snapshot? — **VERIFIED, closed**
 
@@ -991,18 +1041,12 @@ cloned live database; a second host with the template's name is refused with
 1062 before the trigger is involved. So the scalar subquery's missing `LIMIT`
 (line 44) cannot be reached.
 
-**Caveat, and it moves E into UNKNOWN-1 rather than closing it.** That index is
-**not added by any schema step**. Step 161 calls
-`Schema::dropDuplicateData(DATABASE_NAME, ['hosts', ['hostName']])` with
-`$indexNeeded` defaulting to false, so it deletes duplicates and creates
-nothing; the UNIQUE comes from the manifest via `SchemaReconciler`. That is
-exactly the `roles.rName` shape schema step 401 exists to repair. Verified
-present on one real 1.6 database — not proven for a 1.5-origin one.
-
-```
-grep -n -A25 'function dropDuplicateData' packages/web/src/Items/Schema.php
-sed -n '2414,2427p' packages/web/commons/schema.php
-```
+**Which raised a follow-up that is now also closed.** The index is not in
+`CREATE TABLE hosts` and no `ALTER ... ADD UNIQUE` names it, which briefly
+looked like the `roles.rName` shape — a manifest-only index that a 1.5-origin
+database might lack. It is not: schema step 161's `dropDuplicateData()` creates
+it. See UNKNOWN-1, verified on the 1.5-origin install at schema 278 as well as
+on 1.6, so **E is unreachable on any supported database**, not just this one.
 
 **F. The hardcoded `'fog'` literal — VERIFIED, and the real bug is sharper than
 this document claimed.**

--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -1,0 +1,751 @@
+# Splitting what a group is: the work, sized
+
+**Status: proposed, not decided. No code has been written for it.**
+The decisions this sizes are in
+[`docs/adr/0038`](../adr/0038-a-group-grants-it-does-not-copy.md).
+
+Every claim below is labeled **VERIFIED** (with the command that produced it),
+**INFERRED** (reasoned from something verified), or **UNKNOWN**. This was
+written in a cloud session with **no database and no lab**, so anything that
+needs a running server is UNKNOWN with a procedure, not an answer. Section 6
+names the claim that would hurt most if it turned out to be false.
+
+Repository state: `working-1.6` at `4729701`. Plugins at `fog-plugins`
+`ec101b3`.
+
+---
+
+## 1. What is actually there today
+
+### 1.1 The defect
+
+**VERIFIED — every group "assignment" is a bulk write over the current
+membership.** Twenty-three references to `$this->get('hosts')` in one model.
+
+```
+grep -c "get('hosts')" packages/web/src/Items/Group.php     # 23
+grep -n 'function ' packages/web/src/Items/Group.php
+```
+
+| Method | Line | What it writes | Shape |
+|---|---|---|---|
+| `addPrinter()` | 136 | `printerAssoc` rows | one per host × printer |
+| `removePrinter()` | 176 | `deletemass` | over membership |
+| `updateDefault()` | 194 | `paIsDefault` | over membership |
+| `addSnapin()` | 236 | `snapinAssoc` rows | one per host × snapin |
+| `removeSnapin()` | 293 | `deletemass` | over membership |
+| `setSnapinOrder()` | 316 | `saSequence` | `new Host()` per member |
+| `addModule()` | 346 | `moduleStatusByHost` | one per host × module |
+| `setDisp()` | 401 | delete-all + insert | one per host |
+| `setAlo()` | 436 | delete-all + insert | one per host |
+| `addImage()` | 501 | `hosts.hostImage` | one `UPDATE ... IN` |
+| `setAD()` | 1100 | five `hosts` columns | one `UPDATE ... IN` |
+
+**VERIFIED — the group table owns five columns of its own and pushes none of
+them as such.** `groupKernel`, `groupKernelArgs`, `groupPrimaryDisk`,
+`groupInit` are a *template* that prefills the form; `groupBuilding` is
+vestigial (§1.4).
+
+```
+sed -n '42,53p' packages/web/src/Items/Group.php
+```
+
+**VERIFIED — a `Group` is already used as a bare selection carrier, unsaved.**
+`HostManagement::deployMulti()` builds one to cover an ad-hoc host list so a
+multicast session works the way it does for a real group; `Group::loadHosts()`
+short-circuits on an unsaved group specifically to make that safe.
+
+```
+sed -n '1150,1183p' packages/web/src/Items/Group.php
+grep -n 'The carrier for the selection' packages/web/src/Pages/HostManagement.php
+```
+
+This matters for ADR 0038 Decision 1: "the group is only a selection mechanism"
+is not a new idea being introduced, it is an idiom the codebase already relies
+on.
+
+### 1.2 The plugin, read closely
+
+**VERIFIED — the trigger, and what it does beyond the thirteen columns.**
+
+```
+sed -n '30,100p' <fog-plugins>/persistentgroups/src/Managers/PersistentGroupsManager.php
+```
+
+| Line | What | Note |
+|---|---|---|
+| 44 | template = host whose `hostName` = the group's `groupName` | scalar subquery, **no `LIMIT`** |
+| 46–54 | copies the 13 `hosts` columns | the empirical list |
+| 56 | `information_schema` probe for `locationAssoc` | **`table_schema = 'fog'` hardcoded** |
+| 58–60 | copies `locationAssoc` | no `ON DUPLICATE KEY` |
+| 63–65 | copies `printerAssoc` incl. `paIsDefault` | **no `ON DUPLICATE KEY`** |
+| 69–72 | copies `snapinAssoc` | has `ON DUPLICATE KEY`; **never sets `saSequence`** |
+| 75–83 | finds or creates a `snapinJobs` row | **adding a host runs snapins on it** |
+| 86–89 | inserts `snapinTasks` | **never sets `stSequence`** |
+| 92–94 | copies `moduleStatusByHost` incl. `msState` | **no `ON DUPLICATE KEY`** |
+
+**VERIFIED — `printerAssoc` and `moduleStatusByHost` both carry composite
+UNIQUE keys.**
+
+```
+php -r '$m=require "packages/web/commons/schema-expected.php";
+foreach (["printerAssoc","moduleStatusByHost","snapinAssoc"] as $t)
+  echo $m["tables"][$t]["create"], "\n\n";' | grep -o 'UNIQUE KEY [^,]*'
+```
+
+**INFERRED — adding a host to a group fails outright if that host already
+shares any printer, or any module override, with the template host.** The
+copies at lines 63 and 92 carry no `ON DUPLICATE KEY UPDATE`, so a duplicate
+raises error 1062 inside an `AFTER INSERT` trigger, which rolls back the
+`INSERT INTO groupMembers` that fired it. The snapin copy is immune because it
+has the clause. Reproduction in §5.1 (UNKNOWN-3) — this is a mechanism argument
+from MySQL semantics, not something observed.
+
+**VERIFIED — the location branch has silently never run on a server whose
+database is not named `fog`.** Line 56 tests `table_schema = 'fog'` as a
+literal. The core equivalent, schema step 399, uses
+`TABLE_SCHEMA = DATABASE()`.
+
+```
+grep -n "table_schema" <fog-plugins>/persistentgroups/src/Managers/PersistentGroupsManager.php
+grep -n 'TABLE_SCHEMA. = DATABASE()' packages/web/commons/schema.php
+```
+
+**INFERRED — every snapin task the trigger creates ties at sequence 0.** Line
+86 names four columns and `stSequence` is not among them; the column defaults
+to `0` and `snapinTasks` is read in sequence order. So on a plugin-managed
+server the snapin run order for a newly added host is whatever the engine
+returns.
+
+### 1.3 What the group page grew to compensate
+
+**VERIFIED — the tri-state / mixed-value machinery already exists, and it is
+one query over the whole selection.** `_uniformHostValues()` builds
+`COUNT(DISTINCT COALESCE(col,'')) / MIN(COALESCE(col,''))` per requested column
+in a single `SELECT ... WHERE hostID IN (...)`.
+
+```
+sed -n '264,342p' packages/web/src/Pages/GroupManagement.php
+```
+
+This is the single biggest sizing finding for the mass edit form: the "40 hosts
+with 6 images must show *(varies)*" requirement is **already implemented and
+already scale-safe**. It is parameterised by a `key => column` map and keyed off
+a host id list. Porting it to a selection is changing where the id list comes
+from.
+
+**VERIFIED — the no-clobber convention is an in-band string sentinel.** Blank
+means leave alone; the literal `NULL`, case-insensitively, means clear.
+
+```
+sed -n '744,772p' packages/web/src/Pages/GroupManagement.php   # general tab
+sed -n '859,882p' packages/web/src/Pages/GroupManagement.php   # AD tab
+```
+
+**VERIFIED — two fields already use the correct out-of-band form instead.** The
+AD join state and `hostEnforce` are tri-state `<select>`s reading *No change /
+Enable on all / Disable on all*.
+
+```
+sed -n '1396,1430p' packages/web/src/Pages/GroupManagement.php
+grep -n "adstate" packages/web/src/Pages/GroupManagement.php
+```
+
+So the codebase contains both the pattern ADR 0038 Decision 11 adopts and the
+one it rejects, ten screens apart. That is the argument, not a preference.
+
+**VERIFIED — `hostEnforce` is `tinyint(1)` on `working-1.6`, and
+`GROUP_SHARED_STATE.md` still describes it as `enum('0','1')`.** ADR 0028
+changed it; the doc did not follow. Worth fixing when that document is
+rewritten as the mass edit document.
+
+```
+grep -n 'hostEnforce' packages/web/commons/schema-expected.php docs/GROUP_SHARED_STATE.md
+```
+
+### 1.4 `hostBuilding`
+
+**VERIFIED — declared on both models, written by nothing.**
+
+```
+grep -rn "'building'" packages/web/src/ | grep -v @          # 2 hits, both field maps
+grep -rni building packages/web/src packages/web/management/js --include=*.php --include=*.js
+```
+
+The only non-field-map hit anywhere is `fog.host.export.js:8`, an
+`{data: 'building', visible: false}` datatable column. The trigger copies it.
+It does not go in the mass edit form.
+
+### 1.5 The write paths, measured
+
+**VERIFIED — host-column mass writes are one statement, already atomic.**
+`FOGManagerController::perform_update()` builds a single
+`UPDATE ... WHERE id IN (...)`.
+
+```
+sed -n '1929,2010p' packages/web/src/Base/FOGManagerController.php
+```
+
+**VERIFIED — association writes chunk at 500 rows, one statement per chunk.**
+
+```
+grep -n 'array_chunk' packages/web/src/Base/FOGManagerController.php    # :1854
+```
+
+**VERIFIED — there is no transaction support anywhere in the web tier.**
+
+```
+grep -rn 'beginTransaction\|->commit()\|rollBack\|inTransaction' packages/web/src/ | wc -l   # 0
+```
+
+So "all-or-nothing" is not available today without new plumbing in `PDODB`.
+ADR 0038 Decision 12 declines to add it and instead points out that the split
+reduces the declarative half to one chunk.
+
+**VERIFIED — the existing mass authorization gate is per-id.**
+
+```
+sed -n '2270,2280p' packages/web/src/Auth/Authorization.php
+grep -n 'requirePageObjectScopeMass' packages/web/src/Pages/HostManagement.php
+```
+
+### 1.6 The client contract
+
+**VERIFIED — the printer endpoint conflates "no printers" and "resolver
+failed" under the same key, and the failure shape is nevertheless the safe
+one.**
+
+```
+sed -n '52,80p'  packages/web/src/Client/PrinterClient.php    # 'error' => 'np'
+sed -n '218,240p' packages/web/src/Client/FOGClient.php       # catch -> ['error' => msg]
+```
+
+An exception in `json()` yields `{"error": "..."}` with **no `printers` key**.
+The empty case yields `{"error":"np","printers":[],"mode":...}`. So a client
+branching on the presence of `printers` is already safe and a client branching
+on `error` is already wrong.
+
+**VERIFIED — removal is gated on printer level `ar`.**
+
+```
+sed -n '36,50p' packages/web/src/Client/PrinterClient.php
+```
+
+Three modes: `0` no management, `a` FOG-managed only, `ar` FOG handles all
+printers. Only `ar` implies removal. Whether the shipped `fog-client` honours
+that is UNKNOWN-4 — it is a different repository and not readable from here.
+
+### 1.7 The snapshot that already exists
+
+**VERIFIED — `snapinTasks` carries the resolved snapin and its sequence per
+task, under a unique key.**
+
+```
+php -r '$m=require "packages/web/commons/schema-expected.php";
+echo $m["tables"]["snapinTasks"]["create"], "\n";'
+```
+
+`stSnapinID`, `stSequence`, `UNIQUE (stJobID, stSnapinID)`.
+
+**VERIFIED — task creation already reads the association table once for the
+whole membership and materializes an ordered list.** The one-query-per-host
+version was GH-707 and the comment records the fix.
+
+```
+sed -n '966,1080p' packages/web/src/Items/Group.php
+```
+
+This is why the snapin half of ADR 0038 is cheap, and it is also the claim in
+§6.
+
+### 1.8 Group name uniqueness
+
+**VERIFIED at the manifest and in the code's own belief.** The expected schema
+declares `UNIQUE KEY groupName (groupName)` (twice, plus a redundant
+non-unique `new_index`), and `group` is absent from
+`Route::$nonUniqueNameClasses`, whose docblock states the test is "a UNIQUE
+index covering the name column ALONE" and which is held to the manifest by
+`tests/nonunique-names-match-schema.test.php`.
+
+```
+grep -n "UNIQUE KEY .groupName" packages/web/commons/schema-expected.php
+sed -n '677,690p' packages/web/src/Router/Route.php
+```
+
+**VERIFIED — 1.5 adds the index unconditionally in schema step 36.**
+
+```
+git show origin/stable:packages/web/commons/schema.php | grep -n -B2 -A2 'ADD UNIQUE ( .groupName. )'
+```
+
+**UNKNOWN-1 — whether a real upgraded 1.5-origin database actually has it.**
+`roles.rName` is the precedent for exactly this gap: the manifest declared it
+UNIQUE, the accesscontrol plugin never created it, native RBAC adopted the
+table as it found it, and schema step 401 exists to repair it. Query in §5.
+
+### 1.9 Plugin duplication
+
+**VERIFIED — two plugins each ship a host hook and a near-identical group hook
+whose only job is to write one value across many hosts.**
+
+```
+wc -l <fog-plugins>/{ou/src/Hooks/AddOU{Host,Group}.php,location/src/Hooks/AddLocation{Host,Group}.php}
+# 318 / 277 / 317 / 282  = 1194 total, 559 of it group-side
+sed -n '176,205p' <fog-plugins>/ou/src/Hooks/AddOUGroup.php
+```
+
+**VERIFIED — the plugin group hooks always clobber.** `groupOUPost()`
+`deletemass`es every member's association and re-inserts. There is no "leave
+alone" state, so core's no-clobber convention was never extended to the plugin
+fields sitting next to it on the same page.
+
+**VERIFIED — the ABI has a bulk-read seam and a bulk-delete seam and no
+bulk-edit seam.** Only two mass hooks exist in core, and neither is an edit:
+
+```
+grep -rno "'[A-Z_]*MASS[A-Z_]*'\|'[A-Z_]*BULK[A-Z_]*'" packages/web/src/
+# Route.php:3188,:4785  API_MASSDATA_MAPPING   -- decorates a LIST result
+# Route.php:8722        DELETEMASS_API         -- cascading DELETE over a set
+```
+
+Every editing extension point a plugin registers is per-object. The 48 distinct
+hook names the bundled plugins listen on contain no bulk-edit event:
+
+```
+grep -rh "registerInstalled(\[" -A 10 <fog-plugins>/*/src/Hooks/*.php \
+  | grep -o "'[A-Z][A-Z_]*'" | sort -u
+```
+
+**VERIFIED — the plugin ABI is unshipped and changing it is free right now.**
+ADR 0017: "There is no shipped 1.6 plugin ABI, which is why none of the five
+decisions needed a deprecation window."
+
+```
+grep -n 'no shipped 1.6 plugin ABI' docs/adr/0017-hook-dispatch-contract.md
+```
+
+This is the strongest single argument for putting `HOST_MASSEDIT_*` in **1.6.0**
+rather than 1.6.x.
+
+### 1.10 Where the plugin code lives, and what an upgrade removes
+
+**VERIFIED — bundled plugins are fetched into the web tree, which is
+`rm -rf`'d on upgrade; the external plugin root is not.**
+
+```
+grep -n 'Fetched into packages/web/lib/plugins' lib/common/functions.sh   # :3143
+sed -n '2246,2258p' lib/common/functions.sh                              # external root, "never touched"
+```
+
+**INFERRED — deleting `persistentgroups` from `fog-plugins` removes the code
+from a bundled install on the next upgrade, and does nothing whatsoever to the
+trigger.** `DROP TRIGGER` appears only in the plugin's own `uninstall()` and
+`schema()` steps, neither of which an upgrade runs.
+
+```
+grep -n 'DROP TRIGGER' <fog-plugins>/persistentgroups/src/Managers/PersistentGroupsManager.php
+```
+
+### 1.11 The retirement precedent
+
+**VERIFIED — schema step 399 is the pattern, and its comment is the argument
+for why the gate must read table facts.**
+
+```
+sed -n '9980,10036p' packages/web/commons/schema.php
+```
+
+**VERIFIED — the next free core schema step is 402.**
+
+```
+grep -n '^// [0-9]\+$' packages/web/commons/schema.php | tail -3      # 399, 400, 401
+grep -c '^// [0-9]\+$' packages/web/commons/schema.php                # 360 numbered comments in file
+```
+
+### 1.12 Audit
+
+**VERIFIED — ADR 0021 Decision 11 already answers the 400-host question,
+against this exact example.** One header, `affectedCount`, `outcome` allowed or
+partial; no per-object headers; bulk updates carry no `auditChange` rows and
+that gap is named rather than engineered around.
+
+```
+sed -n '484,520p' docs/adr/0021-the-audit-trail.md
+sed -n '300,318p'  docs/adr/0021-the-audit-trail.md
+```
+
+**VERIFIED — `ADPass` and `productKey` are both credentials by pattern and are
+redacted in audit rows regardless of registration.**
+
+```
+grep -n 'CREDENTIAL_PATTERN' packages/web/src/Auth/Redaction.php
+```
+
+---
+
+## 2. Sizing
+
+No clock estimates. Sized by schema steps, file counts, what needs a lab, and
+what is reversible.
+
+### 2.1 Schema steps
+
+| # | Step | Reversible? |
+|---|---|---|
+| 402 | `groupSnapinAssoc` (`gsaGroupID`, `gsaSnapinID`, `gsaSequence`) + FKs per ADR 0031 | yes — drop table, no data lost, nothing read it before |
+| 403 | `groupPrinterAssoc` (`gpaGroupID`, `gpaPrinterID`, `gpaIsDefault`) + FKs | yes, same |
+| 404 | `groups.groupOrder INT NOT NULL DEFAULT 0` + index | yes |
+| 405 | `DROP TRIGGER IF EXISTS persistentGroups` + retire the `plugins` row | **no** — a dropped trigger cannot be un-dropped, only recreated from the plugin source |
+| 406 | *(optional, labelling only)* watermark row: `MAX(saID)`, `MAX(paID)` | yes |
+
+**Four required steps, one optional, and exactly one of them is irreversible.**
+Step 405 is the only step that touches existing state at all; 402–404 are pure
+additions that nothing reads until the resolver ships.
+
+**No step migrates or deletes an existing association row** — that is ADR 0038
+Decision 18, and it is why this list is short.
+
+### 2.2 Core files
+
+Counted, not estimated.
+
+```
+grep -rl "snapinassociation\|SnapinAssociation"  packages/web/src packages/web/service packages/service   # 11
+grep -rl "printerassociation\|PrinterAssociation" packages/web/src packages/web/service packages/service  # 12
+```
+
+| Work | Files | Notes |
+|---|---|---|
+| The resolver | 1 new (`src/Assign/Resolver.php`) + 2 new tests | new autoload-only bucket, free per ADR 0035 |
+| Redirect snapin reads to it | `Items/Group.php`, `Items/Host.php`, `Pages/GroupManagement.php`, `Pages/HostManagement.php` | 4 |
+| Redirect printer reads to it | + `Client/PrinterClient.php`, `Items/Printer.php` | 6 |
+| New group-owned models/managers | 4 new (`Items/` × 2, `Managers/` × 2) | mechanical |
+| Route surface | `Router/Route.php` (`$validClasses`, deletemass cascade), `Auth/Authorization.php` (`API_CLASS_ENTITIES`) | 2 |
+| Group page: snapins/printers become group-owned | `Pages/GroupManagement.php`, `js/fog/group/fog.group.edit.js` | 2 |
+| Mass edit form + apply | `Pages/HostManagement.php`, `js/fog/host/fog.host.list.js` | 2, plus `_uniformHostValues()` lifted to a shared home |
+| Bulk group-membership editing | same 2 files | extends the existing `#addToGroupModal` |
+| `HOST_MASSEDIT_*` hooks | `Pages/HostManagement.php` + `docs/plugin-development.md` | 2 |
+| Retirement step | `commons/schema.php` | 1 |
+| Docs | `GROUP_SHARED_STATE.md` rewritten as the mass edit doc; ADR 0001 amendment note; release notes | 3 |
+
+**Roughly 20 core files touched, 7 new.** The heavy ones are
+`GroupManagement.php` (3532 lines, 8 tabs) and `HostManagement.php` (5256).
+
+### 2.3 Plugin files
+
+| Work | Files | When |
+|---|---|---|
+| `persistentgroups` deleted | 3 (`config/`, `src/Items/`, `src/Managers/`) | with step 405 |
+| `AddOUGroup.php`, `AddLocationGroup.php` deleted | 2, **559 lines** | follow-up, sequenced with the group page's own tab removal |
+| `AddOUHost.php`, `AddLocationHost.php` gain `HOST_MASSEDIT_*` | 2 | with the core hooks |
+
+### 2.4 What needs a lab
+
+Nothing in §2.1–§2.3 can be signed off from a cloud session. The lab-gated
+items, in the order they block work:
+
+1. **UNKNOWN-2** (snapshot sufficiency) — blocks the snapin half's whole design.
+   Cheapest to answer, answer it first.
+2. **UNKNOWN-1** (`groupName` uniqueness on real upgraded databases) — does not
+   block; determines whether step 404 also needs an index repair like 401.
+3. **UNKNOWN-3** (trigger duplicate-key behaviour) — does not block the
+   retirement; determines how the release note describes what admins have been
+   hitting.
+4. **UNKNOWN-4** (client removal semantics under each mode) — blocks shipping
+   the printer resolver, because it decides the blast radius of a resolver bug.
+5. **UNKNOWN-5** (mass authorization cost at 400 hosts) — does not block;
+   determines whether the mass edit needs a set-based scope check.
+6. **A migration rehearsal** on a 1.5-origin dump, per
+   `docs/development/upgrade-rehearsal.md`, for step 405.
+
+### 2.5 1.6.0 or 1.6.x
+
+The honest read, with the argument on both sides.
+
+**What argues for 1.6.0:**
+
+- **The plugin ABI is unshipped** (§1.9). `HOST_MASSEDIT_*` costs nothing now
+  and needs a deprecation window after 1.6.0 ships. This is the strongest
+  argument and it is not about the group split at all — it is about the hook.
+- **There is no destructive migration** (Decision 18). The upgrade is four
+  additive schema steps plus one `DROP TRIGGER`. The usual reason to hold a
+  model change for a point release — "we cannot un-migrate the data" — does not
+  apply, because no data is migrated.
+- **The trigger is active on real servers right now** and every day it runs it
+  copies a domain password between hosts (Decision 15). Step 405 is worth
+  shipping on its own schedule.
+- Behaviour for every existing host and group is unchanged on upgrade, which is
+  what makes the risk profile a point-release profile even though the model
+  change is a major one.
+
+**What argues for 1.6.x:**
+
+- **UNKNOWN-2 is unanswered.** If `snapinTasks` is not a sufficient snapshot,
+  the snapin half needs a real snapshot table and the sizing above is wrong by
+  a schema step and a service-path change.
+- **UNKNOWN-4 is unanswered**, and the failure mode is printers being stripped
+  from a fleet. That is not a bug you ship to find out about.
+- The mass edit form is the largest single piece and it is the one with no
+  existing equivalent to fall back on. Decision 10 forbids removing the group
+  tabs before it is proven, so a half-landed release is *safe* but is also two
+  ways to do the same thing.
+
+**Recommendation, and it is a split rather than a single answer:**
+
+- **1.6.0:** the `HOST_MASSEDIT_*` hooks and the mass edit form; the bulk
+  group-membership editor; schema step 405 (the trigger drop) and the
+  `persistentgroups` deletion. None of these depends on the resolver, all of
+  them are additive, and the ABI half genuinely gets harder after 1.6.0.
+- **1.6.x:** the declarative split itself — steps 402–404, the resolver, the
+  group page rework, and the removal of the group page's imperative tabs. It
+  depends on two UNKNOWNs that need a lab, and Decision 10's sequencing already
+  says the removals come a release later than the replacement.
+
+That ordering also satisfies Decision 10 by construction: mass edit is in the
+earlier release, the removals in the later one.
+
+---
+
+## 3. The three things most likely to be built wrong
+
+Recorded here rather than in the ADR because they are implementation hazards,
+not decisions.
+
+1. **A resolver whose natural unit is one host.** GH-707 was exactly this
+   (§1.7). The signature takes an array of host ids or it will be a thousand
+   round trips the first time a group task calls it.
+2. **A mass edit form that posts every field.** The three-state control is not
+   a nicety; a form without it silently overwrites every field the admin did
+   not touch, and it looks correct in every test where the admin touched
+   everything.
+3. **A printer resolver that returns `[]` on failure.** Under mode `ar` that is
+   a fleet-wide printer removal, delivered one machine at a time as they poll.
+   The resolver throws; §1.6 shows the endpoint already turns a throw into a
+   body with no `printers` key.
+
+---
+
+## 4. Alternatives rejected, with reasons
+
+Design alternatives are in the ADR. These are the ones about *how to do the
+work*.
+
+**Do the split first and the mass edit after.** Rejected: it produces a release
+in which the group page's image tab is gone and nothing replaces it. ADR 0038
+Decision 10.
+
+**Migrate existing associations into group ownership.** Rejected: the data
+cannot distinguish a group push from forty deliberate choices, and the
+destructive form silently removes a snapin from a host that chose it. Decision
+18, and the same argument the UTC document makes at §2.1 for not sweeping
+timestamps.
+
+**Add transactions to `PDODB` so mass edit can be all-or-nothing.** Rejected:
+the imperative half is already one atomic statement (§1.5), and the split
+reduces the declarative half to one chunk, so the case that needs a transaction
+is the one the design removes. Introducing transactions to the DB layer for it
+would be a much larger change with its own failure modes.
+
+**Build a `tags` entity.** Rejected in ADR 0038 Decision 16. The cost is
+measurable from the `site` plugin's absorption: `$validClasses`, the deletemass
+cascade, `SiteScope::$_nodes`, permissions, FKs, a page, five JS files, the API
+description.
+
+**Retire `persistentgroups` by deleting the directory.** Rejected: the trigger
+outlives the code (§1.10), and it is active rather than cosmetic.
+
+**Gate the rollup semantics on a provenance boundary.** Rejected: deciding a
+legacy row came from a group is the same unknowable inference as backfilling
+it, moved to read time. Decision 18.
+
+---
+
+## 5. Queries and procedures to close the UNKNOWNs
+
+Run these against a lab server with a 1.5-origin database restored. Replace
+`fog` with the real schema name where a literal is used.
+
+### UNKNOWN-1 — is `groupName` actually UNIQUE on upgraded servers?
+
+Blocks nothing; decides whether step 404 also repairs an index.
+
+```sql
+-- (a) is the index there?
+SELECT INDEX_NAME, NON_UNIQUE, SEQ_IN_INDEX, COLUMN_NAME
+FROM information_schema.STATISTICS
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'groups'
+ORDER BY INDEX_NAME, SEQ_IN_INDEX;
+
+-- (b) are there duplicates it would have prevented?
+SELECT groupName, COUNT(*) AS n
+FROM `groups` GROUP BY groupName HAVING n > 1;
+
+-- (c) same two questions for hosts, since the trigger joins on hostName
+SELECT hostName, COUNT(*) AS n
+FROM `hosts` GROUP BY hostName HAVING n > 1;
+```
+
+Expected: (a) shows a `NON_UNIQUE = 0` index on `groupName` alone; (b) and (c)
+empty. If (b) returns rows, 1.5's schema step 36 failed on this database and
+step 404 needs the rename-never-delete treatment schema 401 gives `roles`.
+
+If (c) returns rows, the trigger's template subquery (`:44`) returns more than
+one row and **every** `INSERT INTO groupMembers` on this server errors — worth
+knowing before writing the release note.
+
+### UNKNOWN-2 — is `snapinTasks` a sufficient snapshot? *(answer this first)*
+
+This is §6. The question: does anything read `snapinAssoc` **after** a snapin
+job has been created, for that job?
+
+```bash
+# Every read of the association table on the running-task side.
+grep -rn "snapinassociation\|SnapinAssociation\|snapinAssoc" \
+  packages/web/service/ packages/service/ packages/web/src/Client/
+
+# The two client endpoints that matter.
+sed -n '1,200p' packages/web/service/snapins.checkin.php
+sed -n '1,200p' packages/web/service/snapinlisting.php
+```
+
+Then, on the lab, the behavioural test that settles it regardless of what the
+code reading suggests:
+
+1. Host H, snapins A and B associated. Create a snapin job.
+2. Before the client checks in, remove B from H.
+3. Let the client check in and run to completion.
+
+If B runs, the task is the authority and Decision 4 holds. If B is skipped, the
+association table is re-read at run time, Decision 4 is false as written, and
+the snapin half needs a real snapshot table plus a service-path change.
+
+Repeat with the addition case (add C after job creation, see whether C runs).
+
+### UNKNOWN-3 — does the trigger break `add host to group`?
+
+```sql
+-- Setup: a group G, a host T named exactly like G, and a host H that already
+-- shares one printer with T.
+INSERT INTO `printerAssoc` (`paHostID`,`paPrinterID`,`paIsDefault`)
+  VALUES (<T>, <P>, '0'), (<H>, <P>, '0');
+
+-- Now the thing under test:
+INSERT INTO `groupMembers` (`gmHostID`,`gmGroupID`) VALUES (<H>, <G>);
+```
+
+Expected under the inference: error 1062 on `printerAssoc.paHostID`, and the
+`groupMembers` row is **not** created. Repeat with a shared
+`moduleStatusByHost` row.
+
+Also worth capturing, since it decides whether the release note says "this
+plugin has been doing something surprising" or "this plugin has been failing":
+
+```sql
+-- How many servers would hit it: members sharing a printer with the template.
+SELECT g.groupName, COUNT(DISTINCT pa2.paHostID) AS collidingMembers
+FROM `groups` g
+JOIN `hosts` t ON t.hostName = g.groupName
+JOIN `groupMembers` gm ON gm.gmGroupID = g.groupID
+JOIN `printerAssoc` pa1 ON pa1.paHostID = t.hostID
+JOIN `printerAssoc` pa2 ON pa2.paPrinterID = pa1.paPrinterID
+                       AND pa2.paHostID = gm.gmHostID
+WHERE gm.gmHostID <> t.hostID
+GROUP BY g.groupID;
+```
+
+### UNKNOWN-4 — what does the client actually do with the printer list?
+
+**Blocks shipping the printer resolver.** Not answerable from this repository —
+`fog-client` is a separate codebase.
+
+Read side, in the `fog-client` source: find the printer module's handling of
+the response and answer three questions.
+
+1. Under mode `ar`, does a response with **no `printers` key** cause removal,
+   or is it treated as an error and skipped?
+2. Under mode `ar`, does `{"error":"np","printers":[]}` cause removal of every
+   FOG-managed printer? (It should — that is the legitimate empty case.)
+3. Under mode `a`, what exactly counts as "FOG-managed"? Is it tracked
+   client-side, or inferred from the current response?
+
+Behavioural test, on a lab host with mode `ar` and two printers:
+
+```
+# 1. Confirm steady state: both printers present after a poll.
+# 2. Make the endpoint throw (e.g. temporarily point it at a bad snapin id, or
+#    stop MySQL between polls) and watch one poll cycle.
+# 3. Check whether the printers are still on the machine.
+```
+
+Step 3's answer is the blast radius. If a thrown resolver strips printers today,
+that is a **pre-existing** bug worth its own fix regardless of this work, and
+the resolver must not be shipped until it is fixed.
+
+### UNKNOWN-5 — what does the per-id scope check cost at 400 hosts?
+
+```
+# On the lab, with a user restricted to a site, time a 400-host Queue Task
+# (which already runs this gate) and count queries.
+grep -n 'requirePageObjectScopeMass' packages/web/src/Pages/HostManagement.php
+sed -n '2270,2280p' packages/web/src/Auth/Authorization.php
+```
+
+Instrument `Authorization::objectInScope()` to count invocations and elapsed
+time for one `deployMultiPost` of 400 hosts. If it is material, the fix is to
+use `SiteScope::allInScopeIDs()` once and diff, which is the set-based answer
+the class already provides — and it is a pre-existing improvement to the Queue
+Task path, not new work this creates.
+
+### The retirement rehearsal
+
+Per `docs/development/upgrade-rehearsal.md`, on a restored 1.5-origin dump that
+**has** the plugin installed:
+
+```sql
+-- Before: the trigger is there.
+SELECT TRIGGER_NAME, EVENT_MANIPULATION, EVENT_OBJECT_TABLE
+FROM information_schema.TRIGGERS
+WHERE TRIGGER_SCHEMA = DATABASE();
+
+SELECT pName, pInstalled, pVersion, pSchema
+FROM `plugins` WHERE LOWER(pName) = 'persistentgroups';
+```
+
+Run the upgrade. After: the trigger is gone, the row is gone, and — the
+regression that matters — adding a host to a group still works and grants
+nothing.
+
+Then the negative case: the same rehearsal on a dump that **never** installed
+the plugin, where step 405 must be a clean no-op.
+
+---
+
+## 6. The claim that would hurt most if it is false
+
+**That `snapinTasks` already constitutes the snapshot** — §1.7, ADR 0038
+Decision 4.
+
+The snapin half is sized on it. If task creation already materializes an
+ordered per-host list into a table the running task reads, then "snapshot at
+task creation" costs one changed data source in `_createSnapinTasking()` and
+nothing else: no new table, no schema step, no service-path change, and the
+promise that a group edited mid-run does not affect a task in flight is already
+true and merely undocumented.
+
+If it is false — if `service/snapins.checkin.php` or the client re-reads
+`snapinAssoc` for a running job, as a re-resolve or a validity check or a
+fallback when the job row is missing — then three things follow at once. The
+snapin half needs a genuine snapshot table and a schema step it does not
+currently have. Decision 4's documentation promise is a lie that would ship in
+the release notes. And a group edited mid-run *does* change a task in flight
+today, which is a live bug independent of any of this and probably the reason
+somebody would file it.
+
+It is the cheapest UNKNOWN to close (one grep and one three-step lab test,
+§5/UNKNOWN-2) and the one with the largest downstream cost, so it should be
+closed before any code is written.
+
+Second place, and only because its consequence is narrower rather than smaller:
+**UNKNOWN-4**. If the shipped client removes printers on a response it should
+have treated as an error, then that is true *today*, and the printer half of
+this work cannot ship until it is not.


### PR DESCRIPTION
**Draft on purpose.** Auto-merge is armed at open for non-draft PRs against
`working-1.6`, and these documents are a proposal to be argued with, not a
change to land — the ADR's own status is `proposed` and several claims are
still open against the lab. Lift the draft when the decisions are settled and
it arms itself then.

Docs only. No code, no schema, no behaviour change.

## What this is

Two files:

| File | What |
|---|---|
| `docs/adr/0038-a-group-grants-it-does-not-copy.md` | 18 decisions, alternatives rejected with reasons, consequences |
| `docs/development/group-split.md` | Every claim labelled VERIFIED / INFERRED / UNKNOWN with the command behind it, sizing, and the lab procedures for what is still open |

## The defect

`Group::addSnapin()`, `addPrinter()`, `setSnapinOrder()`, `setDisp()`,
`setAlo()`, `addImage()` and `setAD()` all write per-host rows over whatever
the membership was at the moment the button was pressed. Add a host afterward
and it gets nothing; remove one and it keeps everything. Membership reads as
declarative and behaves as historical.

The `persistentgroups` plugin is that defect worked around in SQL — an
`AFTER INSERT` trigger on `groupMembers` that finds a template host by string
equality between `groupName` and `hostName`, copies thirteen columns and four
association tables onto every new member, and creates a snapin job, so adding
a host to a group also runs software on it.

## The split

- **Imperative half** — the thirteen columns. Values a host holds; the group
  is only a selection for writing them. Moves to mass edit from the host list.
- **Declarative half** — snapins and printers. Set membership; stays with the
  group and is evaluated, never copied. Snapins resolved at task creation and
  snapshotted; printers resolved live; both through one resolver taking a set
  of host ids.

## Decisions worth arguing with

- **Groups become the tag concept, presented as tags** (16). No new entity:
  `groupMembers` is already an attribute-free many-to-many labelling table, so
  a second set-of-hosts concept would solve a presentation gap with a data
  model. Decision 16a's five presentation requirements are **binding**, not
  follow-up — a group that is correct but unpleasant to apply in bulk fails at
  what the decision exists to enable.
- **No exclusion mechanism** (17), and the loss is named: it exists today by
  accident and disappears when the semantics are fixed.
- **No backfill of existing associations** (18). Nothing distinguishes a 2019
  group copy from a deliberate choice, and inferring it is the sweep
  `utc-storage-boundary.md` §2.1 rejects. Behaviour is unchanged for every
  existing host and group on upgrade.
- **`DROP TRIGGER IF EXISTS persistentGroups`** as a schema step on 399's
  evidence-gate pattern (14), because removing the plugin leaves the trigger
  running. It has been copying `hostADPass` between hosts, below the PHP layer
  with no audit row, since it shipped (15).

## Sizing

Four required schema steps plus one optional; exactly one irreversible (the
trigger drop). ~22 core files, 7 new. Recommendation is a split: the mass edit
form, all of 16a, and the trigger retirement in **1.6.0** (the plugin ABI is
unshipped, so `HOST_MASSEDIT_*` is free now and needs a deprecation window
later); the declarative split in **1.6.x**, since it depends on lab answers.

## Still open

`docs/development/group-split.md` §5 carries the queries and procedures. The
one that would hurt most if false is UNKNOWN-2 — whether `snapinTasks` is
already a sufficient snapshot. Code reading says yes (nothing under
`packages/web/service/`, `packages/service/` or `src/Client/` references
`snapinAssoc`, and `SnapinTask::getSnapin()` reads the stored `stSnapinID`);
behavioural confirmation is in progress against the lab, along with UNKNOWN-4
(does fog-client strip printers on an error response under mode `ar`) and
UNKNOWN-6 (`saveGroup()` appears to have no CSRF check and no object-scope
bound on its posted host ids — both pre-existing, both in scope because
Decision 16a promotes that endpoint to the primary membership surface).

Findings will be folded into the proposal before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)