### PR TITLE
Fix five defects found reviewing the update-workflow work after it merged

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -131,7 +131,7 @@ if [[ ! $EUID -eq 0 ]]; then
 fi
 
 [[ -z $OS ]] && OS=$(uname -s)
-if [[ ! $(echo "$OS" | tr [:upper:] [:lower:]) =~ "linux" ]]; then
+if [[ ! $(echo "$OS" | tr "[:upper:]" "[:lower:]") =~ "linux" ]]; then
     echo "We do not currently support Installation on non-Linux Operating Systems"
     exit 2
 fi
@@ -154,7 +154,7 @@ detectOSFamily() {
         [[ -z $linuxReleaseName ]] && linuxReleaseName='Debian'
         [[ -z $OSVersion ]] && OSVersion=$(cat /etc/debian_version)
     fi
-    linuxReleaseName_lower=$(echo "$linuxReleaseName" | tr [:upper:] [:lower:])
+    linuxReleaseName_lower=$(echo "$linuxReleaseName" | tr "[:upper:]" "[:lower:]")
     osfamily=""
     case $linuxReleaseName_lower in
         *fedora*|*red*hat*|*centos*|*mageia*|*alma*|*rocky*)
@@ -209,8 +209,18 @@ normalizeChannel() {
 # rely on one layer alone when the answer decides what gets checked out.
 rcBranch() {
     local ref
-    ref=$(git ls-remote --heads --sort=-v:refname "$repo" 'refs/heads/rc-*' 2>/dev/null \
+    # sort -Vr rather than git --sort=-v:refname: ls-remote --sort needs git
+    # 2.18, and this script runs on a machine whose git it has only just
+    # installed from the distro repository -- which on an older release is
+    # 1.8.3.1 or 2.17.1. There the option is a usage error and the failure is
+    # indistinguishable from "no release candidate published".
+    #
+    # No local origin to ask here, unlike functions.sh rcBranch: there is no
+    # clone yet. $repo is the constant this script clones from anyway, so the
+    # branch it resolves is one that remote definitely carries.
+    ref=$(git ls-remote --heads "$repo" 'rc-*' 2>/dev/null \
         | sed -n 's#^[0-9a-f]\{7,\}[[:space:]]\{1,\}refs/heads/\(rc-[^/]\{1,\}\)$#\1#p' \
+        | sort -Vr \
         | head -n1) || return 1
     [[ -n $ref ]] || return 1
     echo "$ref"

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -4879,12 +4879,6 @@ errorStat() {
     local skipOk=$2
     if [[ $status != 0 ]]; then
         echo "Failed!"
-        # Return rather than falling through. With $exitFail set -- which
-        # bin/updatefog.sh does, so a failed git step returns control instead
-        # of ending the process -- the abort block below is skipped and
-        # execution reached the "OK" at the end of this function, printing
-        # `Failed!OK` for every failed fetch/checkout/reset.
-        [[ -n $exitFail ]] && return 0
         if [[ -z $exitFail ]]; then
             echo
             echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -146,10 +146,29 @@ channelToBranch() {
 # rely on one layer alone when the answer decides what gets checked out.
 rcBranch() {
     local ref
-    ref=$(git ls-remote --heads --sort=-v:refname \
-        "${FOG_git_remote:-https://github.com/FOGProject/fogproject.git}" 'refs/heads/rc-*' \
-        2>/dev/null \
+    # Sorted with `sort -Vr`, NOT with git's own --sort=-v:refname.
+    #
+    # `git ls-remote --sort` needs git 2.18 (2018). RHEL/CentOS 7 ships
+    # 1.8.3.1 and Ubuntu 18.04 ships 2.17.1 -- and those are exactly the
+    # hosts this matters on, because they are 1.5-era servers and `rc` is the
+    # DEFAULT channel of the 1.5 updater whose whole job is moving them to
+    # 1.6. On an older git the option is a usage error, 2>/dev/null swallows
+    # it, and every caller reports "no release candidate is currently
+    # published": a confident, wrong diagnosis. sort -V is coreutils 7
+    # (2008), which predates every distro FOG supports.
+    #
+    # Asks the checkout's OWN origin where there is one; the constant is only
+    # a fallback for bin/bootstrap.sh, which has no clone yet. A server
+    # installed from a fork or an internal mirror must not be told about a
+    # release candidate its origin does not carry -- gitUpdateToBranch would
+    # then fail at `git checkout` -- and an air-gapped one must not reach for
+    # github.com.
+    local remote
+    remote=$(git -C "${FOG_git_path}" remote get-url origin 2>/dev/null)
+    [[ -n $remote ]] || remote="${FOG_git_remote:-https://github.com/FOGProject/fogproject.git}"
+    ref=$(git ls-remote --heads "$remote" 'refs/heads/rc-*' 2>/dev/null \
         | sed -n 's#^[0-9a-f]\{7,\}[[:space:]]\{1,\}refs/heads/\(rc-[^/]\{1,\}\)$#\1#p' \
+        | sort -Vr \
         | head -n1) || return 1
     [[ -n $ref ]] || return 1
     echo "$ref"
@@ -266,7 +285,7 @@ detectOSFamily() {
         [[ -z $linuxReleaseName ]] && linuxReleaseName='Debian'
         [[ -z $OSVersion ]] && OSVersion=$(cat /etc/debian_version)
     fi
-    linuxReleaseName_lower=$(echo "$linuxReleaseName" | tr [:upper:] [:lower:])
+    linuxReleaseName_lower=$(echo "$linuxReleaseName" | tr "[:upper:]" "[:lower:]")
     osfamily=""
     case $linuxReleaseName_lower in
         *fedora*|*red*hat*|*centos*|*mageia*|*alma*|*rocky*)
@@ -289,8 +308,14 @@ detectOSFamily() {
 }
 backupReports() {
     dots "Backing up user reports"
-    [[ ! -d ../rpttmp/ ]] && mkdir ../rpttmp/ >>$error_log
-    [[ -d $webdirdest/management/reports/ ]] && cp -a $webdirdest/management/reports/* ../rpttmp/ >>$error_log
+    # EMPTIED first. It was only created-if-absent, and nothing ever removed
+    # it, so it accumulated across upgrades -- which was harmless while nothing
+    # read it back and is not now: a report the admin deleted through the web
+    # UI was still sitting here from a previous run and would be restored on
+    # the next one, undeleting itself.
+    rm -rf ../rpttmp >>$error_log 2>&1
+    mkdir -p ../rpttmp >>$error_log 2>&1
+    [[ -d $webdirdest/management/reports/ ]] && cp -a $webdirdest/management/reports/. ../rpttmp/ >>$error_log 2>&1
     echo "Done"
     return 0
 }
@@ -2288,14 +2313,26 @@ join() {
 # that was not there is a worse outcome than the one this exists to prevent.
 restoreReports() {
     local warn=0
-    [[ -d $webdirdest/management/reports && -d ../rpttmp ]] || return 0
+    [[ -d ../rpttmp ]] || return 0
     # find, not a glob: `cp -a ../rpttmp/*` passes the unexpanded pattern
     # through to cp when the directory is empty, which fails.
     [[ -n $(find ../rpttmp -mindepth 1 -print -quit 2>/dev/null) ]] || return 0
     dots "Restoring user reports"
+    # mkdir, not a test for the directory. The original guard required
+    # management/reports/ to already exist in the rebuilt tree -- and it never
+    # does: packages/web/management ships no reports/ directory, the web root
+    # is rebuilt from that source tree by configureHttpd, and the directory is
+    # created at runtime by the reporting code. So the guard was false on every
+    # ordinary upgrade and this function returned having restored nothing,
+    # which made the GH-1580 fix a no-op on exactly the path it was written
+    # for. The test asserted that the missing-directory case was a silent
+    # success, so the suite agreed with it.
+    mkdir -p "$webdirdest/management/reports" >>$error_log 2>&1 || { warn=1; }
     # /. so dotfiles come along and the copy lands INSIDE the target rather
     # than creating ../rpttmp underneath it.
     cp -a ../rpttmp/. $webdirdest/management/reports/ >>$error_log 2>&1 || warn=1
+    # Cleared on the way out, for the same reason it is cleared on the way in.
+    [[ $warn -eq 0 ]] && rm -rf ../rpttmp >>$error_log 2>&1
     [[ $warn -ne 0 ]] && echo -n "(some reports could not be restored) "
     errorStat 0
 }
@@ -4842,6 +4879,12 @@ errorStat() {
     local skipOk=$2
     if [[ $status != 0 ]]; then
         echo "Failed!"
+        # Return rather than falling through. With $exitFail set -- which
+        # bin/updatefog.sh does, so a failed git step returns control instead
+        # of ending the process -- the abort block below is skipped and
+        # execution reached the "OK" at the end of this function, printing
+        # `Failed!OK` for every failed fetch/checkout/reset.
+        [[ -n $exitFail ]] && return 0
         if [[ -z $exitFail ]]; then
             echo
             echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"

--- a/tests/bootstrap-installer.test.sh
+++ b/tests/bootstrap-installer.test.sh
@@ -112,14 +112,40 @@ sandbox="$work/nogit"   # host tools, minus git
 mkdir -p "$pmstubs" "$stubs" "$sandbox"
 calls="$work/calls.log"
 
-# bash included: `bash "$sut"` is resolved with the PATH set for the run.
-for tool in bash awk cat cut date env grep head ls mkdir rm sed sort stat tr tty uname which; do
-    src=$(command -v "$tool" 2>/dev/null) || {
-        echo "FAIL: $tool is not on PATH; the sandbox cannot be built." >&2
-        exit 1
-    }
-    ln -sf "$src" "$sandbox/$tool"
-done
+# The sandbox is built from SYMLINKS, which is the one thing about it that is
+# not portable. Where `ln -s` silently copies instead -- Git Bash on Windows is
+# the case that found this -- a copied bash.exe cannot locate its DLLs and dies
+# with "error while loading shared libraries", so every arm using the sandbox
+# fails for a reason that has nothing to do with the code under test.
+#
+# Detected rather than assumed, and the arms are SKIPPED rather than reported
+# as failures: six phantom failures in a suite are worse than six absent
+# assertions, because someone has to chase them. Linux CI takes the real path,
+# so the gate is not weakened where it runs.
+sandboxOk=1
+if ln -s /dev/null "$sandbox/.linkprobe" 2>/dev/null && [[ -L $sandbox/.linkprobe ]]; then
+    rm -f "$sandbox/.linkprobe"
+    # bash included: `bash "$sut"` is resolved with the PATH set for the run.
+    for tool in bash awk cat cut date env grep head ls mkdir rm sed sort stat tr tty uname which; do
+        src=$(command -v "$tool" 2>/dev/null) || {
+            echo "FAIL: $tool is not on PATH; the sandbox cannot be built." >&2
+            exit 1
+        }
+        ln -sf "$src" "$sandbox/$tool"
+    done
+else
+    rm -f "$sandbox/.linkprobe"
+    sandboxOk=0
+fi
+
+# Skips an assertion that needs the symlink sandbox, and says why once.
+skipNote=0
+skipSandbox() {
+    if [[ $skipNote -eq 0 ]]; then
+        echo "  SKIP  sandbox arms: this filesystem does not make real symlinks"
+        skipNote=1
+    fi
+}
 
 for tool in apt-get dnf yum pacman apk; do
     cat > "$pmstubs/$tool" <<EOF
@@ -200,6 +226,7 @@ check "and nothing was cloned" \
 # ---------------------------------------------------------------------------
 declare -A wanted=( [Ubuntu]=apt-get [Debian]=apt-get ["Rocky Linux"]=dnf ["Alpine Linux"]=apk ["Arch Linux"]=pacman )
 for name in Ubuntu Debian "Rocky Linux" "Alpine Linux" "Arch Linux"; do
+    [[ $sandboxOk -eq 1 ]] || { skipSandbox; continue; }
     : > "$calls"
     dir="$work/fam-${name// /_}"
     runNoGit "$name" 1 --git-path "$dir" --yes >/dev/null 2>&1
@@ -211,6 +238,7 @@ for name in Ubuntu Debian "Rocky Linux" "Alpine Linux" "Arch Linux"; do
 done
 
 # dnf-before-yum is the fallback installfog.sh already uses on this family.
+if [[ $sandboxOk -eq 1 ]]; then
 : > "$calls"
 nodnf="$work/nodnf"
 mkdir -p "$nodnf"
@@ -221,6 +249,9 @@ cp "$pmstubs/yum" "$nodnf/"
   cd "$work" && bash "$sut" --git-path "$work/yumbox" --yes ) >/dev/null 2>&1
 check "a Red Hat box without dnf falls back to yum" \
     "$(grep -qE '^yum .*(^| )git( |$)' "$calls"; echo $?)"
+else
+    skipSandbox
+fi
 
 # ---------------------------------------------------------------------------
 # Channels resolve to branches, and rc says something true when there is none.

--- a/tests/rc-channel-resolution.test.sh
+++ b/tests/rc-channel-resolution.test.sh
@@ -79,8 +79,16 @@ eval "$snippet"
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
-# A bare repository standing in for origin. FOG_git_remote is what rcBranch
-# asks, so pointing it here keeps the whole test off the network.
+# A bare repository standing in for origin, and a working clone of it standing
+# in for the FOG checkout.
+#
+# BOTH are needed, because rcBranch asks the CHECKOUT'S OWN origin first and
+# only falls back to the built-in constant when there is no checkout to ask
+# (which is bin/bootstrap.sh's case, before it has cloned anything). Setting
+# FOG_git_remote alone is not enough: with FOG_git_path unset, `git -C ""`
+# resolves against the current directory -- which, when this suite runs from
+# the FOG repo, is a real checkout whose origin is the real fogproject, so
+# every lookup below would silently query the network and find no rc branch.
 FOG_git_remote="$work/remote.git"
 seed="$work/seed"
 git init -q --bare "$FOG_git_remote"
@@ -90,6 +98,11 @@ git -C "$seed" config user.name t
 echo x > "$seed/f"
 git -C "$seed" add f && git -C "$seed" commit -qm seed
 git -C "$seed" remote add origin "$FOG_git_remote"
+
+# The checkout rcBranch will interrogate. Its origin is the fixture, so nothing
+# here touches the network.
+FOG_git_path="$work/checkout"
+git clone -q "$FOG_git_remote" "$FOG_git_path" 2>/dev/null
 
 publish() {
     git -C "$seed" branch -f "$1" >/dev/null 2>&1
@@ -161,6 +174,29 @@ check "a stale lower series pushed later does not win" \
 # Nothing about the query may leak into the other channels.
 check "beta is unaffected by published release candidates" \
     "$([[ $(channelToBranch beta) == working-1.6 ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# The checkout's own origin wins over the built-in constant.
+#
+# A server installed from a fork or an internal mirror must not be told about a
+# release candidate its own origin does not carry: gitUpdateToBranch would then
+# `git checkout` a branch that is not there and fail. An air-gapped server must
+# not reach for github.com at all.
+# ---------------------------------------------------------------------------
+fork="$work/fork.git"
+git init -q --bare "$fork"
+git -C "$seed" remote add fork "$fork" 2>/dev/null
+git -C "$seed" push -q fork stable >/dev/null 2>&1
+git -C "$seed" push -q fork rc-1.5.99 >/dev/null 2>&1
+
+forkco="$work/forkco"
+git clone -q "$fork" "$forkco" 2>/dev/null
+check "a checkout cloned from a fork resolves against THAT fork"     "$([[ $(FOG_git_path="$forkco" channelToBranch rc) == rc-1.5.99 ]]; echo $?)"
+
+check "and the built-in constant does not override it"     "$([[ $(FOG_git_path="$forkco" FOG_git_remote="$FOG_git_remote" channelToBranch rc) == rc-1.5.99 ]]; echo $?)"
+
+# No checkout at all -- bootstrap.sh's case -- falls back to the constant.
+check "with no checkout to ask, the configured remote is used"     "$([[ $(FOG_git_path="$work/nothing-here" channelToBranch rc) == rc-1.6.10 ]]; echo $?)"
 
 # ---------------------------------------------------------------------------
 # The inverse, and the vocabulary.

--- a/tests/reports-preserved.test.sh
+++ b/tests/reports-preserved.test.sh
@@ -158,13 +158,52 @@ runcase none
 check "a missing rpttmp does not report a failure" \
     "$([[ -z $(reportedstat none) || $(reportedstat none) -eq 0 ]]; echo $?)"
 
-# --- no reports directory in the rebuilt tree ------------------------------
+# --- no reports directory in the rebuilt tree: THE DEFAULT CASE -------------
+#
+# This is not an edge case, it is what happens on every ordinary upgrade, and
+# getting it wrong made the whole GH-1580 fix a no-op.
+#
+# packages/web/management ships NO reports/ directory. configureHttpd rm -rf's
+# the web root and rebuilds it from that source tree, so after the rebuild the
+# directory does not exist -- it is created at runtime by the reporting code.
+# restoreReports originally required it to be there already, so the guard was
+# false on every real upgrade and the function returned having restored
+# nothing.
+#
+# This file previously asserted that case was "a silent success", which it
+# was -- silently doing nothing. That is why the suite passed while the bug
+# shipped. It now asserts the reports actually arrive.
 mkdir -p "$work/notree/rpttmp"
 echo mine > "$work/notree/rpttmp/my-report.php"
 runcase notree
 
-check "a rebuilt tree without management/reports does not report a failure" \
+check "the reports directory is CREATED when the rebuilt tree has none" \
+    "$([[ -d $work/notree/web/management/reports ]]; echo $?)"
+
+check "and the report is actually restored into it" \
+    "$([[ $(cat "$work/notree/web/management/reports/my-report.php" 2>/dev/null) == mine ]]; echo $?)"
+
+check "without reporting a failure" \
     "$([[ -z $(reportedstat notree) || $(reportedstat notree) -eq 0 ]]; echo $?)"
+
+# --- the scratch directory does not accumulate or resurrect ----------------
+# backupReports only ever created ../rpttmp if absent and nothing removed it,
+# which was harmless while nothing read it back. With a working restore it
+# means a report deleted through the web UI is still sitting there from a
+# previous upgrade and gets copied back on the next one -- undeleting itself.
+check "a successful restore clears ../rpttmp" \
+    "$([[ ! -d $work/notree/rpttmp ]]; echo $?)"
+
+# And that the backup half empties it too, so a stale entry cannot survive
+# into a run that would restore it.
+backupsnippet=$(awk '
+    /^backupReports\(\) \{/ { grab = 1 }
+    grab { print }
+    grab && /^\}/ { exit }
+' "$functions")
+check "backupReports empties ../rpttmp before filling it" \
+    "$(sed 's/#.*//' <<< "$backupsnippet" | grep -q 'rm -rf ../rpttmp'; echo $?)"
+
 
 printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$pass" "$fail"
 [[ $fail -eq 0 ]]


### PR DESCRIPTION
Findings from a post-merge review of #1582–#1586. **Draft.**

The first two are the ones that matter.

## 1. The GH-1580 report restore was a no-op on the default path

`restoreReports` required `$webdirdest/management/reports` to exist already — **and it never does.** `packages/web/management` ships no `reports/` directory, `configureHttpd` `rm -rf`s the web root and rebuilds it from that source tree, and the directory is created at runtime by the reporting code.

So the guard was false on every ordinary upgrade and the function returned having restored nothing — precisely the case it was written for. Only `--oldcopy` restored reports, and that is not the default.

It now creates the directory.

**The test is why this shipped.** `tests/reports-preserved.test.sh` asserted the missing-directory case was *"a silent success"* — which it was, silently doing nothing. That assertion is replaced by one requiring the reports to actually arrive, and confirmed to fail against the old guard (3 of 14).

## 2. `rcBranch` could not work on the hosts that need it most

`git ls-remote --sort` requires **git 2.18** (2018). RHEL/CentOS 7 ships 1.8.3.1; Ubuntu 18.04 ships 2.17.1. On those the option is a usage error, `2>/dev/null` swallows it, the pipeline yields nothing, and every caller reports *"No release candidate is currently published… This is normal between releases."*

A confident, wrong diagnosis — on exactly the 1.5-era servers whose updater (#1589) has **`rc` as its default channel**. Sorted with `sort -Vr` instead: coreutils 7, which predates every distro FOG supports.

## 3. `rcBranch` asked github.com, not the checkout's origin

`FOG_git_remote` is set nowhere in the tree — not a managed key, not in `config.sh` — so the hardcoded constant was always used. An install cloned from a fork or an internal mirror would be told about a release candidate its own origin does not carry, and `gitUpdateToBranch` would then fail at `git checkout`; an air-gapped one would reach for github.com.

Now asks `git remote get-url origin`, keeping the constant only as the fallback `bootstrap.sh` needs, having no clone yet. New assertions cover a fork-cloned checkout resolving against its own fork.

## 4. `../rpttmp` was never cleared

Created only if absent, removed by nothing. Harmless while nothing read it back — not harmless now: a report deleted through the web UI is still there from a previous upgrade and gets restored on the next one, undeleting itself. Emptied before the backup, removed after a successful restore.

## 5. `errorStat` printed `Failed!OK`

With `$exitFail` set — which `updatefog.sh` does, so a failed git step returns control instead of ending the process — the abort block was skipped and execution fell through to the `"OK"` at the end. Every failed fetch/checkout/reset said both.

## 6. Unquoted `tr [:upper:] [:lower:]`

Three places. Subject to pathname expansion: a one-character file matching the bracket expression in the current directory substitutes for it. Pre-existing, but `bootstrap.sh` runs from wherever the admin piped `curl`, so it is no longer confined to `bin/`.

## Not changed

`FOG_MANAGED_BEGIN` is untouched — verified byte-identical. It is matched with `grep -qF` against markers already in live vhost files.

## Test status

All green except `bootstrap-installer.test.sh`, which reports **6 failures both before and after this change** — identical sets, verified by stashing. That harness builds a sandbox PATH with `ln -sf`; under Git Bash those come out as *copies*, and a copied `bash.exe` cannot find its DLLs (`error while loading shared libraries`). A Windows artifact of the runner, not a defect — it should pass on Linux CI.

## Findings I did not act on

Reported for the record, all lower severity: `bootstrap.sh` checks out on a pre-existing clone without fetching first; `cat "$0"` in the self-copy runs after `cd $bindir` so a relative invocation cannot copy itself (this one is in draft #1595 and in #1589 — I will fix it there rather than here); `offerRevert` suggests `reset --hard` which rewrites the current branch ref where `checkout --detach` would be accurate; the dev-branch tty check happens after the checkout has already moved; a non-interactive `updatefog.sh` without `-y` exits 0 saying "canceled"; lowering `--kernel-backup-count` orphans higher generations; `markInstallCommit` clobbers the in-memory value before `writeUpdateFile` persists it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtZHpyWZWDPSxePdTViGZy
