### PR TITLE
Certificates: one card with tabs, and undo the collapsed card

### DIFF
--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -5414,11 +5414,15 @@ abstract class FOGPage extends FOGBase
      * Build our nav-tabs elements.
      *
      * @param mixed      $tabData The tabs we are going to build out.
-     * @param int|object $obj     The object to pass in, -1 = current node + id.
+     * @param int|object|bool $obj The object to pass in, -1 = current node + id.
      *                            Anything falsy means there is no object, which
      *                            skips the hook and plugin-injection blocks --
      *                            that is what a report passes, having no entity
-     *                            for a plugin tab to attach to.
+     *                            for a plugin tab to attach to. false is the
+     *                            value callers actually use for that, so it is
+     *                            in the type: three pages passed it against a
+     *                            declared int|object and two of them carried a
+     *                            baselined error for saying so.
      *
      * @return string
      */

--- a/packages/web/src/Pages/FOGConfigurationPage.php
+++ b/packages/web/src/Pages/FOGConfigurationPage.php
@@ -75,8 +75,8 @@ class FOGConfigurationPage extends FOGPage
      *
      * @param string $title The box title (already translated/escaped).
      * @param string $body  The card-body HTML.
-     * @param array  $opts  color, collapse, cardClass, help, footer, id,
-     *                      bodyId, bodyClass, bodyAttrs.
+     * @param array  $opts  color, collapse, help, footer, id, bodyId,
+     *                      bodyClass, bodyAttrs.
      *
      * @return string
      */
@@ -90,12 +90,6 @@ class FOGConfigurationPage extends FOGPage
         $bodyId    = $opts['bodyId']    ?? '';
         $bodyClass = $opts['bodyClass'] ?? '';
         $bodyAttrs = $opts['bodyAttrs'] ?? '';
-        // Extra classes on the CARD, not the body. 'collapsed-card' is the
-        // only caller today: AdminLTE's collapse toggle reads that class to
-        // decide which way to go, and its own CSS hides the body, so a card
-        // that should arrive shut needs it in the markup rather than a
-        // click's worth of JavaScript after paint.
-        $cardExtra = $opts['cardClass'] ?? '';
 
         $o = '';
         if ($id !== '') {
@@ -104,30 +98,25 @@ class FOGConfigurationPage extends FOGPage
         $cardClass = ($color === 'solid' || $color === '')
             ? 'card'
             : 'card card-' . $color . ' card-outline';
-        if ($cardExtra !== '') {
-            $cardClass .= ' ' . $cardExtra;
-        }
         $o .= '<div class="' . $cardClass . '">';
-        $o .= '<div class="card-header">';
-        if ($collapse) {
-            // Both icons, tagged the way AdminLTE's own CSS expects: it hides
-            // [data-lte-icon=collapse] on a .collapsed-card and hides
-            // [data-lte-icon=expand] on one that is open. FOGPage's shared
-            // $FOGCollapseBox is a bare fa-minus, so a card rendered already
-            // collapsed -- which cardClass now allows -- would sit there
-            // offering to collapse itself again.
-            $o .= '<div class="card-tools float-end">'
-                . '<button type="button" class="btn btn-tool"'
-                . ' data-lte-toggle="card-collapse">'
-                . '<i data-lte-icon="expand" class="fas fa-plus"></i>'
-                . '<i data-lte-icon="collapse" class="fas fa-minus"></i>'
-                . '</button></div>';
+        // A card inside a tab pane carries no title of its own -- the tab is
+        // the title -- and an empty header renders as a bare bar above the
+        // content. Nothing else can suppress it, so an empty title with
+        // nothing else to put up there means no header at all.
+        $hasHeader = ($title !== '' || $help !== '' || $collapse);
+        if ($hasHeader) {
+            $o .= '<div class="card-header">';
+            if ($collapse) {
+                $o .= '<div class="card-tools float-end">'
+                    . self::$FOGCollapseBox
+                    . '</div>';
+            }
+            $o .= '<h4 class="card-title">' . $title . '</h4>';
+            if ($help !== '') {
+                $o .= '<p class="form-text">' . $help . '</p>';
+            }
+            $o .= '</div>';
         }
-        $o .= '<h4 class="card-title">' . $title . '</h4>';
-        if ($help !== '') {
-            $o .= '<p class="form-text">' . $help . '</p>';
-        }
-        $o .= '</div>';
         $o .= '<div class="card-body'
             . ($bodyClass !== '' ? ' ' . $bodyClass : '')
             . '"'
@@ -425,12 +414,29 @@ class FOGConfigurationPage extends FOGPage
      * Show this server's certificate hierarchy, and change the parts of it a
      * browser may safely change.
      *
-     * The page is a TABLE of certificates plus the two controls that change
-     * one, not a card per fact. Everything a certificate has -- subject,
-     * issuer, expiry, fingerprint, a download -- is a column, so the slots can
-     * be read against each other; before this the root's subject and
-     * fingerprint were prose in one card, the imported root's were prose in
-     * another, and the remaining six were a table with none of it.
+     * ONE CARD WITH TABS, the shape nearly every other management page in FOG
+     * uses, built by the same FOGPage::tabFields() they use. It was five
+     * stacked cards, so reading one certificate against another meant
+     * scrolling past 2400px of prose to do it.
+     *
+     * Inside the first tab every certificate is a ROW: subject, what signed
+     * it, expiry, fingerprint, download. The root's subject and fingerprint
+     * used to be prose in one card and the imported root's prose in another,
+     * while the six slots that were already tabulated carried neither.
+     *
+     * The two ALARMS stay outside the tab card, above it. A condition an
+     * administrator must act on cannot live behind a tab they have to know to
+     * click; "the web server can read your CA private key" is not a topic, it
+     * is an interruption.
+     *
+     * NOT a collapsed card, which is what shipped first and had to be undone.
+     * AdminLTE binds the collapse toggle with
+     * `document.querySelectorAll(...).forEach(el => el.addEventListener(...))`
+     * once at DOMContentLoaded -- it is not delegated -- and FOG replaces the
+     * content by AJAX on every sidebar click. So a card that arrives by
+     * navigation has no handler on its toggle, and one rendered
+     * `collapsed-card` is content nobody can reach. It works only on a hard
+     * reload, which is exactly what a static test snapshot is.
      *
      * The reason this page runs the private key check in PHP rather than
      * simply reporting what the installer did: PHP *is* the threat model. The
@@ -461,11 +467,15 @@ class FOGConfigurationPage extends FOGPage
         $status = self::_pkiStatus();
         $mayEdit = Authorization::can('system.pki');
 
+        // Both alarms, emitted above the tab card. A condition an
+        // administrator must act on cannot live behind a tab they have to
+        // know to click.
+        $alarms = $this->_certificateKeyExposure($status);
         if (null === $status) {
             // Says which of the two it is. A page that simply showed less
             // would leave an administrator comparing it against the
             // documentation and finding nothing to explain the difference.
-            echo $this->_box(
+            $alarms .= $this->_box(
                 _('Certificates'),
                 '<p>' . _(
                     'The certificate management helper is not installed on this '
@@ -476,12 +486,45 @@ class FOGConfigurationPage extends FOGPage
                 ['color' => 'warning']
             );
         }
+        echo $alarms;
 
-        $this->_certificateKeyExposure($status);
-        $this->_certificateChain($status);
-        $this->_certificateExternalRoot($status, $mayEdit);
-        $this->_certificatePreferences($status, $mayEdit);
-        $this->_certificateOwnPki($status);
+        // Each builder returns '' when it has nothing to show, so a tab is
+        // never rendered empty -- on a storage node that leaves the one tab
+        // that needs no helper.
+        $tabs = [
+            ['pki-chain', _('Certificates'), $this->_certificateChain($status)],
+            [
+                'pki-external-root',
+                _('External root CA'),
+                $this->_certificateExternalRoot($status, $mayEdit)
+            ],
+            [
+                'pki-preferences',
+                _('Install preferences'),
+                $this->_certificatePreferences($status, $mayEdit)
+            ],
+            ['pki-own', _('Using your own PKI'), $this->_certificateOwnPki($status)]
+        ];
+        $tabData = [];
+        foreach ($tabs as $tab) {
+            if ('' === $tab[2]) {
+                continue;
+            }
+            $tabData[] = [
+                'name' => $tab[1],
+                'id' => $tab[0],
+                // The body is already built; the generator only has to emit
+                // it. tabFields() calls this inside the pane it has opened.
+                'generator' => function () use ($tab) {
+                    echo $tab[2];
+                }
+            ];
+        }
+        // false, not the default -1: that would ask getClass() to resolve an
+        // entity for node 'about', and there is none -- the tab hooks and
+        // plugin injection want a record. Reports pass false for the same
+        // reason.
+        echo self::tabFields($tabData, false);
     }
     /**
      * The check that matters: can this web application read a private key it
@@ -489,13 +532,13 @@ class FOGConfigurationPage extends FOGPage
      *
      * @param array|null $status the helper's report.
      *
-     * @return void
+     * @return string '' when nothing is exposed, which is the normal answer.
      */
     private function _certificateKeyExposure($status)
     {
         $keys = (array) ($status['private_keys'] ?? []);
         if (!$keys) {
-            return;
+            return '';
         }
         $exposed = [];
         foreach ($keys as $key) {
@@ -514,7 +557,7 @@ class FOGConfigurationPage extends FOGPage
             }
         }
         if (!$exposed) {
-            return;
+            return '';
         }
         $warn = '<p>' . _(
             'The web application can read the following private keys. It '
@@ -531,7 +574,7 @@ class FOGConfigurationPage extends FOGPage
             . 'persists, check that nothing else is widening permissions on '
             . 'the snapins directory afterward.'
         ) . '</p>';
-        echo $this->_box(
+        return $this->_box(
             _('Private keys are readable by the web server'),
             $warn,
             ['color' => 'danger']
@@ -594,12 +637,12 @@ class FOGConfigurationPage extends FOGPage
      *
      * @param array|null $status the helper's report.
      *
-     * @return void
+     * @return string '' when there is nothing to tabulate.
      */
     private function _certificateChain($status)
     {
         if (null === $status) {
-            return;
+            return '';
         }
         $labels = [
             'root' => [
@@ -681,9 +724,15 @@ class FOGConfigurationPage extends FOGPage
                 ) . '">' . _('Download') . '</a></td></tr>';
         }
         if ('' === $rows) {
-            return;
+            return '';
         }
-        $body = '<div class="table-responsive">'
+        $body = '<p class="form-text">' . _(
+            'FOG uses certificates for three unrelated jobs: the web server, '
+            . 'the encrypted fog-client check-in, and the signature on the FOS '
+            . 'kernels. They are issued by separate CAs beneath one anchor, so '
+            . 'replacing any one of them leaves the other two alone.'
+        ) . '</p>';
+        $body .= '<div class="table-responsive">'
             . '<table class="table table-sm table-striped align-middle">';
         $body .= '<thead><tr><th>' . _('Certificate') . '</th><th>' . _('Subject')
             . '</th><th>' . _('Expires') . '</th><th>' . _('SHA-256')
@@ -698,20 +747,7 @@ class FOGConfigurationPage extends FOGPage
             . 'Private keys are deliberately absent -- nothing on this page can '
             . 'read one, and nothing on it can hand one out.'
         ) . '</p>';
-        echo $this->_box(
-            _('Certificates'),
-            $body,
-            [
-                'color' => 'info',
-                'help' => _(
-                    'FOG uses certificates for three unrelated jobs: the web '
-                    . 'server, the encrypted fog-client check-in, and the '
-                    . 'signature on the FOS kernels. They are issued by '
-                    . 'separate CAs beneath one anchor, so replacing any one '
-                    . 'of them leaves the other two alone.'
-                )
-            ]
-        );
+        return $this->_box('', $body);
     }
     /**
      * Import and remove an external root CA.
@@ -731,22 +767,22 @@ class FOGConfigurationPage extends FOGPage
      * @param array|null $status  the helper's report.
      * @param bool       $mayEdit does the caller hold system.pki.
      *
-     * @return void
+     * @return string '' when there is no helper to import through.
      */
     private function _certificateExternalRoot($status, $mayEdit)
     {
         if (null === $status) {
-            return;
+            return '';
         }
         $cert = self::_pkiCert($status, 'externalroot');
         $have = $cert && !empty($cert['present']);
-        $help = _(
+        $body = '<p class="form-text">' . _(
             'Upload a root CA certificate to have this server trust it. It is '
             . 'added to the host\'s own trust store, so every HTTPS call this '
             . 'server makes will accept a certificate issued beneath it, and '
             . 'it is re-applied on every later installer run.'
-        );
-        $body = '<p class="form-text">' . _(
+        ) . '</p>';
+        $body .= '<p class="form-text">' . _(
             'This does not change what FOG issues, and it does not change what '
             . 'fog-client pins. Only a self-signed CA certificate is accepted: '
             . 'an intermediate in the same file is dropped rather than trusted, '
@@ -764,12 +800,7 @@ class FOGConfigurationPage extends FOGPage
             ) . '</p>';
         }
         if (!$mayEdit) {
-            echo $this->_box(
-                _('External root CA'),
-                $body,
-                ['color' => 'info', 'help' => $help]
-            );
-            return;
+            return $this->_box('', $body);
         }
         $body .= '<label class="form-label" for="pki-root-file">'
             . _('Root CA certificate (PEM)') . '</label>';
@@ -806,22 +837,18 @@ class FOGConfigurationPage extends FOGPage
                 'btn btn-danger float-start'
             );
         }
-        // Wrapped in its own form: the upload needs multipart, and this card
+        // Wrapped in its own form: the upload needs multipart, and this tab
         // is the only thing on the page that posts a file.
-        echo self::makeFormTag(
+        return self::makeFormTag(
             '',
             'pki-root-form',
             $this->formAction,
             'post',
             'multipart/form-data',
             true
-        );
-        echo $this->_box(
-            _('External root CA'),
-            $body,
-            ['color' => 'info', 'help' => $help, 'footer' => $buttons]
-        );
-        echo '</form>';
+        )
+            . $this->_box('', $body, ['footer' => $buttons])
+            . '</form>';
     }
     /**
      * The three install preferences that decide what FOG does to the web
@@ -840,12 +867,12 @@ class FOGConfigurationPage extends FOGPage
      * @param array|null $status  the helper's report.
      * @param bool       $mayEdit does the caller hold system.pki.
      *
-     * @return void
+     * @return string '' when there is no helper to record a preference.
      */
     private function _certificatePreferences($status, $mayEdit)
     {
         if (null === $status) {
-            return;
+            return '';
         }
         $prefs = (array) ($status['preferences'] ?? []);
         $meta = [
@@ -909,7 +936,13 @@ class FOGConfigurationPage extends FOGPage
             $rows .= '<td><small class="text-muted">'
                 . \Initiator::e($text[1]) . '</small></td></tr>';
         }
-        $body = '<div class="table-responsive">'
+        $body = '<p class="form-text">' . _(
+            'These decide what the NEXT installer run does. Nothing here takes '
+            . 'effect until the installer runs again -- this page records the '
+            . 'preference, it does not rewrite the web server configuration or '
+            . 'reissue a certificate.'
+        ) . '</p>';
+        $body .= '<div class="table-responsive">'
             . '<table class="table table-sm align-middle">';
         $body .= '<thead><tr><th></th><th>' . _('Setting') . '</th><th>'
             . _('What it does') . '</th></tr></thead>';
@@ -937,26 +970,14 @@ class FOGConfigurationPage extends FOGPage
                 . 'setting, so the two cannot disagree.'
             ) . '</p>';
         }
-        echo $this->_box(
-            _('Install preferences'),
-            $body,
-            [
-                'color' => 'info',
-                'help' => _(
-                    'These decide what the NEXT installer run does. Nothing '
-                    . 'here takes effect until the installer runs again -- this '
-                    . 'page records the preference, it does not rewrite the web '
-                    . 'server configuration or reissue a certificate.'
-                )
-            ]
-        );
+        return $this->_box('', $body);
     }
     /**
      * Replacing FOG's own PKI: what it costs, and the command that does it.
      *
-     * Collapsed on arrival. It is reference material for a migration nobody
-     * does twice, and expanded it was the longest thing on a page whose job
-     * is to say what this server's certificates are right now.
+     * Last tab. It is reference material for a migration nobody does twice,
+     * and stacked in line it was the longest thing on a page whose job is to
+     * say what this server's certificates are right now.
      *
      * Deliberately NOT a button. Rotating the root invalidates every
      * fog-client enrollment on the estate at once, and the recovery is to
@@ -966,7 +987,7 @@ class FOGConfigurationPage extends FOGPage
      *
      * @param array|null $status the helper's report.
      *
-     * @return void
+     * @return string
      */
     private function _certificateOwnPki($status)
     {
@@ -1017,15 +1038,7 @@ class FOGConfigurationPage extends FOGPage
                 . 'intermediate, or a certificate for a new storage node.'
             ) . '</p>';
         }
-        echo $this->_box(
-            _('Using your own PKI'),
-            $body,
-            [
-                'color' => 'warning',
-                'collapse' => true,
-                'cardClass' => 'collapsed-card'
-            ]
-        );
+        return $this->_box('', $body);
     }
     /**
      * Hand back one public certificate as a file.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -949,12 +949,6 @@ parameters:
 			path: packages/web/src/Pages/ServiceConfigurationPage.php
 
 		-
-			message: '#^Parameter \#2 \$obj of static method FOG\\Base\\FOGPage\:\:tabFields\(\) expects int\|object, false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: packages/web/src/Pages/ServiceConfigurationPage.php
-
-		-
 			message: '#^Parameter \#2 \$value of static method FOG\\Base\\FOGBase\:\:setSetting\(\) expects string, int given\.$#'
 			identifier: argument.type
 			count: 4
@@ -1149,12 +1143,6 @@ parameters:
 		-
 			message: '#^Constructor of class FOG\\Pages\\TaskManagement has an unused parameter \$name\.$#'
 			identifier: constructor.unusedParameter
-			count: 1
-			path: packages/web/src/Pages/TaskManagement.php
-
-		-
-			message: '#^Parameter \#2 \$obj of static method FOG\\Base\\FOGPage\:\:tabFields\(\) expects int\|object, false given\.$#'
-			identifier: argument.type
 			count: 1
 			path: packages/web/src/Pages/TaskManagement.php
 

--- a/tests/certificate-table.test.php
+++ b/tests/certificate-table.test.php
@@ -1,24 +1,34 @@
 <?php
 /**
- * The Certificates page is a table of certificates, not a card per fact.
+ * The Certificates page is one card with tabs, and its table is a table.
  *
- * Two things are pinned, and they fail in different ways.
+ * Three things are pinned, and they fail in three different ways.
  *
- * THE EXPIRY BADGE is the only thing on the page that reads a certificate
- * and reaches a conclusion, so it is the only thing that can be silently
- * wrong. openssl's notAfter is GMT and the cell renders it with gmdate();
- * swapping that for date() would relabel every row into FOG_TZ_INFO's zone
- * and, within a few hours of midnight, name the wrong day -- which is the
- * same class of error that has already gone wrong elsewhere with that
- * setting. The zone check below runs from a zone BEHIND UTC so the two
- * answers land on different calendar days and a swap cannot pass.
+ * NOTHING SHIPS BEHIND A COLLAPSE. This page briefly rendered its longest
+ * section as an AdminLTE `.collapsed-card`, and the content was unreachable:
+ * AdminLTE binds the collapse toggle with
+ * `document.querySelectorAll(...).forEach(el => el.addEventListener(...))`
+ * once at DOMContentLoaded, it is NOT delegated, and FOG replaces the content
+ * by AJAX on every sidebar click -- so a card arriving by navigation has no
+ * handler on its toggle at all. It works only on a hard reload, which is
+ * exactly what a static snapshot of the page is, which is how it passed
+ * review. Bootstrap's own tab toggle IS delegated, which is why the house
+ * pattern works where that did not. This asserts on the rendered page rather
+ * than on a call site, so re-introducing it any other way still fails.
  *
- * THE TABLE ITSELF is pinned by rendering it, not by grepping for a <table>.
- * The page previously showed the root's subject and fingerprint as prose in
- * one card, the imported root's in a second, and the other six slots in a
- * table carrying neither -- so "every present slot is one row, and every row
- * carries the fingerprint" is exactly the property that was missing and the
- * one worth holding.
+ * THE EXPIRY BADGE is the only thing on the page that reads a certificate and
+ * reaches a conclusion, so it is the only thing that can be silently wrong.
+ * openssl's notAfter is GMT and the cell renders it with gmdate(); swapping
+ * that for date() would relabel every row into FOG_TZ_INFO's zone -- the zone
+ * rows are STORED in -- and, within a few hours of midnight, name the wrong
+ * day. The zone check below runs from a zone BEHIND UTC so the two answers
+ * land on different calendar days and a swap cannot pass.
+ *
+ * THE TABLE is pinned by rendering it, not by grepping for a <table>. The
+ * page used to show the root's subject and fingerprint as prose in one card,
+ * the imported root's in a second, and the other six slots in a table
+ * carrying neither -- so "every present slot is one row, and every row
+ * carries the fingerprint" is exactly the property that was missing.
  *
  * Usage: php tests/certificate-table.test.php
  * Exit status 0 = pass, 1 = fail.
@@ -90,8 +100,8 @@ $t->check(
 );
 
 /*
- * 3. The table. A fixture in the helper's own shape: six present slots, one
- *    absent, one self-signed.
+ * 3. The table. A fixture in the helper's own shape: seven present slots,
+ *    one absent, three self-signed.
  */
 $cert = function ($slot, $selfSigned = false, $present = true) {
     return [
@@ -100,7 +110,7 @@ $cert = function ($slot, $selfSigned = false, $present = true) {
         'subject' => 'CN = subject-' . $slot,
         'issuer' => $selfSigned ? 'CN = subject-' . $slot : 'CN = issuer-' . $slot,
         'not_after' => 'Jul 30 09:12:44 2035 GMT',
-        'sha256' => strtoupper(substr(md5($slot), 0, 2)) . ':FINGERPRINT:' . strtoupper($slot),
+        'sha256' => 'AA:FINGERPRINT:' . strtoupper($slot),
         'self_signed' => $selfSigned,
         'count' => 1
     ];
@@ -123,14 +133,14 @@ $status = [
 // anything -- the fake exists only so the page can be constructed.
 FogTestHarness::fakeDb();
 $page = new \FOG\Pages\FOGConfigurationPage();
-$chain = new \ReflectionMethod(
-    'FOG\\Pages\\FOGConfigurationPage',
-    '_certificateChain'
-);
-$chain->setAccessible(true);
-ob_start();
-$chain->invoke($page, $status);
-$html = (string) ob_get_clean();
+
+$invoke = function ($method, array $args) use ($page) {
+    $m = new \ReflectionMethod('FOG\\Pages\\FOGConfigurationPage', $method);
+    $m->setAccessible(true);
+    return (string) $m->invokeArgs($page, $args);
+};
+
+$html = $invoke('_certificateChain', [$status]);
 
 $t->check(
     'the present slots render as one table',
@@ -160,26 +170,107 @@ $t->check(
 );
 
 /*
- * 4. The reference card arrives shut. AdminLTE hides a .collapsed-card's
- *    body in CSS, so the class in the markup is the whole mechanism -- there
- *    is no JavaScript to fall back on if _box stops emitting it.
+ * 4. Every section is a tab BODY, not a card it echoes for itself -- that is
+ *    what lets certificates() drop a tab whose content is empty rather than
+ *    render an empty pane. A storage node has no helper, so on one of those
+ *    three of the four sections have nothing to say.
  */
-$ownPki = new \ReflectionMethod(
-    'FOG\\Pages\\FOGConfigurationPage',
-    '_certificateOwnPki'
+$t->check(
+    'the chain builder returns its body rather than echoing it',
+    '' !== $html && false !== strpos($html, '<table')
 );
-$ownPki->setAccessible(true);
+foreach (
+    [
+        '_certificateChain' => [null],
+        '_certificateExternalRoot' => [null, true],
+        '_certificatePreferences' => [null, true]
+    ] as $method => $args
+) {
+    $t->check(
+        $method . ' has nothing to show without the helper',
+        '' === $invoke($method, $args)
+    );
+}
+$t->check(
+    '_certificateOwnPki still does -- it needs no helper',
+    '' !== $invoke('_certificateOwnPki', [null])
+);
+
+/*
+ * 4b. The alarm. Its whole job is to fire when the web tier can open a key
+ *     it must not, and to stay quiet for the two keys that are MEANT to be
+ *     readable -- the client communication key, which certDecrypt() opens on
+ *     every fog-client handshake, and the vhost key once an ACME renewal
+ *     owns it. Flagging those would report a correct install as a breach,
+ *     which is the failure that makes an alarm get ignored.
+ */
+$readable = __FILE__;
+$t->check(
+    'a readable key the installer should have locked down raises the alarm',
+    false !== strpos(
+        $invoke('_certificateKeyExposure', [[
+            'private_keys' => [
+                ['label' => 'Root CA private key', 'path' => $readable]
+            ]
+        ]]),
+        'Private keys are readable by the web server'
+    )
+);
+$t->check(
+    'a key that is meant to be readable does not',
+    '' === $invoke('_certificateKeyExposure', [[
+        'private_keys' => [
+            [
+                'label' => 'Client communication key',
+                'path' => $readable,
+                'expect_readable' => true
+            ]
+        ]
+    ]])
+);
+$t->check(
+    'and a key that is not there at all does not',
+    '' === $invoke('_certificateKeyExposure', [[
+        'private_keys' => [
+            ['label' => 'Root CA private key', 'path' => '/nonexistent/ca.key']
+        ]
+    ]])
+);
+
+/*
+ * 5. The page itself. This runs where the PKI helper is absent (no sudoers
+ *    rule for whoever runs the suite), which is the storage-node shape: the
+ *    warning, then a tab card carrying the one section that survives.
+ */
 ob_start();
-$ownPki->invoke($page, null);
-$pki = (string) ob_get_clean();
+$page->certificates();
+$rendered = (string) ob_get_clean();
+
 $t->check(
-    '"Using your own PKI" is collapsed on arrival',
-    false !== strpos($pki, 'collapsed-card')
+    'the page is a card with tabs, like every other management page',
+    false !== strpos($rendered, 'nav nav-tabs')
 );
 $t->check(
-    'and its toggle offers to expand rather than to collapse again',
-    false !== strpos($pki, 'data-lte-icon="expand"')
-        && false !== strpos($pki, 'data-lte-icon="collapse"')
+    'each section is a tab pane',
+    false !== strpos($rendered, 'id="pki-own"')
+        && false !== strpos($rendered, 'data-bs-toggle="tab"')
+);
+$t->check(
+    'a section with nothing to show is not an empty tab',
+    false === strpos($rendered, 'id="pki-chain"')
+);
+$t->check(
+    'the missing-helper warning is rendered',
+    false !== strpos($rendered, 'helper is not installed')
+);
+$t->check(
+    'and it is ABOVE the tabs, not behind one of them',
+    strpos($rendered, 'helper is not installed')
+        < strpos($rendered, 'nav nav-tabs')
+);
+$t->check(
+    'nothing on the page ships behind a collapse an AJAX visit cannot open',
+    false === strpos($rendered, 'collapsed-card')
 );
 
 $t->finish();


### PR DESCRIPTION
Follow-up to #1592, which merged while this was being written. Two things were wrong with what landed there, and one of them is a bug on `working-1.6` right now.

## The collapsed card cannot be opened

`#1592` rendered "Using your own PKI" as an AdminLTE `.collapsed-card`. Clicking its toggle does nothing, so that section is content nobody can reach.

AdminLTE binds the collapse toggle like this:

```js
document.querySelectorAll('[data-lte-toggle="card-collapse"]')
        .forEach(el => el.addEventListener('click', …))
```

Once, at `DOMContentLoaded`. It is **not delegated** — and FOG replaces the content by AJAX on every sidebar click, so a card that arrives by navigation has no handler on its toggle at all. Bootstrap's own tab toggle *is* delegated, which is why the house pattern works where this did not.

It works only on a hard reload, which is exactly what the static page snapshot I verified `#1592` against was. The check passed for a reason the real navigation never touches. This time it was driven the way the page is actually used — dashboard → click Certificates in the sidebar → click each tab — and every pane opens.

So `_box()`'s `cardClass` option and its two-icon collapse toggle are reverted. Nothing needs them now, and neither could ever have worked.

**Note this is a property of the whole UI, not of this page**: every `collapse => true` card in FOG has a dead toggle after AJAX navigation. Cards that merely start *open* degrade to "cannot be collapsed", which is why nobody has noticed. Shipping one that starts *closed* is what turned it into hidden content. Fixing the binding globally is a separate change in shared JS touching every page — happy to do it, but it would dominate this diff.

## It was not the house pattern

Nearly every management page in FOG is one card with a tab strip, built by `FOGPage::tabFields()`. Certificates was five stacked cards. It is now four tabs through that same helper: Certificates, External root CA, Install preferences, Using your own PKI.

The **alarms stay outside the tab card, above it** — an exposed CA private key, and a missing PKI helper. A condition an administrator must act on cannot live behind a tab they have to know to click.

## Supporting changes

- The five section builders **return** their body instead of echoing a card of their own. That is what lets `certificates()` drop a tab whose content is empty rather than render an empty pane — on a storage node, with no helper, three of the four have nothing to say.
- `_box()` emits no `card-header` when there is no title, help or collapse button, because a card inside a tab pane takes its title from the tab.
- `FOGPage::tabFields()` gains `bool` in its `@param` for `$obj`. Its docblock already said "Anything falsy means there is no object" and it branches on `if ($obj)`; the declared `int|object` was simply wrong, and two of the three callers passing `false` carried a baselined phpstan error for saying so. **Both baseline entries are retired rather than a third being added.**

## Gate

`tests/certificate-table.test.php` (33 checks) now also pins that the page is a tab card, that a section with nothing to show is not an empty tab, that the alarms render above the tabs, and that **nothing on the page ships behind a collapse an AJAX visit cannot open** — asserted on the rendered page, so re-introducing it any other way still fails. It gains coverage of the key-exposure alarm's three branches, including the `expect_readable` one that stops a correct install reporting itself as a breach.

Every assertion was made to fail against a mutation of the code it covers: tabs reverted to stacked cards, empty sections given a tab, the PKI section put back behind a collapse, `gmdate`→`date`, the fingerprint cell emptied, `expect_readable` ignored, and the alarms emitted after the tab card.

One gap named rather than papered over: deleting the `_certificateKeyExposure()` call from `certificates()` outright is still not caught, because `_pkiStatus()` caches in a function-static and shells out to a root-only helper, so a test cannot force a non-null status through the page. The builder is covered in all three branches, and "alarms precede the tab card" is gated.

Suite 270/0, both phpstan passes clean, PSR-2 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CreCNucEFLNcrzbZCjchvJ