### PR TITLE
feat: one-click Deploy/Capture/Multi-Cast on the host list

### DIFF
--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -4162,6 +4162,17 @@ $.fn.registerTable = function(onSelect, opts) {
     defaults.dom = "<'row'<'col-sm-6'><'col-sm-6'f>>B<'row'<'col-sm-12'tr>><'row'<'col-sm-12'i>>";
   }
 
+  // Page-specific buttons, APPENDED to the shared set rather than replacing
+  // it. Passing `buttons` in opts cannot do this: fogDefaults() is a shallow
+  // merge, so a page that supplied its own array would silently lose Select
+  // All, the search builder, saved filters, column search, column visibility
+  // and Refresh. Pulled off opts for the same reason columnResize is --
+  // DataTables has no such option and would only carry it around.
+  if (opts.extraButtons && opts.extraButtons.length) {
+    defaults.buttons = defaults.buttons.concat(opts.extraButtons);
+  }
+  delete opts.extraButtons;
+
   // Column resizing is on for every table. Pulled off opts before they reach
   // DataTables, which has no such option and would only carry it around.
   var columnResize = opts.columnResize !== false;

--- a/packages/web/management/js/fog/host/fog.host.list.js
+++ b/packages/web/management/js/fog/host/fog.host.list.js
@@ -23,8 +23,9 @@
     disableButtons(true);
 
     function onSelect(selected) {
-        var disabled = selected.count() == 0;
-        disableButtons(disabled);
+        var count = selected.count();
+        disableButtons(count == 0);
+        applyQuickAvailability(count);
     }
 
     function loadGroupSelect(){
@@ -288,7 +289,127 @@
         });
     }
 
+    // ---------------------------------------------------------------
+    // QUICK TASKS
+    //
+    // One click, one task. The Queue Task button in the toolbar stays and is
+    // still the way to reach anything that needs options -- a snapin choice,
+    // an account to reset, a debug session. These three need none, so making
+    // somebody open a modal, pick the type and then confirm a form with
+    // nothing on it is three clicks spent on a decision already made.
+    //
+    // They sit in the grid's own button bar, under the search box, rather
+    // than in the toolbar with Delete/Queue Task/Add. That bar is where the
+    // controls that act on the SELECTION already live (Select All, Deselect
+    // All), and it is the strip a person's eye is on while they are ticking
+    // rows.
+    //
+    // Which ones are usable is decided by how many rows are ticked, using
+    // the ttIsAccess value the SERVER put on each entry rather than a rule
+    // written again here: 'host' (Capture) means exactly one row, 'group'
+    // (Multi-Cast) means two or more, 'both' (Deploy) means any. The Queue
+    // Task modal filters on the same value and deployMultiPost() refuses on
+    // it, so all three agree by construction and a button that somehow
+    // slipped through enabled still cannot create a task the server would
+    // not have made anyway.
+    var quickTasks = $('#quick-task-data .quicktaskitem').map(function() {
+        var el = $(this);
+        return {
+            type: el.attr('data-type'),
+            access: el.attr('data-access'),
+            icon: el.attr('data-icon'),
+            name: el.attr('data-name'),
+            // The handle enable()/disable() addresses the button by. Class
+            // rather than index because the shared button set sits in front
+            // of these and an index would move the day one is added there.
+            cls: 'quicktask-' + el.attr('data-type')
+        };
+    }).get();
+
+    function quickTaskUsable(access, count) {
+        if (count < 1) {
+            return false;
+        }
+        if (access === 'group') {
+            return count > 1;
+        }
+        if (access === 'host') {
+            return count === 1;
+        }
+        return true;
+    }
+
+    // Gray the ones this many rows cannot run, rather than hiding them. The
+    // Queue Task modal hides its rows because it is a list of everything the
+    // server offers and an unusable entry there is noise; here there are
+    // three fixed buttons in a fixed order, and a button that disappears and
+    // comes back as you tick rows is harder to aim at than one that grays.
+    function applyQuickAvailability(count) {
+        if (!quickTasks.length) {
+            return;
+        }
+        $.each(quickTasks, function(i, task) {
+            table.buttons('.' + task.cls)
+                .enable(quickTaskUsable(task.access, count));
+        });
+    }
+
+    // Guards the window between the click and the server's answer. The
+    // button stays enabled underneath -- disabling it would fight
+    // applyQuickAvailability() on the deselect that follows -- so without
+    // this an impatient double-click is two identical taskings.
+    var quickTaskRunning = false;
+
+    function runQuickTask(task, dt) {
+        var hosts = $.getSelectedIds(dt);
+        if (quickTaskRunning || !quickTaskUsable(task.access, hosts.length)) {
+            return;
+        }
+        quickTaskRunning = true;
+        // Straight to the create. deployMulti (the options form) is skipped
+        // deliberately: there is nothing on it these three types need, and
+        // fetching it only to post it back unchanged is the click this
+        // feature exists to remove. Everything the form's POST is checked
+        // for -- site scope, pending hosts, an assigned and enabled image,
+        // one image across a multicast -- is checked in deployMultiPost(),
+        // not in the form, so nothing is skipped but the rendering.
+        $.apiCall(
+            'post',
+            '../management/index.php?node=host&sub=deployMulti&type='
+                + encodeURIComponent(task.type),
+            {hosts: hosts},
+            function(err) {
+                quickTaskRunning = false;
+                if (err) {
+                    // Keep the selection. The refusal is nearly always
+                    // something about these hosts that the person is about
+                    // to go and fix, and losing the ticks means finding them
+                    // again.
+                    return;
+                }
+                dt.rows({selected: true}).deselect();
+            }
+        );
+    }
+
+    var quickButtons = $.map(quickTasks, function(task) {
+        return {
+            // Escaped: both values are shown as markup here, and a task type
+            // name is admin-editable text from the taskTypes table.
+            text: '<i class="fas fa-' + $.escapeHtml(task.icon) + '"></i> '
+                + $.escapeHtml(task.name),
+            className: task.cls,
+            // Nothing is ticked on first draw, so every one of them starts
+            // grayed rather than enabled-then-corrected on the first select.
+            enabled: false,
+            action: function(e, dt) {
+                runQuickTask(task, dt);
+            }
+        };
+    });
+
     var table = $('#dataTable').registerTable(onSelect, {
+        extraButtons: quickButtons,
         // Sort on the host name. Named rather than numbered for the same
         // reason columnDefs is: the position moves when a column is added
         // or gated, and a stale index silently sorts the wrong column.

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -1845,6 +1845,11 @@ abstract class FOGPage extends FOGBase
                         $queue = $this->queueTaskActions();
                         $actionbox .= $queue['button'];
                         $modals .= $queue['modal'];
+                        // Hidden data, not markup: the one-click task
+                        // buttons are drawn by the browser into the grid's
+                        // own button bar, and this is what tells it which
+                        // ones to draw. Empty when the page offers none.
+                        $modals .= $queue['quick'] ?? '';
                     }
                     if (method_exists($this, 'addModal')) {
                         if ($node == 'host') {

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -131,7 +131,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 405);
-        define('FOG_BCACHE_VER', 355);
+        define('FOG_BCACHE_VER', 356);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -4508,7 +4508,74 @@ class HostManagement extends FOGPage
             'modal-lg'
         );
 
-        return ['button' => $button, 'modal' => $modal];
+        return [
+            'button' => $button,
+            'modal' => $modal,
+            'quick' => $this->_quickTaskItems()
+        ];
+    }
+    /**
+     * The one-click task types offered beside the grid's own controls.
+     *
+     * Data only -- the buttons themselves are built by the browser, because
+     * they live in the DataTables button bar under the search box and that
+     * bar does not exist until the grid initializes. What the server owns is
+     * the part the browser cannot know: which of the three types this
+     * install actually has, what each is called in the reader's language,
+     * which icon it carries, and whether the reader may task at all.
+     *
+     * Three types and no more. Deploy and Capture are the pair a single
+     * host wants; Deploy and Multi-Cast are the pair a set of hosts wants.
+     * Anything else stays behind the Queue Task button, which is where a
+     * task that needs options -- a snapin choice, an account to reset, a
+     * debug session -- belongs. These three take no options, which is the
+     * whole reason they can be one click.
+     *
+     * `access` rides along rather than being hardcoded in the script: it is
+     * the same ttIsAccess the Queue Task modal filters on and the same value
+     * assertSelectionTaskable() refuses on, so all three agree by
+     * construction. 'host' shows only for one selected row (Capture),
+     * 'group' only for two or more (Multi-Cast), 'both' for any (Deploy).
+     *
+     * @return string
+     */
+    private function _quickTaskItems()
+    {
+        // ?node=host&sub=deployMulti resolves to host.task
+        // (Authorization::_subToAction maps the 'deploy' prefix), so a user
+        // without it would be shown three buttons that can only be refused.
+        if (!Authorization::can('host.task')) {
+            return '';
+        }
+
+        $items = '';
+        $types = [TaskType::DEPLOY, TaskType::CAPTURE, TaskType::MULTICAST];
+        foreach ($types as $typeId) {
+            $TaskType = self::getClass('TaskType', $typeId);
+            // A server whose taskTypes row was deleted simply loses that
+            // button, the same way the accordion loses the entry.
+            if (!$TaskType->isValid()) {
+                continue;
+            }
+            // get(), not ->prop. These are FOGController instances built
+            // by getClass(); the class has no __get, so a property read
+            // answers null and the whole span comes out blank -- which is
+            // exactly what the first cut of this did. The accordion above
+            // reads properties because ITS objects come from
+            // Route::getList(), which hands back plain decoded objects.
+            $items .= '<span class="quicktaskitem" '
+                . 'data-type="' . (int)$TaskType->get('id') . '" '
+                . 'data-access="' . \Initiator::e($TaskType->get('access'))
+                . '" '
+                . 'data-icon="' . \Initiator::e($TaskType->get('icon')) . '" '
+                . 'data-name="' . \Initiator::e($TaskType->get('name'))
+                . '"></span>';
+        }
+        if ('' === $items) {
+            return '';
+        }
+
+        return '<div id="quick-task-data" class="d-none">' . $items . '</div>';
     }
     /**
      * The task options form for an ad-hoc selection of hosts.

--- a/tests/host-list-quick-tasks.test.php
+++ b/tests/host-list-quick-tasks.test.php
@@ -1,0 +1,290 @@
+<?php
+/**
+ * One-click tasks on the host list: the parts that fail silently.
+ *
+ * The list gained three buttons in the grid's own button bar -- Deploy,
+ * Capture and Multi-Cast -- that create the tasking on a single click,
+ * skipping the Queue Task modal's type picker and options form. The buttons
+ * themselves are drawn by the browser; what the server owns is
+ * HostManagement::_quickTaskItems(), which says WHICH of the three this
+ * install offers, what each is called, and whether the reader may task at
+ * all. Three things about that are worth a test, and each of them is
+ * invisible when it breaks.
+ *
+ * 1. THE PERMISSION. These buttons create taskings, so they are gated on
+ *    `host.task` -- the same permission ?node=host&sub=deployMulti resolves
+ *    to. Losing the gate does not break anything visibly: a reader without
+ *    it simply gets three buttons whose every click is refused, which reads
+ *    as a broken page rather than as a permission problem.
+ *
+ * 2. THE VALUES ARE READ THROUGH get(), NOT AS PROPERTIES. getClass()
+ *    returns a FOGController, and FOGController declares no __get, so
+ *    `$TaskType->name` is null and `(int)$TaskType->id` is 0 -- with no
+ *    warning that survives the page's output buffer. The first cut of this
+ *    emitted three spans reading data-type="0" data-name="", the browser
+ *    drew three nameless buttons, and nothing anywhere said why. The
+ *    accordion above it in the same file DOES read properties, because its
+ *    objects come from Route::getList(); the two shapes look identical at
+ *    the call site.
+ *
+ * 3. WHICH BUTTONS A SELECTION SIZE CAN USE IS THE ttIsAccess VALUE, and
+ *    the whole feature is specified in those terms: one host selected offers
+ *    Deploy and Capture, two or more offers Deploy and Multi-Cast. That is
+ *    written down nowhere -- not in the script, not in the page. It falls
+ *    out of 'both', 'host' and 'group' sitting on those three rows, run
+ *    through the same assertSelectionTaskable() the create is refused by.
+ *    Asserted as the two sets, so that a change to the rule is a change to
+ *    the sentence a reader can check against the screenshot.
+ *
+ *    What this does NOT pin is the seed. The access values come from the
+ *    fixture below, not from taskTypes, so someone editing the seeded
+ *    ttIsAccess would change the buttons and leave this green. That is
+ *    deliberate -- the effective value on an upgraded server is the product
+ *    of several schema steps, and asserting one step's literal would pin the
+ *    wrong thing -- but it is the gap, and it is why the three ids ARE
+ *    pinned in section 2: the set of types is the half this file owns.
+ *
+ * Usage: php tests/host-list-quick-tasks.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+use FOG\Base\FOGCore;
+use FOG\Items\TaskType;
+use FOG\Pages\HostManagement;
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('host-list-quick-tasks');
+
+$db = FogTestHarness::fakeDb();
+
+// The three rows the method asks for, keyed by id. Only the four fields it
+// reads, plus the seed's real ttIsAccess values -- which are the thing under
+// test in section 3, so they are spelled out rather than taken from the
+// running install.
+/**
+ * One taskTypes row. Every column, not just the four the method reads --
+ * FOGController::setQuery() walks $databaseFields and warns on each one it
+ * cannot find, which buries the test's own output.
+ *
+ * @param int    $id     ttID
+ * @param string $name   ttName
+ * @param string $icon   ttIcon
+ * @param string $access ttIsAccess
+ *
+ * @return array
+ */
+$row = static function ($id, $name, $icon, $access) {
+    return [
+        'ttID' => $id,
+        'ttName' => $name,
+        'ttDescription' => $name,
+        'ttIcon' => $icon,
+        'ttKernel' => '',
+        'ttKernelArgs' => '',
+        'ttType' => '',
+        'ttIsAdvanced' => 0,
+        'ttIsAccess' => $access,
+        'ttInitrd' => ''
+    ];
+};
+$rows = [
+    TaskType::DEPLOY => $row(TaskType::DEPLOY, 'Deploy', 'download', 'both'),
+    TaskType::CAPTURE => $row(TaskType::CAPTURE, 'Capture', 'upload', 'host'),
+    TaskType::MULTICAST => $row(
+        TaskType::MULTICAST,
+        'Multi-Cast',
+        'share-alt',
+        'group'
+    )
+];
+// A single flat row, not a list of rows: FOGController::load() reads
+// fetch()->get() as ONE record, and handing it a nested array leaves the
+// object invalid with nothing said.
+$db->responder = static function ($sql, $params) use ($db, $rows) {
+    $db->error = false;
+    if (false === strpos($sql, 'taskTypes')) {
+        return null;
+    }
+    foreach ($params as $value) {
+        if (isset($rows[(int)$value])) {
+            return $rows[(int)$value];
+        }
+    }
+
+    return [];
+};
+
+$t = new FogChecks();
+
+$items = new \ReflectionMethod(HostManagement::class, '_quickTaskItems');
+$items->setAccessible(true);
+$page = new HostManagement();
+
+/**
+ * Runs _quickTaskItems() as a user holding the given permissions.
+ *
+ * @param array $perms the effective permission list for the acting user
+ *
+ * @return string the emitted markup
+ */
+$emit = static function (array $perms) use ($page, $items) {
+    $user = FOGCore::getClass('User')->set('id', 1)->set('name', 'fog');
+    foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
+        FogTestHarness::setStatic($cls, 'FOGUser', $user);
+    }
+    FogTestHarness::setStatic('Authorization', '_permCache', [1 => $perms]);
+
+    return (string)$items->invoke($page);
+};
+
+// -------------------------------------------------------------------------
+// 1. The permission gate.
+// -------------------------------------------------------------------------
+$t->check(
+    'a reader without host.task is offered no quick tasks at all',
+    '' === $emit(['host.view', 'host.edit'])
+);
+$t->check(
+    'host.task alone is enough',
+    false !== strpos($emit(['host.task']), 'quicktaskitem')
+);
+$t->check(
+    'and so is a wildcard',
+    false !== strpos($emit(['*']), 'quicktaskitem')
+);
+
+// -------------------------------------------------------------------------
+// 2. What the markup actually carries.
+// -------------------------------------------------------------------------
+$markup = $emit(['*']);
+
+preg_match_all(
+    '/<span class="quicktaskitem" data-type="(\d+)" data-access="([^"]*)" '
+    . 'data-icon="([^"]*)" data-name="([^"]*)"><\/span>/',
+    $markup,
+    $m,
+    PREG_SET_ORDER
+);
+$emitted = [];
+foreach ($m as $span) {
+    $emitted[(int)$span[1]] = [
+        'access' => $span[2],
+        'icon' => $span[3],
+        'name' => $span[4]
+    ];
+}
+
+$t->check(
+    'exactly the three quick types are offered',
+    [TaskType::DEPLOY, TaskType::CAPTURE, TaskType::MULTICAST]
+    === array_keys($emitted)
+);
+// The get()-versus-property bug, stated as what a reader would see: an id
+// of zero and a nameless button. Every field has to arrive, or the browser
+// draws a control nobody can identify.
+$t->check(
+    'every span carries a real id, name, icon and access',
+    3 === count($emitted)
+    && count(
+        array_filter(
+            $emitted,
+            static function ($row) {
+                return '' !== $row['access']
+                    && '' !== $row['icon']
+                    && '' !== $row['name'];
+            }
+        )
+    ) === 3
+);
+$t->check(
+    'the names are the task types own, not placeholders',
+    'Deploy' === ($emitted[TaskType::DEPLOY]['name'] ?? '')
+    && 'Capture' === ($emitted[TaskType::CAPTURE]['name'] ?? '')
+    && 'Multi-Cast' === ($emitted[TaskType::MULTICAST]['name'] ?? '')
+);
+
+// -------------------------------------------------------------------------
+// 3. The rule the whole feature is specified in: which buttons light up.
+// -------------------------------------------------------------------------
+$assert = new \ReflectionMethod(HostManagement::class, 'assertSelectionTaskable');
+$assert->setAccessible(true);
+
+/**
+ * A stand-in task type carrying one emitted row's access value.
+ *
+ * @param string $access ttIsAccess: both, host or group
+ * @param string $name   the task type's name
+ *
+ * @return object
+ */
+$taskType = static function ($access, $name) {
+    return new class($access, $name) {
+        /** @var array */
+        private $_d;
+
+        /**
+         * @param string $access ttIsAccess value
+         * @param string $name   task type name
+         */
+        public function __construct($access, $name)
+        {
+            $this->_d = ['access' => $access, 'name' => $name];
+        }
+
+        /**
+         * @param string $key the field to read
+         *
+         * @return string
+         */
+        public function get($key)
+        {
+            return $this->_d[$key] ?? '';
+        }
+    };
+};
+
+/**
+ * The names a selection of this size can task, taken from what was emitted
+ * and filtered by the server's own refusal.
+ *
+ * @param int $count how many rows are ticked
+ *
+ * @return array the usable task type names, in emission order
+ */
+$usable = static function ($count) use ($emitted, $assert, $page, $taskType) {
+    $names = [];
+    foreach ($emitted as $row) {
+        try {
+            $assert->invoke($page, $taskType($row['access'], $row['name']), $count);
+            $names[] = $row['name'];
+        } catch (\Exception $e) {
+            continue;
+        }
+    }
+
+    return $names;
+};
+
+$t->check(
+    'one host selected offers Deploy and Capture',
+    ['Deploy', 'Capture'] === $usable(1)
+);
+$t->check(
+    'two hosts selected offers Deploy and Multi-Cast',
+    ['Deploy', 'Multi-Cast'] === $usable(2)
+);
+$t->check(
+    'a large selection is still Deploy and Multi-Cast',
+    ['Deploy', 'Multi-Cast'] === $usable(250)
+);
+
+$t->finish();


### PR DESCRIPTION
## What

Three buttons in the host list's own button bar — under the Search box, beside Select All — that create a tasking on a **single click**. 1.5 had a per-host shortcut for this; 1.6 lost it, and the Queue Task button costs three clicks (open modal → pick type → confirm a form) to reach the same result.

Which ones are live follows the selection:

| Selection | Live | Grayed |
|---|---|---|
| none | — | Deploy, Capture, Multi-Cast |
| 1 host | Deploy, Capture | Multi-Cast |
| 2 or more | Deploy, Multi-Cast | Capture |

That rule is not written twice. It is the `ttIsAccess` value the server already stores — `both` for Deploy, `host` for Capture, `group` for Multi-Cast — which is the same value the Queue Task modal filters on and the same value `assertSelectionTaskable()` refuses on. All three agree by construction.

**Queue Task is unchanged and stays.** It is still the way to reach anything that needs options — a snapin choice, an account to reset, a debug session. These three take no options, which is the whole reason they can be one click.

## How

- `HostManagement::_quickTaskItems()` emits a hidden data block naming the three types with their id, name, icon and access. Gated on `host.task`.
- `FOGPage::process()` carries it out alongside the Queue Task button (one line, `?? ''`, so a page defining only `button`/`modal` is unaffected).
- `fog.host.list.js` builds the buttons from that block and drives `enable()`/`disable()` off the selection count.
- `registerTable()` gains `extraButtons`, **appended** to the shared button set. Passing `buttons` in `opts` cannot do this — `fogDefaults()` is a shallow merge, so the page would have silently lost Select All, Deselect All, Filter, Saved filters, Column search, Column Visibility and Refresh.

**No new endpoint.** The buttons POST straight to the existing `?node=host&sub=deployMulti`, skipping only the options form. Every check that path makes — `host.task`, site scope, pending hosts, an assigned and enabled image, one image across a multicast — lives in `deployMultiPost()`, not in the form. Nothing is skipped but the rendering.

No route added or changed, so `OpenAPI::document()` is untouched.

## Verified

Against the lab database through a shadow tree (nothing written to `/var/www`), on two throwaway hosts whose MACs are locally administered and match no hardware:

- Deploy on 1 host → `201 {"msg":"Tasking created for 1 hosts"}`, body `hosts[]=229`
- Capture on 1 host → `201`, `type=2`
- Multi-Cast on 2 hosts → `201 {"msg":"Tasking created for 2 hosts"}`, **one** session covering both
- The enable/disable table above holds on a direct load *and* on a sidebar (AJAX) navigation, with no page errors
- The seven shared DataTables buttons are all still present
- Fixture hosts, their tasks and the multicast session were removed afterwards; `fog_active_tasks` is empty

`tests/host-list-quick-tasks.test.php` pins the permission gate, the three types emitted, and the two usable sets. Every assertion in it was made to fail before being trusted — dropping the `host.task` gate, gating on an ungrantable permission, reverting `get()` to property access (the bug this cost), and dropping Multi-Cast from the offered types each turned the expected checks red.

Full suite green (0 failing), both phpstan passes clean, php-cs-fixer clean.

## Screenshots

Captured headless from the shadow tree; the PNGs are on the box at
`/home/telliott/labs/quicktask-browser/one-selected.png` and `two-selected.png`.

- **one-selected** — button bar reads `Select All | Deselect All | Filter | Saved filters | Column search | Column Visibility | Refresh | Deploy | Capture | Multi-Cast`, with Multi-Cast the only dim one.
- **two-selected** — same bar, Capture dim, Multi-Cast live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SAeGKvENjVu7eLPnijqNL
