### PR TITLE
Schema for group-owned grants (ADR 0038 steps 403-405)

### DIFF
--- a/docs/adr/0031-referential-integrity-is-declared-in-the-database.md
+++ b/docs/adr/0031-referential-integrity-is-declared-in-the-database.md
@@ -15,7 +15,7 @@ windowskey 2, ldap 6, oidc 8, capone 2, subnetgroup 1 -- are declared in
 core's map and applied by a step in each plugin's own `schema()` in
 `FOGProject/fog-plugins`.
 
-**101 of the map's 117 relationships are declared.** The other 16 are not
+**105 of the map's 121 relationships are declared.** The other 16 are not
 pending work: they carry action `none`, which the map's docblock defines as a
 decision rather than an omission. Nine are audit rows, which MUST NOT
 constrain the thing they record (ADR 0021, `schema.php` step 341); seven are

--- a/docs/development/foreign-keys.md
+++ b/docs/development/foreign-keys.md
@@ -603,7 +603,7 @@ half-converted column.
 ## Phase D — plugins, and the direction rule
 
 18 plugin tables ship in `FOGProject/fog-plugins`. All 18 clone cleanly into
-the survey and 25 of the map's 117 relationships live in them.
+the survey and 25 of the map's 121 relationships live in them.
 
 ### Direction is the whole rule
 

