### PR TITLE
Resolve a host's printers live, group grants included

### DIFF
--- a/docs/GROUP_SHARED_STATE.md
+++ b/docs/GROUP_SHARED_STATE.md
@@ -18,10 +18,20 @@ anything.
 > **no‑clobber**: a blank field leaves each host's value alone, so you only
 > change what you intend to.
 
+> **⚠️ This is changing. Snapins have already changed.**
+> A group is becoming something that **grants**, rather than something that
+> copies rows onto whoever happened to be a member when a button was pressed.
+> The first half has landed: see
+> [Snapins are granted, not copied](#snapins-are-granted-not-copied) below.
+> Everything else on this page still describes the push‑to‑all model and is
+> still accurate for the page as it stands today. The reasoning, and what is
+> left to move, are in [ADR 0038](adr/0038-a-group-grants-it-does-not-copy.md).
+
 ---
 
 ## Table of contents
 
+- [Snapins are granted, not copied](#snapins-are-granted-not-copied)
 - [Associations (tri‑state)](#associations-tri-state)
   - [What "has it" means](#what-has-it-means)
   - [The badge and Has/Missing drill‑down](#the-badge-and-hasmissing-drill-down)
@@ -33,6 +43,56 @@ anything.
   - [General fields](#general-fields)
   - [Default printer](#default-printer)
 - [Out of scope](#out-of-scope)
+
+---
+
+## Snapins are granted, not copied
+
+A group can now hold a snapin **grant** of its own. The grant is a row about the
+*group* (`groupSnapinAssoc`), not a pile of rows copied onto the hosts that were
+members at the time, and that single change fixes both halves of the old
+behavior:
+
+- a host **added** to the group afterward is covered by the grant, without
+  anyone re‑pushing anything;
+- a host **removed** from the group stops being covered, instead of silently
+  keeping a snapin nobody can now explain.
+
+### When it is worked out — and the one thing everybody gets wrong
+
+**The list is resolved when a task is created, and written onto the task.
+Editing the group afterward does not change a task that is already in flight.
+Re‑tasking is the only way to pick a change up.**
+
+That sentence is the whole rule, and it is worth reading twice, because the
+natural assumption is that the group is consulted at the moment the snapin runs.
+It is not. `snapinTasks` records what was decided when the task was made, which
+is what makes a queued task reproducible: you can look at a task from last
+Tuesday and see what it was actually going to install, not what the group would
+say today.
+
+If you change a group's snapins and want the change to reach machines with
+tasks already queued, **cancel and re‑task them**.
+
+### What a host ends up with, in order
+
+1. The snapins on the **host itself**, in the order the host has them.
+2. Then the snapins its **groups grant**, groups in the order they are given
+   (an explicit order on the group, then by name), and within a group in the
+   order the grant has them.
+
+A snapin reached **both** ways appears **once**, in the position the *host*
+gave it. A group grant never reorders something an admin deliberately placed on
+a host.
+
+Group order is an explicit setting rather than alphabetical for one reason:
+**renaming a group must never silently change what installs on a thousand
+machines.** An install that never sets it behaves alphabetically, which is the
+answer an admin can predict.
+
+> Printers have **not** moved yet, and the group Printers tab still pushes rows
+> onto member hosts as before. Nothing on the host side of printers has
+> changed.
 
 ---
 

--- a/docs/GROUP_SHARED_STATE.md
+++ b/docs/GROUP_SHARED_STATE.md
@@ -21,7 +21,7 @@ anything.
 > **⚠️ This is changing. Snapins have already changed.**
 > A group is becoming something that **grants**, rather than something that
 > copies rows onto whoever happened to be a member when a button was pressed.
-> The first half has landed: see
+> The first half has landed for **snapins and printers**: see
 > [Snapins are granted, not copied](#snapins-are-granted-not-copied) below.
 > Everything else on this page still describes the push‑to‑all model and is
 > still accurate for the page as it stands today. The reasoning, and what is
@@ -32,6 +32,7 @@ anything.
 ## Table of contents
 
 - [Snapins are granted, not copied](#snapins-are-granted-not-copied)
+  - [Printers work the same way, but are worked out live](#printers-work-the-same-way-but-are-worked-out-live)
 - [Associations (tri‑state)](#associations-tri-state)
   - [What "has it" means](#what-has-it-means)
   - [The badge and Has/Missing drill‑down](#the-badge-and-hasmissing-drill-down)
@@ -90,9 +91,25 @@ Group order is an explicit setting rather than alphabetical for one reason:
 machines.** An install that never sets it behaves alphabetically, which is the
 answer an admin can predict.
 
-> Printers have **not** moved yet, and the group Printers tab still pushes rows
-> onto member hosts as before. Nothing on the host side of printers has
-> changed.
+### Printers work the same way, but are worked out live
+
+A group can hold a **printer** grant too, and the precedence is identical: the
+host's own printers first, then what its groups grant, a printer reached both
+ways appearing once at the host's position. A **host's own default printer wins
+outright**; otherwise the default comes from the first group in order that names
+one.
+
+The difference is *when*. There is no task to attach a printer list to — the FOG
+client reconciles its printers on a schedule, and a removal has to reach the
+machine — so **the printer list is worked out fresh on every client request**.
+A change to a group's printers reaches its members on their next check-in, with
+no re-tasking.
+
+> **On printer level `ar` ("FOG Handles all printers"), the list is
+> authoritative in both directions:** the client removes every installed
+> printer that is not on it, including ones FOG did not add. That has always
+> been true of this mode; it is worth re-reading now that a group can add to
+> the list.
 
 ---
 

--- a/docs/release/1.6.0-release-notes.DRAFT.md
+++ b/docs/release/1.6.0-release-notes.DRAFT.md
@@ -227,11 +227,10 @@ pre-upgrade *dump* — it is not a schema rollback.
   disagreement is logged, so nothing is lost silently.
 - **The `accesscontrol` plugin is retired**, replaced by native RBAC. Its
   registration row is removed during the upgrade.
-- **A group's snapins are now a grant, and they are resolved when a task is
-  created.** A group no longer copies snapin rows onto whichever hosts happened
-  to be members when you pressed the button; it holds the assignment itself, so
-  a host added to the group later is covered by it and a host removed stops
-  being covered.
+- **A group's snapins and printers are now grants rather than copies.** A
+  group no longer copies rows onto whichever hosts happened to be members when
+  you pressed the button; it holds the assignment itself, so a host added to
+  the group later is covered by it and a host removed stops being covered.
 
   **The part to remember: editing a group does not change a task that is
   already queued. Re-tasking is the only way to pick a change up.** The list is
@@ -246,9 +245,23 @@ pre-upgrade *dump* — it is not a schema rollback.
   by name, so that **renaming a group cannot silently change what installs on a
   thousand machines**.
 
-  Printers have not moved yet and are unaffected in this release.
-  <!-- verified: docs/adr/0038 decisions 4, 6 and 7; FOG\Assign\Resolver;
-  docs/GROUP_SHARED_STATE.md -->
+  **Printers work the same way, with one difference: they are worked out
+  fresh on every client check-in**, not written onto a task. A change to a
+  group's printers therefore reaches its members on their next check-in with
+  no re-tasking. A host's own default printer beats a group's; otherwise the
+  default comes from the first group in order that names one.
+
+  On printer level `ar` ("FOG Handles all printers") the list the server sends
+  is authoritative in both directions -- the client removes every installed
+  printer that is not on it. That has always been true of that mode, and is
+  worth re-reading now that a group can add to the list.
+
+  The wire format has NOT changed: a host with no printers at all still
+  answers `np` exactly as before. Turning that into an ordinary empty result
+  is a separate change, deliberately not bundled with this one, so that a
+  fleet reporting missing printers has something to bisect.
+  <!-- verified: docs/adr/0038 decisions 4, 5, 6, 7 and 9; FOG\Assign\Resolver;
+  Client/PrinterClient.php; docs/GROUP_SHARED_STATE.md -->
 - **The `persistentgroups` plugin is retired**, and its database TRIGGER is
   dropped. This one matters more than a plugin removal usually would, because
   the trigger outlived the plugin's files: deleting the code never stopped it

--- a/docs/release/1.6.0-release-notes.DRAFT.md
+++ b/docs/release/1.6.0-release-notes.DRAFT.md
@@ -227,6 +227,28 @@ pre-upgrade *dump* — it is not a schema rollback.
   disagreement is logged, so nothing is lost silently.
 - **The `accesscontrol` plugin is retired**, replaced by native RBAC. Its
   registration row is removed during the upgrade.
+- **A group's snapins are now a grant, and they are resolved when a task is
+  created.** A group no longer copies snapin rows onto whichever hosts happened
+  to be members when you pressed the button; it holds the assignment itself, so
+  a host added to the group later is covered by it and a host removed stops
+  being covered.
+
+  **The part to remember: editing a group does not change a task that is
+  already queued. Re-tasking is the only way to pick a change up.** The list is
+  worked out when the task is made and written onto it, which is what lets you
+  look at a task from last week and see what it was really going to install.
+  Everyone assumes the group is consulted at the moment the snapin runs; it is
+  not, and it never was.
+
+  A snapin a host has *both* directly and through a group runs **once**, in the
+  position the host gave it -- a group grant never reorders something placed on
+  a host deliberately. Groups themselves run in an explicit order you set, then
+  by name, so that **renaming a group cannot silently change what installs on a
+  thousand machines**.
+
+  Printers have not moved yet and are unaffected in this release.
+  <!-- verified: docs/adr/0038 decisions 4, 6 and 7; FOG\Assign\Resolver;
+  docs/GROUP_SHARED_STATE.md -->
 - **The `persistentgroups` plugin is retired**, and its database TRIGGER is
   dropped. This one matters more than a plugin removal usually would, because
   the trigger outlived the plugin's files: deleting the code never stopped it

--- a/packages/web/src/Client/PrinterClient.php
+++ b/packages/web/src/Client/PrinterClient.php
@@ -13,6 +13,7 @@
 
 namespace FOG\Client;
 
+use FOG\Assign\Resolver;
 use FOG\Router\Route;
 
 /**
@@ -65,9 +66,31 @@ class PrinterClient extends FOGClient
             'name'
         );
         @natcasesort($allPrinters);
-        $printerIDs = self::$Host->get('printers');
+        // ADR 0038 decision 5: printers resolve LIVE, on each request. There
+        // is no task to hang a snapshot on -- fog-client reconciles desired
+        // state on a schedule and a removal has to reach the machine -- so
+        // the list is computed every time rather than written down anywhere.
+        //
+        // The host's own printers plus whatever its groups GRANT, with a
+        // group grant never displacing a printer the host holds directly and
+        // a host-direct default always beating a group's.
+        $hostID = (int)self::$Host->get('id');
+        $resolved = Resolver::resolvePrinters([$hostID])[$hostID]
+            ?? ['printers' => [], 'default' => null];
+        $printerIDs = $resolved['printers'];
         $printerCount = count($printerIDs ?: []);
         if ($printerCount < 1) {
+            // STILL SPELLED `np`, and that is deliberate rather than
+            // leftover. ADR 0038 decision 9 makes this an ordinary success
+            // carrying an explicit flag instead of an error, and traces
+            // through fog-client to show it is safe -- but that trace has
+            // not been WATCHED happen on a mode-`ar` host with steady
+            // printers (UNKNOWN-4), and `np` is the single string that
+            // triggers removal-on-empty in the client. Changing where the
+            // list comes from and what the empty case means to the client
+            // in one step would leave nothing to bisect if a fleet came
+            // back with no printers. So this release changes only the
+            // source of the list; the wire format moves separately.
             return [
                 'error' => 'np',
                 'mode' => self::$_modes[$level],
@@ -76,30 +99,33 @@ class PrinterClient extends FOGClient
                 'printers' => [],
             ];
         }
-        $find = [
-            'hostID' => self::$Host->get('id'),
-            'isDefault' => 1
-        ];
-        $defaultID = Route::getIds(
-            'printerassociation',
-            $find,
-            'printerID'
-        );
-        $find = ['id' => $defaultID];
-        $defaultName = Route::getIds(
-            'printer',
-            $find,
-            'name'
-        );
-        if (count($defaultName ?: []) != 1) {
-            $default = '';
-        } else {
-            $default = array_shift($defaultName);
+        $default = '';
+        if (null !== $resolved['default']) {
+            $defaultName = Route::getIds(
+                'printer',
+                ['id' => [$resolved['default']]],
+                'name'
+            );
+            if (count($defaultName ?: []) === 1) {
+                $default = array_shift($defaultName);
+            }
         }
+        // Indexed by id, then emitted in RESOLVED order. The old loop walked
+        // the printer catalog and kept the ones the host had, so the payload
+        // came out in catalog order and the precedence the resolver just
+        // worked out was thrown away on the wire. Nothing in the client
+        // depends on the order, but a list whose order contradicts the rule
+        // that produced it is a thing somebody eventually has to explain.
         $Printers = Route::getList('printer');
-        $printers = [];
+        $byID = [];
         foreach ($Printers as $Printer) {
-            if (!in_array($Printer->id, $printerIDs)) {
+            $byID[(int)$Printer->id] = $Printer;
+        }
+        unset($Printers);
+        $printers = [];
+        foreach ($printerIDs as $printerID) {
+            $Printer = $byID[(int)$printerID] ?? null;
+            if (null === $Printer) {
                 continue;
             }
             $printers[] = [
@@ -113,7 +139,6 @@ class PrinterClient extends FOGClient
             ];
             unset($Printer);
         }
-        unset($Printers);
         return [
             'mode' => self::$_modes[$level],
             'allPrinters' => $allPrinters,

--- a/packages/web/src/Items/Group.php
+++ b/packages/web/src/Items/Group.php
@@ -13,6 +13,7 @@
 
 namespace FOG\Items;
 
+use FOG\Assign\Resolver;
 use FOG\Base\FOGController;
 use FOG\Boot\SecureBootState;
 use FOG\Boot\UbootTftpSync;
@@ -968,28 +969,28 @@ class Group extends FOGController
         if ($snapin === false) {
             return;
         }
-        $find = ['hostID' => $this->get('hosts')];
-        $hostIDs = $find['hostID'];
+        $hostIDs = $this->get('hosts');
         $snapins = [];
         $snapinJobs = [];
-        // GH-707: the "all snapins" case used to query snapinAssoc once per
-        // member host inside the loop below -- a thousand round trips for a
-        // thousand-host group. The association table answers every host in
-        // one pass, so read it once here and index it by host; the loop then
-        // just looks the host up.
+        // ADR 0038 decision 4: the "all snapins" list is RESOLVED here, at
+        // task creation, and what it resolves to is written onto the task.
+        // `snapinTasks` is already the snapshot -- it carries the snapin and
+        // its sequence per row -- so nothing about the task side changes.
+        // What changed is only where the list comes from: the host's own
+        // associations plus whatever its groups GRANT, in the one order
+        // Resolver promises. A group edited while a task is in flight does
+        // not change that task; re-tasking is the only way to pick a change
+        // up.
+        //
+        // Still one pass over the whole membership, which is not incidental.
+        // GH-707 was this exact code querying snapinAssoc once per member
+        // host inside the loop below -- a thousand round trips for a
+        // thousand-host group -- and a resolver taking one host at a time
+        // would have reintroduced it here first. That is why resolveSnapins()
+        // takes a set.
         $assocByHost = [];
         if ($snapin == -1) {
-            $assocs = Route::getIds(
-                'snapinassociation',
-                $find,
-                ['hostID', 'snapinID'],
-                'AND',
-                'sequence'
-            );
-            foreach ($assocs as $assoc) {
-                $assocByHost[$assoc['hostID']][] = $assoc['snapinID'];
-            }
-            unset($assocs);
+            $assocByHost = Resolver::resolveSnapins($hostIDs);
         }
         foreach ($hostIDs as $hostID) {
             if ($snapin == -1) {

--- a/packages/web/src/Items/Host.php
+++ b/packages/web/src/Items/Host.php
@@ -13,6 +13,7 @@
 
 namespace FOG\Items;
 
+use FOG\Assign\Resolver;
 use FOG\Base\FOGController;
 use FOG\Boot\SecureBootState;
 use FOG\Boot\UbootTftpSync;
@@ -950,9 +951,23 @@ class Host extends FOGController
         $Task = false
     ) {
         try {
+            // ADR 0038 decision 4. The "all snapins" list is RESOLVED once,
+            // here, and written onto the task: the host's own associations
+            // plus whatever its groups grant, in the order Resolver
+            // promises. `snapinTasks` is already the snapshot, so a group
+            // edited while this task is in flight does not change it --
+            // re-tasking is the only way to pick a change up.
+            //
+            // Resolved ONCE and reused below rather than read twice. The old
+            // code called $this->get('snapins') here for the emptiness guard
+            // and again further down for the ids, which was harmless when
+            // both came off the same loaded property and is not once the
+            // answer involves a query.
+            $resolved = [];
             if (-1 == $snapin) {
-                $snapins = $this->get('snapins');
-                if (count($snapins ?: []) <= 0) {
+                $hostID = (int)$this->get('id');
+                $resolved = Resolver::resolveSnapins([$hostID])[$hostID] ?? [];
+                if (count($resolved) <= 0) {
                     throw new \Exception(_('No snapins associated'));
                 }
             }
@@ -980,7 +995,7 @@ class Host extends FOGController
             $insert_fields = ['jobID', 'stateID', 'snapinID', 'sequence'];
             $insert_values = [];
             if ($snapin == -1) {
-                $snapin = $this->get('snapins');
+                $snapin = $resolved;
             }
             // Drop any 0/blank snapin id before it becomes a snapintask row
             // that renders as a phantom "null" snapin. Mirrors the same guard

--- a/tests/printer-client-resolves.test.php
+++ b/tests/printer-client-resolves.test.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Pins the printer endpoint to the resolver, and pins `np` in place.
+ *
+ * Two separate things, and the second is the one that matters.
+ *
+ * 1. The list the client is told to install comes from the resolver, so a
+ *    group's printer grant reaches its members. ADR 0038 decision 5: printers
+ *    resolve LIVE on each request, because there is no task to hang a
+ *    snapshot on and a removal has to reach the machine.
+ *
+ * 2. THE EMPTY CASE IS STILL SPELLED `np`. Under printer level `ar` the
+ *    resolved list is authoritative in both directions -- fog-client removes
+ *    every installed printer that is not on it -- and `np`, matched
+ *    case-insensitively against ReturnCode, is the ONE string that triggers
+ *    removal-on-empty. Decision 9 turns the empty case into an ordinary
+ *    success carrying an explicit flag instead, and traces through
+ *    fog-client 0.13.0 to show that is safe. That trace has not been watched
+ *    happen on a mode-`ar` host with steady printers (UNKNOWN-4). Changing
+ *    where the list comes from AND what the empty case means to the client in
+ *    one release leaves nothing to bisect if a fleet comes back with no
+ *    printers, so this test holds the wire format still while the source of
+ *    the list moves.
+ *
+ *    When decision 9 does land, this check is expected to be REPLACED, not
+ *    deleted quietly -- by one asserting the new flag alongside `np` for the
+ *    release they overlap.
+ *
+ * Source-anchored, for the reason set out at length in
+ * tests/task-creation-resolves-assignments.test.php: the resolver's behavior
+ * is covered behaviorally against a real database, and reaching
+ * PrinterClient::json() needs a configured FOG, a host and a client session,
+ * at which point the test is an install rehearsal rather than a gate.
+ *
+ * Usage: php tests/printer-client-resolves.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+$path = $root . '/packages/web/src/Client/PrinterClient.php';
+$body = @file_get_contents($path);
+if (false === $body) {
+    fwrite(STDERR, "FAIL: cannot read $path\n");
+    exit(1);
+}
+$body = (string)$body;
+
+$checks = 0;
+$failures = [];
+$check = static function ($what, $ok) use (&$checks, &$failures) {
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+};
+
+$check(
+    'the printer endpoint resolves through the resolver',
+    false !== strpos(
+        $body,
+        "\$resolved = Resolver::resolvePrinters([\$hostID])[\$hostID]"
+    )
+);
+$check(
+    'PrinterClient imports the resolver',
+    false !== strpos($body, 'use FOG\Assign\Resolver;')
+);
+$check(
+    'the list sent to the client is the resolved one',
+    false !== strpos($body, "\$printerIDs = \$resolved['printers'];")
+);
+$check(
+    'the endpoint no longer sends the host-direct printers alone',
+    false === strpos($body, "\$printerIDs = self::\$Host->get('printers');")
+);
+$check(
+    'the default sent is the resolved default',
+    false !== strpos($body, "if (null !== \$resolved['default']) {")
+);
+
+// The `np` guard. Anchored as the whole return, and required to sit inside
+// the empty-list branch: an `np` string surviving somewhere else in the file
+// would satisfy a bare search while the empty case had quietly stopped
+// emitting it.
+$emptyBranch = "if (\$printerCount < 1) {";
+$emptyAt = strpos($body, $emptyBranch);
+$npAt = strpos($body, "'error' => 'np',");
+$check(
+    'the empty case is still reached by a count check',
+    false !== $emptyAt
+);
+$check(
+    'the empty case still answers `np`',
+    false !== $npAt && false !== $emptyAt && $npAt > $emptyAt
+);
+$check(
+    'nothing else in the endpoint answers `np`',
+    1 === substr_count($body, "'np'")
+);
+
+if (count($failures)) {
+    fwrite(STDERR, "FAIL: the printer endpoint changed in a way that matters:\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    fwrite(
+        STDERR,
+        sprintf("%d of %d checks failed\n", count($failures), $checks)
+    );
+    exit(1);
+}
+
+printf("PASS  printer endpoint resolves: %d checks\n", $checks);
+exit(0);

--- a/tests/task-creation-resolves-assignments.test.php
+++ b/tests/task-creation-resolves-assignments.test.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Pins both snapin-tasking paths to the resolver.
+ *
+ * ADR 0038 decision 4: the ordered snapin list is computed WHEN A TASK IS
+ * CREATED and written onto the task. There are two places that create snapin
+ * tasking -- Host::_createSnapinTasking() for one host, and
+ * Group::_createSnapinTasking() for a whole membership -- and the defect this
+ * guards against is one of them quietly going back to reading a host's own
+ * associations. That is not a crash. It is a group grant that applies to
+ * every host tasked one way and to none tasked the other, which looks like
+ * flaky snapins and is diagnosed by nobody.
+ *
+ * WHAT THIS IS AND IS NOT. This asserts on SOURCE TEXT, which this suite
+ * normally refuses to do, so the reason has to be better than convenience.
+ * The resolver's BEHAVIOR -- the order, the dedupe, the throw -- is covered
+ * behaviorally and at length by tests/assign-resolver.test.php against a real
+ * database. What is left over is exactly the question source text can answer
+ * and a unit test cannot reach without standing up a configured FOG: does
+ * this call site still call it. Constructing a Host far enough to reach
+ * _createSnapinTasking() needs a live config, a task, a snapin job and a
+ * schema, at which point the test is an install rehearsal rather than a gate.
+ *
+ * So the assertions anchor WHOLE STATEMENTS rather than grepping for the
+ * class name. A grep for "Resolver" passes against a resolver call sitting
+ * dead above the old association read; anchoring the assignment and the
+ * absence of the old read together does not.
+ *
+ * Usage: php tests/task-creation-resolves-assignments.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+$src = $root . '/packages/web/src';
+
+$checks = 0;
+$failures = [];
+$check = static function ($what, $ok) use (&$checks, &$failures) {
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+};
+
+$read = static function ($path) {
+    $body = @file_get_contents($path);
+    if (false === $body) {
+        fwrite(STDERR, "FAIL: cannot read $path\n");
+        exit(1);
+    }
+    return (string)$body;
+};
+
+$group = $read($src . '/Items/Group.php');
+$host = $read($src . '/Items/Host.php');
+
+/**
+ * Returns just the body of a method, so an assertion about "this method does
+ * not read snapinAssoc" cannot be satisfied or broken by an unrelated method
+ * in the same file that legitimately does.
+ */
+$method = static function ($source, $signature) {
+    $start = strpos($source, $signature);
+    if (false === $start) {
+        return null;
+    }
+    $open = strpos($source, '{', $start);
+    if (false === $open) {
+        return null;
+    }
+    $depth = 0;
+    $len = strlen($source);
+    for ($i = $open; $i < $len; $i++) {
+        if ('{' === $source[$i]) {
+            $depth++;
+        } elseif ('}' === $source[$i]) {
+            $depth--;
+            if (0 === $depth) {
+                return substr($source, $open, $i - $open + 1);
+            }
+        }
+    }
+    return null;
+};
+
+$groupBody = $method($group, 'private function _createSnapinTasking(');
+$hostBody = $method($host, 'private function _createSnapinTasking(');
+
+$check(
+    'Group::_createSnapinTasking() is still findable',
+    null !== $groupBody
+);
+$check(
+    'Host::_createSnapinTasking() is still findable',
+    null !== $hostBody
+);
+if (null === $groupBody || null === $hostBody) {
+    fwrite(STDERR, "FAIL: a tasking method moved or was renamed; this test is\n");
+    fwrite(STDERR, "      pinning nothing until its signatures are updated.\n");
+    exit(1);
+}
+
+// The group path. The whole assignment is anchored, not the class name: a
+// resolver call whose result is thrown away would satisfy a looser check.
+$check(
+    'the group path resolves the whole membership in one call',
+    false !== strpos(
+        $groupBody,
+        '$assocByHost = Resolver::resolveSnapins($hostIDs);'
+    )
+);
+// ...and it must pass the SET. A resolver called per host inside the loop is
+// GH-707 returning: a thousand round trips for a thousand-host group. That
+// is why the signature takes an array, and why this is worth its own check.
+$check(
+    'the group path does not resolve one host at a time',
+    false === strpos($groupBody, 'resolveSnapins([$hostID]')
+);
+$check(
+    'the group path no longer reads snapinassociation itself',
+    false === stripos($groupBody, 'snapinassociation')
+);
+
+// The host path. Resolved once into a local and reused, rather than read
+// twice: the emptiness guard and the id list must agree, and they only
+// certainly agree if they are the same value.
+$check(
+    'the host path resolves through the resolver',
+    false !== strpos(
+        $hostBody,
+        '$resolved = Resolver::resolveSnapins([$hostID])[$hostID] ?? [];'
+    )
+);
+$check(
+    'the host path tasks what it resolved',
+    false !== strpos($hostBody, '$snapin = $resolved;')
+);
+$check(
+    'the host path no longer tasks the raw snapins property',
+    false === strpos($hostBody, "\$snapin = \$this->get('snapins');")
+);
+
+// Both files must actually import it. A fully-qualified call would work and
+// would also be the first sign somebody pasted the line in without meaning
+// to, so the import is required rather than tolerated.
+$check(
+    'Group.php imports the resolver',
+    false !== strpos($group, 'use FOG\Assign\Resolver;')
+);
+$check(
+    'Host.php imports the resolver',
+    false !== strpos($host, 'use FOG\Assign\Resolver;')
+);
+
+// The resolver has to exist under the name both files import, which is the
+// one thing here that would otherwise be caught only at runtime, on a server,
+// during a deploy.
+$check(
+    'the resolver is where those imports say it is',
+    is_readable($src . '/Assign/Resolver.php')
+        && false !== strpos(
+            $read($src . '/Assign/Resolver.php'),
+            'namespace FOG\Assign;'
+        )
+);
+
+if (count($failures)) {
+    fwrite(STDERR, "FAIL: snapin tasking no longer resolves assignments:\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    fwrite(
+        STDERR,
+        sprintf("%d of %d checks failed\n", count($failures), $checks)
+    );
+    exit(1);
+}
+
+printf("PASS  task creation resolves assignments: %d checks\n", $checks);
+exit(0);


### PR DESCRIPTION
ADR 0038 decision 5. **Stacked on #1612**, which is stacked on #1611 — merge in that order.

The printer endpoint asks the resolver what a host is assigned, so a group's printer grant reaches its members: host-direct printers first, then group grants, a printer reached both ways appearing once at the host's position, and a host-direct default beating a group's.

**Resolved live, on every request**, rather than snapshotted. There is no task to hang a printer list on — fog-client reconciles desired state on a schedule and a removal has to reach the machine — so a change to a group's printers reaches its members on their next check-in with no re-tasking. That is the *opposite* of the snapin rule in #1612, and both documents now say which is which.

## The wire format does not change, and that is a decision

Decision 9 makes "this host has no printers" an ordinary success carrying an explicit flag instead of an error, and traces through fog-client 0.13.0 to show that is safe. **That trace has not been watched happen** on a mode-`ar` host with steady printers (UNKNOWN-4), and `np` — matched case-insensitively against `ReturnCode` — is the one string that triggers removal-on-empty in the client.

Moving the source of the list and the meaning of the empty case in the same release would leave nothing to bisect if a fleet came back with no printers. So the empty case still answers `np`, the format moves separately, and `tests/printer-client-resolves.test.php` pins that in place — including a note saying what should *replace* that check when decision 9 lands, rather than letting it be deleted quietly.

## One thing changed that nothing asked for

The payload is emitted in **resolved order**. The old loop walked the printer catalog keeping the ones the host had, so the list came out in catalog order and the precedence the resolver had just worked out was discarded on the wire. Nothing in the client depends on the order, but a list whose order contradicts the rule that produced it is something somebody eventually has to explain.

## Gates

8 checks, 4 mutations — reverting to the host-direct list, dropping the resolver call, dropping the resolved default, and respelling the empty case each turn it red. Full suite green, both phpstan configs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)