### PR TITLE
Retire persistentgroups: drop its trigger, and say so on upgrade

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -10986,23 +10986,47 @@ EOF
 # not a hand-kept list that would drift the moment a plugin joins or leaves
 # fog-plugins.
 #
-# Remove the retired accesscontrol plugin from the backup, remembering that it
-# was there.
+# Bundled plugins 1.6 RETIRES rather than relocates, in the order they should
+# be reported.
 #
-# The removal itself is old behavior and is right: 1.6 replaces that plugin with
-# core roles and permissions, its registration row is deleted by schema step 307,
-# and --oldcopy restoring its PHP into a 1.6 tree would lay a retired plugin back
-# down beside the core that retired it.
+# Top level rather than inside the backup step so it is a property of the
+# installer that both _stripRetiredPlugins and the test suite can read. A copy
+# living inside one step would let the list and its coverage drift apart
+# silently, which is the whole failure mode a retirement list exists to stop.
+#
+# Each is deleted from the backup so --oldcopy cannot lay it back down beside
+# the core that replaced it, and each gets its OWN advice in
+# _warnUnrecognizedPlugins -- the "copy it to $fogprogramdir/plugins" line the
+# rest of that notice gives would tell an admin to reinstall what this upgrade
+# just removed.
+retiredplugins="accesscontrol persistentgroups"
+# Remove each RETIRED bundled plugin from the backup, remembering which were
+# there.
+#
+# The removal itself is old behavior and is right: 1.6 replaces these plugins
+# with core, their registration rows are deleted by schema steps (307 for
+# accesscontrol, 402 for persistentgroups), and --oldcopy restoring their PHP
+# into a 1.6 tree would lay a retired plugin back down beside the core that
+# retired it.
 #
 # What was missing is the record. This runs inside the backup step, which is
 # BEFORE _warnUnrecognizedPlugins scans that same backup -- so by the time
-# anything could name accesscontrol, the directory is already gone. No scan of
+# anything could name one of these, the directory is already gone. No scan of
 # the backup can find it however it is written, which is why the fact is carried
 # in a variable instead.
-_stripRetiredAccessControl() {
-    local ac="${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/accesscontrol"
-    [[ -d $ac ]] && accesscontrolstripped=1
-    rm -rf "$ac"
+#
+# persistentgroups joined the list for ADR 0038: core now resolves group grants
+# instead of copying them onto hosts, so the plugin compensates for a defect
+# that no longer exists. Its retirement matters more than accesscontrol's,
+# because it leaves behind something no file deletion reaches -- an AFTER INSERT
+# trigger on `groupMembers`, dropped by schema step 402.
+_stripRetiredPlugins() {
+    local name dir
+    for name in $retiredplugins; do
+        dir="${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/${name}"
+        [[ -d $dir ]] && retiredpluginsstripped="${retiredpluginsstripped} ${name}"
+        rm -rf "$dir"
+    done
     # Never fatal, and never the step's exit status: this sits between a cp and
     # an errorStat $? that is reporting on the BACKUP, not on this.
     return 0
@@ -11010,28 +11034,45 @@ _stripRetiredAccessControl() {
 # Detection only -- nothing here copies, deletes or blocks anything.
 _warnUnrecognizedPlugins() {
     local oldplugins="${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins"
-    # accesscontrol is named FIRST and outside every guard below, because it is
-    # not an unrecognized plugin -- it is a RETIRED one, and the advice the rest
-    # of this function gives would be wrong for it. Its 1.6 equivalent is core
-    # roles and permissions, so copying it to $fogprogramdir/plugins would
+    # Retired plugins are named FIRST and outside every guard below, because
+    # they are not unrecognized plugins -- they are RETIRED ones, and the advice
+    # the rest of this function gives would be wrong for them. Their 1.6
+    # equivalent is core, so copying them to $fogprogramdir/plugins would
     # reinstall the thing the upgrade just replaced.
     #
-    # Outside the guards for two reasons. It cannot come from the scan at all
-    # (_stripRetiredAccessControl deleted it from the backup already), and it is
+    # Outside the guards for two reasons. They cannot come from the scan at all
+    # (_stripRetiredPlugins deleted them from the backup already), and this is
     # not a comparison against the bundled set -- so neither "no old plugins
     # directory" nor "nothing bundled to compare against" has any bearing on
     # whether this is worth saying.
-    if [[ -n ${accesscontrolstripped:-} ]]; then
+    local retired
+    for retired in ${retiredpluginsstripped:-}; do
         echo
-        echo "  The retired accesscontrol plugin was in the old web tree."
-        echo "  1.6 replaces it with core roles and permissions -- your roles and"
-        echo "  user assignments were migrated into them by the schema update, and"
-        echo "  the plugin's own registration row was removed."
-        echo "  Do NOT copy it to ${fogprogramdir:-/opt/fog}/plugins: it is not a"
-        echo "  plugin to relocate, and it is not carried into the backup either."
-        echo "  Review what came across under Role Management once this finishes."
+        case $retired in
+            accesscontrol)
+                echo "  The retired accesscontrol plugin was in the old web tree."
+                echo "  1.6 replaces it with core roles and permissions -- your roles and"
+                echo "  user assignments were migrated into them by the schema update, and"
+                echo "  the plugin's own registration row was removed."
+                echo "  Do NOT copy it to ${fogprogramdir:-/opt/fog}/plugins: it is not a"
+                echo "  plugin to relocate, and it is not carried into the backup either."
+                echo "  Review what came across under Role Management once this finishes."
+                ;;
+            persistentgroups)
+                echo "  The retired persistentgroups plugin was in the old web tree."
+                echo "  1.6 makes a group's snapins and printers a standing grant that is"
+                echo "  resolved when it is used, so a host added to a group picks them up"
+                echo "  without anything being copied onto it -- which is what that plugin"
+                echo "  existed to fake."
+                echo "  Its database TRIGGER has been dropped by the schema update. That"
+                echo "  matters, because the trigger outlived the plugin's files: removing"
+                echo "  the code never stopped it firing."
+                echo "  Do NOT copy it to ${fogprogramdir:-/opt/fog}/plugins: installing it"
+                echo "  again re-creates that trigger."
+                ;;
+        esac
         echo
-    fi
+    done
     [[ -d $oldplugins ]] || return 0
     # "Unrecognized" is decided by comparison, so with nothing to compare
     # against there is no finding to report -- only a list of every plugin
@@ -11209,18 +11250,18 @@ configureHttpd() {
     # ${WEB_docroot}fog was a symlink this run removed. See the report at the end
     # of this step for why that has to be said out loud.
     webbackedup=""
-    # Whether the retired accesscontrol plugin was in the tree just backed
-    # up. Set by _stripRetiredAccessControl below, read by
-    # _warnUnrecognizedPlugins, because by the time that runs the evidence
-    # has been deleted.
-    accesscontrolstripped=""
+    # Which retired plugins were actually in the tree just backed up. Set by
+    # _stripRetiredPlugins below, read by _warnUnrecognizedPlugins, because by
+    # the time that runs the evidence has been deleted. The list itself is
+    # $retiredplugins, defined at the top level beside those two functions.
+    retiredpluginsstripped=""
     if [[ -d ${DB_backup_path}/fog_web_${version}.BACKUP ]]; then
         rm -rf ${DB_backup_path}/fog_web_${version}.BACKUP >>$error_log 2>&1
     fi
     if [[ -d $webdirdest ]]; then
         cp -RT "$webdirdest" "${DB_backup_path}/fog_web_${version}.BACKUP" >>$error_log 2>&1
         webbackedup=1
-        _stripRetiredAccessControl
+        _stripRetiredPlugins
         rm -rf "$webdirdest" >>$error_log 2>&1
     elif [[ -n $priorwebdir && -d $priorwebdir ]]; then
         # Copy only, no removal. The branch above deletes $webdirdest because
@@ -11230,7 +11271,7 @@ configureHttpd() {
         # and deleting it would be a new behavior nobody asked for.
         cp -RT "$priorwebdir" "${DB_backup_path}/fog_web_${version}.BACKUP" >>$error_log 2>&1
         webbackedup=1
-        _stripRetiredAccessControl
+        _stripRetiredPlugins
     fi
     if [[ ${FOG_os_id} -eq 2 ]]; then
         # GH-953: this removed ${WEB_docroot} -- the whole document root, taking any

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -10228,3 +10228,76 @@ $this->schema[] = [
         return true;
     },
 ];
+
+// 402
+$this->schema[] = [
+    // Retire the persistentgroups plugin: drop its TRIGGER, then its row.
+    //
+    // ADR 0038 decision 14. The plugin existed to make a group assignment
+    // stick to hosts added later, which core now does by resolving group
+    // grants instead of copying them. Deleting the plugin's code is not
+    // enough on its own, and that is the whole reason this step exists:
+    //
+    //   THE TRIGGER OUTLIVES THE PLUGIN. Bundled plugins live in
+    //   packages/web/lib/plugins, which configureHttpd() rm -rf's and
+    //   re-lays on every upgrade, so removing it from fog-plugins does
+    //   remove the code. It does not touch the database. `persistentGroups`
+    //   is an AFTER INSERT trigger on `groupMembers` and would go on firing
+    //   forever, silently, with nothing left on disk to explain it.
+    //
+    // Unlike the stale `site` row step 399 cleaned up, this one is ACTIVE
+    // rather than cosmetic. Verified 2026-09-01 against a clone of a live
+    // 1.6 database, in a throwaway container: the trigger copies 13 `hosts`
+    // columns -- `hostADPass` among them -- plus locationAssoc, printerAssoc,
+    // snapinAssoc and moduleStatusByHost rows from a "template" host onto
+    // every host added to a matching group, and creates snapinJobs and
+    // snapinTasks rows, i.e. it queues software onto the machine.
+    //
+    // It is also substantially BROKEN on 1.6 data, which is worth knowing
+    // when reading a bug report from before this ran. The printerAssoc and
+    // moduleStatusByHost copies carry no ON DUPLICATE KEY UPDATE, so a
+    // collision raises 1062 inside an AFTER INSERT trigger and rolls back
+    // the INSERT INTO groupMembers that fired it -- the host is not added at
+    // all. 85 of 86 hosts on the database tested carried moduleStatusByHost
+    // rows, so for a group using the template convention nearly every add
+    // failed with a database error.
+    //
+    // THE DROP IS UNCONDITIONAL, the row delete is not.
+    //
+    // DROP TRIGGER IF EXISTS is already a no-op on a server that never
+    // installed the plugin, so gating it would only add a way to be wrong.
+    // Deleting the `plugins` row is gated on evidence, on step 399's
+    // pattern and for step 399's reason: step 334 tried to retire the `site`
+    // row by reading `plugins`.`pLocation`, which 1.5 never wrote, so its
+    // gate matched the empty string on every upgraded row and the DELETE was
+    // unreachable. A step runs once and cannot be corrected in place.
+    //
+    // Here the evidence is the trigger itself -- a fact this database
+    // carries, not a column whose value depends on which branch wrote it --
+    // read BEFORE the drop, because afterward there is nothing to read.
+    // No filesystem path is consulted, so an unmounted external plugin root
+    // cannot make this decide anything.
+    function () {
+        $row = self::$DB->query(
+            "SELECT COUNT(*) AS `n` FROM `information_schema`.`TRIGGERS`"
+            . " WHERE `TRIGGER_SCHEMA` = DATABASE()"
+            . " AND `TRIGGER_NAME` = 'persistentGroups'"
+        )->fetch(\PDO::FETCH_ASSOC)->get();
+        $hadTrigger = (int)($row['n'] ?? 0) > 0;
+
+        // TRIGGER_SCHEMA = DATABASE(), never a literal. The plugin's own
+        // location-copy branch hardcoded `table_schema = 'fog'` against
+        // information_schema.tables, which is SERVER-global: it asked about
+        // whatever database on the server happened to be named `fog` and
+        // then wrote to its own. Both failure directions are reachable on a
+        // box hosting two FOG databases, which is not hypothetical.
+        self::$DB->query("DROP TRIGGER IF EXISTS `persistentGroups`");
+
+        if ($hadTrigger) {
+            self::$DB->query(
+                "DELETE FROM `plugins` WHERE LOWER(`pName`) = 'persistentgroups'"
+            );
+        }
+        return true;
+    },
+];

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -130,7 +130,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 401);
+        define('FOG_SCHEMA', 402);
         define('FOG_BCACHE_VER', 355);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -81,7 +81,7 @@ parameters:
 		-
 			message: '#^Accessing self\:\:\$DB outside of class scope\.$#'
 			identifier: outOfClass.self
-			count: 116
+			count: 119
 			path: packages/web/commons/schema.php
 
 		-
@@ -129,7 +129,7 @@ parameters:
 		-
 			message: '#^Variable \$this might not be defined\.$#'
 			identifier: variable.undefined
-			count: 371
+			count: 372
 			path: packages/web/commons/schema.php
 
 		-

--- a/tests/unrecognized-plugin-notice.test.sh
+++ b/tests/unrecognized-plugin-notice.test.sh
@@ -40,7 +40,7 @@
 #      of this notice gives would tell an admin to reinstall the thing the
 #      upgrade just removed. It is also unreachable by the scan: the backup
 #      step deletes it out of the backup before this function ever runs, so
-#      the notice keys on a flag _stripRetiredAccessControl sets, and is
+#      the notice keys on a flag _stripRetiredPlugins sets, and is
 #      emitted ahead of both guards that exist only for the comparison.
 #
 # No install, no network, no root.
@@ -191,11 +191,11 @@ fi
 # retired.
 #
 # It also cannot come from the scan the rest of this function does. The backup
-# step calls _stripRetiredAccessControl, which DELETES the directory out of the
+# step calls _stripRetiredPlugins, which DELETES the directory out of the
 # backup, and only then does configureHttpd call _warnUnrecognizedPlugins --
 # so at scan time there is nothing on disk to find. The flag is the only record.
 reset_old_tree
-accesscontrolstripped=1
+retiredpluginsstripped="accesscontrol"
 mkdir -p "${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/hostext"
 out="$(_warnUnrecognizedPlugins)"
 if [[ $out == *"accesscontrol"* ]]; then
@@ -213,7 +213,7 @@ if [[ $out == *"Role Management"* ]]; then
 else
     bad "expected 'Role Management' in output, got: $out"
 fi
-accesscontrolstripped=""
+retiredpluginsstripped=""
 
 # --- 9. no accesscontrol, no accesscontrol notice ----------------------------
 reset_old_tree
@@ -233,7 +233,7 @@ fi
 # configureHttpd with an empty $webdirsrc/lib/plugins, installfog.sh:1353)
 # would otherwise swallow it.
 reset_old_tree
-accesscontrolstripped=1
+retiredpluginsstripped="accesscontrol"
 out="$(_warnUnrecognizedPlugins)"
 if [[ $out == *"accesscontrol"* ]]; then
     ok "accesscontrol is named with no old lib/plugins/ left to scan"
@@ -251,9 +251,9 @@ else
     bad "the empty-bundled-set guard swallowed the accesscontrol notice: $out"
 fi
 webdirsrc="$saved_src"
-accesscontrolstripped=""
+retiredpluginsstripped=""
 
-# --- 11. _stripRetiredAccessControl: removes it, records it, never fails -----
+# --- 11. _stripRetiredPlugins: removes them, records them, never fails ----
 #
 # The removal is not new -- it predates this notice and is correct. What is
 # pinned here is that it still happens, that the flag is set only when the
@@ -261,26 +261,26 @@ accesscontrolstripped=""
 # an `errorStat $?` reporting on the BACKUP, so a non-zero here would report a
 # failed backup that did not fail.
 reset_old_tree
-accesscontrolstripped=""
+retiredpluginsstripped=""
 mkdir -p "${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/accesscontrol/class"
-_stripRetiredAccessControl
+_stripRetiredPlugins
 rc=$?
 if [[ ! -d "${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/accesscontrol" ]]; then
     ok "accesscontrol is removed from the backup"
 else
     bad "accesscontrol was left in the backup"
 fi
-[[ -n $accesscontrolstripped ]] && ok "the strip records that it happened" \
+[[ $retiredpluginsstripped == *accesscontrol* ]] && ok "the strip records that it happened" \
     || bad "the strip did not record that accesscontrol was there"
 [[ $rc -eq 0 ]] && ok "the strip returns 0 (it feeds an errorStat for the backup)" \
     || bad "the strip returned $rc"
 
 reset_old_tree
-accesscontrolstripped=""
+retiredpluginsstripped=""
 mkdir -p "${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/hostext"
-_stripRetiredAccessControl
+_stripRetiredPlugins
 rc=$?
-if [[ -z $accesscontrolstripped ]]; then
+if [[ $retiredpluginsstripped != *accesscontrol* ]]; then
     ok "the strip records nothing when accesscontrol was not there"
 else
     bad "the strip claimed accesscontrol was there when it was not"
@@ -290,12 +290,108 @@ fi
 
 # --- 12. still never fatal with the accesscontrol notice to print -----------
 reset_old_tree
-accesscontrolstripped=1
+retiredpluginsstripped="accesscontrol"
 _warnUnrecognizedPlugins >/dev/null
 rc=$?
 [[ $rc -eq 0 ]] && ok "the accesscontrol notice is non-fatal too" \
     || bad "should never be fatal, returned $rc"
-accesscontrolstripped=""
+retiredpluginsstripped=""
+
+# --- 13. the production retirement list, read from functions.sh -------------
+#
+# The point of $retiredplugins being top level rather than assigned inside the
+# backup step: this asserts the list the INSTALLER uses, so a name dropped from
+# it fails here instead of silently losing its notice. Everything below sets
+# $retiredpluginsstripped by hand to exercise the reporting, which would keep
+# passing against an empty production list.
+if [[ $retiredplugins == *accesscontrol* ]]; then
+    ok "accesscontrol is on the installer's retirement list"
+else
+    bad "accesscontrol missing from retiredplugins='$retiredplugins'"
+fi
+if [[ $retiredplugins == *persistentgroups* ]]; then
+    ok "persistentgroups is on the installer's retirement list"
+else
+    bad "persistentgroups missing from retiredplugins='$retiredplugins'"
+fi
+
+# --- 14. persistentgroups is retired too, with its OWN advice ---------------
+#
+# ADR 0038. It is on the same list for the same reason -- core replaced it, so
+# "copy it to $fogprogramdir/plugins" would reinstall what the upgrade removed
+# -- but its advice is not accesscontrol's, and the difference is the point:
+# this plugin left a database TRIGGER behind that deleting its files never
+# reached, so the notice has to say the trigger is gone and that reinstalling
+# brings it back. Schema step 402 is what actually drops it.
+reset_old_tree
+retiredpluginsstripped="persistentgroups"
+mkdir -p "${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/hostext"
+out="$(_warnUnrecognizedPlugins)"
+if [[ $out == *"persistentgroups"* ]]; then
+    ok "the retired persistentgroups plugin is named"
+else
+    bad "expected 'persistentgroups' in output, got: $out"
+fi
+if [[ $out == *"TRIGGER"* ]]; then
+    ok "the notice says the database trigger was dropped"
+else
+    bad "expected the trigger to be mentioned, got: $out"
+fi
+if [[ $out == *"Do NOT copy it to ${fogprogramdir}/plugins"* ]]; then
+    ok "persistentgroups is told NOT to be relocated"
+else
+    bad "expected the do-not-relocate line for persistentgroups, got: $out"
+fi
+if [[ $out == *"Role Management"* ]]; then
+    bad "gave persistentgroups accesscontrol's advice: $out"
+else
+    ok "persistentgroups does not get accesscontrol's Role Management advice"
+fi
+retiredpluginsstripped=""
+
+# --- 15. both at once, each with its own advice -----------------------------
+#
+# The list is iterated, so two retired plugins in one old tree must produce two
+# notices rather than the first one only.
+reset_old_tree
+retiredpluginsstripped="accesscontrol persistentgroups"
+out="$(_warnUnrecognizedPlugins)"
+if [[ $out == *"accesscontrol"* && $out == *"persistentgroups"* ]]; then
+    ok "both retired plugins are named when both were present"
+else
+    bad "expected both retired plugins, got: $out"
+fi
+if [[ $out == *"Role Management"* && $out == *"TRIGGER"* ]]; then
+    ok "each retired plugin keeps its own advice"
+else
+    bad "expected both advice blocks, got: $out"
+fi
+retiredpluginsstripped=""
+
+# --- 16. the strip walks the whole list ------------------------------------
+reset_old_tree
+retiredpluginsstripped=""
+mkdir -p "${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/accesscontrol/class"
+mkdir -p "${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/persistentgroups/src"
+mkdir -p "${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/hostext"
+_stripRetiredPlugins
+rc=$?
+if [[ ! -d "${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/persistentgroups" ]]; then
+    ok "persistentgroups is removed from the backup"
+else
+    bad "persistentgroups was left in the backup"
+fi
+if [[ -d "${DB_backup_path}/fog_web_${version}.BACKUP/lib/plugins/hostext" ]]; then
+    ok "a third-party plugin beside them is NOT removed"
+else
+    bad "the strip removed a plugin that is not retired"
+fi
+[[ $retiredpluginsstripped == *accesscontrol* && $retiredpluginsstripped == *persistentgroups* ]] \
+    && ok "the strip records every retired plugin it found" \
+    || bad "the strip recorded '$retiredpluginsstripped'"
+[[ $rc -eq 0 ]] && ok "the multi-plugin strip returns 0" \
+    || bad "the strip returned $rc"
+retiredpluginsstripped=""
 
 echo
 echo "  $PASS passed, $FAIL failed"


### PR DESCRIPTION
Unit **A** of ADR 0038's build order. Independent of the rest of the split — the trigger is doing harm on real servers today, so this stands alone.

### Deleting the plugin is not enough

Bundled plugins live in `packages/web/lib/plugins`, which `configureHttpd()` `rm -rf`s and re-lays on every upgrade. Removing it from `fog-plugins` removes the code — it does **not** touch the database. `persistentGroups` is an `AFTER INSERT` trigger on `groupMembers` and would keep firing forever, silently, with nothing left on disk to explain it: copying 13 `hosts` columns (`hostADPass` among them) from a "template" host, plus `locationAssoc` / `printerAssoc` / `snapinAssoc` / `moduleStatusByHost` rows, and creating `snapinJobs` + `snapinTasks` rows — i.e. queueing software onto the machine.

It is also **substantially broken on 1.6 data**, which is worth knowing when reading any bug report from before this lands. The `printerAssoc` and `moduleStatusByHost` copies carry no `ON DUPLICATE KEY UPDATE`, so a collision raises 1062 inside an `AFTER INSERT` trigger and rolls back the `INSERT INTO groupMembers` that fired it — the host is not added at all. **85 of 86 hosts (98.8%)** on the database tested carry `moduleStatusByHost` rows, so for a group using the template convention nearly every add failed with a database error.

### Schema step 402

Drops the trigger unconditionally (`IF EXISTS` makes it a no-op where it was never installed) and deletes the `plugins` row **only when the trigger was really there**. The gate is read *before* the drop, because afterward there is nothing to read, and it uses `TRIGGER_SCHEMA = DATABASE()` rather than a literal — step 399's pattern for step 399's reason: step 334 gated on a column 1.5 never wrote, so its `DELETE` was unreachable, and a step cannot be corrected in place.

Verified in a throwaway container against a clone of the live 1.6 database:

| Case | Result |
|---|---|
| trigger present | gate reads 1 → trigger dropped, row deleted, and an `INSERT INTO groupMembers` that previously failed 1062 on `msHostID` **succeeds** (5 members → 6) |
| run again | gate reads 0, `DROP ... IF EXISTS` is a clean no-op |
| trigger absent | plugins row **survives** — correct: an admin whose plugin never created one keeps the listing |
| other plugins | all 14 untouched |

### The installer half is not optional

`_warnUnrecognizedPlugins` scans the backup and tells the admin to copy anything unrecognized to `$fogprogramdir/plugins`. For a *retired* plugin that is advice to reinstall what the upgrade just removed — and here it would **re-create the trigger**. `accesscontrol` already carried a bespoke exemption for exactly this; `persistentgroups` makes it two, so `_stripRetiredAccessControl` becomes `_stripRetiredPlugins` over a `$retiredplugins` list with per-plugin advice.

`$retiredplugins` is defined at the **top level** rather than inside the backup step, so the installer's real list is what the test reads. A copy living inside one step would let the list and its coverage drift apart silently — the exact failure a retirement list exists to stop.

### Test

`tests/unrecognized-plugin-notice.test.sh`: 22 → 34 checks. Every new one was made to fail before being trusted:

| Mutation | Result |
|---|---|
| drop `persistentgroups` from the production list | red (3) |
| remove the TRIGGER line from its advice | red (2) |
| `break` the strip loop after one entry | red (2) |
| `break` the notice loop after one entry | red (2) |
| make the strip remove a non-retired plugin | red (1) |
| restored | **green, 34/34** |

Full suite **276 passed, 0 failed**; both phpstan passes clean.

### Named, not silently skipped

`/opt/fog/plugins` is never touched by the installer (ADR 0009), so an admin who copied `persistentgroups` there keeps the files, and installing it again re-creates the trigger. **The notice says so in as many words.** Core refusing to install a retired plugin is the other half of that mitigation and is deliberately not built for one hypothetical — the drop runs on every upgrade regardless, so the trigger cannot survive an update.

The matching `fog-plugins` deletion is a separate PR in that repo.