### PR TITLE
Move the rehearsal baseline for the four group-grant foreign keys

### DIFF
--- a/tests/fixtures/upgrade-rehearsal-baseline.txt
+++ b/tests/fixtures/upgrade-rehearsal-baseline.txt
@@ -1,5 +1,5 @@
-  constraints declared and applicable here: 76
-  constraints actually present:             74
+  constraints declared and applicable here: 80
+  constraints actually present:             78
   MISSING:                                  2
     fk_hostMAC_hmHostID                      CASCADE     orphan rows: 0
     fk_nfsGroupMembers_ngmGroupID            RESTRICT    orphan rows: 1


### PR DESCRIPTION
working-1.6 is currently RED on `upgrade rehearsal`, and so is every open PR against it. #1604 merged one commit before this fixture update, which was on the same branch but pushed a minute too late for the merge.

The change is the two numbers the rehearsal prints: 76 -> 80 constraints declared and applicable, 74 -> 78 present. Step 404 applies constraint group 9, so `groupSnapinAssoc` and `groupPrinterAssoc` each gain two keys and both counts move together.

`MISSING` stays at 2 and names the same two keys, which is the part that matters — the fixture exists to catch a NEW failure appearing, and nothing regressed.

Verified by running `tests/upgrade-rehearsal-ci.test.sh` against a throwaway `mariadb:11`: red on the old fixture, green on this one, from a fresh database in both directions. The four keys were then named out of `information_schema` in the rehearsed database rather than inferred from the count moving by four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)