### PR TITLE
Keep AdminLTE's card tools working after an AJAX page load

### DIFF
--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -4592,6 +4592,73 @@ function macVendorIcon(vendor) {
 })();
 
 /**
+ * AdminLTE's card tools, re-armed for FOG's AJAX navigation.
+ *
+ * adminlte4 binds them exactly once, inside its own DOMContentLoaded:
+ *
+ *   document.querySelectorAll('[data-lte-toggle="card-collapse"]')
+ *           .forEach(el => el.addEventListener('click', ...))
+ *
+ * That is not delegated, and doPageLoad() replaces #ajaxPageWrapper wholesale
+ * on every sidebar click -- so every card that arrives by navigation, which is
+ * almost every card anyone ever sees, has a dead toggle. The three tools are
+ * all bound that way: collapse, remove and maximize.
+ *
+ * It went unreported for as long as it did because a card that starts OPEN
+ * only degrades to "cannot be collapsed", which reads as a UI nobody uses. A
+ * card rendered `collapsed-card` is the loud version: its body is
+ * display:none from AdminLTE's own CSS and the only thing that removes the
+ * class is the listener that was never attached, so the content is
+ * unreachable. That is how it was found (GH-1600).
+ *
+ * CAPTURE phase, deliberately. The handler has to run before the element's own
+ * listener whether or not AdminLTE managed to attach one, because a card that
+ * WAS present at DOMContentLoaded still carries it -- and two handlers both
+ * calling toggle() would collapse and expand in the same click, leaving the
+ * button looking just as dead. stopPropagation() during capture keeps the
+ * event from reaching the target at all, so exactly one of the two runs and it
+ * is this one. That also means the fix does not depend on script order, on
+ * which cards were present when, or on AdminLTE keeping its current binding.
+ *
+ * Not re-running AdminLTE's own initializer after each page load: it is not
+ * exported, and re-running it would re-bind the persistent chrome outside
+ * #ajaxPageWrapper once per navigation.
+ */
+(function () {
+  var METHODS = {
+    'card-collapse': 'toggle',
+    'card-remove': 'remove',
+    'card-maximize': 'toggleMaximize'
+  };
+  var TOOLS = '[data-lte-toggle="card-collapse"],'
+    + '[data-lte-toggle="card-remove"],'
+    + '[data-lte-toggle="card-maximize"]';
+
+  document.addEventListener('click', function (e) {
+    var target = e.target;
+    if (!target || !target.closest) {
+      return;
+    }
+    var tool = target.closest(TOOLS);
+    if (!tool) {
+      return;
+    }
+    // If AdminLTE is not loaded there is nothing to take over, and swallowing
+    // the click would be worse than leaving it alone -- the login page loads a
+    // different, smaller asset list and has no cards at all.
+    if (!window.adminlte || typeof window.adminlte.CardWidget !== 'function') {
+      return;
+    }
+    e.preventDefault();
+    e.stopPropagation();
+    // The button, not e.target, which is the <i> whenever the tool carries an
+    // icon. CardWidget resolves .closest('.card') either way, so this is the
+    // same answer by a route that does not depend on where the click landed.
+    new window.adminlte.CardWidget(tool, {})[METHODS[tool.dataset.lteToggle]]();
+  }, true);
+})();
+
+/**
  * Live vendor lookup for MAC inputs on the host create/edit forms.
  *
  * Delegated on document so it covers the create modal (rendered after page

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -131,7 +131,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 402);
-        define('FOG_BCACHE_VER', 355);
+        define('FOG_BCACHE_VER', 356);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/tests/card-tools-survive-ajax-nav.test.php
+++ b/tests/card-tools-survive-ajax-nav.test.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * AdminLTE's card tools keep working after an AJAX page load.
+ *
+ * adminlte4 binds collapse, remove and maximize exactly once, inside its own
+ * DOMContentLoaded:
+ *
+ *   document.querySelectorAll('[data-lte-toggle="card-collapse"]')
+ *           .forEach(el => el.addEventListener('click', ...))
+ *
+ * It is not delegated, and doPageLoad() replaces #ajaxPageWrapper wholesale on
+ * every sidebar click -- so a card that arrives by navigation has no handler
+ * on its toggle. ClientManagement is the shipped page this bites: node=client
+ * IS a sidebar link, so both its collapse buttons were dead. It went
+ * unreported because a card that starts OPEN only degrades to "cannot be
+ * collapsed"; a card rendered `collapsed-card` is the loud version, because
+ * its body is display:none from AdminLTE's own CSS and the only thing that
+ * removes the class is the listener that was never attached (GH-1600).
+ *
+ * fog.common.js takes the three tools over with one delegated listener in the
+ * CAPTURE phase. Capture matters twice over: it runs before the element's own
+ * listener whether or not AdminLTE attached one, and stopPropagation() there
+ * keeps the event from reaching the target at all -- so a card that WAS
+ * present at DOMContentLoaded does not get toggled twice by two handlers and
+ * end up looking just as dead.
+ *
+ * WHAT THIS CAN AND CANNOT PIN. The behavior was proven in a browser against
+ * the shadow tree: node=client reached through the sidebar, collapse clicked,
+ * card collapses and re-expands; the same page with this block deleted, same
+ * route, click does nothing; and the same page reached by a FULL load, where
+ * AdminLTE's own listener also exists, still toggles once per click. None of
+ * that is reachable from a PHP suite with no JS engine. What is pinned here is
+ * the contract between FOG and the vendored library -- every tool AdminLTE
+ * binds is a tool FOG takes over, and every method FOG names still exists on
+ * the class it calls. Those are the parts an AdminLTE upgrade breaks silently,
+ * and the expectations are read out of the vendored file rather than restated,
+ * so a fourth tool or a renamed method fails this rather than passing it.
+ *
+ * Usage: php tests/card-tools-survive-ajax-nav.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('card-tools-survive-ajax-nav');
+
+$t = new FogChecks();
+$js = dirname(__DIR__) . '/packages/web/management/js';
+$lte = (string) file_get_contents($js . '/adminlte4.min.js');
+$fog = (string) file_get_contents($js . '/fog/fog.common.js');
+
+/*
+ * 1. The takeover exists and is delegated on the document in the capture
+ *    phase. Both halves are load-bearing and neither is obvious to read, so
+ *    both are named: without capture the handler runs after AdminLTE's, and
+ *    without stopPropagation both run and the card toggles twice.
+ */
+$block = '';
+if (preg_match('#/\*\*\s+\* AdminLTE\'s card tools.*?\n\}\)\(\);#s', $fog, $m)) {
+    $block = $m[0];
+}
+$t->check(
+    'fog.common.js takes the card tools over',
+    '' !== $block
+);
+// Assert on CODE, never on the comment above it. Every string checked below
+// -- stopPropagation, the capture flag, all three tool names -- is also
+// written out in that docblock, so matching the block whole would pass
+// against a takeover whose body had been deleted. Two of these checks did
+// exactly that until a mutation run caught them.
+$code = (string) preg_replace('#/\*.*?\*/#s', '', $block);
+$code = (string) preg_replace('#^\s*//.*$#m', '', $code);
+$t->check(
+    'delegated on document, not per element',
+    false !== strpos($code, 'document.addEventListener(\'click\'')
+);
+$t->check(
+    'in the capture phase, so it beats the element\'s own listener',
+    (bool) preg_match('#\},\s*true\s*\);#', $code)
+);
+$t->check(
+    'and stops the event there, so AdminLTE\'s listener cannot also fire',
+    false !== strpos($code, 'stopPropagation()')
+);
+
+/*
+ * 2. Every card tool AdminLTE binds is one FOG takes over. Read out of the
+ *    vendored file: an upgrade that adds a fourth fails this rather than
+ *    shipping one more dead button.
+ */
+preg_match_all('/data-lte-toggle="(card-[a-z]+)"/', $lte, $m);
+$bound = array_values(array_unique($m[1]));
+$t->check(
+    'the vendored AdminLTE still binds card tools by that attribute',
+    count($bound) >= 3
+);
+foreach ($bound as $tool) {
+    $t->check(
+        'FOG takes over ' . $tool,
+        false !== strpos($code, '"' . $tool . '"')
+    );
+}
+
+/*
+ * 3. Every CardWidget method FOG names still exists on the class it calls,
+ *    and the class is still exported. FOG reaches it as
+ *    window.adminlte.CardWidget; nothing else on the page does, so a renamed
+ *    export would be a silent no-op on every card tool at once.
+ */
+$t->check(
+    'AdminLTE still exports CardWidget',
+    (bool) preg_match('/\be\.CardWidget=/', $lte)
+);
+preg_match_all('/\'(card-[a-z]+)\':\s*\'([A-Za-z]+)\'/', $code, $m);
+$mapped = array_combine($m[1], $m[2]);
+$t->check(
+    'FOG maps every tool it handles to a method',
+    count($mapped) === count($bound)
+);
+foreach ($mapped as $tool => $method) {
+    $t->check(
+        $tool . ' calls CardWidget.' . $method . '(), which still exists',
+        (bool) preg_match('/\b' . preg_quote($method, '/') . '\(\)\{/', $lte)
+    );
+}
+
+/*
+ * 4. Changing shipped JS without moving the asset version leaves every
+ *    browser that has already loaded the old file on the old file until a
+ *    hard refresh. Hygiene rather than correctness, and cheap to hold.
+ */
+$sys = (string) file_get_contents(
+    dirname(__DIR__) . '/packages/web/src/Base/System.php'
+);
+preg_match('/FOG_BCACHE_VER\',\s*(\d+)/', $sys, $m);
+$t->check(
+    'FOG_BCACHE_VER is past the version this shipped against',
+    isset($m[1]) && (int) $m[1] >= 356
+);
+
+$t->finish();


### PR DESCRIPTION
Follows #1600, which found this. **First, a correction to what I told you there:** I said every collapsible card in the UI was half-broken. That overstated it — the honest scope is below.

## The bug

adminlte4 binds collapse, remove and maximize exactly once, inside its own `DOMContentLoaded`:

```js
document.querySelectorAll('[data-lte-toggle="card-collapse"]')
        .forEach(el => el.addEventListener('click', …))
```

Not delegated. `doPageLoad()` replaces `#ajaxPageWrapper` wholesale on every sidebar click, so a card arriving by navigation has no handler on its toggle.

## Actual scope: three buttons on one page

I checked every render site rather than assuming:

| Site | Reached by | Status |
|---|---|---|
| `ClientManagement` (`node=client`) | **sidebar link → AJAX** | **broken today** — 2 collapse buttons dead |
| `ImageManagement` edit | grid link → full page load | fine, AdminLTE binds it |
| `ServerInfo` (`node=hwinfo`) | not in the sidebar | fine |
| `_box(collapse => true)` | no caller passes it | n/a |

It went unreported because a card that starts *open* only degrades to "cannot be collapsed", which reads as a feature nobody uses. A card rendered `collapsed-card` is the loud version — its body is `display:none` from AdminLTE's own CSS, and the only thing that removes the class is the listener that was never attached. That is how #1600 found it.

## The fix

One delegated listener on `document`, in the **capture** phase. Capture does two jobs:

- it runs before the element's own listener whether or not AdminLTE attached one, and
- `stopPropagation()` there keeps the event from reaching the target — so a card that *was* present at `DOMContentLoaded` isn't toggled twice by two handlers, which would collapse and re-expand in one click and look just as dead.

That also means the fix doesn't depend on script order or on which cards were present when. There is already precedent for this exact shape in `fog.common.js` (the DataTables collection keydown suppressor).

Not re-running AdminLTE's initializer per page load: it isn't exported, and re-running it would re-bind the persistent chrome outside `#ajaxPageWrapper` once per navigation.

`FOG_BCACHE_VER` 355 → 356, since shipped JS changed.

## Verification — in a browser, on the route that failed

Shadow tree, real app, real AJAX navigation. Not a static snapshot; that is what let the #1592 bug through.

| Case | Result |
|---|---|
| Sidebar → Client, click collapse | collapses, then re-expands |
| **Same page and route, this block deleted** | **click does nothing** — bug reproduced |
| Same page by full page load (both handlers exist) | toggles once per click — no double-fire |
| Remove / maximize on a card injected after load | both work, including a click landing on the child `<i>` |

## Gate

`tests/card-tools-survive-ajax-nav.test.php` (14 checks) pins the **contract with the vendored library** rather than restating this code: every tool AdminLTE binds is one FOG takes over, and every `CardWidget` method FOG names still exists on the class — both read out of `adminlte4.min.js`. An upgrade that adds a fourth tool or renames a method fails the build instead of shipping a dead button.

It asserts on the code **with comments stripped**. `stopPropagation`, the capture flag and all three tool names also appear in the docblock above the handler, and two checks were passing against that prose until a mutation run caught them — so the mutation pass earned its keep here.

Mutations proven to fail: capture flag dropped, `stopPropagation` dropped, a tool no longer taken over, a `CardWidget` method renamed to one that doesn't exist, the whole takeover removed, and `FOG_BCACHE_VER` left behind.

What the suite **cannot** prove, since it has no JS engine: that the click actually works. That is the browser table above.

Suite 279/0, both phpstan passes clean, PSR-2 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CreCNucEFLNcrzbZCjchvJ