### PR TITLE
Copy the script from its resolved path, not from $0

### DIFF
--- a/bin/updatefog.sh
+++ b/bin/updatefog.sh
@@ -43,7 +43,12 @@
 #
 # What is left is the one thing installfog.sh genuinely cannot do for itself:
 # change which commit it is about to install.
-bindir=$(dirname $(readlink -f "$BASH_SOURCE"))
+# Resolved BEFORE the cd, and kept: the self-copy below reads this path, and
+# $0 is whatever the caller typed. Invoked as `bash bin/updatefog.sh` from the
+# repository root -- or from a cron entry with a relative path -- $0 is
+# `bin/updatefog.sh`, which stops resolving the moment this cd happens.
+selfpath=$(readlink -f "$BASH_SOURCE")
+bindir=$(dirname "$selfpath")
 cd $bindir
 workingdir=$(pwd)
 
@@ -146,7 +151,11 @@ done
 # removes itself on exit, not here, because it is the file being read.
 # ---------------------------------------------------------------------------
 if [[ -z $FOG_UPDATE_RELAUNCHED ]]; then
-    updateSelfCopy=$(mktemp -t fog-updatefog.XXXXXX) && cat "$0" > "$updateSelfCopy" || {
+    updateSelfCopy=$(mktemp -t fog-updatefog.XXXXXX) && cat "$selfpath" > "$updateSelfCopy" || {
+        # Removing it here too: mktemp may well have succeeded and the cat
+        # failed, which would otherwise leave an empty file in /tmp on every
+        # attempt.
+        [[ -n $updateSelfCopy ]] && rm -f "$updateSelfCopy"
         echo " * Could not copy this script to a temporary location."
         echo " | The update has to run from a copy, because checking out another"
         echo " | branch rewrites this file while bash is still reading it."

--- a/tests/revert-offer.test.sh
+++ b/tests/revert-offer.test.sh
@@ -241,15 +241,44 @@ buildFixture() {
 }
 
 if buildFixture; then
-    out=$( cd "$uwork/bin" && VICTIM="$uwork/bin/updatefog.sh"            bash ./updatefog.sh --channel beta --yes 2>&1 )
+    mkdir -p "$uwork/tmp"
+    out=$( cd "$uwork/bin" && VICTIM="$uwork/bin/updatefog.sh" TMPDIR="$uwork/tmp"            bash ./updatefog.sh --channel beta --yes 2>&1 )
     st=$?
     check "updatefog.sh keeps executing after its own file is emptied mid-run"         "$(grep -q 'No existing FOG install found' <<< "$out"; echo $?)"
     check "and exits deliberately rather than falling off the end of a lost file"         "$([[ $st -eq 1 ]]; echo $?)"
     check "the original really was emptied, so that proved something"         "$([[ ! -s $uwork/bin/updatefog.sh ]]; echo $?)"
-    check "no temporary copy is left behind"         "$([[ $(ls /tmp/fog-updatefog.* 2>/dev/null | wc -l) -eq 0 ]]; echo $?)"
+    # Counted inside this run's own TMPDIR, not /tmp: a global count picks up
+    # copies left by anything else on the machine -- including an earlier
+    # manual run of this very script -- and fails for reasons that have
+    # nothing to do with the code under test.
+    check "no temporary copy is left behind"         "$([[ $(ls "$uwork"/tmp/fog-updatefog.* 2>/dev/null | wc -l) -eq 0 ]]; echo $?)"
 else
     check "could not build the self-rewrite fixture (a source line moved)" 1
 fi
+
+# Invoked by a RELATIVE path, which is how a cron entry or a hand-typed
+# `bash bin/updatefog.sh` from the repository root reaches it.
+#
+# The self-copy reads the script off disk, and the script cd's to its own bin/
+# before that point -- so copying from "$0" resolved the caller's relative path
+# against the new directory and failed, breaking an invocation form that worked
+# before the copy existed. It must read the path resolved before the cd.
+relwork="$work/relative"
+mkdir -p "$relwork/repo/bin"
+sed -e 's/^if \[\[ ! \$EUID -eq 0 \]\]; then$/if false; then/' \
+    -e 's#^\. \.\./lib/common/functions\.sh$#echo reached-past-the-relaunch; exit 0#' \
+    "$updater" > "$relwork/repo/bin/updatefog.sh"
+
+if grep -q 'reached-past-the-relaunch' "$relwork/repo/bin/updatefog.sh"; then
+    relout=$( cd "$relwork/repo" && bash bin/updatefog.sh --channel beta --yes 2>&1 )
+    check "a relative invocation can still copy itself" \
+        "$(grep -q 'reached-past-the-relaunch' <<< "$relout"; echo $?)"
+    check "and does not report that it could not copy itself" \
+        "$(! grep -q 'Could not copy this script' <<< "$relout"; echo $?)"
+else
+    check "could not build the relative-invocation fixture" 1
+fi
+
 
 u=$(sed 's/#.*//' "$updater")
 


### PR DESCRIPTION
Follows #1595 — **base it on `working-1.6` once #1595 merges** (it is in the queue; I could not push this onto that branch). **Draft.**

Found in the post-merge review, alongside #1601.

## `cat "$0"` runs after `cd $bindir`

The self-copy added in #1595 reads `"$0"`, and the script `cd`s to its own `bin/` several lines earlier. Invoked by a **relative path** — `bash bin/updatefog.sh` from the repository root, or a cron entry with a relative path — `$0` is `bin/updatefog.sh`, which stops resolving the moment that `cd` happens:

```
 * Could not copy this script to a temporary location.
```

...and exit 1, for an invocation form that worked fine before the copy existed.

`readlink -f "$BASH_SOURCE"` was already being computed one line earlier to find `bindir`; it is now kept in `$selfpath` and the copy reads that.

Verified both directions: the relative invocation fails with `cat "$0"` and succeeds with `cat "$selfpath"`.

## The failure path leaked a temp file

`mktemp` can succeed and the `cat` fail, which left an empty file in `/tmp` on every attempt — and did, while I was testing this. It is removed now.

## Test

Covers the relative invocation directly. It also counts leftover copies inside **its own `TMPDIR`** rather than in `/tmp` — a global count picks up anything else on the machine, including an earlier manual run of the same script, and fails for reasons unrelated to the code. That bit me while writing it.

`tests/revert-offer.test.sh`: 32 assertions, all passing.

## Same defect on dev-branch

`bin/updatefog.sh` from #1589 has the identical `cat "$0"`-after-`cd` shape. Fixed separately there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtZHpyWZWDPSxePdTViGZy
