### PR TITLE
Copy from the resolved path, and refuse a headless run before moving anything

### DIFF
--- a/bin/updatefog.sh
+++ b/bin/updatefog.sh
@@ -49,7 +49,13 @@
 #   1 not root, or no install found     3 bad argument
 #   6 git failed                        7 no terminal for an interactive install
 
-bindir=$(dirname $(readlink -f "$BASH_SOURCE"))
+# Resolved BEFORE the cd, and kept: relaunchFromCopy() reads this path, and $0
+# is whatever the caller typed. Invoked as `bash bin/updatefog.sh` from the
+# checkout root -- or from a cron entry with a relative path -- $0 is
+# `bin/updatefog.sh`, which stops resolving the moment this cd happens, and the
+# copy this script cannot run without would fail.
+selfpath=$(readlink -f "$BASH_SOURCE")
+bindir=$(dirname "$selfpath")
 cd "$bindir"
 workingdir=$(pwd)
 
@@ -95,7 +101,7 @@ fail() {
 relaunchFromCopy() {
     local copy
     copy=$(mktemp -t fog-updatefog.XXXXXX) || return 1
-    cat "$0" > "$copy" || { rm -f "$copy"; return 1; }
+    cat "$selfpath" > "$copy" || { rm -f "$copy"; return 1; }
     chmod +x "$copy"
     FOG_UPDATE_RELAUNCHED=1 FOG_UPDATE_ORIGIN="$workingdir" \
         FOG_UPDATE_COPY="$copy" exec bash "$copy" "$@"
@@ -264,6 +270,22 @@ if [[ $crossing -eq 1 ]]; then
     echo
 fi
 
+# Checked BEFORE the checkout, not after.
+#
+# It used to sit beside the installer invocation, which meant a headless run
+# -- cron, CI, a container with no tty -- moved the working copy to 1.6 and
+# only then discovered it could not run the installer, leaving a 1.5 server
+# with a 1.6 source tree. bin/bootstrap.sh gets this ordering right and so
+# should this: the test costs nothing here and refuses before anything moves.
+if [[ -z $autoYes ]] && ! (exec < /dev/tty) 2>/dev/null; then
+    fail "No terminal is available, so the installer cannot run interactively." \
+         "Nothing has been changed." \
+         "" \
+         "Re-run from a terminal, or with --yes for an unattended install." \
+         "For a 1.5 -> 1.6 crossing --yes is a poor idea: the 1.6 installer" \
+         "asks about settings your .fogsettings has never held." 7
+fi
+
 if [[ -z $autoYes ]]; then
     echo -n " * Continue? (Y/N) "
     read confirmGo
@@ -302,14 +324,8 @@ if [[ -n $autoYes ]]; then
     (cd "${gitpath}/bin" && bash installfog.sh -Y)
     installStatus=$?
 else
-    if ! (exec < /dev/tty) 2>/dev/null; then
-        fail "No terminal is available, so the installer cannot run interactively." \
-             "The checkout has already been moved to ${branch}; only the install" \
-             "did not start. Re-run this from a terminal, or with --yes." \
-             "" \
-             "To put the checkout back:" \
-             "  git -C ${gitpath} reset --hard ${currentCommit}" 7
-    fi
+    # No tty test here any more -- it happens before the checkout now, so by
+    # this point a terminal is known to exist.
     echo " * Starting the installer"
     echo
     (cd "${gitpath}/bin" && bash installfog.sh < /dev/tty)

--- a/tests/updatefog-1-5-crossing.test.sh
+++ b/tests/updatefog-1-5-crossing.test.sh
@@ -252,8 +252,14 @@ check "without --yes the installer is never given -Y" \
 
 if [[ $st -eq 7 ]]; then
     ok "with no terminal available it refuses (exit 7) rather than going unattended"
-    check "and tells the user how to put the checkout back" \
-        "$(grep -q 'reset --hard' <<< "$out"; echo $?)"
+    # The refusal now happens BEFORE the checkout, so there is nothing to put
+    # back and the message must not imply otherwise. It used to sit beside the
+    # installer invocation, which left a headless run with a 1.5 server and a
+    # 1.6 source tree.
+    check "and says nothing has been changed" \
+        "$(grep -qi 'Nothing has been changed' <<< "$out"; echo $?)"
+    check "and the checkout was never moved" \
+        "$(! grep -q 'checkout' "$calls"; echo $?)"
     check "and does not start the installer at all" \
         "$(! grep -q '^installfog' "$calls"; echo $?)"
 else


### PR DESCRIPTION
Two defects in #1589, found in the post-merge review. **Draft.**

## `cat "$0"` runs after `cd "$bindir"`

The self-copy reads `"$0"`, and the script `cd`s to its own `bin/` forty lines earlier. Invoked by a **relative path** — `bash bin/updatefog.sh` from the checkout root, or a cron entry with a relative path — `$0` is `bin/updatefog.sh`, which stops resolving the moment that `cd` happens:

```
cat: bin/updatefog.sh: No such file or directory
 * Could not copy this script to a temporary location.
```

And the copy is the one thing this script cannot run without — it exists so that checking out 1.6 cannot rewrite the file bash is still reading. `readlink -f "$BASH_SOURCE"` was already being computed to find `bindir`, so it is kept in `$selfpath` and the copy reads that. Verified in both directions.

## The `/dev/tty` test happened *after* the checkout

A headless run without `--yes` — cron, CI, a container with no tty — moved the working copy to 1.6 and *only then* discovered it could not run the installer, leaving a **1.5 server with a 1.6 source tree**.

The message did disclose that and print the reset command, so the damage was bounded. But the right answer is not to get there: `bin/bootstrap.sh` tests the terminal before it clones, and this now tests it before the confirmation prompt, which is before any git work. Nothing has moved when it refuses, and the message says so rather than explaining how to undo something that did not happen.

## Test

`tests/updatefog-1-5-crossing.test.sh`: 39 assertions, all passing. The tty case now asserts *"nothing has been changed"* and that no checkout was attempted, replacing the assertion that described the old post-checkout refusal.

## Same defect on working-1.6

The `cat "$0"` shape is in `working-1.6`'s `bin/updatefog.sh` too — fixed in #1603.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtZHpyWZWDPSxePdTViGZy
