### PR TITLE
Make the Certificates page a table rather than a train of cards

### DIFF
--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -115,6 +115,10 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
+msgid "%d days left"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -2159,10 +2163,6 @@ msgstr "Aktuelle Datensätze"
 msgid "Current member-host AD state"
 msgstr ""
 
-#, fuzzy
-msgid "Currently imported"
-msgstr "Aktuelle Datensätze"
-
 msgid "DMI Field"
 msgstr ""
 
@@ -2528,7 +2528,7 @@ msgstr "Dauer"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
-msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered; the SHA-256 is what to compare against a client's trust store when working out why one stopped authenticating. Private keys are deliberately absent -- nothing on this page can read one, and nothing on it can hand one out."
 msgstr ""
 
 msgid "Edit"
@@ -2731,6 +2731,10 @@ msgstr "Bestehendes Objekt muss boolean sein"
 
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
+
+#, fuzzy
+msgid "Expired"
+msgstr "Sitzungsname"
 
 msgid "Expires"
 msgstr ""
@@ -4753,6 +4757,10 @@ msgstr "Token zurücksetzen"
 msgid "Issue a token on behalf of a user"
 msgstr ""
 
+#, php-format
+msgid "Issued by %s"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
@@ -6285,6 +6293,9 @@ msgstr ""
 msgid "One entry per row. The element shape follows the requested fields: a scalar when a single column is projected, an object when several are."
 msgstr ""
 
+msgid "One is imported. It is the \"Imported root\" row in the table above."
+msgstr ""
+
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
@@ -6954,9 +6965,6 @@ msgstr "Private Schlüssel nicht lesbar"
 
 msgid "Private key path not found"
 msgstr "Privater Schlüsselpfad nicht gefunden"
-
-msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
-msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -7740,6 +7748,9 @@ msgstr "Wählen Sie einen Crontyp"
 #, fuzzy
 msgid "Selected tasks canceled!"
 msgstr "geplante Tasks wurde erfolgreich erstellt"
+
+msgid "Self-signed"
+msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
@@ -9126,10 +9137,6 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
-#, fuzzy
-msgid "The certificate chain"
-msgstr "Neuen Standort erstellen"
-
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
 msgstr ""
 
@@ -9353,7 +9360,7 @@ msgstr "Der einer/mehrere Speichergruppen zugeordnete Speicherknoten ist ungült
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
-msgid "The trust anchor. Every fog-client pins this one."
+msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."
 msgstr ""
 
 msgid "The upload did not arrive."
@@ -9554,9 +9561,6 @@ msgstr ""
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
 msgstr ""
 
-msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
-msgstr ""
-
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9754,9 +9758,6 @@ msgid "Transport to the master storage node failed, or the row would not save af
 msgstr ""
 
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
-msgstr ""
-
-msgid "Trust anchor"
 msgstr ""
 
 msgid "Trust anchor bundle"
@@ -10331,10 +10332,6 @@ msgstr ""
 msgid "VNC"
 msgstr ""
 
-#, php-format
-msgid "Valid until %s."
-msgstr ""
-
 msgid "Value"
 msgstr "Wert"
 
@@ -10424,6 +10421,10 @@ msgstr ""
 
 #, fuzzy
 msgid "What gets enrolled"
+msgstr "wurde abgebrochen"
+
+#, fuzzy
+msgid "What it does"
 msgstr "wurde abgebrochen"
 
 msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
@@ -11306,9 +11307,6 @@ msgstr ""
 msgid "previous install if needed"
 msgstr "Installation zurück zu kehren, falls erforderlich."
 
-msgid "published as ca.cert.der and pinned by every fog-client"
-msgstr ""
-
 msgid "re-run the installer and check the installation log for a key generation or signing failure"
 msgstr ""
 
@@ -11794,6 +11792,10 @@ msgstr ""
 #~ msgstr "Kein Knoten verknüpft"
 
 #, fuzzy
+#~ msgid "Currently imported"
+#~ msgstr "Aktuelle Datensätze"
+
+#, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "Pfad ist nicht verfügbar"
 
@@ -12250,6 +12252,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Dieser Host ist bereits vorhanden."
+
+#, fuzzy
+#~ msgid "The certificate chain"
+#~ msgstr "Neuen Standort erstellen"
 
 #, fuzzy
 #~ msgid "There are no "

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -120,6 +120,10 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
+msgid "%d days left"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -2162,10 +2166,6 @@ msgstr "Current Records"
 msgid "Current member-host AD state"
 msgstr ""
 
-#, fuzzy
-msgid "Currently imported"
-msgstr "Current Records"
-
 msgid "DMI Field"
 msgstr ""
 
@@ -2531,7 +2531,7 @@ msgstr "Duration"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
-msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered; the SHA-256 is what to compare against a client's trust store when working out why one stopped authenticating. Private keys are deliberately absent -- nothing on this page can read one, and nothing on it can hand one out."
 msgstr ""
 
 msgid "Edit"
@@ -2733,6 +2733,10 @@ msgstr ""
 
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
+
+#, fuzzy
+msgid "Expired"
+msgstr "Session Name"
 
 msgid "Expires"
 msgstr ""
@@ -4755,6 +4759,10 @@ msgstr "Access Token"
 msgid "Issue a token on behalf of a user"
 msgstr ""
 
+#, php-format
+msgid "Issued by %s"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
@@ -6296,6 +6304,9 @@ msgstr ""
 msgid "One entry per row. The element shape follows the requested fields: a scalar when a single column is projected, an object when several are."
 msgstr ""
 
+msgid "One is imported. It is the \"Imported root\" row in the table above."
+msgstr ""
+
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
@@ -6965,9 +6976,6 @@ msgstr "Private key not readable"
 
 msgid "Private key path not found"
 msgstr "Private key path not found"
-
-msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
-msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -7751,6 +7759,9 @@ msgstr "Select a cron type"
 #, fuzzy
 msgid "Selected tasks canceled!"
 msgstr "has been successfully updated"
+
+msgid "Self-signed"
+msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
@@ -9135,10 +9146,6 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
-#, fuzzy
-msgid "The certificate chain"
-msgstr "Create New %s"
-
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
 msgstr ""
 
@@ -9362,7 +9369,7 @@ msgstr "The storage groups associated storage node is not valid"
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
-msgid "The trust anchor. Every fog-client pins this one."
+msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."
 msgstr ""
 
 msgid "The upload did not arrive."
@@ -9560,9 +9567,6 @@ msgid "This is the only time it will be shown. FOG stores only a hash of it and 
 msgstr ""
 
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
-msgstr ""
-
-msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
 msgstr ""
 
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
@@ -9763,9 +9767,6 @@ msgid "Transport to the master storage node failed, or the row would not save af
 msgstr ""
 
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
-msgstr ""
-
-msgid "Trust anchor"
 msgstr ""
 
 msgid "Trust anchor bundle"
@@ -10340,10 +10341,6 @@ msgstr ""
 msgid "VNC"
 msgstr ""
 
-#, php-format
-msgid "Valid until %s."
-msgstr ""
-
 msgid "Value"
 msgstr "Value"
 
@@ -10433,6 +10430,10 @@ msgstr ""
 
 #, fuzzy
 msgid "What gets enrolled"
+msgstr "has been successfully updated"
+
+#, fuzzy
+msgid "What it does"
 msgstr "has been successfully updated"
 
 msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
@@ -11312,9 +11313,6 @@ msgstr ""
 msgid "previous install if needed"
 msgstr ""
 
-msgid "published as ca.cert.der and pinned by every fog-client"
-msgstr ""
-
 msgid "re-run the installer and check the installation log for a key generation or signing failure"
 msgstr ""
 
@@ -11792,6 +11790,10 @@ msgstr ""
 #~ msgstr "No node associated"
 
 #, fuzzy
+#~ msgid "Currently imported"
+#~ msgstr "Current Records"
+
+#, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "No hash available"
 
@@ -12210,6 +12212,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Printer already exists"
+
+#, fuzzy
+#~ msgid "The certificate chain"
+#~ msgstr "Create New %s"
 
 #, fuzzy
 #~ msgid "There are no "

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -118,6 +118,10 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
+msgid "%d days left"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -2182,10 +2186,6 @@ msgstr "Registros actuales"
 msgid "Current member-host AD state"
 msgstr ""
 
-#, fuzzy
-msgid "Currently imported"
-msgstr "Registros actuales"
-
 msgid "DMI Field"
 msgstr ""
 
@@ -2563,7 +2563,7 @@ msgstr "Configuración"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
-msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered; the SHA-256 is what to compare against a client's trust store when working out why one stopped authenticating. Private keys are deliberately absent -- nothing on this page can read one, and nothing on it can hand one out."
 msgstr ""
 
 msgid "Edit"
@@ -2767,6 +2767,10 @@ msgstr ""
 
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
+
+#, fuzzy
+msgid "Expired"
+msgstr "Nombre de sesión"
 
 msgid "Expires"
 msgstr ""
@@ -4843,6 +4847,10 @@ msgstr "impresora iPrint"
 msgid "Issue a token on behalf of a user"
 msgstr ""
 
+#, php-format
+msgid "Issued by %s"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
@@ -6407,6 +6415,9 @@ msgstr ""
 msgid "One entry per row. The element shape follows the requested fields: a scalar when a single column is projected, an object when several are."
 msgstr ""
 
+msgid "One is imported. It is the \"Imported root\" row in the table above."
+msgstr ""
+
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
@@ -7088,9 +7099,6 @@ msgstr "clave privada no se puede leer"
 
 msgid "Private key path not found"
 msgstr "ruta de la clave privada no encontrado"
-
-msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
-msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -7881,6 +7889,9 @@ msgstr "Seleccione un tipo de cron"
 #, fuzzy
 msgid "Selected tasks canceled!"
 msgstr "se ha actualizado correctamente"
+
+msgid "Self-signed"
+msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
@@ -9298,10 +9309,6 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
-#, fuzzy
-msgid "The certificate chain"
-msgstr "Crear nuevo grupo"
-
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
 msgstr ""
 
@@ -9526,7 +9533,7 @@ msgstr ""
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
-msgid "The trust anchor. Every fog-client pins this one."
+msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."
 msgstr ""
 
 msgid "The upload did not arrive."
@@ -9726,9 +9733,6 @@ msgstr ""
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
 msgstr ""
 
-msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
-msgstr ""
-
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9921,9 +9925,6 @@ msgid "Transport to the master storage node failed, or the row would not save af
 msgstr ""
 
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
-msgstr ""
-
-msgid "Trust anchor"
 msgstr ""
 
 msgid "Trust anchor bundle"
@@ -10503,10 +10504,6 @@ msgstr ""
 msgid "VNC"
 msgstr ""
 
-#, php-format
-msgid "Valid until %s."
-msgstr ""
-
 msgid "Value"
 msgstr "Valor"
 
@@ -10595,6 +10592,10 @@ msgstr ""
 
 #, fuzzy
 msgid "What gets enrolled"
+msgstr "se ha actualizado correctamente"
+
+#, fuzzy
+msgid "What it does"
 msgstr "se ha actualizado correctamente"
 
 msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
@@ -11475,9 +11476,6 @@ msgstr ""
 msgid "previous install if needed"
 msgstr ""
 
-msgid "published as ca.cert.der and pinned by every fog-client"
-msgstr ""
-
 msgid "re-run the installer and check the installation log for a key generation or signing failure"
 msgstr ""
 
@@ -11947,6 +11945,10 @@ msgstr ""
 #~ msgstr "No nodo asociado"
 
 #, fuzzy
+#~ msgid "Currently imported"
+#~ msgstr "Registros actuales"
+
+#, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "No se dispone de hash"
 
@@ -12370,6 +12372,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Impresora ya existe"
+
+#, fuzzy
+#~ msgid "The certificate chain"
+#~ msgstr "Crear nuevo grupo"
 
 #, fuzzy
 #~ msgid "There are no "

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -115,6 +115,10 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
+msgid "%d days left"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -2159,10 +2163,6 @@ msgstr "Aktuelle Datensätze"
 msgid "Current member-host AD state"
 msgstr ""
 
-#, fuzzy
-msgid "Currently imported"
-msgstr "Aktuelle Datensätze"
-
 msgid "DMI Field"
 msgstr ""
 
@@ -2528,7 +2528,7 @@ msgstr "Dauer"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
-msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered; the SHA-256 is what to compare against a client's trust store when working out why one stopped authenticating. Private keys are deliberately absent -- nothing on this page can read one, and nothing on it can hand one out."
 msgstr ""
 
 msgid "Edit"
@@ -2731,6 +2731,10 @@ msgstr "Bestehendes Objekt muss boolean sein"
 
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
+
+#, fuzzy
+msgid "Expired"
+msgstr "Sitzungsname"
 
 msgid "Expires"
 msgstr ""
@@ -4754,6 +4758,10 @@ msgstr "Token zurücksetzen"
 msgid "Issue a token on behalf of a user"
 msgstr ""
 
+#, php-format
+msgid "Issued by %s"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
@@ -6286,6 +6294,9 @@ msgstr ""
 msgid "One entry per row. The element shape follows the requested fields: a scalar when a single column is projected, an object when several are."
 msgstr ""
 
+msgid "One is imported. It is the \"Imported root\" row in the table above."
+msgstr ""
+
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
@@ -6955,9 +6966,6 @@ msgstr "Private Schlüssel nicht lesbar"
 
 msgid "Private key path not found"
 msgstr "Privater Schlüsselpfad nicht gefunden"
-
-msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
-msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -7741,6 +7749,9 @@ msgstr "Wählen Sie einen Crontyp"
 #, fuzzy
 msgid "Selected tasks canceled!"
 msgstr "geplante Tasks wurde erfolgreich erstellt"
+
+msgid "Self-signed"
+msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
@@ -9127,10 +9138,6 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
-#, fuzzy
-msgid "The certificate chain"
-msgstr "Neuen Standort erstellen"
-
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
 msgstr ""
 
@@ -9354,7 +9361,7 @@ msgstr "Der einer/mehrere Speichergruppen zugeordnete Speicherknoten ist ungült
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
-msgid "The trust anchor. Every fog-client pins this one."
+msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."
 msgstr ""
 
 msgid "The upload did not arrive."
@@ -9555,9 +9562,6 @@ msgstr ""
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
 msgstr ""
 
-msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
-msgstr ""
-
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -9755,9 +9759,6 @@ msgid "Transport to the master storage node failed, or the row would not save af
 msgstr ""
 
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
-msgstr ""
-
-msgid "Trust anchor"
 msgstr ""
 
 msgid "Trust anchor bundle"
@@ -10332,10 +10333,6 @@ msgstr ""
 msgid "VNC"
 msgstr ""
 
-#, php-format
-msgid "Valid until %s."
-msgstr ""
-
 msgid "Value"
 msgstr "Wert"
 
@@ -10425,6 +10422,10 @@ msgstr ""
 
 #, fuzzy
 msgid "What gets enrolled"
+msgstr "wurde abgebrochen"
+
+#, fuzzy
+msgid "What it does"
 msgstr "wurde abgebrochen"
 
 msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
@@ -11307,9 +11308,6 @@ msgstr ""
 msgid "previous install if needed"
 msgstr "Installation zurück zu kehren, falls erforderlich."
 
-msgid "published as ca.cert.der and pinned by every fog-client"
-msgstr ""
-
 msgid "re-run the installer and check the installation log for a key generation or signing failure"
 msgstr ""
 
@@ -11795,6 +11793,10 @@ msgstr ""
 #~ msgstr "Kein Knoten verknüpft"
 
 #, fuzzy
+#~ msgid "Currently imported"
+#~ msgstr "Aktuelle Datensätze"
+
+#, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "Pfad ist nicht verfügbar"
 
@@ -12251,6 +12253,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Dieser Host ist bereits vorhanden."
+
+#, fuzzy
+#~ msgid "The certificate chain"
+#~ msgstr "Neuen Standort erstellen"
 
 #, fuzzy
 #~ msgid "There are no "

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -121,6 +121,10 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
+msgid "%d days left"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -2163,10 +2167,6 @@ msgstr "Enregistrements courants"
 msgid "Current member-host AD state"
 msgstr ""
 
-#, fuzzy
-msgid "Currently imported"
-msgstr "Enregistrements courants"
-
 msgid "DMI Field"
 msgstr ""
 
@@ -2532,7 +2532,7 @@ msgstr "Durée"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
-msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered; the SHA-256 is what to compare against a client's trust store when working out why one stopped authenticating. Private keys are deliberately absent -- nothing on this page can read one, and nothing on it can hand one out."
 msgstr ""
 
 msgid "Edit"
@@ -2734,6 +2734,10 @@ msgstr ""
 
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
+
+#, fuzzy
+msgid "Expired"
+msgstr "Nom de session"
 
 msgid "Expires"
 msgstr ""
@@ -4756,6 +4760,10 @@ msgstr "Jeton d'accès"
 msgid "Issue a token on behalf of a user"
 msgstr ""
 
+#, php-format
+msgid "Issued by %s"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
@@ -6283,6 +6291,9 @@ msgstr ""
 msgid "One entry per row. The element shape follows the requested fields: a scalar when a single column is projected, an object when several are."
 msgstr ""
 
+msgid "One is imported. It is the \"Imported root\" row in the table above."
+msgstr ""
+
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
@@ -6952,9 +6963,6 @@ msgstr "La clé privée pas lisible"
 
 msgid "Private key path not found"
 msgstr "chemin de la clé privée non trouvée"
-
-msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
-msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -7737,6 +7745,9 @@ msgstr "Sélectionnez un type de cron"
 #, fuzzy
 msgid "Selected tasks canceled!"
 msgstr "a été mis à jour avec succès"
+
+msgid "Self-signed"
+msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
@@ -9120,10 +9131,6 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
-#, fuzzy
-msgid "The certificate chain"
-msgstr "Créer un nouveau %s"
-
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
 msgstr ""
 
@@ -9347,7 +9354,7 @@ msgstr "Le nœud de stockage des groupes de stockage associé est pas valide"
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
-msgid "The trust anchor. Every fog-client pins this one."
+msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."
 msgstr ""
 
 msgid "The upload did not arrive."
@@ -9545,9 +9552,6 @@ msgid "This is the only time it will be shown. FOG stores only a hash of it and 
 msgstr ""
 
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
-msgstr ""
-
-msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
 msgstr ""
 
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
@@ -9748,9 +9752,6 @@ msgid "Transport to the master storage node failed, or the row would not save af
 msgstr ""
 
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
-msgstr ""
-
-msgid "Trust anchor"
 msgstr ""
 
 msgid "Trust anchor bundle"
@@ -10325,10 +10326,6 @@ msgstr ""
 msgid "VNC"
 msgstr ""
 
-#, php-format
-msgid "Valid until %s."
-msgstr ""
-
 msgid "Value"
 msgstr "Valeur"
 
@@ -10418,6 +10415,10 @@ msgstr ""
 
 #, fuzzy
 msgid "What gets enrolled"
+msgstr "a été mis à jour avec succès"
+
+#, fuzzy
+msgid "What it does"
 msgstr "a été mis à jour avec succès"
 
 msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
@@ -11297,9 +11298,6 @@ msgstr ""
 msgid "previous install if needed"
 msgstr ""
 
-msgid "published as ca.cert.der and pinned by every fog-client"
-msgstr ""
-
 msgid "re-run the installer and check the installation log for a key generation or signing failure"
 msgstr ""
 
@@ -11777,6 +11775,10 @@ msgstr ""
 #~ msgstr "Aucun noeud associé"
 
 #, fuzzy
+#~ msgid "Currently imported"
+#~ msgstr "Enregistrements courants"
+
+#, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "Pas de hachage disponible"
 
@@ -12203,6 +12205,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Imprimante existe déjà"
+
+#, fuzzy
+#~ msgid "The certificate chain"
+#~ msgstr "Créer un nouveau %s"
 
 #, fuzzy
 #~ msgid "There are no "

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -120,6 +120,10 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
+msgid "%d days left"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -2102,10 +2106,6 @@ msgstr "Current Records"
 msgid "Current member-host AD state"
 msgstr ""
 
-#, fuzzy
-msgid "Currently imported"
-msgstr "Current Records"
-
 msgid "DMI Field"
 msgstr ""
 
@@ -2464,7 +2464,7 @@ msgstr "Durata"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
-msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered; the SHA-256 is what to compare against a client's trust store when working out why one stopped authenticating. Private keys are deliberately absent -- nothing on this page can read one, and nothing on it can hand one out."
 msgstr ""
 
 msgid "Edit"
@@ -2665,6 +2665,10 @@ msgstr "Exists deve essere boolean"
 
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
+
+#, fuzzy
+msgid "Expired"
+msgstr "Nome sessione"
 
 msgid "Expires"
 msgstr ""
@@ -4615,6 +4619,10 @@ msgstr "Reset Token"
 msgid "Issue a token on behalf of a user"
 msgstr ""
 
+#, php-format
+msgid "Issued by %s"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
@@ -6097,6 +6105,9 @@ msgstr ""
 msgid "One entry per row. The element shape follows the requested fields: a scalar when a single column is projected, an object when several are."
 msgstr ""
 
+msgid "One is imported. It is the \"Imported root\" row in the table above."
+msgstr ""
+
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
@@ -6745,9 +6756,6 @@ msgstr "chiave privata non leggibile"
 
 msgid "Private key path not found"
 msgstr "Percorso chiave privata non trovata"
-
-msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
-msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -7514,6 +7522,9 @@ msgstr "Selezionare un tipo di cron"
 #, fuzzy
 msgid "Selected tasks canceled!"
 msgstr "Attività pianificate create con successo"
+
+msgid "Self-signed"
+msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
@@ -8841,10 +8852,6 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
-#, fuzzy
-msgid "The certificate chain"
-msgstr "Crea nuova posizione"
-
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
 msgstr ""
 
@@ -9067,7 +9074,7 @@ msgstr "Il nodo di archiviazione gruppi di archiviazione associato non è valido
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
-msgid "The trust anchor. Every fog-client pins this one."
+msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."
 msgstr ""
 
 msgid "The upload did not arrive."
@@ -9260,9 +9267,6 @@ msgid "This is the only time it will be shown. FOG stores only a hash of it and 
 msgstr ""
 
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
-msgstr ""
-
-msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
 msgstr ""
 
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
@@ -9458,9 +9462,6 @@ msgid "Transport to the master storage node failed, or the row would not save af
 msgstr ""
 
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
-msgstr ""
-
-msgid "Trust anchor"
 msgstr ""
 
 msgid "Trust anchor bundle"
@@ -10017,10 +10018,6 @@ msgstr ""
 msgid "VNC"
 msgstr ""
 
-#, php-format
-msgid "Valid until %s."
-msgstr ""
-
 msgid "Value"
 msgstr "Valore"
 
@@ -10104,6 +10101,10 @@ msgstr ""
 
 #, fuzzy
 msgid "What gets enrolled"
+msgstr "è stato cancellato"
+
+#, fuzzy
+msgid "What it does"
 msgstr "è stato cancellato"
 
 msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
@@ -10948,9 +10949,6 @@ msgstr ""
 msgid "previous install if needed"
 msgstr "installazione precedente se necessario"
 
-msgid "published as ca.cert.der and pinned by every fog-client"
-msgstr ""
-
 msgid "re-run the installer and check the installation log for a key generation or signing failure"
 msgstr ""
 
@@ -11417,6 +11415,10 @@ msgstr ""
 #~ msgstr "Nessun nodo associato"
 
 #, fuzzy
+#~ msgid "Currently imported"
+#~ msgstr "Current Records"
+
+#, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "Percorso non disponibile"
 
@@ -11857,6 +11859,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Questo host esiste già"
+
+#, fuzzy
+#~ msgid "The certificate chain"
+#~ msgstr "Crea nuova posizione"
 
 #, fuzzy
 #~ msgid "There are no "

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -111,6 +111,10 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
+msgid "%d days left"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -2088,10 +2092,6 @@ msgstr "現在のレコード"
 msgid "Current member-host AD state"
 msgstr ""
 
-#, fuzzy
-msgid "Currently imported"
-msgstr "現在のレコード"
-
 msgid "DMI Field"
 msgstr "DMI フィールド"
 
@@ -2449,7 +2449,7 @@ msgstr "期間"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
-msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered; the SHA-256 is what to compare against a client's trust store when working out why one stopped authenticating. Private keys are deliberately absent -- nothing on this page can read one, and nothing on it can hand one out."
 msgstr ""
 
 msgid "Edit"
@@ -2650,6 +2650,10 @@ msgstr "Exists 項目はブール値である必要があります"
 
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
+
+#, fuzzy
+msgid "Expired"
+msgstr "セッション名"
 
 msgid "Expires"
 msgstr ""
@@ -4575,6 +4579,10 @@ msgstr "トークンをリセット"
 msgid "Issue a token on behalf of a user"
 msgstr ""
 
+#, php-format
+msgid "Issued by %s"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
@@ -6062,6 +6070,9 @@ msgstr ""
 msgid "One entry per row. The element shape follows the requested fields: a scalar when a single column is projected, an object when several are."
 msgstr ""
 
+msgid "One is imported. It is the \"Imported root\" row in the table above."
+msgstr ""
+
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr "\"snapinfiles[]\" マルチパートフィールドを使用して、1 つ以上のファイルをアップロードする必要があります"
 
@@ -6715,9 +6726,6 @@ msgstr "秘密鍵を読み取れません"
 
 msgid "Private key path not found"
 msgstr "秘密鍵のパスが見つかりません"
-
-msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
-msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -7474,6 +7482,9 @@ msgstr "選択したログイン"
 #, fuzzy
 msgid "Selected tasks canceled!"
 msgstr "スケジュール済みタスクを作成しました"
+
+msgid "Self-signed"
+msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
@@ -8785,10 +8796,6 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
-#, fuzzy
-msgid "The certificate chain"
-msgstr "新しいロケーションを作成"
-
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
 msgstr ""
 
@@ -9013,7 +9020,7 @@ msgstr "ストレージグループに関連付けられたストレージノー
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
-msgid "The trust anchor. Every fog-client pins this one."
+msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."
 msgstr ""
 
 msgid "The upload did not arrive."
@@ -9205,9 +9212,6 @@ msgid "This is the only time it will be shown. FOG stores only a hash of it and 
 msgstr ""
 
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
-msgstr ""
-
-msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
 msgstr ""
 
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
@@ -9404,9 +9408,6 @@ msgid "Transport to the master storage node failed, or the row would not save af
 msgstr ""
 
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
-msgstr ""
-
-msgid "Trust anchor"
 msgstr ""
 
 msgid "Trust anchor bundle"
@@ -9965,10 +9966,6 @@ msgstr ""
 msgid "VNC"
 msgstr "VNC"
 
-#, php-format
-msgid "Valid until %s."
-msgstr ""
-
 msgid "Value"
 msgstr "値"
 
@@ -10051,6 +10048,10 @@ msgstr ""
 
 #, fuzzy
 msgid "What gets enrolled"
+msgstr "強制終了されました"
+
+#, fuzzy
+msgid "What it does"
 msgstr "強制終了されました"
 
 msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
@@ -10895,9 +10896,6 @@ msgstr ""
 msgid "previous install if needed"
 msgstr "必要に応じて以前のインストール"
 
-msgid "published as ca.cert.der and pinned by every fog-client"
-msgstr ""
-
 msgid "re-run the installer and check the installation log for a key generation or signing failure"
 msgstr ""
 
@@ -11546,6 +11544,10 @@ msgstr ""
 
 #~ msgid "Current settings"
 #~ msgstr "現在の設定"
+
+#, fuzzy
+#~ msgid "Currently imported"
+#~ msgstr "現在のレコード"
 
 #~ msgid "DMI Key"
 #~ msgstr "DMI キー"
@@ -13055,6 +13057,10 @@ msgstr ""
 
 #~ msgid "The below items are only used for the old client."
 #~ msgstr "以下の項目は旧クライアントでのみ使用されます。"
+
+#, fuzzy
+#~ msgid "The certificate chain"
+#~ msgstr "新しいロケーションを作成"
 
 #~ msgid "The clients will checkin with the server from time"
 #~ msgstr "クライアントは一定時間ごとにサーバーへチェックインします"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -96,6 +96,10 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
+msgid "%d days left"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -1855,9 +1859,6 @@ msgstr ""
 msgid "Current member-host AD state"
 msgstr ""
 
-msgid "Currently imported"
-msgstr ""
-
 msgid "DMI Field"
 msgstr ""
 
@@ -2169,7 +2170,7 @@ msgstr ""
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
-msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered; the SHA-256 is what to compare against a client's trust store when working out why one stopped authenticating. Private keys are deliberately absent -- nothing on this page can read one, and nothing on it can hand one out."
 msgstr ""
 
 msgid "Edit"
@@ -2351,6 +2352,9 @@ msgid "Exists item must be boolean"
 msgstr ""
 
 msgid "Expand - walk the chain (any directory)"
+msgstr ""
+
+msgid "Expired"
 msgstr ""
 
 msgid "Expires"
@@ -4053,6 +4057,10 @@ msgstr ""
 msgid "Issue a token on behalf of a user"
 msgstr ""
 
+#, php-format
+msgid "Issued by %s"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
@@ -5360,6 +5368,9 @@ msgstr ""
 msgid "One entry per row. The element shape follows the requested fields: a scalar when a single column is projected, an object when several are."
 msgstr ""
 
+msgid "One is imported. It is the \"Imported root\" row in the table above."
+msgstr ""
+
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
@@ -5937,9 +5948,6 @@ msgid "Private key not readable"
 msgstr ""
 
 msgid "Private key path not found"
-msgstr ""
-
-msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
 msgstr ""
 
 msgid "Private keys are readable by the web server"
@@ -6612,6 +6620,9 @@ msgid "Selectable on"
 msgstr ""
 
 msgid "Selected tasks canceled!"
+msgstr ""
+
+msgid "Self-signed"
 msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
@@ -7774,9 +7785,6 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
-msgid "The certificate chain"
-msgstr ""
-
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
 msgstr ""
 
@@ -7983,7 +7991,7 @@ msgstr ""
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
-msgid "The trust anchor. Every fog-client pins this one."
+msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."
 msgstr ""
 
 msgid "The upload did not arrive."
@@ -8171,9 +8179,6 @@ msgstr ""
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
 msgstr ""
 
-msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
-msgstr ""
-
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
 msgstr ""
 
@@ -8356,9 +8361,6 @@ msgid "Transport to the master storage node failed, or the row would not save af
 msgstr ""
 
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
-msgstr ""
-
-msgid "Trust anchor"
 msgstr ""
 
 msgid "Trust anchor bundle"
@@ -8842,10 +8844,6 @@ msgstr ""
 msgid "VNC"
 msgstr ""
 
-#, php-format
-msgid "Valid until %s."
-msgstr ""
-
 msgid "Value"
 msgstr ""
 
@@ -8925,6 +8923,9 @@ msgid "What Setup Mode means (firmware usually calls it \"Custom\")"
 msgstr ""
 
 msgid "What gets enrolled"
+msgstr ""
+
+msgid "What it does"
 msgstr ""
 
 msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
@@ -9703,9 +9704,6 @@ msgid "present"
 msgstr ""
 
 msgid "previous install if needed"
-msgstr ""
-
-msgid "published as ca.cert.der and pinned by every fog-client"
 msgstr ""
 
 msgid "re-run the installer and check the installation log for a key generation or signing failure"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -120,6 +120,10 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
+msgid "%d days left"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -2162,10 +2166,6 @@ msgstr "Registros atuais"
 msgid "Current member-host AD state"
 msgstr ""
 
-#, fuzzy
-msgid "Currently imported"
-msgstr "Registros atuais"
-
 msgid "DMI Field"
 msgstr ""
 
@@ -2531,7 +2531,7 @@ msgstr "Duração"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
-msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered; the SHA-256 is what to compare against a client's trust store when working out why one stopped authenticating. Private keys are deliberately absent -- nothing on this page can read one, and nothing on it can hand one out."
 msgstr ""
 
 msgid "Edit"
@@ -2733,6 +2733,10 @@ msgstr ""
 
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
+
+#, fuzzy
+msgid "Expired"
+msgstr "Nome da sessão"
 
 msgid "Expires"
 msgstr ""
@@ -4755,6 +4759,10 @@ msgstr "token de acesso"
 msgid "Issue a token on behalf of a user"
 msgstr ""
 
+#, php-format
+msgid "Issued by %s"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
@@ -6283,6 +6291,9 @@ msgstr ""
 msgid "One entry per row. The element shape follows the requested fields: a scalar when a single column is projected, an object when several are."
 msgstr ""
 
+msgid "One is imported. It is the \"Imported root\" row in the table above."
+msgstr ""
+
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
@@ -6952,9 +6963,6 @@ msgstr "chave privada não pode ser lido"
 
 msgid "Private key path not found"
 msgstr "caminho da chave privada não encontrados"
-
-msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
-msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -7738,6 +7746,9 @@ msgstr "Selecione um tipo de cron"
 #, fuzzy
 msgid "Selected tasks canceled!"
 msgstr "foi atualizado com sucesso"
+
+msgid "Self-signed"
+msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
@@ -9122,10 +9133,6 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
-#, fuzzy
-msgid "The certificate chain"
-msgstr "Criar novo %s"
-
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
 msgstr ""
 
@@ -9349,7 +9356,7 @@ msgstr "O nó de armazenamento grupos de armazenamento associado não é válido
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
-msgid "The trust anchor. Every fog-client pins this one."
+msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."
 msgstr ""
 
 msgid "The upload did not arrive."
@@ -9547,9 +9554,6 @@ msgid "This is the only time it will be shown. FOG stores only a hash of it and 
 msgstr ""
 
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
-msgstr ""
-
-msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
 msgstr ""
 
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
@@ -9750,9 +9754,6 @@ msgid "Transport to the master storage node failed, or the row would not save af
 msgstr ""
 
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
-msgstr ""
-
-msgid "Trust anchor"
 msgstr ""
 
 msgid "Trust anchor bundle"
@@ -10327,10 +10328,6 @@ msgstr ""
 msgid "VNC"
 msgstr ""
 
-#, php-format
-msgid "Valid until %s."
-msgstr ""
-
 msgid "Value"
 msgstr "Valor"
 
@@ -10420,6 +10417,10 @@ msgstr ""
 
 #, fuzzy
 msgid "What gets enrolled"
+msgstr "foi atualizado com sucesso"
+
+#, fuzzy
+msgid "What it does"
 msgstr "foi atualizado com sucesso"
 
 msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
@@ -11299,9 +11300,6 @@ msgstr ""
 msgid "previous install if needed"
 msgstr ""
 
-msgid "published as ca.cert.der and pinned by every fog-client"
-msgstr ""
-
 msgid "re-run the installer and check the installation log for a key generation or signing failure"
 msgstr ""
 
@@ -11779,6 +11777,10 @@ msgstr ""
 #~ msgstr "No nó associado"
 
 #, fuzzy
+#~ msgid "Currently imported"
+#~ msgstr "Registros atuais"
+
+#, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "Nenhum de hash disponíveis"
 
@@ -12205,6 +12207,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "Impressora já existe"
+
+#, fuzzy
+#~ msgid "The certificate chain"
+#~ msgstr "Criar novo %s"
 
 #, fuzzy
 #~ msgid "There are no "

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -120,6 +120,10 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
+msgid "%d days left"
+msgstr ""
+
+#, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
@@ -2162,10 +2166,6 @@ msgstr "当前记录"
 msgid "Current member-host AD state"
 msgstr ""
 
-#, fuzzy
-msgid "Currently imported"
-msgstr "当前记录"
-
 msgid "DMI Field"
 msgstr ""
 
@@ -2531,7 +2531,7 @@ msgstr "为期"
 msgid "Each client needs this certificate enrolled once, by someone physically at the machine"
 msgstr ""
 
-msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered."
+msgid "Each of these is a public certificate. Downloading one is how you add this server to another machine's trust store, hand an auditor the chain, or check what a client is actually being offered; the SHA-256 is what to compare against a client's trust store when working out why one stopped authenticating. Private keys are deliberately absent -- nothing on this page can read one, and nothing on it can hand one out."
 msgstr ""
 
 msgid "Edit"
@@ -2733,6 +2733,10 @@ msgstr ""
 
 msgid "Expand - walk the chain (any directory)"
 msgstr ""
+
+#, fuzzy
+msgid "Expired"
+msgstr "会话名称"
 
 msgid "Expires"
 msgstr ""
@@ -4755,6 +4759,10 @@ msgstr "访问令牌"
 msgid "Issue a token on behalf of a user"
 msgstr ""
 
+#, php-format
+msgid "Issued by %s"
+msgstr ""
+
 msgid "Issuer"
 msgstr ""
 
@@ -6283,6 +6291,9 @@ msgstr ""
 msgid "One entry per row. The element shape follows the requested fields: a scalar when a single column is projected, an object when several are."
 msgstr ""
 
+msgid "One is imported. It is the \"Imported root\" row in the table above."
+msgstr ""
+
 msgid "One or more files must be uploaded via the \"snapinfiles[]\" multipart field"
 msgstr ""
 
@@ -6952,9 +6963,6 @@ msgstr "私钥不可读"
 
 msgid "Private key path not found"
 msgstr "私钥未找到路径"
-
-msgid "Private keys are deliberately absent. Nothing on this page can read one, and nothing on it can hand one out."
-msgstr ""
 
 #, fuzzy
 msgid "Private keys are readable by the web server"
@@ -7738,6 +7746,9 @@ msgstr "选择一个cron类型"
 #, fuzzy
 msgid "Selected tasks canceled!"
 msgstr "已成功更新"
+
+msgid "Self-signed"
+msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
@@ -9122,10 +9133,6 @@ msgstr ""
 msgid "The calling user's preferences."
 msgstr ""
 
-#, fuzzy
-msgid "The certificate chain"
-msgstr "新建%s"
-
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
 msgstr ""
 
@@ -9349,7 +9356,7 @@ msgstr "存储组相关联的存储节点无效"
 msgid "The task finishes on the client with nobody at the keyboard"
 msgstr ""
 
-msgid "The trust anchor. Every fog-client pins this one."
+msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."
 msgstr ""
 
 msgid "The upload did not arrive."
@@ -9547,9 +9554,6 @@ msgid "This is the only time it will be shown. FOG stores only a hash of it and 
 msgstr ""
 
 msgid "This is the only time it will be shown. Hand it to the person or service it was issued for &mdash; you are seeing a credential that belongs to another account."
-msgstr ""
-
-msgid "This is the value to compare against a client's trust store when working out why a client stopped authenticating."
 msgstr ""
 
 msgid "This is what MokManager's own View key screen shows after enrolling from the PXE menu -- that route never runs the script above, so check it against this value instead."
@@ -9750,9 +9754,6 @@ msgid "Transport to the master storage node failed, or the row would not save af
 msgstr ""
 
 msgid "True only when the server capped an unbounded request at MAX_ROWS. Never set when the caller sent start/length."
-msgstr ""
-
-msgid "Trust anchor"
 msgstr ""
 
 msgid "Trust anchor bundle"
@@ -10327,10 +10328,6 @@ msgstr ""
 msgid "VNC"
 msgstr ""
 
-#, php-format
-msgid "Valid until %s."
-msgstr ""
-
 msgid "Value"
 msgstr "值"
 
@@ -10420,6 +10417,10 @@ msgstr ""
 
 #, fuzzy
 msgid "What gets enrolled"
+msgstr "已成功更新"
+
+#, fuzzy
+msgid "What it does"
 msgstr "已成功更新"
 
 msgid "What the browser is shown. Replaced by an ACME renewal where one is configured."
@@ -11299,9 +11300,6 @@ msgstr ""
 msgid "previous install if needed"
 msgstr ""
 
-msgid "published as ca.cert.der and pinned by every fog-client"
-msgstr ""
-
 msgid "re-run the installer and check the installation log for a key generation or signing failure"
 msgstr ""
 
@@ -11779,6 +11777,10 @@ msgstr ""
 #~ msgstr "无关联的节点"
 
 #, fuzzy
+#~ msgid "Currently imported"
+#~ msgstr "当前记录"
+
+#, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "没有可用的散列"
 
@@ -12205,6 +12207,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "That mapping already exists."
 #~ msgstr "打印机已经存在"
+
+#, fuzzy
+#~ msgid "The certificate chain"
+#~ msgstr "新建%s"
 
 #, fuzzy
 #~ msgid "There are no "

--- a/packages/web/src/Pages/FOGConfigurationPage.php
+++ b/packages/web/src/Pages/FOGConfigurationPage.php
@@ -75,8 +75,8 @@ class FOGConfigurationPage extends FOGPage
      *
      * @param string $title The box title (already translated/escaped).
      * @param string $body  The card-body HTML.
-     * @param array  $opts  color, collapse, help, footer, id, bodyId,
-     *                      bodyClass, bodyAttrs.
+     * @param array  $opts  color, collapse, cardClass, help, footer, id,
+     *                      bodyId, bodyClass, bodyAttrs.
      *
      * @return string
      */
@@ -90,6 +90,12 @@ class FOGConfigurationPage extends FOGPage
         $bodyId    = $opts['bodyId']    ?? '';
         $bodyClass = $opts['bodyClass'] ?? '';
         $bodyAttrs = $opts['bodyAttrs'] ?? '';
+        // Extra classes on the CARD, not the body. 'collapsed-card' is the
+        // only caller today: AdminLTE's collapse toggle reads that class to
+        // decide which way to go, and its own CSS hides the body, so a card
+        // that should arrive shut needs it in the markup rather than a
+        // click's worth of JavaScript after paint.
+        $cardExtra = $opts['cardClass'] ?? '';
 
         $o = '';
         if ($id !== '') {
@@ -98,12 +104,24 @@ class FOGConfigurationPage extends FOGPage
         $cardClass = ($color === 'solid' || $color === '')
             ? 'card'
             : 'card card-' . $color . ' card-outline';
+        if ($cardExtra !== '') {
+            $cardClass .= ' ' . $cardExtra;
+        }
         $o .= '<div class="' . $cardClass . '">';
         $o .= '<div class="card-header">';
         if ($collapse) {
+            // Both icons, tagged the way AdminLTE's own CSS expects: it hides
+            // [data-lte-icon=collapse] on a .collapsed-card and hides
+            // [data-lte-icon=expand] on one that is open. FOGPage's shared
+            // $FOGCollapseBox is a bare fa-minus, so a card rendered already
+            // collapsed -- which cardClass now allows -- would sit there
+            // offering to collapse itself again.
             $o .= '<div class="card-tools float-end">'
-                . self::$FOGCollapseBox
-                . '</div>';
+                . '<button type="button" class="btn btn-tool"'
+                . ' data-lte-toggle="card-collapse">'
+                . '<i data-lte-icon="expand" class="fas fa-plus"></i>'
+                . '<i data-lte-icon="collapse" class="fas fa-minus"></i>'
+                . '</button></div>';
         }
         $o .= '<h4 class="card-title">' . $title . '</h4>';
         if ($help !== '') {
@@ -407,6 +425,13 @@ class FOGConfigurationPage extends FOGPage
      * Show this server's certificate hierarchy, and change the parts of it a
      * browser may safely change.
      *
+     * The page is a TABLE of certificates plus the two controls that change
+     * one, not a card per fact. Everything a certificate has -- subject,
+     * issuer, expiry, fingerprint, a download -- is a column, so the slots can
+     * be read against each other; before this the root's subject and
+     * fingerprint were prose in one card, the imported root's were prose in
+     * another, and the remaining six were a table with none of it.
+     *
      * The reason this page runs the private key check in PHP rather than
      * simply reporting what the installer did: PHP *is* the threat model. The
      * whole point of the key isolation is that a compromise of this web
@@ -436,38 +461,21 @@ class FOGConfigurationPage extends FOGPage
         $status = self::_pkiStatus();
         $mayEdit = Authorization::can('system.pki');
 
-        // --- what the certificates are for, and what fog-client pins --------
-        $body = '<p>' . _(
-            'FOG uses certificates for three unrelated jobs: the web server, '
-            . 'the encrypted fog-client check-in, and the signature on the FOS '
-            . 'kernels. They are issued by separate CAs beneath one anchor, so '
-            . 'replacing any one of them leaves the other two alone.'
-        ) . '</p>';
-        $root = self::_pkiCert($status, 'root');
-        if ($root && !empty($root['present'])) {
-            $body .= '<p><strong>' . _('Trust anchor') . '</strong> &mdash; '
-                . _('published as ca.cert.der and pinned by every fog-client')
-                . '</p>';
-            $body .= '<pre>' . \Initiator::e($root['subject']) . '</pre>';
-            $body .= '<p><strong>' . _('SHA-256') . '</strong></p>';
-            $body .= '<pre>' . \Initiator::e($root['sha256']) . '</pre>';
-            $body .= '<p>' . _(
-                'This is the value to compare against a client\'s trust store '
-                . 'when working out why a client stopped authenticating.'
-            ) . '</p>';
-        }
         if (null === $status) {
             // Says which of the two it is. A page that simply showed less
             // would leave an administrator comparing it against the
             // documentation and finding nothing to explain the difference.
-            $body .= '<p class="text-warning">' . _(
-                'The certificate management helper is not installed on this '
-                . 'server, so this page can only show what it can read for '
-                . 'itself. Re-run the installer to enable it. On a storage '
-                . 'node this is expected: a node has no CA of its own.'
-            ) . '</p>';
+            echo $this->_box(
+                _('Certificates'),
+                '<p>' . _(
+                    'The certificate management helper is not installed on this '
+                    . 'server, so this page can only show what it can read for '
+                    . 'itself. Re-run the installer to enable it. On a storage '
+                    . 'node this is expected: a node has no CA of its own.'
+                ) . '</p>',
+                ['color' => 'warning']
+            );
         }
-        echo $this->_box(_('Certificates'), $body, ['color' => 'info']);
 
         $this->_certificateKeyExposure($status);
         $this->_certificateChain($status);
@@ -530,7 +538,48 @@ class FOGConfigurationPage extends FOGPage
         );
     }
     /**
-     * The chain, and a download for each public certificate in it.
+     * The Expires cell: the date, and a badge when it is worth acting on.
+     *
+     * A certificate table that cannot answer "is anything about to break" is
+     * only a list of names, so the badge is the point of the column and the
+     * date is context for it.
+     *
+     * Rendered in UTC rather than through FOG_TZ_INFO. That setting is the
+     * zone rows are STORED in and relabeling a value with it is how dates
+     * elsewhere have gone wrong before; openssl's notAfter is already GMT, so
+     * saying so is both correct and one fewer thing to get wrong. A value
+     * strtotime cannot read is shown verbatim rather than dropped -- the raw
+     * string is still the answer to the question.
+     *
+     * @param array $cert one entry of the helper's certificates list.
+     *
+     * @return string
+     */
+    private static function _certExpiry(array $cert)
+    {
+        $raw = (string) ($cert['not_after'] ?? '');
+        $ts = '' !== $raw ? strtotime($raw) : false;
+        if (false === $ts) {
+            return '<small>' . \Initiator::e($raw) . '</small>';
+        }
+        $out = '<small class="text-nowrap">'
+            . \Initiator::e(gmdate('Y-m-d', $ts)) . '</small>';
+        $days = (int) floor(($ts - time()) / 86400);
+        if ($days < 0) {
+            $out .= '<br><span class="badge bg-danger">'
+                . _('Expired') . '</span>';
+        } elseif ($days <= 30) {
+            // 30 days is the window every ACME client renews inside, so a
+            // certificate still amber here is one nothing is renewing.
+            $out .= '<br><span class="badge bg-warning">' . sprintf(
+                _('%d days left'),
+                $days
+            ) . '</span>';
+        }
+        return $out;
+    }
+    /**
+     * Every certificate this server holds, one row each.
      *
      * Every file here is public: the root is already published as
      * ca.cert.der, the vhost certificate is handed to anyone who connects,
@@ -538,6 +587,10 @@ class FOGConfigurationPage extends FOGPage
      * settings.view rather than a plain link only because the page is, and
      * because the web tier cannot read most of them off disk -- pki/web/ca
      * and pki/web/leaf are 0700 root:root, so the helper fetches them.
+     *
+     * The fingerprint is a column rather than a card because comparing one
+     * against a client's trust store is the reason anybody opens this page,
+     * and it was previously shown for two of the eight slots.
      *
      * @param array|null $status the helper's report.
      *
@@ -551,7 +604,7 @@ class FOGConfigurationPage extends FOGPage
         $labels = [
             'root' => [
                 _('Root'),
-                _('The trust anchor. Every fog-client pins this one.')
+                _('The trust anchor, published as ca.cert.der. Every fog-client pins this one.')
             ],
             'webca' => [
                 _('Web CA'),
@@ -589,20 +642,40 @@ class FOGConfigurationPage extends FOGPage
                 continue;
             }
             $count = (int) ($cert['count'] ?? 1);
+            $sub = '<td><code>' . \Initiator::e($cert['subject']) . '</code>';
+            // Issuer, not as its own column: a second distinguished name that
+            // wide would push the fingerprint off the table on any laptop, and
+            // what the reader wants from it is which row above signed this one.
+            if (!empty($cert['self_signed'])) {
+                $sub .= '<br><small class="text-muted">'
+                    . _('Self-signed') . '</small>';
+            } elseif (!empty($cert['issuer'])) {
+                $sub .= '<br><small class="text-muted">' . sprintf(
+                    _('Issued by %s'),
+                    \Initiator::e($cert['issuer'])
+                ) . '</small>';
+            }
+            if ($count > 1) {
+                $sub .= '<br><small class="text-muted">' . sprintf(
+                    _('%d certificates in this file'),
+                    $count
+                ) . '</small>';
+            }
+            $sub .= '</td>';
             $rows .= '<tr><td><strong>' . \Initiator::e($meta[0]) . '</strong>'
                 . '<br><small class="text-muted">' . \Initiator::e($meta[1])
                 . '</small></td>'
-                . '<td><code>' . \Initiator::e($cert['subject']) . '</code>'
-                . ($count > 1
-                    ? '<br><small class="text-muted">' . sprintf(
-                        _('%d certificates in this file'),
-                        $count
-                    ) . '</small>'
-                    : '')
-                . '</td>'
-                . '<td class="text-nowrap"><small>'
-                . \Initiator::e($cert['not_after']) . '</small></td>'
-                . '<td class="text-nowrap"><a class="btn btn-sm btn-secondary" href="'
+                . $sub
+                . '<td>' . self::_certExpiry($cert) . '</td>'
+                // user-select-all so one click takes the whole fingerprint --
+                // it is 95 characters and it exists to be pasted somewhere
+                // else. break-all rather than the text-break utility, which is
+                // word-wrap and will not break a colon-separated hex run.
+                . '<td><small class="font-monospace user-select-all"'
+                . ' style="word-break:break-all">'
+                . \Initiator::e($cert['sha256'] ?? '') . '</small></td>'
+                . '<td class="text-end text-nowrap">'
+                . '<a class="btn btn-sm btn-secondary" href="'
                 . \Initiator::e(
                     '?node=about&sub=certificatedownload&slot=' . $slot
                 ) . '">' . _('Download') . '</a></td></tr>';
@@ -610,24 +683,43 @@ class FOGConfigurationPage extends FOGPage
         if ('' === $rows) {
             return;
         }
-        $body = '<p>' . _(
+        $body = '<div class="table-responsive">'
+            . '<table class="table table-sm table-striped align-middle">';
+        $body .= '<thead><tr><th>' . _('Certificate') . '</th><th>' . _('Subject')
+            . '</th><th>' . _('Expires') . '</th><th>' . _('SHA-256')
+            . '</th><th></th></tr></thead>';
+        $body .= '<tbody>' . $rows . '</tbody></table></div>';
+        $body .= '<p class="form-text">' . _(
             'Each of these is a public certificate. Downloading one is how you '
             . 'add this server to another machine\'s trust store, hand an '
             . 'auditor the chain, or check what a client is actually being '
-            . 'offered.'
-        ) . '</p>';
-        $body .= '<div class="table-responsive"><table class="table table-sm align-middle">';
-        $body .= '<thead><tr><th>' . _('Certificate') . '</th><th>' . _('Subject')
-            . '</th><th>' . _('Expires') . '</th><th></th></tr></thead>';
-        $body .= '<tbody>' . $rows . '</tbody></table></div>';
-        $body .= '<p class="form-text">' . _(
-            'Private keys are deliberately absent. Nothing on this page can '
+            . 'offered; the SHA-256 is what to compare against a client\'s '
+            . 'trust store when working out why one stopped authenticating. '
+            . 'Private keys are deliberately absent -- nothing on this page can '
             . 'read one, and nothing on it can hand one out.'
         ) . '</p>';
-        echo $this->_box(_('The certificate chain'), $body, ['color' => 'info']);
+        echo $this->_box(
+            _('Certificates'),
+            $body,
+            [
+                'color' => 'info',
+                'help' => _(
+                    'FOG uses certificates for three unrelated jobs: the web '
+                    . 'server, the encrypted fog-client check-in, and the '
+                    . 'signature on the FOS kernels. They are issued by '
+                    . 'separate CAs beneath one anchor, so replacing any one '
+                    . 'of them leaves the other two alone.'
+                )
+            ]
+        );
     }
     /**
-     * Import, show and remove an external root CA.
+     * Import and remove an external root CA.
+     *
+     * What is imported is a ROW in the table above, so this card is only the
+     * control. It used to repeat the subject, the fingerprint and the expiry
+     * as prose, which is the same three facts in a second shape and the thing
+     * that made the page a train of cards.
      *
      * The narrow case that --ca-root cannot express on its own: a corporate
      * or step-ca root that FOG issues nothing from and nothing chains to, but
@@ -648,32 +740,21 @@ class FOGConfigurationPage extends FOGPage
         }
         $cert = self::_pkiCert($status, 'externalroot');
         $have = $cert && !empty($cert['present']);
-        $body = '<p>' . _(
+        $help = _(
             'Upload a root CA certificate to have this server trust it. It is '
             . 'added to the host\'s own trust store, so every HTTPS call this '
             . 'server makes will accept a certificate issued beneath it, and '
             . 'it is re-applied on every later installer run.'
-        ) . '</p>';
-        $body .= '<p>' . _(
+        );
+        $body = '<p class="form-text">' . _(
             'This does not change what FOG issues, and it does not change what '
             . 'fog-client pins. Only a self-signed CA certificate is accepted: '
             . 'an intermediate in the same file is dropped rather than trusted, '
             . 'because anchoring an intermediate would trust it as a root.'
         ) . '</p>';
-        if ($have) {
-            $body .= '<p><strong>' . _('Currently imported') . '</strong></p>';
-            $body .= '<pre>' . \Initiator::e($cert['subject']) . '</pre>';
-            $body .= '<p><strong>' . _('SHA-256') . '</strong></p>';
-            $body .= '<pre>' . \Initiator::e($cert['sha256']) . '</pre>';
-            $body .= '<p class="form-text">' . sprintf(
-                _('Valid until %s.'),
-                \Initiator::e($cert['not_after'])
-            ) . '</p>';
-        } else {
-            $body .= '<p class="form-text">' . _(
-                'No external root is imported on this server.'
-            ) . '</p>';
-        }
+        $body .= '<p class="form-text">' . ($have
+            ? _('One is imported. It is the "Imported root" row in the table above.')
+            : _('No external root is imported on this server.')) . '</p>';
         $store = (array) ($status['trust_store'] ?? []);
         if (empty($store['available'])) {
             $body .= '<p class="text-warning">' . _(
@@ -683,7 +764,11 @@ class FOGConfigurationPage extends FOGPage
             ) . '</p>';
         }
         if (!$mayEdit) {
-            echo $this->_box(_('External root CA'), $body, ['color' => 'info']);
+            echo $this->_box(
+                _('External root CA'),
+                $body,
+                ['color' => 'info', 'help' => $help]
+            );
             return;
         }
         $body .= '<label class="form-label" for="pki-root-file">'
@@ -734,7 +819,7 @@ class FOGConfigurationPage extends FOGPage
         echo $this->_box(
             _('External root CA'),
             $body,
-            ['color' => 'info', 'footer' => $buttons]
+            ['color' => 'info', 'help' => $help, 'footer' => $buttons]
         );
         echo '</form>';
     }
@@ -742,10 +827,10 @@ class FOGConfigurationPage extends FOGPage
      * The three install preferences that decide what FOG does to the web
      * certificate on its next run.
      *
-     * Each one states its consequence beside the control, because that is the
-     * whole difference between setting this here and setting it on a command
-     * line: an installer flag is read back before it runs, and a checkbox is
-     * not.
+     * A row each: switch, what it is, what turning it on costs. Each one
+     * states its consequence beside the control, because that is the whole
+     * difference between setting this here and setting it on a command line:
+     * an installer flag is read back before it runs, and a checkbox is not.
      *
      * They are PREFERENCES, not switches -- nothing on this page rewrites the
      * vhost or rebuilds iPXE. Saying so at the point of change is the only
@@ -800,7 +885,8 @@ class FOGConfigurationPage extends FOGPage
         $rows = '';
         foreach ($meta as $key => $text) {
             $on = 'yes' === (string) ($prefs[$key] ?? 'no');
-            $rows .= '<div class="form-check form-switch mb-3">';
+            $rows .= '<tr><td class="text-nowrap">';
+            $rows .= '<div class="form-check form-switch mb-0">';
             // data-action rather than reading it off the upload form: that
             // form is only rendered when an external root can be imported, so
             // the switches would have lost their POST target on a server where
@@ -812,20 +898,22 @@ class FOGConfigurationPage extends FOGPage
                 . ($on ? ' checked' : '')
                 . ($mayEdit ? '' : ' disabled')
                 . '>';
-            $rows .= '<label class="form-check-label" for="'
+            $rows .= '</div></td>';
+            // The label still points at the checkbox, so the setting name is
+            // the click target it always was -- it has just moved a cell.
+            $rows .= '<td><label class="form-check-label" for="'
                 . \Initiator::e($key) . '"><strong>'
                 . \Initiator::e($text[0]) . '</strong>'
-                . '<br><span class="text-muted">' . \Initiator::e($text[1])
-                . '</span><br><code>' . \Initiator::e($key) . '</code></label>';
-            $rows .= '</div>';
+                . '<br><code class="small">' . \Initiator::e($key)
+                . '</code></label></td>';
+            $rows .= '<td><small class="text-muted">'
+                . \Initiator::e($text[1]) . '</small></td></tr>';
         }
-        $body = '<p>' . _(
-            'These decide what the NEXT installer run does. Nothing here takes '
-            . 'effect until the installer runs again -- this page records the '
-            . 'preference, it does not rewrite the web server configuration or '
-            . 'reissue a certificate.'
-        ) . '</p>';
-        $body .= $rows;
+        $body = '<div class="table-responsive">'
+            . '<table class="table table-sm align-middle">';
+        $body .= '<thead><tr><th></th><th>' . _('Setting') . '</th><th>'
+            . _('What it does') . '</th></tr></thead>';
+        $body .= '<tbody>' . $rows . '</tbody></table></div>';
         $body .= '<p class="form-text">' . sprintf(
             '%s <a href="%s" target="_blank" rel="noopener">%s</a>.',
             _('A worked example of the first one, end to end:'),
@@ -852,11 +940,23 @@ class FOGConfigurationPage extends FOGPage
         echo $this->_box(
             _('Install preferences'),
             $body,
-            ['color' => 'info']
+            [
+                'color' => 'info',
+                'help' => _(
+                    'These decide what the NEXT installer run does. Nothing '
+                    . 'here takes effect until the installer runs again -- this '
+                    . 'page records the preference, it does not rewrite the web '
+                    . 'server configuration or reissue a certificate.'
+                )
+            ]
         );
     }
     /**
      * Replacing FOG's own PKI: what it costs, and the command that does it.
+     *
+     * Collapsed on arrival. It is reference material for a migration nobody
+     * does twice, and expanded it was the longest thing on a page whose job
+     * is to say what this server's certificates are right now.
      *
      * Deliberately NOT a button. Rotating the root invalidates every
      * fog-client enrollment on the estate at once, and the recovery is to
@@ -920,7 +1020,11 @@ class FOGConfigurationPage extends FOGPage
         echo $this->_box(
             _('Using your own PKI'),
             $body,
-            ['color' => 'warning']
+            [
+                'color' => 'warning',
+                'collapse' => true,
+                'cardClass' => 'collapsed-card'
+            ]
         );
     }
     /**

--- a/tests/certificate-table.test.php
+++ b/tests/certificate-table.test.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * The Certificates page is a table of certificates, not a card per fact.
+ *
+ * Two things are pinned, and they fail in different ways.
+ *
+ * THE EXPIRY BADGE is the only thing on the page that reads a certificate
+ * and reaches a conclusion, so it is the only thing that can be silently
+ * wrong. openssl's notAfter is GMT and the cell renders it with gmdate();
+ * swapping that for date() would relabel every row into FOG_TZ_INFO's zone
+ * and, within a few hours of midnight, name the wrong day -- which is the
+ * same class of error that has already gone wrong elsewhere with that
+ * setting. The zone check below runs from a zone BEHIND UTC so the two
+ * answers land on different calendar days and a swap cannot pass.
+ *
+ * THE TABLE ITSELF is pinned by rendering it, not by grepping for a <table>.
+ * The page previously showed the root's subject and fingerprint as prose in
+ * one card, the imported root's in a second, and the other six slots in a
+ * table carrying neither -- so "every present slot is one row, and every row
+ * carries the fingerprint" is exactly the property that was missing and the
+ * one worth holding.
+ *
+ * Usage: php tests/certificate-table.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('certificate-table');
+
+$t = new FogChecks();
+
+$expiry = new \ReflectionMethod(
+    'FOG\\Pages\\FOGConfigurationPage',
+    '_certExpiry'
+);
+$expiry->setAccessible(true);
+
+/*
+ * 1. The badge, at each of the three thresholds plus the unparseable case.
+ *    30 days is the window every ACME client renews inside.
+ */
+$far = $expiry->invoke(null, ['not_after' => gmdate('M j H:i:s Y', time() + 400 * 86400) . ' GMT']);
+$t->check(
+    'a certificate a year out carries no badge',
+    false === strpos($far, 'badge')
+);
+
+$soon = $expiry->invoke(null, ['not_after' => gmdate('M j H:i:s Y', time() + 10 * 86400) . ' GMT']);
+$t->check(
+    'one inside 30 days is amber',
+    false !== strpos($soon, 'badge bg-warning')
+);
+$t->check(
+    'and says how many days are left',
+    false !== strpos($soon, '10 days left')
+);
+
+$gone = $expiry->invoke(null, ['not_after' => gmdate('M j H:i:s Y', time() - 86400) . ' GMT']);
+$t->check(
+    'an expired one is red',
+    false !== strpos($gone, 'badge bg-danger')
+);
+$t->check(
+    'and says so rather than showing a negative count',
+    false !== strpos($gone, 'Expired')
+        && false === strpos($gone, 'days left')
+);
+
+$junk = $expiry->invoke(null, ['not_after' => 'not a date at all']);
+$t->check(
+    'a date strtotime cannot read is shown verbatim, not dropped',
+    false !== strpos($junk, 'not a date at all')
+        && false === strpos($junk, 'badge')
+);
+
+/*
+ * 2. The date is UTC. Run from a zone eight hours behind it against a
+ *    notAfter half an hour after midnight, so date() and gmdate() disagree
+ *    about the calendar day and only one of them can pass.
+ */
+$tz = date_default_timezone_get();
+date_default_timezone_set('America/Los_Angeles');
+$boundary = $expiry->invoke(null, ['not_after' => 'Jan  1 00:30:00 2030 GMT']);
+date_default_timezone_set($tz);
+$t->check(
+    'the expiry date is rendered in UTC, not the server\'s display zone',
+    false !== strpos($boundary, '2030-01-01')
+        && false === strpos($boundary, '2029-12-31')
+);
+
+/*
+ * 3. The table. A fixture in the helper's own shape: six present slots, one
+ *    absent, one self-signed.
+ */
+$cert = function ($slot, $selfSigned = false, $present = true) {
+    return [
+        'slot' => $slot,
+        'present' => $present,
+        'subject' => 'CN = subject-' . $slot,
+        'issuer' => $selfSigned ? 'CN = subject-' . $slot : 'CN = issuer-' . $slot,
+        'not_after' => 'Jul 30 09:12:44 2035 GMT',
+        'sha256' => strtoupper(substr(md5($slot), 0, 2)) . ':FINGERPRINT:' . strtoupper($slot),
+        'self_signed' => $selfSigned,
+        'count' => 1
+    ];
+};
+$status = [
+    'certificates' => [
+        $cert('root', true),
+        $cert('webca'),
+        $cert('webchain'),
+        $cert('anchor', true),
+        $cert('vhost'),
+        $cert('commleaf'),
+        $cert('sbca', false, false),
+        $cert('externalroot', true)
+    ]
+];
+
+// FOGPage's constructor fires PAGES_WITH_OBJECTS, which reaches
+// Route::getIds() and dereferences FOGBase::$DB. Nothing below queries
+// anything -- the fake exists only so the page can be constructed.
+FogTestHarness::fakeDb();
+$page = new \FOG\Pages\FOGConfigurationPage();
+$chain = new \ReflectionMethod(
+    'FOG\\Pages\\FOGConfigurationPage',
+    '_certificateChain'
+);
+$chain->setAccessible(true);
+ob_start();
+$chain->invoke($page, $status);
+$html = (string) ob_get_clean();
+
+$t->check(
+    'the present slots render as one table',
+    1 === substr_count($html, '<table')
+);
+$t->check(
+    'one download per present slot, and none for the absent one',
+    7 === substr_count($html, 'sub=certificatedownload')
+);
+$t->check(
+    'the absent slot is not a row',
+    false === strpos($html, 'slot=sbca')
+);
+foreach (['root', 'webca', 'webchain', 'anchor', 'vhost', 'commleaf', 'externalroot'] as $slot) {
+    $t->check(
+        'the ' . $slot . ' row carries its fingerprint',
+        false !== strpos($html, ':FINGERPRINT:' . strtoupper($slot))
+    );
+}
+$t->check(
+    'a self-signed certificate says so instead of naming its own issuer',
+    false !== strpos($html, 'Self-signed')
+);
+$t->check(
+    'an issued one names what signed it',
+    false !== strpos($html, 'issuer-webca')
+);
+
+/*
+ * 4. The reference card arrives shut. AdminLTE hides a .collapsed-card's
+ *    body in CSS, so the class in the markup is the whole mechanism -- there
+ *    is no JavaScript to fall back on if _box stops emitting it.
+ */
+$ownPki = new \ReflectionMethod(
+    'FOG\\Pages\\FOGConfigurationPage',
+    '_certificateOwnPki'
+);
+$ownPki->setAccessible(true);
+ob_start();
+$ownPki->invoke($page, null);
+$pki = (string) ob_get_clean();
+$t->check(
+    '"Using your own PKI" is collapsed on arrival',
+    false !== strpos($pki, 'collapsed-card')
+);
+$t->check(
+    'and its toggle offers to expand rather than to collapse again',
+    false !== strpos($pki, 'data-lte-icon="expand"')
+        && false !== strpos($pki, 'data-lte-icon="collapse"')
+);
+
+$t->finish();


### PR DESCRIPTION
The Certificates page showed the root's subject and SHA-256 as prose in one card, the imported root's subject, SHA-256 and expiry as prose in a second, and the remaining six slots in a table carrying neither — the same three facts in two shapes, six certificates with no fingerprint anywhere on the page, and 2400px of cards between any two rows you wanted to compare.

Every certificate is now one row of one table.

| | before | after |
|---|---|---|
| Slots showing a fingerprint | 2 of 8 | 8 of 8 |
| Cards | 5 | 4, one of them collapsed |
| What signed a certificate | not shown | sub-line under the subject |
| Expiry status | date only | date, plus red past / amber inside 30 days |

## What changed

- **One table**: label and purpose, subject with its issuer, expiry, SHA-256, download. The fingerprint is the reason anyone opens this page — it is what you compare against a client's trust store when a client stops authenticating — and it reached two of the eight slots.
- **Expiry badges.** Red once past, amber inside 30 days, which is the window every ACME client renews in. A certificate still amber there is one nothing is renewing. Rendered with `gmdate()`: openssl's `notAfter` is already GMT, and relabeling it into `FOG_TZ_INFO`'s zone — the zone rows are *stored* in — is how dates elsewhere have named the wrong day.
- **Install preferences** become a row each (switch, setting, what it does) instead of three stacked prose blocks.
- **"Using your own PKI"** — reference material for a migration nobody does twice, and the longest thing on the page — arrives collapsed.
- **External root CA** keeps only its control; what is imported is now a row in the table above, so the card stopped repeating the subject, fingerprint and expiry a third time.

Two supporting changes, both confined to this page:

- `_box()` takes a `cardClass` option so a card can render already collapsed. AdminLTE hides a `.collapsed-card`'s body in CSS, so the class in the markup is the whole mechanism.
- its collapse toggle emits both `data-lte-icon` elements. `FOGPage`'s shared `$FOGCollapseBox` is a hardcoded `fa-minus`, so a card rendered collapsed sat there offering to collapse itself again.

No JavaScript change — the switches keep their ids, `.pki-pref` class and `data-action`, and the downloads are still plain links. No CSS change, so `FOG_BCACHE_VER` is untouched.

## Verification

- Rendered against a shadow tree with an eight-slot PKI fixture, at 1440px and 900px, in both themes: no horizontal overflow, tables scroll inside their own `.table-responsive`.
- The helper-absent path (`_pkiStatus()` returns null) still renders the warning and nothing else, and the exposed-private-key danger card still leads the page.
- `tests/certificate-table.test.php` (new, 21 checks) renders the table and asserts every present slot is a row carrying its fingerprint, an absent slot is not a row, a self-signed certificate says so rather than naming itself as issuer, and the badge thresholds. The UTC check runs from `America/Los_Angeles` against a `notAfter` half an hour after midnight, so `date()` and `gmdate()` land on different calendar days and only one can pass.
- **Every assertion was made to fail** against a mutation of the code it covers: `gmdate`→`date`, the 30-day branch removed, the fingerprint cell emptied, the present-slot skip removed, the issuer sub-line dropped, `collapsed-card` removed, and the two-icon toggle reverted.
- Suite: 270 passed, 0 failed. Both `phpstan` passes clean.

Nothing here changes what the page can do or who may do it — `certificates()` is still `settings.view`, the POST actions are still `system.pki`, and `tests/certificate-management-permission.test.php` passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CreCNucEFLNcrzbZCjchvJ