### PR TITLE
Gate the bulk Add to Group endpoint, and ask for the narrower permission

### DIFF
--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -10577,6 +10577,10 @@ msgid "You do not have permission to change site grants."
 msgstr ""
 
 #, fuzzy
+msgid "You do not have permission to create groups."
+msgstr "Keine Verbindung zur Datenbank"
+
+#, fuzzy
 msgid "You do not have permission to export the database."
 msgstr "Keine Verbindung zur Datenbank"
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -10586,6 +10586,10 @@ msgid "You do not have permission to change site grants."
 msgstr ""
 
 #, fuzzy
+msgid "You do not have permission to create groups."
+msgstr "No connection to the database"
+
+#, fuzzy
 msgid "You do not have permission to export the database."
 msgstr "No connection to the database"
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -10748,6 +10748,10 @@ msgid "You do not have permission to change site grants."
 msgstr ""
 
 #, fuzzy
+msgid "You do not have permission to create groups."
+msgstr "Haga clic en el botón para exportar la base de datos."
+
+#, fuzzy
 msgid "You do not have permission to export the database."
 msgstr "Haga clic en el botón para exportar la base de datos."
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -10578,6 +10578,10 @@ msgid "You do not have permission to change site grants."
 msgstr ""
 
 #, fuzzy
+msgid "You do not have permission to create groups."
+msgstr "Keine Verbindung zur Datenbank"
+
+#, fuzzy
 msgid "You do not have permission to export the database."
 msgstr "Keine Verbindung zur Datenbank"
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -10571,6 +10571,10 @@ msgid "You do not have permission to change site grants."
 msgstr ""
 
 #, fuzzy
+msgid "You do not have permission to create groups."
+msgstr "Pas de connexion à la base de données"
+
+#, fuzzy
 msgid "You do not have permission to export the database."
 msgstr "Pas de connexion à la base de données"
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -10254,6 +10254,10 @@ msgid "You do not have permission to change site grants."
 msgstr ""
 
 #, fuzzy
+msgid "You do not have permission to create groups."
+msgstr "Nessuna connessione al database"
+
+#, fuzzy
 msgid "You do not have permission to export the database."
 msgstr "Nessuna connessione al database"
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -10197,6 +10197,10 @@ msgid "You do not have permission to change site grants."
 msgstr "少なくとも 1 つのグループを関連付ける必要があります"
 
 #, fuzzy
+msgid "You do not have permission to create groups."
+msgstr "少なくとも 1 つのグループを関連付ける必要があります"
+
+#, fuzzy
 msgid "You do not have permission to export the database."
 msgstr "少なくとも 1 つのグループを関連付ける必要があります"
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -9062,6 +9062,9 @@ msgstr ""
 msgid "You do not have permission to change site grants."
 msgstr ""
 
+msgid "You do not have permission to create groups."
+msgstr ""
+
 msgid "You do not have permission to export the database."
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -10573,6 +10573,10 @@ msgid "You do not have permission to change site grants."
 msgstr ""
 
 #, fuzzy
+msgid "You do not have permission to create groups."
+msgstr "Sem conexão com o banco de dados"
+
+#, fuzzy
 msgid "You do not have permission to export the database."
 msgstr "Sem conexão com o banco de dados"
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -10573,6 +10573,10 @@ msgid "You do not have permission to change site grants."
 msgstr ""
 
 #, fuzzy
+msgid "You do not have permission to create groups."
+msgstr "没有连接到数据库"
+
+#, fuzzy
 msgid "You do not have permission to export the database."
 msgstr "没有连接到数据库"
 

--- a/packages/web/src/Auth/Authorization.php
+++ b/packages/web/src/Auth/Authorization.php
@@ -154,7 +154,20 @@ class Authorization extends FOGBase
             'activescheduleddels' => ['GET' => 'task.view', 'POST' => 'task.task']
         ],
         'host' => [
-            'savegroup' => 'group.create',
+            // Bulk group membership from the host list. group.EDIT, not
+            // group.create: adding existing hosts to existing groups is an
+            // edit to a group, and requiring the permission to mint groups
+            // for it means an operator who may label hosts must also be able
+            // to create them -- which is backwards once a group is the
+            // labeling primitive (ADR 0038 decisions 16 and 16a.6).
+            //
+            // The route-level permission is the FLOOR, i.e. what every call
+            // needs. The privileged case -- groups_new[] naming a group that
+            // does not exist yet -- is checked inside the handler against
+            // group.create, because "am I creating a group" is a property of
+            // the request body rather than of the route. Same reasoning, and
+            // the same shape, as savedfilters' global case below.
+            'savegroup' => 'group.edit',
             // The Login History tab. _subToAction() reads the 'get' prefix
             // and answers host.view, which is the grant nearly every
             // operator holds -- so per-host login records for named people

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -4116,7 +4116,9 @@ class HostManagement extends FOGPage
         $groups_new = array_values(
             array_filter(
                 array_map('trim', (array)($items['groups_new'] ?: [])),
-                'strlen'
+                function ($name) {
+                    return '' !== $name;
+                }
             )
         );
         // Airtight, both directions: one host outside the caller's site scope
@@ -4143,7 +4145,6 @@ class HostManagement extends FOGPage
                     ]
                 )
             );
-            return;
         }
         try {
             if (!count($hosts)) {

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -4082,6 +4082,12 @@ class HostManagement extends FOGPage
      */
     public function saveGroup()
     {
+        // This handler mutates and was reachable without either -- a session
+        // cookie alone was enough, from any origin. Every other mutating
+        // handler on this page calls it; saveGroup was missed because the
+        // router's CSRF gate keys off a *Post/*Ajax suffix and this method
+        // has neither (ADR 0038 decision 16a, UNKNOWN-6).
+        self::checkAuthAndCSRF();
         header('Content-type: application/json');
         $flags = ['flags' => FILTER_REQUIRE_ARRAY];
         $items = filter_input_array(
@@ -4092,17 +4098,61 @@ class HostManagement extends FOGPage
                 'groups_new' => $flags
             ]
         );
-        $groups = $items['groups'];
-        $hosts = $items['hosts'];
-        $groups_new = $items['groups_new'];
+        // Normalized to ints before anything is bounded by them: the ids come
+        // from the browser, and requirePageObjectScopeMass() below is the only
+        // place they are checked. Same shape as deployMultiPost().
+        $ids = function ($v) {
+            return array_values(
+                array_unique(
+                    array_filter(
+                        array_map('intval', (array)$v)
+                    )
+                )
+            );
+        };
+        $groups = $ids($items['groups']);
+        $hosts = $ids($items['hosts']);
+        // Names, not ids -- deliberately not passed through $ids().
+        $groups_new = array_values(
+            array_filter(
+                array_map('trim', (array)($items['groups_new'] ?: [])),
+                'strlen'
+            )
+        );
+        // Airtight, both directions: one host outside the caller's site scope
+        // denies the whole request rather than quietly adding the rest, and
+        // the same for the target groups. A site-scoped operator could
+        // previously add ANY host to ANY group from here, because neither
+        // side was bounded.
+        Authorization::requirePageObjectScopeMass('host', $hosts);
+        Authorization::requirePageObjectScopeMass('group', $groups);
+        // The body-dependent half of the permission split. The route requires
+        // group.edit (Authorization::SUB_OVERRIDES); creating a group needs
+        // group.create as well, and only when the request actually asks for
+        // one. Checked here rather than at the route because the route cannot
+        // see the body.
+        if (count($groups_new) && !Authorization::can('group.create')) {
+            $this->jsonSend(
+                HTTPResponseCodes::HTTP_FORBIDDEN,
+                json_encode(
+                    [
+                        'error' => _(
+                            'You do not have permission to create groups.'
+                        ),
+                        'title' => _('Add Hosts to Group Fail')
+                    ]
+                )
+            );
+            return;
+        }
         try {
-            if (!count($hosts ?: [])) {
+            if (!count($hosts)) {
                 throw new \Exception(_('No hosts selected to be added'));
             }
-            if (!count($groups ?: []) && !count($groups_new ?: [])) {
+            if (!count($groups) && !count($groups_new)) {
                 throw new \Exception(_('No groups are being created or selected'));
             }
-            if (count($groups ?: [])) {
+            if (count($groups)) {
                 foreach ($groups as &$group) {
                     $Group = new Group($group);
                     if (!$Group->isValid()) {
@@ -4112,7 +4162,7 @@ class HostManagement extends FOGPage
                     unset($group);
                 }
             }
-            if (count($groups_new ?: [])) {
+            if (count($groups_new)) {
                 foreach ($groups_new as &$group) {
                     self::getClass('Group')
                         ->set('name', $group)

--- a/phpstan-tests-baseline.neon
+++ b/phpstan-tests-baseline.neon
@@ -874,6 +874,12 @@ parameters:
 			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
 			identifier: new.resultUnused
 			count: 1
+			path: tests/savegroup-is-gated.test.php
+
+		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
 			path: tests/site-scope.test.php
 
 		-
@@ -937,7 +943,7 @@ parameters:
 			path: tests/usertracking-permission-split.test.php
 
 		-
-			message: '#^Offset ''getloginhist'' on array\{savegroup\?\: ''group\.create'', getloginhist\: ''usertracking\.view''\} on left side of \?\? always exists and is not nullable\.$#'
+			message: '#^Offset ''getloginhist'' on array\{savegroup\?\: ''group\.edit'', getloginhist\: ''usertracking\.view''\} on left side of \?\? always exists and is not nullable\.$#'
 			identifier: nullCoalesce.offset
 			count: 1
 			path: tests/usertracking-permission-split.test.php

--- a/tests/savegroup-is-gated.test.php
+++ b/tests/savegroup-is-gated.test.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * The bulk "Add to Group" endpoint is authenticated, CSRF-gated, bounded to
+ * the caller's sites, and asks for the narrow permission.
+ *
+ * `host&sub=saveGroup` is the handler behind the host list's Add to Group
+ * modal. Three separate gates were missing from it, all three verified
+ * against a running 1.6 server before this test was written (ADR 0038,
+ * proposal §5 UNKNOWN-6):
+ *
+ *   1. NO CSRF CHECK. The router's gate keys off a `*Post`/`*Ajax` method
+ *      suffix and this handler has neither, so a session cookie alone was
+ *      enough from any origin. The control that shows this is not a quirk of
+ *      the test: `deployMultiPost`, the same request shape on the same page,
+ *      answered 403 to the identical unheadered request while this answered
+ *      202.
+ *   2. NO OBJECT SCOPE. Neither the posted host ids nor the posted group ids
+ *      were bounded, so a site-scoped operator could add any host on the
+ *      server to any group on the server.
+ *   3. THE WRONG PERMISSION. SUB_OVERRIDES pointed it at `group.create`.
+ *      Adding existing hosts to existing groups is an edit, and once a group
+ *      is the labeling primitive (ADR 0038 decision 16) requiring the
+ *      permission to MINT groups in order to APPLY one is backwards.
+ *
+ * The permission half is executed rather than read: resolvePagePermission()
+ * is what the router actually calls, so this pins the resolution and not the
+ * constant it happens to consult. Both verbs are also checked against
+ * coreRegistry(), because the fix is only safe if it uses vocabulary that
+ * already exists -- a bespoke sixth verb on the `group` node would leave
+ * every existing role without it and break labeling on upgrade for
+ * everybody.
+ *
+ * The three call sites cannot be executed without a session and a database,
+ * so they are pinned POSITIONALLY: each must appear inside saveGroup() and
+ * BEFORE its try block. A grep for the bare symbol would pass on
+ * `if (false && ...)` or on a gate that had drifted into the catch, which is
+ * the failure this shape is chosen to avoid.
+ *
+ * DB-free, like usertracking-permission-split.test.php: the Initiator
+ * constructor only registers the autoloader, and everything executed here is
+ * a class constant or a pure resolver.
+ *
+ * Usage: php tests/savegroup-is-gated.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+use FOG\Auth\Authorization;
+
+$root = dirname(__DIR__);
+$webroot = $root . '/packages/web';
+$init = $webroot . '/commons/init.php';
+if (!is_readable($init)) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+
+$tmp = sys_get_temp_dir() . '/fog-savegroup-gated-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
+register_shutdown_function(
+    function () use ($tmp) {
+        if (!is_dir($tmp)) {
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($tmp, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $f) {
+            $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+        }
+        @rmdir($tmp);
+    }
+);
+
+if (!defined('FOG_CACHE_DIR')) {
+    define('FOG_CACHE_DIR', $tmp . '/cache');
+}
+if (!defined('FOG_LOG_DIR')) {
+    define('FOG_LOG_DIR', $tmp . '/log');
+}
+if (!defined('FOG_PLUGIN_DIR')) {
+    define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+}
+
+require_once $init;
+new Initiator();
+
+$failures = [];
+$checks = 0;
+
+function check($label, $cond, array &$failures, &$checks)
+{
+    $checks++;
+    if (!$cond) {
+        $failures[] = $label;
+    }
+}
+
+if (!class_exists(\FOG\Auth\Authorization::class, true)) {
+    fwrite(STDERR, "FAIL: Authorization did not resolve\n");
+    exit(1);
+}
+
+/**
+ * resolvePagePermission() reaches exemptNodes() and registry(), both of
+ * which fire hook events, and a CLI harness has no HookManager. Same stub
+ * as api-server-owned-fields.test.php: the events carry nothing this test
+ * depends on, so a no-op listener registry is the whole requirement.
+ */
+class SaveGroupStubHooks
+{
+    public function processEvent($event, $arguments = [])
+    {
+    }
+}
+
+$hooks = new \ReflectionProperty(\FOG\Base\FOGBase::class, 'HookManager');
+$hooks->setAccessible(true);
+$hooks->setValue(null, new SaveGroupStubHooks());
+
+/*
+ * 1. The permission the ROUTER resolves, exercised. group.edit is the floor
+ *    for every call; group.create is the handler's business because it
+ *    depends on the request body.
+ */
+$perm = Authorization::resolvePagePermission('host', 'savegroup');
+check(
+    "resolvePagePermission('host','savegroup') is 'group.edit' (got '$perm')",
+    'group.edit' === $perm,
+    $failures,
+    $checks
+);
+check(
+    'and is no longer group.create',
+    'group.create' !== $perm,
+    $failures,
+    $checks
+);
+
+/*
+ * 2. Both verbs already exist on the group node. If either did not, the fix
+ *    would be inventing registry vocabulary, and every role on an upgraded
+ *    server would lack it.
+ */
+$core = Authorization::coreRegistry();
+$groupActions = (array)($core['group'] ?? []);
+foreach (['edit', 'create'] as $action) {
+    check(
+        "coreRegistry()['group'] declares '$action'",
+        in_array($action, $groupActions, true),
+        $failures,
+        $checks
+    );
+}
+
+/*
+ * 3. The three gates, inside saveGroup() and ahead of its try block.
+ */
+$src = (string)file_get_contents($webroot . '/src/Pages/HostManagement.php');
+$start = strpos($src, 'public function saveGroup()');
+check(
+    'HostManagement declares saveGroup()',
+    false !== $start,
+    $failures,
+    $checks
+);
+
+$body = '';
+if (false !== $start) {
+    $next = strpos($src, "\n    public function ", $start + 10);
+    $body = substr(
+        $src,
+        $start,
+        (false === $next ? strlen($src) : $next) - $start
+    );
+}
+
+$tryAt = strpos($body, 'try {');
+check(
+    'saveGroup() still has its try block',
+    false !== $tryAt,
+    $failures,
+    $checks
+);
+
+$gates = [
+    'authenticates and checks CSRF' => 'self::checkAuthAndCSRF();',
+    'bounds the posted host ids to the caller sites'
+        => "Authorization::requirePageObjectScopeMass('host', \$hosts);",
+    'bounds the posted group ids to the caller sites'
+        => "Authorization::requirePageObjectScopeMass('group', \$groups);",
+];
+foreach ($gates as $label => $needle) {
+    $at = strpos($body, $needle);
+    check(
+        "saveGroup() $label",
+        false !== $at,
+        $failures,
+        $checks
+    );
+    check(
+        "saveGroup() does so BEFORE its try block ($label)",
+        false !== $at && false !== $tryAt && $at < $tryAt,
+        $failures,
+        $checks
+    );
+}
+
+/*
+ * 4. The body-dependent half: creating a group needs group.create, and the
+ *    check is tied to groups_new actually carrying something. Matched as one
+ *    expression so that dropping either half is a failure -- an unconditional
+ *    check would take labeling away from a role that may only edit, and a
+ *    condition with no check would give group creation away for free.
+ */
+check(
+    'saveGroup() demands group.create only when groups_new[] is non-empty',
+    1 === preg_match(
+        '/if\s*\(\s*count\(\$groups_new\)\s*&&\s*'
+        . '!\s*Authorization::can\(\s*\'group\.create\'\s*\)\s*\)/',
+        $body
+    ),
+    $failures,
+    $checks
+);
+check(
+    'and refuses with 403 rather than a generic 400',
+    1 === preg_match(
+        '/HTTPResponseCodes::HTTP_FORBIDDEN/',
+        substr($body, 0, false === $tryAt ? strlen($body) : $tryAt)
+    ),
+    $failures,
+    $checks
+);
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks checks passed\n";
+exit(0);


### PR DESCRIPTION
Unit **B** of ADR 0038's build order (proposal §2.5). Independent of everything else in that plan — these are live bugs on `working-1.6` today, and the fix stands on its own whether or not the rest of the group split lands.

`host&sub=saveGroup` is the handler behind the host list's **Add to Group** modal. Three gates were missing. All three were verified against a running 1.6 server before this change (proposal §5, UNKNOWN-6), each against a control that shows the difference is the missing gate and not something about the session or the user.

| Test | `saveGroup` before | Control (`deployMultiPost`) |
|---|---|---|
| Admin session, no `X-CSRF-Token`, no `_csrf` | `202` — hosts added | `403 Forbidden (invalid CSRF token)` |
| site1-scoped user, `hosts[]=1` (host outside site1) | `202` — host joined the group | `403 You do not have permission…` |

### What changed

1. **CSRF.** The router's gate keys off a `*Post`/`*Ajax` method suffix and this handler has neither, so a session cookie alone was enough from any origin. Now calls `self::checkAuthAndCSRF()`, like every other mutating handler on the page.
2. **Object scope.** Neither the posted host ids nor the posted group ids were bounded — a site-scoped operator could add any host on the server to any group on the server. Both sides are bounded now, and one id outside scope denies the whole request rather than quietly adding the rest, which is the stance `deployMultiPost` already takes.
3. **The permission.** `SUB_OVERRIDES` pointed the route at `group.create`. Adding existing hosts to existing groups is an *edit*; requiring the permission to **mint** groups in order to **apply** one is backwards once a group is the labeling primitive (ADR 0038 decision 16). The route now requires `group.edit`; `group.create` is checked inside the handler, and only when `groups_new[]` actually names a group to create — that is a property of the request body, not of the route. Same shape as `savedfilters`' global case.

### Why `group.edit` and not something new

- **`group.assign` was rejected.** `coreRegistry()` declares a fixed action vocabulary per node. A sixth verb would be the registry's first, and every role on an upgraded server would lack it — labeling would stop working for everyone until an admin edited every role.
- **`host.edit` was rejected** as the *wider* grant: it carries image, AD credentials and kernel args, which is exactly what ADR 0038 separates membership from.
- **`group.edit` already exists on every role that manages groups** and is strictly narrower than the `group.create` in force today, so this only ever removes reach. No role gains anything and no upgrade step is needed.

### Test

`tests/savegroup-is-gated.test.php`, 14 checks. The permission half is **executed** through `resolvePagePermission()` rather than read off the constant, so it pins the resolution the router actually performs. The three call sites cannot run without a session and a database, so they are pinned **positionally** — present in `saveGroup()` *and* before its `try` block — because a bare symbol grep would pass on `if (false && …)` or on a gate that had drifted into the `catch`.

Every check was made to fail before being trusted:

| Mutation | Result |
|---|---|
| permission reverted to `group.create` | red (2/14) |
| `checkAuthAndCSRF()` deleted | red (2/14) |
| host scope bound deleted | red (2/14) |
| group scope bound deleted | red (2/14) |
| `group.create` check made unconditional | red (1/14) |
| restored | **green, 14/14** |

Full local suite: **274 passed, 0 failed**.

Depends on nothing. #1590 (the ADR and proposal) is the reasoning behind item 3 but is not required for this to merge.