### PR TITLE
Release notes: persistentgroups retirement and the saveGroup permission narrowing

### DIFF
--- a/docs/release/1.6.0-release-notes.DRAFT.md
+++ b/docs/release/1.6.0-release-notes.DRAFT.md
@@ -227,6 +227,44 @@ pre-upgrade *dump* — it is not a schema rollback.
   disagreement is logged, so nothing is lost silently.
 - **The `accesscontrol` plugin is retired**, replaced by native RBAC. Its
   registration row is removed during the upgrade.
+- **The `persistentgroups` plugin is retired**, and its database TRIGGER is
+  dropped. This one matters more than a plugin removal usually would, because
+  the trigger outlived the plugin's files: deleting the code never stopped it
+  firing. On every host added to a group whose name matched a host's name it
+  copied 13 `hosts` columns -- the Active Directory join password among them --
+  plus location, printer, snapin and module rows, and it created snapin tasking
+  that queued software onto the machine. All of that happened in the database,
+  below the PHP layer, so none of it appears in the audit trail.
+
+  If you are rotating a domain join account, note that the password propagated
+  to hosts you never edited and nothing in the interface would have told you.
+
+  On 1.6 data the trigger had also stopped working for its own purpose: the
+  printer and module copies carry no `ON DUPLICATE KEY UPDATE`, so a collision
+  raised a duplicate-key error inside an `AFTER INSERT` trigger and rolled back
+  the membership row that fired it -- the host was not added at all. If group
+  additions have been failing with a database error, this is why.
+
+  Do not copy the plugin into `/opt/fog/plugins` to keep it: installing it again
+  re-creates the trigger. Core now resolves a group's snapins and printers when
+  they are used, which is what the plugin existed to fake.
+  <!-- verified: docs/adr/0038 decisions 14 and 15; schema step 402;
+  lib/common/functions.sh _stripRetiredPlugins()/_warnUnrecognizedPlugins() -->
+- **Bulk "Add to Group" from the host list now requires `group.edit`, not
+  `group.create`.** Adding existing hosts to existing groups is an edit, so
+  requiring the permission to *mint* groups in order to *apply* one was
+  backwards. `group.create` is still required, but only when the request names
+  a group that does not exist yet.
+
+  This is strictly narrower than before, so no role gains reach -- but a role
+  holding `group.create` **without** `group.edit` loses the bulk add it had.
+  Grant it `group.edit` and it behaves as it did.
+
+  The same endpoint also gained the CSRF check and the site-scope bound it was
+  missing: it previously accepted a request with no CSRF token, and did not
+  bound the posted host or group ids to the caller's sites.
+  <!-- verified: docs/adr/0038 decision 16a.6; Authorization::SUB_OVERRIDES;
+  tests/savegroup-is-gated.test.php -->
 - **Foreign keys are now declared**, which makes previously-tolerated orphan
   rows an error rather than a curiosity. The upgrade sweeps them first —
   nullable columns are set to `NULL`, `NOT NULL` ones have the row deleted,


### PR DESCRIPTION
Two Breaking-changes entries for work already merged (#1593, #1598), written for an admin who has to act rather than merely notice.

**persistentgroups.** The entry leads with the TRIGGER, not the plugin, because that is the surprising part: deleting the plugin`s files never stopped it firing. A site that "removed" it years ago has been copying 13 `hosts` columns onto member hosts ever since -- `hostADPass` among them -- below the PHP layer, so none of it is in the audit trail. Anyone rotating a domain join account needs to know the password propagated to hosts they never edited.

It also records two things people will have HIT without knowing the cause:

- the printer and module copies carry no `ON DUPLICATE KEY UPDATE`, so on 1.6 data a collision raised a duplicate-key error inside an `AFTER INSERT` trigger and rolled back the membership row that fired it. The host was not added at all.
- reinstalling the plugin to keep the behaviour re-creates the trigger. Said explicitly, because it is the obvious thing to try.

**The saveGroup narrowing.** `group.create` -> `group.edit` for bulk add is strictly narrower, so nothing gains reach and the change is otherwise silent -- which is precisely how a narrowing gets reported as a regression. The entry names the one role shape that loses something: `group.create` WITHOUT `group.edit`. It also notes the CSRF check and site-scope bound the same endpoint gained.

Docs only. Both entries carry `<!-- verified: ... -->` pointers to the ADR decision and the code that implements them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)