### PR TITLE
Resolve a host's snapins at task creation, group grants included

### DIFF
--- a/bin/psr4-scan.php
+++ b/bin/psr4-scan.php
@@ -153,6 +153,12 @@ const TABLE = [
     // that identity's reach. The audit is a reader of the answer, not its
     // owner. See ADR 0033.
     'Identity' => 'Auth',
+    // Assign, not Items: it is policy, not a row. Resolver decides WHAT A
+    // HOST IS ASSIGNED out of its own associations plus what its groups
+    // grant, and putting it next to the ORM models in Items would say it
+    // was one of them. Same reasoning that puts SiteScope in Auth rather
+    // than beside the sites row it reads. See ADR 0038 decision 8.
+    'Resolver' => 'Assign',
     'Audit' => 'Audit',
     'ActivityWindow' => 'Audit',
     'AuditStats' => 'Audit',

--- a/docs/GROUP_SHARED_STATE.md
+++ b/docs/GROUP_SHARED_STATE.md
@@ -18,10 +18,20 @@ anything.
 > **no‑clobber**: a blank field leaves each host's value alone, so you only
 > change what you intend to.
 
+> **⚠️ This is changing. Snapins have already changed.**
+> A group is becoming something that **grants**, rather than something that
+> copies rows onto whoever happened to be a member when a button was pressed.
+> The first half has landed: see
+> [Snapins are granted, not copied](#snapins-are-granted-not-copied) below.
+> Everything else on this page still describes the push‑to‑all model and is
+> still accurate for the page as it stands today. The reasoning, and what is
+> left to move, are in [ADR 0038](adr/0038-a-group-grants-it-does-not-copy.md).
+
 ---
 
 ## Table of contents
 
+- [Snapins are granted, not copied](#snapins-are-granted-not-copied)
 - [Associations (tri‑state)](#associations-tri-state)
   - [What "has it" means](#what-has-it-means)
   - [The badge and Has/Missing drill‑down](#the-badge-and-hasmissing-drill-down)
@@ -33,6 +43,56 @@ anything.
   - [General fields](#general-fields)
   - [Default printer](#default-printer)
 - [Out of scope](#out-of-scope)
+
+---
+
+## Snapins are granted, not copied
+
+A group can now hold a snapin **grant** of its own. The grant is a row about the
+*group* (`groupSnapinAssoc`), not a pile of rows copied onto the hosts that were
+members at the time, and that single change fixes both halves of the old
+behavior:
+
+- a host **added** to the group afterward is covered by the grant, without
+  anyone re‑pushing anything;
+- a host **removed** from the group stops being covered, instead of silently
+  keeping a snapin nobody can now explain.
+
+### When it is worked out — and the one thing everybody gets wrong
+
+**The list is resolved when a task is created, and written onto the task.
+Editing the group afterward does not change a task that is already in flight.
+Re‑tasking is the only way to pick a change up.**
+
+That sentence is the whole rule, and it is worth reading twice, because the
+natural assumption is that the group is consulted at the moment the snapin runs.
+It is not. `snapinTasks` records what was decided when the task was made, which
+is what makes a queued task reproducible: you can look at a task from last
+Tuesday and see what it was actually going to install, not what the group would
+say today.
+
+If you change a group's snapins and want the change to reach machines with
+tasks already queued, **cancel and re‑task them**.
+
+### What a host ends up with, in order
+
+1. The snapins on the **host itself**, in the order the host has them.
+2. Then the snapins its **groups grant**, groups in the order they are given
+   (an explicit order on the group, then by name), and within a group in the
+   order the grant has them.
+
+A snapin reached **both** ways appears **once**, in the position the *host*
+gave it. A group grant never reorders something an admin deliberately placed on
+a host.
+
+Group order is an explicit setting rather than alphabetical for one reason:
+**renaming a group must never silently change what installs on a thousand
+machines.** An install that never sets it behaves alphabetically, which is the
+answer an admin can predict.
+
+> Printers have **not** moved yet, and the group Printers tab still pushes rows
+> onto member hosts as before. Nothing on the host side of printers has
+> changed.
 
 ---
 

--- a/docs/release/1.6.0-release-notes.DRAFT.md
+++ b/docs/release/1.6.0-release-notes.DRAFT.md
@@ -227,6 +227,28 @@ pre-upgrade *dump* — it is not a schema rollback.
   disagreement is logged, so nothing is lost silently.
 - **The `accesscontrol` plugin is retired**, replaced by native RBAC. Its
   registration row is removed during the upgrade.
+- **A group's snapins are now a grant, and they are resolved when a task is
+  created.** A group no longer copies snapin rows onto whichever hosts happened
+  to be members when you pressed the button; it holds the assignment itself, so
+  a host added to the group later is covered by it and a host removed stops
+  being covered.
+
+  **The part to remember: editing a group does not change a task that is
+  already queued. Re-tasking is the only way to pick a change up.** The list is
+  worked out when the task is made and written onto it, which is what lets you
+  look at a task from last week and see what it was really going to install.
+  Everyone assumes the group is consulted at the moment the snapin runs; it is
+  not, and it never was.
+
+  A snapin a host has *both* directly and through a group runs **once**, in the
+  position the host gave it -- a group grant never reorders something placed on
+  a host deliberately. Groups themselves run in an explicit order you set, then
+  by name, so that **renaming a group cannot silently change what installs on a
+  thousand machines**.
+
+  Printers have not moved yet and are unaffected in this release.
+  <!-- verified: docs/adr/0038 decisions 4, 6 and 7; FOG\Assign\Resolver;
+  docs/GROUP_SHARED_STATE.md -->
 - **The `persistentgroups` plugin is retired**, and its database TRIGGER is
   dropped. This one matters more than a plugin removal usually would, because
   the trigger outlived the plugin's files: deleting the code never stopped it

--- a/packages/web/src/Assign/Resolver.php
+++ b/packages/web/src/Assign/Resolver.php
@@ -1,0 +1,364 @@
+<?php
+/**
+ * Resolves what a host is actually assigned, host-direct plus group-granted.
+ *
+ * PHP version 7.4+
+ *
+ * @category Resolver
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Assign;
+
+use FOG\Base\FOGBase;
+
+/**
+ * Resolves what a host is actually assigned, host-direct plus group-granted.
+ *
+ * ADR 0038. A group GRANTS a snapin or a printer; it does not copy rows onto
+ * whichever hosts happened to be members when a button was pressed. The grant
+ * is a row keyed by group (`groupSnapinAssoc`, `groupPrinterAssoc`), and what
+ * a given host ends up with is computed here, from that grant plus the host's
+ * own direct associations.
+ *
+ * ONE function answers it, for every caller -- task creation, the client's
+ * printer request, and any UI preview. Three sorts in three files drift, and
+ * the symptom is a preview that does not match what runs, which is
+ * unfalsifiable from a bug report and miserable to diagnose. The precedent is
+ * SiteScope::_inScopeSelect(), whose docblock states the same reasoning for
+ * the same reason.
+ *
+ * TWO THINGS HERE ARE LOAD-BEARING AND BOTH LOOK LIKE STYLE.
+ *
+ * 1. THE UNIT IS A SET OF HOSTS, NOT A HOST. GH-707 was exactly this: the
+ *    "all snapins" path queried snapinAssoc once per member host inside a
+ *    loop -- a thousand round trips for a thousand-host group. A resolver
+ *    whose natural unit is one host reintroduces that the first time a group
+ *    task calls it. The single-host client path passes a one-element array.
+ *
+ * 2. IT READS THE ASSOCIATION TABLES DIRECTLY, NOT THROUGH THEIR MANAGERS.
+ *    FOGController::buildQuery() walks $databaseFieldClassRelationships
+ *    TRANSITIVELY and folds a fourth-element filter into the WHERE rather
+ *    than the ON, so every query whose class chain reaches Host picks up
+ *    `AND hostMAC.hmPrimary = '1'` from Host's own MACAddressAssociation
+ *    declaration. That turns the LEFT JOIN into an effective inner one and
+ *    silently drops every host with no primary MAC -- measured on the 1.5
+ *    lab as 95 rows where the raw COUNT(*) was 1000. There is no flag that
+ *    suppresses it; PR #1233 fixed the same problem the same way. A resolver
+ *    that silently omits a host is a printer resolver that strips that host's
+ *    printers, so this is not a performance note.
+ *
+ * ORDER (decision 6). Host-direct first, then group-granted:
+ *
+ *   1. host-direct, by the association's sequence, then by its id.
+ *   2. group-granted, groups by `groupOrder`, then `groupName`, then
+ *      `groupID`; within a group by the grant's own sequence, then its id.
+ *
+ * The id tiebreaks are not decoration. `saSequence` defaults to 0 and
+ * Host::loadSnapins() orders by sequence alone, so any two rows both sitting
+ * at 0 -- which is every row Group::addSnapin() wrote before
+ * appendSnapinSequence() numbered them -- come back in whatever order the
+ * engine chose. Ordering groups on NAME alone was rejected outright: renaming
+ * a group must not silently reorder what installs on a thousand machines.
+ *
+ * DEDUPLICATION TAKES THE HOST'S POSITION (decision 7). A snapin reached both
+ * directly and through a group appears once, where the host put it. A group
+ * grant does not get to move an order an admin chose. It is done here rather
+ * than by leaning on `UNIQUE (stJobID, stSnapinID)`, because insertBatch()
+ * UPSERTS -- a duplicate reaching the insert would overwrite the sequence
+ * silently instead of being rejected.
+ *
+ * FAILURE THROWS. It never returns an empty list to mean failure (decision
+ * 9). Under printer level `ar` the resolved list is authoritative in both
+ * directions -- the client removes what is not on it -- so a resolver that
+ * errs by returning nothing strips printers from every machine that polls,
+ * one machine at a time, for as long as nobody notices. The shipped client
+ * (fog-client 0.13.0, Modules/PrinterManager/PrinterManager.cs) does bail on
+ * `if (data.Error) return;` before touching a printer, so an exception is
+ * genuinely safe; an empty list that reaches the wire as the string `np` is
+ * not, because `np` is the one and only removal-on-empty trigger there.
+ *
+ * @category Resolver
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class Resolver extends FOGBase
+{
+    /**
+     * Resolves the ordered snapin list for each host.
+     *
+     * @param array $hostIDs the hosts to resolve for
+     *
+     * @return array hostID => [snapinID, ...] in run order. EVERY host id
+     *               passed in is a key, with an empty array when it has
+     *               nothing. A missing key would be indistinguishable from
+     *               "resolved to nothing" at the call site, and the two want
+     *               opposite handling.
+     * @throws \RuntimeException on any query failure
+     */
+    public static function resolveSnapins(array $hostIDs)
+    {
+        $hostIDs = self::_ids($hostIDs);
+        if (count($hostIDs) < 1) {
+            return [];
+        }
+        $resolved = [];
+        $direct = [];
+        $rows = self::_rows(
+            'SELECT `saHostID`, `saSnapinID` FROM `snapinAssoc` '
+            . 'WHERE `saHostID` IN (' . implode(',', $hostIDs) . ') '
+            . 'ORDER BY `saHostID`, `saSequence`, `saID`'
+        );
+        foreach ($rows as $row) {
+            $direct[(int)$row['saHostID']][] = (int)$row['saSnapinID'];
+        }
+
+        list($groupsByHost, $groupIDs) = self::_membership($hostIDs);
+        $byGroup = [];
+        if (count($groupIDs) > 0) {
+            $rows = self::_rows(
+                'SELECT `gsaGroupID`, `gsaSnapinID` FROM `groupSnapinAssoc` '
+                . 'WHERE `gsaGroupID` IN (' . implode(',', $groupIDs) . ') '
+                . 'ORDER BY `gsaSequence`, `gsaID`'
+            );
+            foreach ($rows as $row) {
+                $byGroup[(int)$row['gsaGroupID']][] = (int)$row['gsaSnapinID'];
+            }
+        }
+        $ordered = self::_orderedGroupIDs($groupIDs);
+
+        foreach ($hostIDs as $hostID) {
+            $out = $direct[$hostID] ?? [];
+            $seen = array_flip($out);
+            foreach ($ordered as $groupID) {
+                if (!isset($groupsByHost[$hostID][$groupID])) {
+                    continue;
+                }
+                foreach ($byGroup[$groupID] ?? [] as $snapinID) {
+                    if (isset($seen[$snapinID])) {
+                        continue;
+                    }
+                    $seen[$snapinID] = true;
+                    $out[] = $snapinID;
+                }
+            }
+            $resolved[$hostID] = $out;
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Resolves the printer list and default printer for each host.
+     *
+     * @param array $hostIDs the hosts to resolve for
+     *
+     * @return array hostID => ['printers' => [printerID, ...],
+     *               'default' => printerID|null]. Every host id passed in is
+     *               a key; see resolveSnapins() for why.
+     * @throws \RuntimeException on any query failure
+     */
+    public static function resolvePrinters(array $hostIDs)
+    {
+        $hostIDs = self::_ids($hostIDs);
+        if (count($hostIDs) < 1) {
+            return [];
+        }
+        $resolved = [];
+        $direct = [];
+        $directDefault = [];
+        $rows = self::_rows(
+            'SELECT `paHostID`, `paPrinterID`, `paIsDefault` '
+            . 'FROM `printerAssoc` '
+            . 'WHERE `paHostID` IN (' . implode(',', $hostIDs) . ') '
+            . 'ORDER BY `paHostID`, `paID`'
+        );
+        foreach ($rows as $row) {
+            $hostID = (int)$row['paHostID'];
+            $printerID = (int)$row['paPrinterID'];
+            $direct[$hostID][] = $printerID;
+            // paIsDefault is varchar(2) on a 1.5-origin database and carries
+            // '1', '0' and '' -- it predates booleans-are-tinyint. Compare it
+            // as the string the writers actually store rather than casting,
+            // which would make the empty string a 0 and read the same either
+            // way, but only by luck.
+            if ('1' === (string)$row['paIsDefault']
+                && !isset($directDefault[$hostID])
+            ) {
+                $directDefault[$hostID] = $printerID;
+            }
+        }
+
+        list($groupsByHost, $groupIDs) = self::_membership($hostIDs);
+        $byGroup = [];
+        $groupDefault = [];
+        if (count($groupIDs) > 0) {
+            $rows = self::_rows(
+                'SELECT `gpaGroupID`, `gpaPrinterID`, `gpaIsDefault` '
+                . 'FROM `groupPrinterAssoc` '
+                . 'WHERE `gpaGroupID` IN (' . implode(',', $groupIDs) . ') '
+                . 'ORDER BY `gpaID`'
+            );
+            foreach ($rows as $row) {
+                $groupID = (int)$row['gpaGroupID'];
+                $printerID = (int)$row['gpaPrinterID'];
+                $byGroup[$groupID][] = $printerID;
+                if ((int)$row['gpaIsDefault'] > 0
+                    && !isset($groupDefault[$groupID])
+                ) {
+                    $groupDefault[$groupID] = $printerID;
+                }
+            }
+        }
+        $ordered = self::_orderedGroupIDs($groupIDs);
+
+        foreach ($hostIDs as $hostID) {
+            $out = $direct[$hostID] ?? [];
+            $seen = array_flip($out);
+            // A host-direct default wins outright. Otherwise the default
+            // comes from the FIRST group in the resolved order that names
+            // one -- same precedence as the list itself, so an admin who can
+            // predict the order can predict the default.
+            $default = $directDefault[$hostID] ?? null;
+            foreach ($ordered as $groupID) {
+                if (!isset($groupsByHost[$hostID][$groupID])) {
+                    continue;
+                }
+                foreach ($byGroup[$groupID] ?? [] as $printerID) {
+                    if (isset($seen[$printerID])) {
+                        continue;
+                    }
+                    $seen[$printerID] = true;
+                    $out[] = $printerID;
+                }
+                if (null === $default && isset($groupDefault[$groupID])) {
+                    $default = $groupDefault[$groupID];
+                }
+            }
+            $resolved[$hostID] = ['printers' => $out, 'default' => $default];
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Reads group membership for a set of hosts.
+     *
+     * Straight off `groupMembers`, for the transitive-filter reason in the
+     * class docblock: a membership read that goes through a manager drops
+     * every host with no primary MAC.
+     *
+     * @param array $hostIDs the hosts, already sanitized
+     *
+     * @return array [hostID => [groupID => true], [groupID, ...]]
+     * @throws \RuntimeException on any query failure
+     */
+    private static function _membership(array $hostIDs)
+    {
+        $byHost = [];
+        $groupIDs = [];
+        $rows = self::_rows(
+            'SELECT `gmHostID`, `gmGroupID` FROM `groupMembers` '
+            . 'WHERE `gmHostID` IN (' . implode(',', $hostIDs) . ')'
+        );
+        foreach ($rows as $row) {
+            $groupID = (int)$row['gmGroupID'];
+            $byHost[(int)$row['gmHostID']][$groupID] = true;
+            $groupIDs[$groupID] = true;
+        }
+
+        return [$byHost, array_keys($groupIDs)];
+    }
+
+    /**
+     * Puts group ids into the one order every resolution uses.
+     *
+     * Factored out so the snapin list, the printer list and the default
+     * printer are ordered by ONE piece of code. Decision 6 is a promise about
+     * what an admin sees, and a promise implemented three times is a promise
+     * that stops holding somewhere without anything failing.
+     *
+     * @param array $groupIDs the groups to order, already sanitized
+     *
+     * @return array the ids, ordered
+     * @throws \RuntimeException on any query failure
+     */
+    private static function _orderedGroupIDs(array $groupIDs)
+    {
+        if (count($groupIDs) < 1) {
+            return [];
+        }
+        $rows = self::_rows(
+            'SELECT `groupID` FROM `groups` '
+            . 'WHERE `groupID` IN (' . implode(',', $groupIDs) . ') '
+            // groupID last, and kept even though the manifest declares
+            // groupName UNIQUE. It costs one clause, and it is the
+            // difference between a resolver that is deterministic and one
+            // that is deterministic as long as an index nobody re-checks is
+            // still there. roles.rName is the precedent for the manifest and
+            // the disk disagreeing; schema step 401 exists because of it.
+            . 'ORDER BY `groupOrder`, `groupName`, `groupID`'
+        );
+        $ordered = [];
+        foreach ($rows as $row) {
+            $ordered[] = (int)$row['groupID'];
+        }
+
+        return $ordered;
+    }
+
+    /**
+     * Runs a read and returns its rows, or throws.
+     *
+     * PDODB::query() does NOT throw by default -- it records the message on
+     * ->error and hands the object back, so an unchecked caller reads a
+     * successful-looking empty result out of a failed query. That is the
+     * exact shape decision 9 forbids here, so every read goes through this.
+     *
+     * @param string $sql the statement to run
+     *
+     * @return array the rows, as associative arrays
+     * @throws \RuntimeException when the query failed
+     */
+    private static function _rows($sql)
+    {
+        $res = self::$DB->query($sql);
+        if (false !== $res->error) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Assignment resolution failed: %s',
+                    (string)$res->error
+                )
+            );
+        }
+        $rows = $res->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+
+        return (array)$rows;
+    }
+
+    /**
+     * Sanitizes an id list.
+     *
+     * @param array $ids the ids
+     *
+     * @return array positive ints, deduplicated, renumbered
+     */
+    private static function _ids(array $ids)
+    {
+        return array_values(
+            array_unique(
+                array_filter(
+                    array_map('intval', $ids),
+                    function ($id) {
+                        return $id > 0;
+                    }
+                )
+            )
+        );
+    }
+}

--- a/packages/web/src/Items/Group.php
+++ b/packages/web/src/Items/Group.php
@@ -13,6 +13,7 @@
 
 namespace FOG\Items;
 
+use FOG\Assign\Resolver;
 use FOG\Base\FOGController;
 use FOG\Boot\SecureBootState;
 use FOG\Boot\UbootTftpSync;
@@ -968,28 +969,28 @@ class Group extends FOGController
         if ($snapin === false) {
             return;
         }
-        $find = ['hostID' => $this->get('hosts')];
-        $hostIDs = $find['hostID'];
+        $hostIDs = $this->get('hosts');
         $snapins = [];
         $snapinJobs = [];
-        // GH-707: the "all snapins" case used to query snapinAssoc once per
-        // member host inside the loop below -- a thousand round trips for a
-        // thousand-host group. The association table answers every host in
-        // one pass, so read it once here and index it by host; the loop then
-        // just looks the host up.
+        // ADR 0038 decision 4: the "all snapins" list is RESOLVED here, at
+        // task creation, and what it resolves to is written onto the task.
+        // `snapinTasks` is already the snapshot -- it carries the snapin and
+        // its sequence per row -- so nothing about the task side changes.
+        // What changed is only where the list comes from: the host's own
+        // associations plus whatever its groups GRANT, in the one order
+        // Resolver promises. A group edited while a task is in flight does
+        // not change that task; re-tasking is the only way to pick a change
+        // up.
+        //
+        // Still one pass over the whole membership, which is not incidental.
+        // GH-707 was this exact code querying snapinAssoc once per member
+        // host inside the loop below -- a thousand round trips for a
+        // thousand-host group -- and a resolver taking one host at a time
+        // would have reintroduced it here first. That is why resolveSnapins()
+        // takes a set.
         $assocByHost = [];
         if ($snapin == -1) {
-            $assocs = Route::getIds(
-                'snapinassociation',
-                $find,
-                ['hostID', 'snapinID'],
-                'AND',
-                'sequence'
-            );
-            foreach ($assocs as $assoc) {
-                $assocByHost[$assoc['hostID']][] = $assoc['snapinID'];
-            }
-            unset($assocs);
+            $assocByHost = Resolver::resolveSnapins($hostIDs);
         }
         foreach ($hostIDs as $hostID) {
             if ($snapin == -1) {

--- a/packages/web/src/Items/Host.php
+++ b/packages/web/src/Items/Host.php
@@ -13,6 +13,7 @@
 
 namespace FOG\Items;
 
+use FOG\Assign\Resolver;
 use FOG\Base\FOGController;
 use FOG\Boot\SecureBootState;
 use FOG\Boot\UbootTftpSync;
@@ -950,9 +951,23 @@ class Host extends FOGController
         $Task = false
     ) {
         try {
+            // ADR 0038 decision 4. The "all snapins" list is RESOLVED once,
+            // here, and written onto the task: the host's own associations
+            // plus whatever its groups grant, in the order Resolver
+            // promises. `snapinTasks` is already the snapshot, so a group
+            // edited while this task is in flight does not change it --
+            // re-tasking is the only way to pick a change up.
+            //
+            // Resolved ONCE and reused below rather than read twice. The old
+            // code called $this->get('snapins') here for the emptiness guard
+            // and again further down for the ids, which was harmless when
+            // both came off the same loaded property and is not once the
+            // answer involves a query.
+            $resolved = [];
             if (-1 == $snapin) {
-                $snapins = $this->get('snapins');
-                if (count($snapins ?: []) <= 0) {
+                $hostID = (int)$this->get('id');
+                $resolved = Resolver::resolveSnapins([$hostID])[$hostID] ?? [];
+                if (count($resolved) <= 0) {
                     throw new \Exception(_('No snapins associated'));
                 }
             }
@@ -980,7 +995,7 @@ class Host extends FOGController
             $insert_fields = ['jobID', 'stateID', 'snapinID', 'sequence'];
             $insert_values = [];
             if ($snapin == -1) {
-                $snapin = $this->get('snapins');
+                $snapin = $resolved;
             }
             // Drop any 0/blank snapin id before it becomes a snapintask row
             // that renders as a phantom "null" snapin. Mirrors the same guard

--- a/phpstan-tests-baseline.neon
+++ b/phpstan-tests-baseline.neon
@@ -55,6 +55,12 @@ parameters:
 			path: tests/arch-compatibility.test.php
 
 		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/assign-resolver.test.php
+
+		-
 			message: '#^Result of \|\| is always false\.$#'
 			identifier: booleanOr.alwaysFalse
 			count: 1

--- a/tests/assign-resolver.test.php
+++ b/tests/assign-resolver.test.php
@@ -1,0 +1,440 @@
+<?php
+/**
+ * Proves FOG\Assign\Resolver resolves the order ADR 0038 decision 6 promises.
+ *
+ * The resolver is the single place that answers "what is this host actually
+ * assigned". Everything it gets wrong is silent: a snapin runs in the wrong
+ * order, a printer quietly disappears from a machine, a host with no primary
+ * MAC resolves to nothing. None of those raise anything, so the only way to
+ * know is to seed a database and read the answer back.
+ *
+ * Seeds a scratch database with the REAL table definitions, lifted out of
+ * commons/schema-expected.php rather than retyped, so a column that changes
+ * shape cannot leave this test passing against a table nobody has any more.
+ *
+ * WHAT EACH CASE IS ABLE TO CATCH -- every one of these was made to fail
+ * before it was kept:
+ *
+ *   1-2  host-direct order, sequence first. The saID tiebreak underneath
+ *        it is check 13 and is pinned differently -- see the comment there,
+ *        because a behavioral assertion genuinely cannot cover it.
+ *   3-4  group grants come after host-direct, and groups run in groupOrder
+ *        order rather than alphabetical -- the specific thing decision 6
+ *        exists to guarantee, since a rename must never reorder installs.
+ *   5    the groupName tiebreak, for the install that never sets an order.
+ *   6    dedupe keeps the HOST's position, not the group's.
+ *   7    a host id with nothing still comes back as a key. A missing key and
+ *        an empty list want opposite handling at the call site.
+ *   8    a host that exists ONLY in the association tables still resolves.
+ *        This is the manager-bypass property standing in for the primary-MAC
+ *        drop: the moment someone rewrites a read to go through a manager,
+ *        the class chain reaches Host, `hostMAC.hmPrimary = '1'` lands in the
+ *        WHERE, and hosts start vanishing from their own printer lists.
+ *   9-11 printer default precedence: host-direct wins, otherwise the first
+ *        group in the resolved order that names one, otherwise null.
+ *   12   a failed query THROWS. Decision 9: an empty list is a legitimate
+ *        answer meaning "no printers", so a resolver that returns one on
+ *        failure strips the fleet under printer mode `ar`, one machine at a
+ *        time, for as long as nobody notices.
+ *
+ * Skips without FOG_TEST_DSN, exactly as tests/schema-executes.test.php does.
+ *
+ * Usage: FOG_TEST_DSN=... php tests/assign-resolver.test.php
+ * Exit status 0 = pass or skip, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$dsn = getenv('FOG_TEST_DSN');
+if ($dsn === false || $dsn === '') {
+    echo "SKIP  no FOG_TEST_DSN set; the resolver is not checked on a server\n";
+    exit(0);
+}
+if (!in_array('mysql', \PDO::getAvailableDrivers(), true)) {
+    fwrite(STDERR, "FAIL: FOG_TEST_DSN is set but the pdo_mysql driver is missing.\n");
+    exit(1);
+}
+
+$user = getenv('FOG_TEST_USER');
+$pass = getenv('FOG_TEST_PASS');
+$user = ($user === false) ? 'root' : $user;
+$pass = ($pass === false) ? '' : $pass;
+
+$root = dirname(__DIR__);
+$webroot = $root . '/packages/web';
+
+// A scratch database, never the one the DSN names. This one plants and drops
+// tables, so it must not be able to land in a real FOG database even if the
+// DSN points at one.
+$db = 'fog_assign_resolver_test';
+
+$tmp = sys_get_temp_dir() . '/fog-assign-resolver-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
+register_shutdown_function(
+    function () use ($tmp) {
+        if (!is_dir($tmp)) {
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($tmp, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $f) {
+            $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+        }
+        @rmdir($tmp);
+    }
+);
+if (!defined('FOG_CACHE_DIR')) {
+    define('FOG_CACHE_DIR', $tmp . '/cache');
+}
+if (!defined('FOG_LOG_DIR')) {
+    define('FOG_LOG_DIR', $tmp . '/log');
+}
+if (!defined('FOG_PLUGIN_DIR')) {
+    define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+}
+
+$init = $webroot . '/commons/init.php';
+if (!is_readable($init)) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+require_once $init;
+new Initiator();
+
+$checks = 0;
+$failures = [];
+$check = static function ($what, $ok) use (&$checks, &$failures) {
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+};
+
+try {
+    $pdo = new \PDO(
+        $dsn,
+        $user,
+        $pass,
+        [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]
+    );
+} catch (\PDOException $e) {
+    fwrite(STDERR, 'FAIL: cannot connect: ' . $e->getMessage() . "\n");
+    exit(1);
+}
+
+/**
+ * The `self::$DB` the resolver talks to, over a real PDO handle.
+ *
+ * Mirrors the PDODB contract the resolver actually depends on and NOTHING
+ * else: query() records a message on ->error instead of throwing, fetch()
+ * takes a fetch style plus the 'fetch_all' marker, and get() returns the
+ * rows. ->error being a MESSAGE on failure and the boolean false on success
+ * is the part that matters -- the resolver tests `false !== $res->error`,
+ * and a stub that used a plain boolean would let a broken check pass.
+ */
+class ResolverTestDB
+{
+    /** @var \PDO */
+    public $pdo;
+
+    /** @var string|bool false when the last statement succeeded */
+    public $error = false;
+
+    /** @var \PDOStatement|null */
+    private $_stmt = null;
+
+    /** @var bool */
+    private $_all = false;
+
+    public function __construct(\PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function query($sql = null, $data = [], $params = [])
+    {
+        $this->error = false;
+        $this->_stmt = null;
+        try {
+            $this->_stmt = $this->pdo->prepare((string)$sql);
+            $this->_stmt->execute($params ?: null);
+        } catch (\PDOException $e) {
+            $this->_stmt = null;
+            $this->error = $e->getMessage();
+        }
+        return $this;
+    }
+
+    public function fetch($type = null, $fetchType = null, $params = false)
+    {
+        $this->_all = ('fetch_all' === $fetchType);
+        return $this;
+    }
+
+    public function get($key = null)
+    {
+        if (null === $this->_stmt) {
+            return null;
+        }
+        return $this->_all
+            ? $this->_stmt->fetchAll(\PDO::FETCH_ASSOC)
+            : $this->_stmt->fetch(\PDO::FETCH_ASSOC);
+    }
+}
+
+$pdo->exec("DROP DATABASE IF EXISTS `$db`");
+$pdo->exec("CREATE DATABASE `$db`");
+register_shutdown_function(
+    function () use ($pdo, $db) {
+        try {
+            $pdo->exec("DROP DATABASE IF EXISTS `$db`");
+        } catch (\PDOException $e) {
+            // best effort; the scratch database is named, not guessed
+        }
+    }
+);
+$pdo->exec("USE `$db`");
+
+// The real definitions, not retyped ones. schema-expected.php is generated
+// DATA, so a table that changes shape changes here too rather than leaving
+// this test green against a table that no longer exists in that form.
+$manifest = include $webroot . '/commons/schema-expected.php';
+$expected = $manifest['tables'] ?? [];
+$need = [
+    'groups',
+    'groupMembers',
+    'snapinAssoc',
+    'printerAssoc',
+    'groupSnapinAssoc',
+    'groupPrinterAssoc',
+];
+foreach ($need as $table) {
+    if (!isset($expected[$table]['create'])) {
+        fwrite(
+            STDERR,
+            "FAIL: commons/schema-expected.php has no `$table`; regenerate it\n"
+        );
+        exit(1);
+    }
+    $pdo->exec($expected[$table]['create']);
+}
+
+$dbProp = new \ReflectionProperty(\FOG\Base\FOGBase::class, 'DB');
+$dbProp->setAccessible(true);
+$dbProp->setValue(null, new ResolverTestDB($pdo));
+
+/*
+ * The scenario, chosen so that the RIGHT answer and the several plausible
+ * WRONG ones are different lists rather than the same list in a different
+ * order.
+ *
+ * THE IDS FIGHT THE ANSWER ON PURPOSE. Ordering by groupID alone, or by
+ * groupName alone, must each produce a DIFFERENT list from the right one --
+ * otherwise the assertions pass under a resolver that ignores groupOrder
+ * entirely, which is the single thing decision 6 is about. A first cut of
+ * this test had group ids running 1,2,3 in resolved order, and ordering by
+ * id alone sailed through it.
+ *
+ * groups, and the order they must resolve in:
+ *   3  'zebra'     groupOrder 1  -> first,  though last by name and by id
+ *   1  'middle'    groupOrder 5  -> second, though first by id
+ *   2  'aaa-last'  groupOrder 9  -> third,  though first by name
+ *   5  'alpha'     groupOrder 0  \ both sit at 0, so they fall to the name
+ *   4  'beta'      groupOrder 0  / tiebreak: alpha(5) before beta(4), which
+ *                                  is the opposite of their id order
+ *
+ * host 10 is in groups 1, 2, 3 and has three direct snapins.
+ * host 11 is in groups 4 and 5 only.
+ * host 12 is in no group and has nothing.
+ * host 13 exists ONLY here -- no `hosts` row at all.
+ */
+$pdo->exec(
+    "INSERT INTO `groups` (`groupID`,`groupName`,`groupOrder`) VALUES "
+    . "(3,'zebra',1),(1,'middle',5),(2,'aaa-last',9),"
+    . "(5,'alpha',0),(4,'beta',0)"
+);
+$pdo->exec(
+    "INSERT INTO `groupMembers` (`gmHostID`,`gmGroupID`) VALUES "
+    . "(10,1),(10,2),(10,3),(11,4),(11,5),(13,3)"
+);
+
+// Both direct rows sit at sequence 0 on purpose: that is what every row
+// written before appendSnapinSequence() numbered them looks like, and the
+// saID tiebreak is the only thing that makes the answer repeatable.
+$pdo->exec(
+    "INSERT INTO `snapinAssoc` (`saID`,`saHostID`,`saSnapinID`,`saSequence`) "
+    . "VALUES (1,10,700,0),(2,10,701,0),(3,10,702,5)"
+);
+// 701 is ALSO granted by group 1. It must stay at the host's position
+// (second), not move to where the group would put it.
+$pdo->exec(
+    "INSERT INTO `groupSnapinAssoc` "
+    . "(`gsaID`,`gsaGroupID`,`gsaSnapinID`,`gsaSequence`) VALUES "
+    . "(1,3,800,2),(2,3,801,1),(3,3,701,3),"
+    . "(4,1,810,0),(5,2,820,0),"
+    . "(6,5,830,0),(7,4,840,0)"
+);
+
+$resolved = \FOG\Assign\Resolver::resolveSnapins([10, 11, 12, 13]);
+
+// 1-2: host-direct first, sequence then id. 702 has sequence 5 so it sorts
+// after both zero-sequence rows; 700 before 701 on id alone.
+$check(
+    'host-direct snapins lead the list, ordered by sequence then id',
+    array_slice($resolved[10] ?? [], 0, 3) === [700, 701, 702]
+);
+// 3-4-6: then groups in groupOrder order -- zebra(1), middle(5), aaa-last(9)
+// -- and within group 1 by gsaSequence: 801(1), 800(2), then 701 which is
+// dropped as a duplicate because the host already placed it.
+$check(
+    'group grants follow, groups in groupOrder and grants in gsaSequence',
+    ($resolved[10] ?? []) === [700, 701, 702, 801, 800, 810, 820]
+);
+$check(
+    'a snapin granted twice keeps the position the HOST gave it',
+    array_search(701, $resolved[10] ?? [], true) === 1
+);
+// 5: groups 4 and 5 both sit at groupOrder 0, so alpha precedes beta.
+$check(
+    'groups at the same groupOrder fall back to groupName',
+    ($resolved[11] ?? []) === [830, 840]
+);
+// 7: present as a key, empty as a value.
+$check(
+    'a host with nothing is still a key in the result',
+    array_key_exists(12, $resolved) && [] === $resolved[12]
+);
+// 8: host 13 has no `hosts` row and no MAC. It must still resolve.
+$check(
+    'a host with no hosts row still resolves from its associations',
+    ($resolved[13] ?? null) === [801, 800, 701]
+);
+
+/*
+ * Printers. paIsDefault is varchar(2) here, which is what a 1.5-origin
+ * database still carries, so the values planted are the strings it really
+ * holds rather than ints that happen to compare equal.
+ *
+ * host 10: three direct printers, one of them the default -> direct wins.
+ *          The two that are NOT the default carry '0' and '' respectively,
+ *          which are both spellings a 1.5-origin varchar(2) column really
+ *          holds. A comparison loose enough to read either as truthy makes
+ *          the FIRST printer the default, which is a wrong answer nothing
+ *          would report.
+ * host 11: no direct printers; group 4 (alpha, first) names no default,
+ *          group 5 (beta) does -> beta's default, and only because alpha
+ *          declined it.
+ * host 12: nothing at all -> null, not an error.
+ */
+$pdo->exec(
+    "INSERT INTO `printerAssoc` (`paID`,`paHostID`,`paPrinterID`,`paIsDefault`) "
+    . "VALUES (1,10,900,'0'),(2,10,901,'1'),(3,10,902,'')"
+);
+$pdo->exec(
+    "INSERT INTO `groupPrinterAssoc` "
+    . "(`gpaID`,`gpaGroupID`,`gpaPrinterID`,`gpaIsDefault`) VALUES "
+    . "(1,3,910,1),(2,1,901,0),(3,5,920,0),(4,4,930,1)"
+);
+
+$printers = \FOG\Assign\Resolver::resolvePrinters([10, 11, 12]);
+
+$check(
+    'printers list host-direct first, then group grants, deduplicated',
+    ($printers[10]['printers'] ?? null) === [900, 901, 902, 910]
+);
+// 9: group 1 declares 910 the default, but the host declared 901. The host
+// wins, and this is the case that would silently flip a thousand desktops.
+$check(
+    'a host-direct default beats a group default',
+    ($printers[10]['default'] ?? null) === 901
+);
+// 10: no host-direct default, so the first group in the resolved order that
+// names one. alpha comes first and names none, so beta's stands.
+$check(
+    'with no host default, the first group in order that names one wins',
+    ($printers[11]['default'] ?? null) === 930
+        && ($printers[11]['printers'] ?? null) === [920, 930]
+);
+// 11: nothing is a legitimate answer, and it is not an error.
+$check(
+    'a host with no printers resolves to an empty list and a null default',
+    array_key_exists(12, $printers)
+        && [] === $printers[12]['printers']
+        && null === $printers[12]['default']
+);
+
+/*
+ * 13: the saID tiebreak, pinned STRUCTURALLY, which needs justifying because
+ * this file otherwise refuses to assert on source text.
+ *
+ * The defect that clause guards is NONDETERMINISM: two snapinAssoc rows both
+ * sitting at saSequence 0, which is every row written before
+ * appendSnapinSequence() numbered them. Remove `saID` from the ORDER BY and
+ * this test still passes -- verified, not assumed -- because InnoDB hands
+ * back clustered-index order, which happens to BE id order. A behavioral
+ * assertion cannot tell "ordered by id" from "the engine felt like it", so a
+ * green run proves nothing about the clause and the test would be claiming
+ * coverage it does not have.
+ *
+ * So the clause itself is the assertion. It anchors the whole ORDER BY rather
+ * than grepping for the column name, so a rewrite that reorders the keys is a
+ * visible failure rather than a passing grep.
+ */
+$source = (string)file_get_contents(
+    $root . '/packages/web/src/Assign/Resolver.php'
+);
+$check(
+    'the host-direct read still breaks its sequence tie on saID',
+    false !== strpos(
+        $source,
+        'ORDER BY `saHostID`, `saSequence`, `saID`'
+    )
+);
+
+// 12: the decision-9 gate. A failed read must not look like "no printers".
+$pdo->exec('DROP TABLE `groupPrinterAssoc`');
+$threw = false;
+$message = '';
+try {
+    \FOG\Assign\Resolver::resolvePrinters([10, 11]);
+} catch (\RuntimeException $e) {
+    $threw = true;
+    $message = $e->getMessage();
+}
+// The message is asserted, not just the throw: a RuntimeException escaping
+// from somewhere else in the call would satisfy a bare catch and leave the
+// thing this check exists for -- the resolver refusing to answer -- unproven.
+$check(
+    'a failed query throws rather than resolving to an empty list',
+    $threw && 0 === strpos($message, 'Assignment resolution failed')
+);
+
+$pdo->exec('DROP TABLE `groupSnapinAssoc`');
+$threw = false;
+try {
+    \FOG\Assign\Resolver::resolveSnapins([10]);
+} catch (\RuntimeException $e) {
+    $threw = true;
+}
+$check('a failed snapin read throws too', $threw);
+
+if (count($failures)) {
+    fwrite(STDERR, "FAIL: the resolver did not order what it promises:\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    fwrite(STDERR, sprintf("%d of %d checks failed\n", count($failures), $checks));
+    exit(1);
+}
+
+printf("PASS  assign resolver: %d checks\n", $checks);
+exit(0);

--- a/tests/task-creation-resolves-assignments.test.php
+++ b/tests/task-creation-resolves-assignments.test.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Pins both snapin-tasking paths to the resolver.
+ *
+ * ADR 0038 decision 4: the ordered snapin list is computed WHEN A TASK IS
+ * CREATED and written onto the task. There are two places that create snapin
+ * tasking -- Host::_createSnapinTasking() for one host, and
+ * Group::_createSnapinTasking() for a whole membership -- and the defect this
+ * guards against is one of them quietly going back to reading a host's own
+ * associations. That is not a crash. It is a group grant that applies to
+ * every host tasked one way and to none tasked the other, which looks like
+ * flaky snapins and is diagnosed by nobody.
+ *
+ * WHAT THIS IS AND IS NOT. This asserts on SOURCE TEXT, which this suite
+ * normally refuses to do, so the reason has to be better than convenience.
+ * The resolver's BEHAVIOR -- the order, the dedupe, the throw -- is covered
+ * behaviorally and at length by tests/assign-resolver.test.php against a real
+ * database. What is left over is exactly the question source text can answer
+ * and a unit test cannot reach without standing up a configured FOG: does
+ * this call site still call it. Constructing a Host far enough to reach
+ * _createSnapinTasking() needs a live config, a task, a snapin job and a
+ * schema, at which point the test is an install rehearsal rather than a gate.
+ *
+ * So the assertions anchor WHOLE STATEMENTS rather than grepping for the
+ * class name. A grep for "Resolver" passes against a resolver call sitting
+ * dead above the old association read; anchoring the assignment and the
+ * absence of the old read together does not.
+ *
+ * Usage: php tests/task-creation-resolves-assignments.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+$src = $root . '/packages/web/src';
+
+$checks = 0;
+$failures = [];
+$check = static function ($what, $ok) use (&$checks, &$failures) {
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+};
+
+$read = static function ($path) {
+    $body = @file_get_contents($path);
+    if (false === $body) {
+        fwrite(STDERR, "FAIL: cannot read $path\n");
+        exit(1);
+    }
+    return (string)$body;
+};
+
+$group = $read($src . '/Items/Group.php');
+$host = $read($src . '/Items/Host.php');
+
+/**
+ * Returns just the body of a method, so an assertion about "this method does
+ * not read snapinAssoc" cannot be satisfied or broken by an unrelated method
+ * in the same file that legitimately does.
+ */
+$method = static function ($source, $signature) {
+    $start = strpos($source, $signature);
+    if (false === $start) {
+        return null;
+    }
+    $open = strpos($source, '{', $start);
+    if (false === $open) {
+        return null;
+    }
+    $depth = 0;
+    $len = strlen($source);
+    for ($i = $open; $i < $len; $i++) {
+        if ('{' === $source[$i]) {
+            $depth++;
+        } elseif ('}' === $source[$i]) {
+            $depth--;
+            if (0 === $depth) {
+                return substr($source, $open, $i - $open + 1);
+            }
+        }
+    }
+    return null;
+};
+
+$groupBody = $method($group, 'private function _createSnapinTasking(');
+$hostBody = $method($host, 'private function _createSnapinTasking(');
+
+$check(
+    'Group::_createSnapinTasking() is still findable',
+    null !== $groupBody
+);
+$check(
+    'Host::_createSnapinTasking() is still findable',
+    null !== $hostBody
+);
+if (null === $groupBody || null === $hostBody) {
+    fwrite(STDERR, "FAIL: a tasking method moved or was renamed; this test is\n");
+    fwrite(STDERR, "      pinning nothing until its signatures are updated.\n");
+    exit(1);
+}
+
+// The group path. The whole assignment is anchored, not the class name: a
+// resolver call whose result is thrown away would satisfy a looser check.
+$check(
+    'the group path resolves the whole membership in one call',
+    false !== strpos(
+        $groupBody,
+        '$assocByHost = Resolver::resolveSnapins($hostIDs);'
+    )
+);
+// ...and it must pass the SET. A resolver called per host inside the loop is
+// GH-707 returning: a thousand round trips for a thousand-host group. That
+// is why the signature takes an array, and why this is worth its own check.
+$check(
+    'the group path does not resolve one host at a time',
+    false === strpos($groupBody, 'resolveSnapins([$hostID]')
+);
+$check(
+    'the group path no longer reads snapinassociation itself',
+    false === stripos($groupBody, 'snapinassociation')
+);
+
+// The host path. Resolved once into a local and reused, rather than read
+// twice: the emptiness guard and the id list must agree, and they only
+// certainly agree if they are the same value.
+$check(
+    'the host path resolves through the resolver',
+    false !== strpos(
+        $hostBody,
+        '$resolved = Resolver::resolveSnapins([$hostID])[$hostID] ?? [];'
+    )
+);
+$check(
+    'the host path tasks what it resolved',
+    false !== strpos($hostBody, '$snapin = $resolved;')
+);
+$check(
+    'the host path no longer tasks the raw snapins property',
+    false === strpos($hostBody, "\$snapin = \$this->get('snapins');")
+);
+
+// Both files must actually import it. A fully-qualified call would work and
+// would also be the first sign somebody pasted the line in without meaning
+// to, so the import is required rather than tolerated.
+$check(
+    'Group.php imports the resolver',
+    false !== strpos($group, 'use FOG\Assign\Resolver;')
+);
+$check(
+    'Host.php imports the resolver',
+    false !== strpos($host, 'use FOG\Assign\Resolver;')
+);
+
+// The resolver has to exist under the name both files import, which is the
+// one thing here that would otherwise be caught only at runtime, on a server,
+// during a deploy.
+$check(
+    'the resolver is where those imports say it is',
+    is_readable($src . '/Assign/Resolver.php')
+        && false !== strpos(
+            $read($src . '/Assign/Resolver.php'),
+            'namespace FOG\Assign;'
+        )
+);
+
+if (count($failures)) {
+    fwrite(STDERR, "FAIL: snapin tasking no longer resolves assignments:\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    fwrite(
+        STDERR,
+        sprintf("%d of %d checks failed\n", count($failures), $checks)
+    );
+    exit(1);
+}
+
+printf("PASS  task creation resolves assignments: %d checks\n", $checks);
+exit(0);


### PR DESCRIPTION
ADR 0038 decision 4. **Stacked on #1611** (the resolver) — merge that first; this branch contains its commit, so the diff here is the wiring only once #1611 lands.

Both snapin-tasking paths now ask the resolver what a host is assigned instead of reading the host's own associations. What a group GRANTS reaches its members without anything being copied onto them, and a host added to the group tomorrow is covered by the same grant.

## The task side does not change

Worth saying out loud, because it sounds like it should. `snapinTasks` was already the snapshot — it carries the snapin and its sequence per row — so what a task records is still exactly what was decided when it was created.

**A group edited while a task is in flight does not change that task. Re-tasking is the only way to pick a change up.** Everyone will assume live evaluation and be wrong, so the docs say it in those words.

## Two things that are not tidiness

`Group::_createSnapinTasking()` resolves the **whole membership in one call**. GH-707 was this exact code querying `snapinAssoc` once per member host inside the loop — a thousand round trips for a thousand-host group. A resolver taking one host at a time would have reintroduced it here first; that is why `resolveSnapins()` takes a set, and the test has a check specifically for the per-host shape.

`Host::_createSnapinTasking()` resolves **once** into a local and reuses it. The old code read `$this->get(snapins)` twice, once for the emptiness guard and once for the ids — harmless when both came off the same loaded property, not once the answer involves a query.

## The test asserts on source text, and says why

`tests/task-creation-resolves-assignments.test.php` pins both call sites. This suite otherwise refuses source assertions, so the docblock justifies it: the resolver's behavior is covered behaviorally against a real database in #1611, and what is left over is the one question source text can answer and a unit test cannot reach without standing up a configured FOG — *does this call site still call it*. Reaching `_createSnapinTasking()` needs a live config, a task, a snapin job and a schema, at which point the test is an install rehearsal rather than a gate.

The assertions anchor **whole statements**, not the class name, so a resolver call left dead above a restored association read does not satisfy them. Four mutations confirm it: reverting either path, and resolving per host in the group loop, each turn it red.

## Not in this PR

Printers. That half carries a wire-format decision and a client behavior nobody has watched happen (UNKNOWN-4 in the proposal), so it ships on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)