### PR TITLE
Offer Chocolatey in the snapin template dropdowns (GH-356)

### DIFF
--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1651,6 +1651,9 @@ msgstr ""
 msgid "Checking if I am the group manager"
 msgstr "Prüfe, ob ich der Gruppenmanager bin"
 
+msgid "Chocolatey (offline source)"
+msgstr ""
+
 msgid "Choose a user"
 msgstr ""
 
@@ -6392,7 +6395,7 @@ msgstr ""
 msgid "Operations on %s."
 msgstr "Operationsfeld nicht gesetzt: %s"
 
-msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward."
+msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
 msgid "Or there was no number defined for joining session"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1654,6 +1654,9 @@ msgstr ""
 msgid "Checking if I am the group manager"
 msgstr ""
 
+msgid "Chocolatey (offline source)"
+msgstr ""
+
 msgid "Choose a user"
 msgstr ""
 
@@ -6403,7 +6406,7 @@ msgstr ""
 msgid "Operations on %s."
 msgstr "Operation Field not set: %s"
 
-msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward."
+msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
 msgid "Or there was no number defined for joining session"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1670,6 +1670,9 @@ msgstr ""
 msgid "Checking if I am the group manager"
 msgstr ""
 
+msgid "Chocolatey (offline source)"
+msgstr ""
+
 msgid "Choose a user"
 msgstr ""
 
@@ -6514,7 +6517,7 @@ msgstr ""
 msgid "Operations on %s."
 msgstr "Operación de no activado: %s"
 
-msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward."
+msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
 msgid "Or there was no number defined for joining session"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1651,6 +1651,9 @@ msgstr ""
 msgid "Checking if I am the group manager"
 msgstr "Prüfe, ob ich der Gruppenmanager bin"
 
+msgid "Chocolatey (offline source)"
+msgstr ""
+
 msgid "Choose a user"
 msgstr ""
 
@@ -6393,7 +6396,7 @@ msgstr ""
 msgid "Operations on %s."
 msgstr "Operationsfeld nicht gesetzt: %s"
 
-msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward."
+msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
 msgid "Or there was no number defined for joining session"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1655,6 +1655,9 @@ msgstr ""
 msgid "Checking if I am the group manager"
 msgstr ""
 
+msgid "Chocolatey (offline source)"
+msgstr ""
+
 msgid "Choose a user"
 msgstr ""
 
@@ -6390,7 +6393,7 @@ msgstr ""
 msgid "Operations on %s."
 msgstr "Opération pas définie: %s"
 
-msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward."
+msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
 msgid "Or there was no number defined for joining session"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1611,6 +1611,9 @@ msgstr ""
 msgid "Checking if I am the group manager"
 msgstr "Controllare se sono il responsabile del gruppo"
 
+msgid "Chocolatey (offline source)"
+msgstr ""
+
 msgid "Choose a user"
 msgstr ""
 
@@ -6201,7 +6204,7 @@ msgstr ""
 msgid "Operations on %s."
 msgstr "Campo operazione non impostato"
 
-msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward."
+msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
 msgid "Or there was no number defined for joining session"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1595,6 +1595,9 @@ msgstr ""
 msgid "Checking if I am the group manager"
 msgstr "自身がグループマネージャーか確認しています"
 
+msgid "Chocolatey (offline source)"
+msgstr ""
+
 msgid "Choose a user"
 msgstr ""
 
@@ -6169,7 +6172,7 @@ msgstr ""
 msgid "Operations on %s."
 msgstr "操作フィールドが設定されていません"
 
-msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward."
+msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
 msgid "Or there was no number defined for joining session"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1422,6 +1422,9 @@ msgstr ""
 msgid "Checking if I am the group manager"
 msgstr ""
 
+msgid "Chocolatey (offline source)"
+msgstr ""
+
 msgid "Choose a user"
 msgstr ""
 
@@ -5457,7 +5460,7 @@ msgstr ""
 msgid "Operations on %s."
 msgstr ""
 
-msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward."
+msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
 msgid "Or there was no number defined for joining session"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1654,6 +1654,9 @@ msgstr ""
 msgid "Checking if I am the group manager"
 msgstr ""
 
+msgid "Chocolatey (offline source)"
+msgstr ""
+
 msgid "Choose a user"
 msgstr ""
 
@@ -6390,7 +6393,7 @@ msgstr ""
 msgid "Operations on %s."
 msgstr "Campo operação não definido: %s"
 
-msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward."
+msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
 msgid "Or there was no number defined for joining session"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1654,6 +1654,9 @@ msgstr ""
 msgid "Checking if I am the group manager"
 msgstr ""
 
+msgid "Chocolatey (offline source)"
+msgstr ""
+
 msgid "Choose a user"
 msgstr ""
 
@@ -6390,7 +6393,7 @@ msgstr ""
 msgid "Operations on %s."
 msgstr "操作字段没有设置： %s"
 
-msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward."
+msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
 msgid "Or there was no number defined for joining session"

--- a/packages/web/src/Pages/SnapinManagement.php
+++ b/packages/web/src/Pages/SnapinManagement.php
@@ -52,7 +52,20 @@ class SnapinManagement extends FOGPage
             '-ExecutionPolicy Bypass -NoProfile -File',
             ''
         ],
-        'Mono' => ['mono', '', '']
+        'Mono' => ['mono', '', ''],
+        // GH-356. The client always injects the downloaded snapin file as a
+        // quoted positional argument BETWEEN runWithArgs and args, so a
+        // template can only work if the uploaded file is something the tool
+        // consumes positionally. For Chocolatey that is a packages.config:
+        // `choco install <pkg|packages.config>`, where any argument ending
+        // in .config is read as a package list and may be an absolute path.
+        // Installing from a .nupkg path is deprecated upstream, so the
+        // config file is the shape that keeps working.
+        'Chocolatey (packages.config)' => [
+            '%ProgramData%\\chocolatey\\bin\\choco.exe',
+            'install',
+            '-y -r --no-progress'
+        ]
     ];
     /**
      * Template for non-pack.
@@ -172,6 +185,15 @@ class SnapinManagement extends FOGPage
                 'mono',
                 '&quot;[FOG_SNAPIN_PATH]/MyFile.exe&quot;'
             ],
+            // GH-356. A pack unzips on the client and nothing is appended
+            // to the command, so here Chocolatey can be given package names
+            // -- which is what makes the unpacked directory usable as an
+            // offline `--source` holding the .nupkg files from the archive.
+            _('Chocolatey (offline source)') => [
+                '%ProgramData%\\chocolatey\\bin\\choco.exe',
+                'install MyPackage --source=&quot;[FOG_SNAPIN_PATH]&quot; '
+                . '-y -r --no-progress'
+            ],
         ];
         ob_start();
         printf(
@@ -219,7 +241,10 @@ class SnapinManagement extends FOGPage
             'template' => '<p class="form-text">'
                 . _(
                     'Optional. Pick a type to pre-fill the command fields '
-                    . 'below; you can still edit them afterward.'
+                    . 'below; you can still edit them afterward. The '
+                    . 'Chocolatey entry expects the uploaded file to be a '
+                    . 'Chocolatey packages.config naming the packages to '
+                    . 'install.'
                 )
                 . '</p>',
             'packargs' => '<p class="form-text packtemplate d-none">'

--- a/tests/snapin-template-chocolatey.test.php
+++ b/tests/snapin-template-chocolatey.test.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * The Chocolatey snapin templates compose into a command choco will accept.
+ *
+ * GH-356 asked for Chocolatey in the snapin template dropdowns. A template
+ * is three strings, so the whole of the correctness lives in whether the
+ * command the FOG client assembles from them is one the tool understands --
+ * and the client's assembly rule is what constrains the answer:
+ *
+ *   non-pack  runWith  runWithArgs  "<downloaded file>"  args
+ *   pack      runWith  runWithArgs                            (args forced
+ *                                                              empty, and
+ *                                                              [FOG_SNAPIN_PATH]
+ *                                                              substituted)
+ *
+ * (fog-client Modules/SnapinClient/SnapinClient.cs, GenerateProcess() and
+ * GenerateSnapinPackProcess().)
+ *
+ * The downloaded file is injected UNCONDITIONALLY in non-pack mode, and the
+ * client refuses to run a snapin whose hash is empty -- so "no file at all"
+ * was never available and the placeholder .bat in the issue was working
+ * around that, not around a missing feature. `choco install` reads any
+ * argument ending in `.config` as a package list and accepts an absolute
+ * path to it, which makes the forced injection the right shape rather than
+ * an obstacle. Installing from a `.nupkg` path is deprecated upstream, so
+ * that variant is deliberately not offered. `choco upgrade` REJECTS a
+ * .config outright ("A packages.config file is only used with installs."),
+ * which is why there is no upgrade counterpart of the non-pack entry.
+ *
+ * A pack has no injected file, so there the package is named directly and
+ * the unpacked directory serves as an offline `--source`.
+ *
+ * The templates are read by reflection and the command is assembled here in
+ * the client's own order, so an edit that leaves the strings looking
+ * plausible but breaks the resulting command fails this.
+ *
+ * Usage: php tests/snapin-template-chocolatey.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('snapin-template-chocolatey');
+
+$t = new FogChecks();
+
+$class = new \ReflectionClass('FOG\Pages\SnapinManagement');
+
+/*
+ * 1. The non-pack template.
+ */
+$prop = $class->getProperty('_argTypes');
+$prop->setAccessible(true);
+$argTypes = $prop->getValue();
+
+$choco = null;
+$chocoLabel = '';
+foreach ($argTypes as $label => $cmd) {
+    if (false !== stripos($label, 'chocolatey')) {
+        $choco = $cmd;
+        $chocoLabel = $label;
+        break;
+    }
+}
+
+if (!$t->check('the non-pack dropdown offers a Chocolatey template', null !== $choco)) {
+    $t->finish();
+}
+
+$t->check(
+    'its label says which file to upload',
+    false !== stripos($chocoLabel, 'packages.config')
+);
+$t->check(
+    'it runs choco.exe',
+    false !== stripos($choco[0], 'choco.exe')
+);
+$t->check(
+    'the path to choco.exe is one the client can expand',
+    false !== strpos($choco[0], '%ProgramData%')
+);
+
+// The client puts the downloaded file straight after runWithArgs, so
+// anything else in there becomes a second positional package name.
+$t->check(
+    'runWithArgs is the bare install verb',
+    'install' === trim($choco[1])
+);
+$t->check(
+    'the switches are unattended and non-interactive',
+    false !== strpos($choco[2], '-y')
+    && false !== strpos($choco[2], '--no-progress')
+);
+// [FOG_SNAPIN_PATH] is a pack-only token; in non-pack mode it is passed
+// through to the command line verbatim and choco sees a literal directory
+// name that does not exist.
+foreach ($choco as $i => $part) {
+    $t->check(
+        "non-pack field $i carries no [FOG_SNAPIN_PATH] token",
+        false === strpos($part, '[FOG_SNAPIN_PATH]')
+    );
+}
+
+// Assembled the way GenerateProcess() does it, with the file the label
+// tells the user to upload.
+$file = 'C:\\Program Files (x86)\\FOG\\tmp\\packages.config';
+$command = trim(
+    $choco[0] . ' ' . trim($choco[1]) . ' "' . $file . '" ' . $choco[2]
+);
+$t->check(
+    'the assembled command is choco install <packages.config> <switches>',
+    '%ProgramData%\\chocolatey\\bin\\choco.exe install'
+    . ' "C:\\Program Files (x86)\\FOG\\tmp\\packages.config"'
+    . ' -y -r --no-progress' === $command
+);
+
+/*
+ * 2. The pack template. _maker() is a private instance method that only
+ * builds a string, so it runs on an object made without its constructor.
+ */
+$page = $class->newInstanceWithoutConstructor();
+$maker = $class->getMethod('_maker');
+$maker->setAccessible(true);
+$packHtml = (string)$maker->invoke($page);
+
+$t->check(
+    'the pack dropdown offers a Chocolatey template too',
+    false !== stripos($packHtml, 'Chocolatey')
+);
+if (preg_match(
+    '#<option file="([^"]*)" args="([^"]*)">[^<]*Chocolatey[^<]*</option>#i',
+    $packHtml,
+    $m
+)) {
+    $t->check('the pack template runs choco.exe', false !== stripos($m[1], 'choco.exe'));
+    // A pack gets no injected file, so the package is named directly and
+    // the unpacked directory is what makes an offline install possible.
+    $t->check(
+        'the pack template sources packages from the unpacked directory',
+        false !== strpos($m[2], '--source=')
+        && false !== strpos($m[2], '[FOG_SNAPIN_PATH]')
+    );
+    $t->check(
+        'the pack template does not pass a packages.config',
+        false === stripos($m[2], '.config')
+    );
+} else {
+    $t->check('the pack Chocolatey option renders as an <option>', false);
+}
+
+$t->finish();


### PR DESCRIPTION
Closes #356 (needs closing by hand — closing keywords are inert off the default branch).

## What

Adds Chocolatey to both snapin template lists on the Snapin Management page.

| Dropdown | Run with | Run with args | Args |
|---|---|---|---|
| Normal snapin — `Chocolatey (packages.config)` | `%ProgramData%\chocolatey\bin\choco.exe` | `install` | `-y -r --no-progress` |
| Snapin pack — `Chocolatey (offline source)` | `%ProgramData%\chocolatey\bin\choco.exe` | `install MyPackage --source="[FOG_SNAPIN_PATH]" -y -r --no-progress` | — |

## Why these strings

A template is three strings; the client assembles them, so the only real question was which strings produce a command `choco` accepts. The client's rule (`fog-client` `Modules/SnapinClient/SnapinClient.cs`, `GenerateProcess()` / `GenerateSnapinPackProcess()`):

```
non-pack   runWith  runWithArgs  "<downloaded file>"  args
pack       runWith  runWithArgs                        (args forced empty,
                                                        [FOG_SNAPIN_PATH] substituted)
```

Two facts settle the design:

* **The downloaded file is injected unconditionally in non-pack mode**, and the client aborts on an empty hash (`SnapinClient.cs:76`). So "a snapin with no file" was never available — the placeholder `.bat` in the issue was working around *that*, not around a missing template.
* **`choco install <pkg|packages.config>` reads any argument ending in `.config` as a package list**, and it may be an absolute path (verified in `chocolatey/choco`, `ChocolateyInstallCommand.cs` help text). That turns the forced injection from an obstacle into exactly the right shape: the uploaded file becomes a real `packages.config`, which also gives the version pinning the issue's own example wanted:

```xml
<?xml version="1.0" encoding="utf-8"?>
<packages>
  <package id="SkypeForBusiness" version="12130.20272" />
</packages>
```

→ `choco.exe install "C:\...\SkypeForBusiness.config" -y -r --no-progress`

Deliberately **not** offered:

* **`.nupkg` path** — marked `(DEPRECATED)` upstream in the same help text.
* **an `upgrade` variant** (asked for in a comment on the issue) — `choco upgrade` throws `A packages.config file is only used with installs.` (`ChocolateyPackageService.cs:1143-1145`). The pack entry covers upgrade, since it names packages rather than passing a file.

`choco.exe` is given as `%ProgramData%\chocolatey\bin\choco.exe` rather than bare: the client runs as a service and expands environment variables in `runWith`, but inherits the `PATH` it was started with — which predates a later Chocolatey install.

## Verification

`tests/snapin-template-chocolatey.test.php` reads both templates by reflection and assembles the command in the client's own order, so this pins the resulting *command*, not the presence of a string.

Proven by mutation — each of these turns it red:

| Mutation | Failed check |
|---|---|
| non-pack entry removed | `the non-pack dropdown offers a Chocolatey template` |
| `runWithArgs` → `install MyPackage` | `runWithArgs is the bare install verb`, assembled command |
| pack entry removed | `the pack dropdown offers a Chocolatey template too` |
| `choco.exe` no longer absolute | `the path to choco.exe is one the client can expand`, assembled command |
| pack entry passes a `packages.config` | `the pack template does not pass a packages.config` |

Local: `sh tests/run-all.sh` → 278 passed, 0 failed. Both `phpstan` passes clean.

No client change, no schema change, no route change — so nothing for `OpenAPI::document()` and nothing downstream in FogApi.