--- a/packages/web/commons/schema-constraints.php
+++ b/packages/web/commons/schema-constraints.php
@@ -287,6 +287,19 @@ return [
     ['child' => 'savedFilterGroupAssoc', 'column' => 'sfgaUserGroupID', 'parent' => 'userGroups', 'pcolumn' => 'ugID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 8],
     ['child' => 'savedFilterRoleAssoc', 'column' => 'sfraFilterID', 'parent' => 'savedFilters', 'pcolumn' => 'sfID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 8],
     ['child' => 'savedFilterRoleAssoc', 'column' => 'sfraRoleID', 'parent' => 'roles', 'pcolumn' => 'rID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 8],
+    // ADR 0038 group grants. Group 9, created empty by step 403 so there is
+    // nothing to sweep before the flip.
+    //
+    // All four CASCADE, same reasoning on each: a group grant is meaningless
+    // once either end is gone. A deleted group has no grants; a deleted
+    // snapin or printer cannot be granted. Leaving an orphan row would
+    // silently offer a grant against an id that has since been reused, which
+    // on the printer side means the resolver hands a machine somebody else's
+    // printer.
+    ['child' => 'groupSnapinAssoc', 'column' => 'gsaGroupID', 'parent' => 'groups', 'pcolumn' => 'groupID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 9],
+    ['child' => 'groupSnapinAssoc', 'column' => 'gsaSnapinID', 'parent' => 'snapins', 'pcolumn' => 'sID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 9],
+    ['child' => 'groupPrinterAssoc', 'column' => 'gpaGroupID', 'parent' => 'groups', 'pcolumn' => 'groupID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 9],
+    ['child' => 'groupPrinterAssoc', 'column' => 'gpaPrinterID', 'parent' => 'printers', 'pcolumn' => 'pID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 9],
     ['child' => 'ldapUserGrant', 'column' => 'lugTargetID', 'parent' => '(lugTargetType)', 'pcolumn' => '-', 'class' => 'poly', 'action' => 'none'],
     ['child' => 'oidcUserGrant', 'column' => 'ougTargetID', 'parent' => '(ougTargetType)', 'pcolumn' => '-', 'class' => 'poly', 'action' => 'none'],
 ];

--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -199,8 +199,26 @@ return [
                 'gmGroupID' => 'int(11) NOT NULL',
             ],
         ],
+        'groupPrinterAssoc' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `groupPrinterAssoc` ( `gpaID` int(11) NOT NULL AUTO_INCREMENT, `gpaGroupID` int(11) NOT NULL, `gpaPrinterID` int(11) NOT NULL, `gpaIsDefault` tinyint(1) NOT NULL DEFAULT 0, PRIMARY KEY (`gpaID`), UNIQUE KEY `gpaGroupPrinter` (`gpaGroupID`,`gpaPrinterID`), KEY `gpaPrinterID` (`gpaPrinterID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'gpaID' => 'int(11) NOT NULL',
+                'gpaGroupID' => 'int(11) NOT NULL',
+                'gpaPrinterID' => 'int(11) NOT NULL',
+                'gpaIsDefault' => 'tinyint(1) NOT NULL DEFAULT 0',
+            ],
+        ],
+        'groupSnapinAssoc' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `groupSnapinAssoc` ( `gsaID` int(11) NOT NULL AUTO_INCREMENT, `gsaGroupID` int(11) NOT NULL, `gsaSnapinID` int(11) NOT NULL, `gsaSequence` int(11) NOT NULL DEFAULT 0, PRIMARY KEY (`gsaID`), UNIQUE KEY `gsaGroupSnapin` (`gsaGroupID`,`gsaSnapinID`), KEY `gsaSnapinID` (`gsaSnapinID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'gsaID' => 'int(11) NOT NULL',
+                'gsaGroupID' => 'int(11) NOT NULL',
+                'gsaSnapinID' => 'int(11) NOT NULL',
+                'gsaSequence' => 'int(11) NOT NULL DEFAULT 0',
+            ],
+        ],
         'groups' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `groups` ( `groupID` int(11) NOT NULL AUTO_INCREMENT, `groupName` varchar(50) NOT NULL, `groupDesc` longtext NOT NULL DEFAULT \'\', `groupDateTime` timestamp NOT NULL DEFAULT current_timestamp(), `groupCreateBy` varchar(50) NOT NULL DEFAULT \'\', `groupBuilding` int(11) NOT NULL DEFAULT 0, `groupKernel` varchar(255) NOT NULL DEFAULT \'\', `groupKernelArgs` varchar(255) NOT NULL DEFAULT \'\', `groupPrimaryDisk` varchar(255) NOT NULL DEFAULT \'\', `groupInit` longtext NOT NULL DEFAULT \'\', PRIMARY KEY (`groupID`), UNIQUE KEY `groupName` (`groupName`), UNIQUE KEY `groupName_2` (`groupName`), KEY `new_index` (`groupName`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `groups` ( `groupID` int(11) NOT NULL AUTO_INCREMENT, `groupName` varchar(50) NOT NULL, `groupDesc` longtext NOT NULL DEFAULT \'\', `groupDateTime` timestamp NOT NULL DEFAULT current_timestamp(), `groupCreateBy` varchar(50) NOT NULL DEFAULT \'\', `groupBuilding` int(11) NOT NULL DEFAULT 0, `groupKernel` varchar(255) NOT NULL DEFAULT \'\', `groupKernelArgs` varchar(255) NOT NULL DEFAULT \'\', `groupPrimaryDisk` varchar(255) NOT NULL DEFAULT \'\', `groupInit` longtext NOT NULL DEFAULT \'\', `groupOrder` int(11) NOT NULL DEFAULT 0, PRIMARY KEY (`groupID`), UNIQUE KEY `groupName` (`groupName`), UNIQUE KEY `groupName_2` (`groupName`), KEY `new_index` (`groupName`), KEY `groupOrder` (`groupOrder`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'groupID' => 'int(11) NOT NULL',
                 'groupName' => 'varchar(50) NOT NULL',
@@ -212,6 +230,7 @@ return [
                 'groupKernelArgs' => 'varchar(255) NOT NULL DEFAULT \'\'',
                 'groupPrimaryDisk' => 'varchar(255) NOT NULL DEFAULT \'\'',
                 'groupInit' => 'longtext NOT NULL DEFAULT \'\'',
+                'groupOrder' => 'int(11) NOT NULL DEFAULT 0',
             ],
         ],
         'history' => [

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -10301,3 +10301,94 @@ $this->schema[] = [
         return true;
     },
 ];
+
+// 403
+$this->schema[] = [
+    // ADR 0038 decisions 1 and 4/5: the two tables that let a GROUP own a
+    // grant, instead of a group assignment copying rows onto whichever hosts
+    // happened to be members when a button was pressed.
+    //
+    // These are the declarative half of the split. `snapinAssoc` and
+    // `printerAssoc` keep meaning exactly what they meant -- a HOST-direct
+    // association -- and nothing already in them is migrated or touched
+    // (decision 18). These tables start empty and nothing reads them until
+    // the resolver ships, which is what makes this step reversible: drop
+    // them and no data is lost, because no data was ever moved in.
+    //
+    // Why a group-side table at all, rather than a `gsaHostID`-style flag on
+    // the existing ones: the whole defect is that a group grant has no
+    // representation of its own. It exists today only as its side effects on
+    // member hosts, so a host added later cannot see it and a host removed
+    // keeps it. A row keyed by group is the smallest thing that makes the
+    // grant a fact about the group.
+    "CREATE TABLE IF NOT EXISTS `groupSnapinAssoc` ( "
+    . "`gsaID` int(11) NOT NULL AUTO_INCREMENT, "
+    . "`gsaGroupID` int(11) NOT NULL, "
+    . "`gsaSnapinID` int(11) NOT NULL, "
+    // Explicit, and explicitly NOT defaulted to 0 for everything the way
+    // saSequence is. ADR 0038 decision 6: saSequence defaults to 0 and
+    // Host::loadSnapins() orders by sequence alone, so every row sitting at 0
+    // comes back in whatever order the engine chose. The resolver breaks that
+    // tie on the association id, but the group side gets a real sequence from
+    // the start so the ordering is an admin's decision rather than an
+    // accident that has to be untangled later.
+    . "`gsaSequence` int(11) NOT NULL DEFAULT 0, "
+    . "PRIMARY KEY (`gsaID`), "
+    . "UNIQUE KEY `gsaGroupSnapin` (`gsaGroupID`,`gsaSnapinID`), "
+    . "KEY `gsaSnapinID` (`gsaSnapinID`) "
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC",
+    "CREATE TABLE IF NOT EXISTS `groupPrinterAssoc` ( "
+    . "`gpaID` int(11) NOT NULL AUTO_INCREMENT, "
+    . "`gpaGroupID` int(11) NOT NULL, "
+    . "`gpaPrinterID` int(11) NOT NULL, "
+    // tinyint(1), NOT the varchar(2) printerAssoc.paIsDefault still carries.
+    // A new boolean column added as anything else is what
+    // tests/booleans-are-tinyint.test.php exists to refuse, and there is no
+    // legacy value here to be compatible with.
+    . "`gpaIsDefault` tinyint(1) NOT NULL DEFAULT 0, "
+    . "PRIMARY KEY (`gpaID`), "
+    . "UNIQUE KEY `gpaGroupPrinter` (`gpaGroupID`,`gpaPrinterID`), "
+    . "KEY `gpaPrinterID` (`gpaPrinterID`) "
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC",
+];
+
+// 404
+// The foreign keys for the two tables step 403 just created, per ADR 0031.
+//
+// Group 9. Like groups 7 and 8 it has nothing to migrate: tables created
+// empty one step earlier cannot hold an orphan, so there is no sweep to
+// sequence before the flip.
+//
+// Every column CASCADE, and the reasoning is the same on all four. A group
+// grant is meaningless once either end of it is gone -- a deleted group has
+// no grants, and a deleted snapin or printer cannot be granted. Leaving the
+// row would silently offer a grant against an id that has since been reused,
+// which on the printer side means the resolver hands a machine somebody
+// else's printer.
+$this->schema[] =
+    function () {
+        \FOG\Db\SchemaReconciler::applyConstraints(9);
+
+        return true;
+    };
+
+// 405
+$this->schema[] = [
+    // ADR 0038 decision 6: the explicit order column, so that a rename never
+    // changes what runs.
+    //
+    // The resolved order for a host is host-direct snapins first, then
+    // group-granted ones with the GROUPS ordered by this column, then
+    // `groupName`, then `groupID`. Ordering on name alone was rejected: an
+    // admin renaming a group must not silently reorder installs on a thousand
+    // machines, and there is no way to notice that they have.
+    //
+    // Defaulting every existing group to 0 is deliberate. It means an install
+    // that never sets this behaves alphabetically, which is the answer an
+    // admin can predict, and it makes this step pure addition -- nothing
+    // reads the column until the resolver ships.
+    "ALTER TABLE `groups` ADD COLUMN IF NOT EXISTS "
+    . "`groupOrder` int(11) NOT NULL DEFAULT 0",
+    "ALTER TABLE `groups` ADD INDEX IF NOT EXISTS "
+    . "`groupOrder` (`groupOrder`)",
+];

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -130,7 +130,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 402);
+        define('FOG_SCHEMA', 405);
         define('FOG_BCACHE_VER', 355);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -129,7 +129,7 @@ parameters:
 		-
 			message: '#^Variable \$this might not be defined\.$#'
 			identifier: variable.undefined
-			count: 372
+			count: 375
 			path: packages/web/commons/schema.php
 
 		-

--- a/tests/foreign-key-map.test.php
+++ b/tests/foreign-key-map.test.php
@@ -334,6 +334,13 @@ $expected = [
     'savedFilterGroupAssoc.sfgaUserGroupID',
     'savedFilterRoleAssoc.sfraFilterID',
     'savedFilterRoleAssoc.sfraRoleID',
+    // Group 9 -- ADR 0038 group grants. Both ends CASCADE on both tables: a
+    // grant is meaningless once either the group or the granted object is
+    // gone, and an orphan row would offer a grant against a reused id.
+    'groupSnapinAssoc.gsaGroupID',
+    'groupSnapinAssoc.gsaSnapinID',
+    'groupPrinterAssoc.gpaGroupID',
+    'groupPrinterAssoc.gpaPrinterID',
     // Plugin groups, named for the plugin rather than numbered. Each
     // lands in that plugin's own repo, in an appended step of its
     // manager's schema(); see fog-plugins tests/foreign-keys.test.php,

--- a/tests/site-plugin-row-retired.test.php
+++ b/tests/site-plugin-row-retired.test.php
@@ -156,14 +156,21 @@ function deleted(array $log)
     return false;
 }
 
-// The step under test has to BE the last one, or every assertion below is
-// about something else entirely.
-$last = end($steps);
+// The step under test has to be the one this test THINKS it is, or every
+// assertion below is about something else entirely.
+//
+// Indexed by SITE_RETIRE_STEP, not end($steps), for the reason runRetireStep()
+// already gives: keying on the last step retargets this test at whatever
+// landed most recently. That was fixed there and missed here, so this
+// assertion went on passing by luck -- steps 400, 401 and 402 all happen to
+// carry a closure. Step 405 does not, and it turned this red on code it does
+// not test.
+$under = $steps[SITE_RETIRE_STEP - 1];
 $hasClosure = false;
-foreach ((array)$last as $u) {
+foreach ((array)$under as $u) {
     $hasClosure = $hasClosure || is_callable($u);
 }
-$t->check('the last schema step is a closure', $hasClosure);
+$t->check('step ' . SITE_RETIRE_STEP . ' is a closure', $hasClosure);
 $t->check(
     'FOG_SCHEMA matches the step count',
     $fogSchema === count($steps)


### PR DESCRIPTION
First half of unit **C**. Additive and reversible — nothing reads these until the resolver lands, which is the next PR on top.

### Why a group-side table at all

Today a group's snapins and printers exist only as their **side effects on member hosts** — rows written into `snapinAssoc` / `printerAssoc` when a button was pressed. That is the defect ADR 0038 names: a host added later cannot see the grant, and a host removed keeps it. A row keyed by *group* is the smallest thing that makes the grant a fact about the group rather than a bulk write onto whoever happened to be a member.

| Step | What |
|---|---|
| 403 | `groupSnapinAssoc` (`gsaGroupID`, `gsaSnapinID`, `gsaSequence`), `groupPrinterAssoc` (`gpaGroupID`, `gpaPrinterID`, `gpaIsDefault`) |
| 404 | their four foreign keys — constraint group 9 |
| 405 | `groups.groupOrder int NOT NULL DEFAULT 0` + index |

**Nothing is migrated and nothing existing is touched** (decision 18). `snapinAssoc` and `printerAssoc` keep meaning exactly what they meant: a *host-direct* association. These tables start empty, so all three steps are reversible — drop them and no data is lost, because no data was ever moved in.

Two smaller choices worth flagging:

- `gpaIsDefault` is `tinyint(1)`, **not** the `varchar(2)` that `printerAssoc.paIsDefault` still carries. There is no legacy value here to stay compatible with, and `booleans-are-tinyint.test.php` exists to refuse anything else on a new column.
- `groupOrder` defaults to `0` for every existing group deliberately: an install that never sets it orders alphabetically, which is the answer an admin can predict. Decision 6 is that a **rename must never change execution order**, so the resolver will sort groups by this column first, then `groupName`, then `groupID`.

All four constraints CASCADE — a grant is meaningless once either end is gone, and an orphan row would offer a grant against a reused id, which on the printer side means handing a machine somebody else's printer.

### Verified, not assumed

Against a clone of the live 1.6 database in a throwaway container (removed afterward):

| Check | Result |
|---|---|
| both tables + the column create cleanly | ok |
| all four FKs apply | ok — so the referenced types match |
| orphan `gsaGroupID` | refused, `1452` |
| orphan `gpaPrinterID` | refused, `1452` |
| delete a group carrying 2 grants | grants go 2 → 0 |

### The manifest is spliced, not regenerated

Regenerating from a live database also swept in drift that is **not** part of this change — `fileDeleteQueue` gaining two `fk_*` indexes the manifest does not declare, and an `auditLog` index pair in a different order. Real findings, but not this PR's business, so the manifest diff is **20 insertions, 1 deletion**: exactly the two tables and the one column. Pre-commit confirms *"manifest covers all 78 tables schema.php builds, 0 difference(s)"*.

### Two tests needed updating, both right to fail

- **`foreign-key-map.test.php`** refuses a constraint that is enabled but absent from its expected list. The four new keys are declared there, and the two documents stating the map's totals go **101/117 → 105/121**.
- **`site-plugin-row-retired.test.php`** asserted *"the last schema step is a closure"*. Its own `runRetireStep()` had already been fixed to index by `SITE_RETIRE_STEP`, with a comment explaining that keying on the last step retargets the test at whatever landed most recently — this one assertion was missed and went on passing **by luck**, because steps 400, 401 and 402 all happen to carry a closure. Step 405 does not. Now indexed the same way as its sibling.

Suite **278 passed, 0 failed**; both phpstan passes clean.