### PR TITLE
Set error_log, and re-exec updatefog.sh from a copy before it rewrites itself (GH-1594)

### DIFF
--- a/bin/updatefog.sh
+++ b/bin/updatefog.sh
@@ -90,6 +90,9 @@ optargs=$(getopt -o $shortopts -l $longopts -n "$0" -- "$@")
 [[ $? -ne 0 ]] && usage
 eval set -- "$optargs"
 
+# Kept before the option loop shifts them away: the re-exec below needs the
+# ORIGINAL arguments.
+origArgs=("$@")
 autoYes=""
 while :; do
     case $1 in
@@ -123,6 +126,50 @@ while :; do
             ;;
     esac
 done
+
+# ---------------------------------------------------------------------------
+# Re-exec from a copy of this file, before going anywhere near git.
+#
+# This script replaces itself. gitUpdateToBranch() checks out a different
+# branch, which rewrites bin/updatefog.sh underneath a bash process that is
+# still reading it -- and bash reads a script incrementally, seeking by byte
+# offset, so a file that changes length mid-run makes it resume in the middle
+# of a different line. The failure is silent, arbitrary, and happens AFTER the
+# checkout has already succeeded: the server's code has moved and the process
+# driving the update is executing fragments.
+#
+# It is not hypothetical here. Every channel switch changes this file, and the
+# 1.5 -> 1.6 crossing changes it beyond recognition.
+#
+# So: copy, re-exec, and do the git work from a file nothing is going to
+# rewrite. FOG_UPDATE_RELAUNCHED marks the copy so it does not loop; the copy
+# removes itself on exit, not here, because it is the file being read.
+# ---------------------------------------------------------------------------
+if [[ -z $FOG_UPDATE_RELAUNCHED ]]; then
+    updateSelfCopy=$(mktemp -t fog-updatefog.XXXXXX) && cat "$0" > "$updateSelfCopy" || {
+        echo " * Could not copy this script to a temporary location."
+        echo " | The update has to run from a copy, because checking out another"
+        echo " | branch rewrites this file while bash is still reading it."
+        exit 1
+    }
+    chmod +x "$updateSelfCopy"
+    FOG_UPDATE_RELAUNCHED=1 FOG_UPDATE_ORIGIN="$workingdir" \
+        FOG_UPDATE_COPY="$updateSelfCopy" exec bash "$updateSelfCopy" "${origArgs[@]}"
+fi
+[[ -n $FOG_UPDATE_COPY ]] && trap 'rm -f "$FOG_UPDATE_COPY"' EXIT
+# After the re-exec $bindir is the temp directory, so everything that has to
+# resolve against the CHECKOUT uses the original location instead.
+workingdir="${FOG_UPDATE_ORIGIN:-$workingdir}"
+cd "$workingdir"
+
+# The update log. Set AFTER the re-exec, so it lands in the checkout rather
+# than beside the temporary copy -- and before anything that writes to it:
+# gitUpdateToBranch redirects into $error_log, and with it unset that is a
+# redirect into a file named "".
+[[ ! -d ./error_logs/ ]] && mkdir -p ./error_logs >/dev/null 2>&1
+error_log="${workingdir}/error_logs/fog_update_error.log"
+: > "$error_log"
+
 
 # Un-exported on purpose: it inverts errorStat so a failed git step returns
 # control here instead of ending the process, and it must NOT leak into the

--- a/bin/updatefog.sh
+++ b/bin/updatefog.sh
@@ -284,7 +284,21 @@ if [[ -z $autoYes ]]; then
 fi
 
 if ! gitUpdateToBranch "$branch"; then
-    echo " * Git update failed -- nothing was installed. See $error_log."
+    echo " * Git update failed -- nothing was installed."
+    # SHOW it, do not just name it. errorStat's own non-exitFail path already
+    # tails the log for exactly this reason, and this path is the one an admin
+    # reaches most: the git error ("couldn't find remote ref", "would be
+    # overwritten by checkout") is the whole diagnosis, and naming a file makes
+    # them go and open it. exitFail is set here, so errorStat returned instead
+    # of doing this itself.
+    if [[ -s $error_log ]]; then
+        echo " |"
+        while IFS= read -r line; do
+            echo " | $line"
+        done < <(tail -n 5 "$error_log")
+        echo " |"
+    fi
+    echo " * Full log: $error_log"
     exit 1
 fi
 

--- a/tests/revert-offer.test.sh
+++ b/tests/revert-offer.test.sh
@@ -201,5 +201,76 @@ check "updatefog.sh no longer calls writeUpdateFile itself" \
 check "updatefog.sh forwards --channel to the installer" \
     "$(grep -q 'channelArgs' "$root/bin/updatefog.sh"; echo $?)"
 
+# ---------------------------------------------------------------------------
+# updatefog.sh replaces itself.
+#
+# gitUpdateToBranch() checks out a different branch, which rewrites
+# bin/updatefog.sh underneath a bash process still reading it. Bash reads a
+# script incrementally and seeks by byte offset, so a file that changes length
+# mid-run resumes in the middle of a different line -- silently, arbitrarily,
+# and only AFTER the checkout has succeeded. Every channel switch changes this
+# file, so it is not hypothetical.
+#
+# Exercised for real: the original is emptied while it runs, and it has to
+# finish anyway.
+# ---------------------------------------------------------------------------
+updater="$root/bin/updatefog.sh"
+uwork="$work/selfrewrite"
+mkdir -p "$uwork/bin"
+
+# Built fresh each time, because running it is what destroys it.
+#
+# HONEST LIMIT OF THE BEHAVIOURAL CHECK BELOW. Bash reads ahead in blocks, and
+# this script is small enough that a given bash on a given filesystem may
+# already hold the rest of it when the truncation lands -- so the run can
+# survive WITHOUT the copy too, and this fixture was observed doing exactly
+# that. It is a regression check (the guard must not break the ordinary path),
+# not a proof that the guard is required.
+#
+# What pins the guard is the pair of structural assertions after it: that the
+# re-exec exists, and that it happens before gitUpdateToBranch. Those do fail
+# when the guard is removed, which was verified. The behavioural case is kept
+# because the failure it describes is real -- it just cannot be provoked
+# reliably on a file this size, and a check that only sometimes reproduces is
+# worth having as long as nobody reads it as the proof.
+buildFixture() {
+    sed -e 's/^if \[\[ ! \$EUID -eq 0 \]\]; then$/if false; then/'         -e 's#^\. \.\./lib/common/functions\.sh$#: > "$VICTIM"#'         "$updater" > "$uwork/bin/updatefog.sh"
+    chmod +x "$uwork/bin/updatefog.sh"
+    grep -q 'if false; then' "$uwork/bin/updatefog.sh" &&
+        grep -q ': > "$VICTIM"' "$uwork/bin/updatefog.sh"
+}
+
+if buildFixture; then
+    out=$( cd "$uwork/bin" && VICTIM="$uwork/bin/updatefog.sh"            bash ./updatefog.sh --channel beta --yes 2>&1 )
+    st=$?
+    check "updatefog.sh keeps executing after its own file is emptied mid-run"         "$(grep -q 'No existing FOG install found' <<< "$out"; echo $?)"
+    check "and exits deliberately rather than falling off the end of a lost file"         "$([[ $st -eq 1 ]]; echo $?)"
+    check "the original really was emptied, so that proved something"         "$([[ ! -s $uwork/bin/updatefog.sh ]]; echo $?)"
+    check "no temporary copy is left behind"         "$([[ $(ls /tmp/fog-updatefog.* 2>/dev/null | wc -l) -eq 0 ]]; echo $?)"
+else
+    check "could not build the self-rewrite fixture (a source line moved)" 1
+fi
+
+u=$(sed 's/#.*//' "$updater")
+
+check "updatefog.sh re-execs from a copy before touching git" \
+    "$(grep -q 'FOG_UPDATE_RELAUNCHED' <<< "$u"; echo $?)"
+
+# The re-exec has to happen BEFORE the git work, or it protects nothing.
+relaunchAt=$(grep -n 'exec bash' <<< "$u" | head -1 | cut -d: -f1)
+gitAt=$(grep -n 'gitUpdateToBranch' <<< "$u" | head -1 | cut -d: -f1)
+check "the re-exec comes before gitUpdateToBranch" \
+    "$([[ -n $relaunchAt && -n $gitAt && $relaunchAt -lt $gitAt ]]; echo $?)"
+
+# $error_log is read by gitUpdateToBranch and by the tee that shows the
+# installer. Unset, `>>$error_log` redirects into a file named "".
+check "updatefog.sh sets error_log" \
+    "$(grep -q '^error_log=' <<< "$u"; echo $?)"
+logAt=$(grep -n '^error_log=' <<< "$u" | head -1 | cut -d: -f1)
+firstUse=$(grep -n '[$]error_log' <<< "$u" | head -1 | cut -d: -f1)
+check "and sets it before its first use" \
+    "$([[ -n $logAt && -n $firstUse && $logAt -lt $firstUse ]]; echo $?)"
+
+
 printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$pass" "$fail"
 [[ $fail -eq 0 ]]

--- a/tests/revert-offer.test.sh
+++ b/tests/revert-offer.test.sh
@@ -220,7 +220,7 @@ mkdir -p "$uwork/bin"
 
 # Built fresh each time, because running it is what destroys it.
 #
-# HONEST LIMIT OF THE BEHAVIOURAL CHECK BELOW. Bash reads ahead in blocks, and
+# HONEST LIMIT OF THE BEHAVIORAL CHECK BELOW. Bash reads ahead in blocks, and
 # this script is small enough that a given bash on a given filesystem may
 # already hold the rest of it when the truncation lands -- so the run can
 # survive WITHOUT the copy too, and this fixture was observed doing exactly
@@ -229,7 +229,7 @@ mkdir -p "$uwork/bin"
 #
 # What pins the guard is the pair of structural assertions after it: that the
 # re-exec exists, and that it happens before gitUpdateToBranch. Those do fail
-# when the guard is removed, which was verified. The behavioural case is kept
+# when the guard is removed, which was verified. The behavioral case is kept
 # because the failure it describes is real -- it just cannot be provoked
 # reliably on a file this size, and a check that only sometimes reproduces is
 # worth having as long as nobody reads it as the proof.


### PR DESCRIPTION
Fixes #1594. **Draft.**

Two fixes to `bin/updatefog.sh` — one a regression I introduced in #1584, one a latent bug the regression fix made obvious.

## `$error_log` is never set (GH-1594, live on working-1.6 now)

The assignment was lost when the script was rewritten. It's read four times and set nowhere.

`gitUpdateToBranch()` redirects **every** git command with `>>$error_log 2>&1` — unset, that's a redirect into a file named `""`, so each one fails before the git command runs. The `tee` that shows the installer fails the same way, and the failure messages read *"See ."* with no path. `exitFail` is set here on purpose, so the run continues past the broken redirects instead of stopping at the first.

My test in #1584 didn't catch it because it exercises `offerRevert()` and `markInstallCommit()` directly rather than running the script end to end. It now asserts `error_log` is set, and set *before its first use*.

## The script replaces itself

`gitUpdateToBranch()` checks out a different branch, which rewrites `bin/updatefog.sh` underneath a bash process still reading it. Bash reads a script incrementally and seeks by byte offset, so a file that changes length mid-run resumes in the middle of a different line — silently, arbitrarily, and only **after** the checkout has succeeded: the code has moved and the process driving the update is executing fragments. Every channel switch changes this file.

So it copies itself out of the checkout and re-execs before going near git. `error_log` is set after that, so it lands in the checkout rather than beside the temporary copy.

## What the test proves, and what it doesn't

Being straight about this. Bash reads ahead in blocks, and this script is small enough that a run can survive the truncation **without** the copy — the fixture was observed doing exactly that. So the behavioural case is a regression check (the guard must not break the ordinary path), **not** proof the guard is required, and the comment says so rather than letting a future reader take it for more than it is.

What pins the guard is the pair of structural assertions: that the re-exec exists, and that it comes **before** `gitUpdateToBranch`. Those do fail when the guard is removed — verified.

`tests/revert-offer.test.sh`: 30 assertions, all passing.

## Related

The same guard is already in the 1.5 port (#1589), where the hazard is worse — that file doesn't exist on the branch being left and appears only after the checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtZHpyWZWDPSxePdTViGZy
