### PR TITLE
UbootTftpSync: chmod uploaded files to 0644

### DIFF
--- a/packages/web/src/Boot/UbootTftpSync.php
+++ b/packages/web/src/Boot/UbootTftpSync.php
@@ -139,6 +139,13 @@ class UbootTftpSync extends FOGBase
      * "send these bytes" over the sftp wrapper the rest of FOG already
      * uses for this same TFTP host.
      *
+     * chmod's 0644 afterward for the same reason FOGPage.php's kernel-upload
+     * path already does: an SFTP PUT's resulting permissions follow the
+     * server's own umask, not FOG's, and a TFTP daemon reading as a
+     * different user than the SFTP login has no way to negotiate that --
+     * it either has read access or it does not. Parity with the existing
+     * upload path, not a confirmed fix for any specific report.
+     *
      * @param string $remotePath the full remote path to write
      * @param string $content    the bytes to write there
      *
@@ -150,6 +157,7 @@ class UbootTftpSync extends FOGBase
         file_put_contents($tmp, $content);
         try {
             self::$FOGSSH->put($tmp, $remotePath);
+            self::$FOGSSH->sftp_chmod($remotePath, 0644);
         } finally {
             @unlink($tmp);
         }

--- a/tests/uboot-tftp-sync.test.php
+++ b/tests/uboot-tftp-sync.test.php
@@ -185,6 +185,9 @@ class FakeTftpFs extends \FOG\Net\FOGSSH
     /** @var string[] every path sftp_mkdir() was asked to create */
     public $mkdirCalls = [];
 
+    /** @var array path => mode, every sftp_chmod() call */
+    public $chmodCalls = [];
+
     /**
      * Mirrors the real connect()'s actual contract (self|false), not its
      * @return object docblock -- the real method's own catch branch returns
@@ -231,6 +234,13 @@ class FakeTftpFs extends \FOG\Net\FOGSSH
     {
         $this->tree[$remotefile] = 'file';
         $this->contents[$remotefile] = file_get_contents($localfile);
+    }
+
+    public function sftp_chmod($path, $mode)
+    {
+        $this->chmodCalls[$path] = $mode;
+
+        return true;
     }
 
     public function unlinkFile($path)
@@ -332,6 +342,12 @@ $t->check(
     '_write() uploads the exact bytes it was given',
     "DEFAULT localboot\n"
     === ($fakeFs->contents['/tftpboot/pxelinux.cfg/01-aa-bb-cc-dd-ee-ff'] ?? null)
+);
+$t->check(
+    '_write() chmods the file to 0644 -- an SFTP PUT\'s permissions follow '
+    . 'the server umask, not FOG, and a TFTP daemon reading as a different '
+    . 'user than the SFTP login needs read access explicitly granted',
+    0644 === ($fakeFs->chmodCalls['/tftpboot/pxelinux.cfg/01-aa-bb-cc-dd-ee-ff'] ?? null)
 );
 
 /*


### PR DESCRIPTION
## Summary

- `UbootTftpSync::_write()` uploads via `FOGSSH::put()` but never chmod'd the result, unlike the existing kernel-upload path in `FOGPage.php`, which chmods to `0644` after every `put()` for the same TFTP host. An SFTP PUT's permissions follow the server's umask, not FOG's, so a TFTP daemon reading as a different user than the SFTP login has no guarantee of read access.
- Prompted by real hardware feedback on forums topic 18229: U-Boot's `pxe get` found the generated file by name, then timed out mid-transfer. Most likely cause is a firewall blocking TFTP's ephemeral data-port range rather than this -- this is parity with the established pattern, not a confirmed fix for that report.

## Test plan

- [x] `tests/uboot-tftp-sync.test.php` -- 36 checks (was 35), new check mutation-tested (removed the `sftp_chmod` call, confirmed it goes red)
- [x] `bash tests/run-all.sh` -- 269 passed, 0 failed
- [x] `vendor/bin/phpstan analyse` (main + `phpstan-tests.neon`) -- no errors
- [x] `php bin/psr4-scan.php --check` / `tests/psr4-layout.test.php` -- clean
- [x] `php tests/us-spelling.test.php` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBgcEakksay1L5XtiVDXKZ