### PR TITLE
fix: bump FOG_BCACHE_VER, which two merged branches both set to 356

### DIFF
--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -131,7 +131,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 405);
-        define('FOG_BCACHE_VER', 356);
+        define('FOG_BCACHE_VER', 357);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a


### PR DESCRIPTION
## The bug

`#1613` (host list quick tasks) and `fix/sidebar-unisearch-white-text` both branched off a tree at `FOG_BCACHE_VER 355` and both bumped it to `356`. The two diffs are byte-identical, so git merged them without a conflict and `working-1.6` is at **356 having shipped two rounds of JS under one cache-buster**.

The Unisearch fix deployed first. So every browser that has touched the UI since is holding:

- `fog.host.list.js?ver=356` — pre-quick-task contents
- `fog.common.js?ver=356` — pre-`extraButtons` contents

Deploying #1613 on top changes the files on disk and **nothing on the page**. The server emits `<div id="quick-task-data">`, the cached script has never heard of it, and the three buttons never appear. It reads as a broken feature rather than as a caching problem — which is precisely what `FOG_BCACHE_VER` exists to prevent.

Reproduced on 10.255.20.1: `md5sum` on the served `fog.host.list.js` matched the pre-merge file while `working-1.6` carried the new one.

## The fix

357. Not reachable from either branch, so it busts both.

## Worth knowing

**A bump is not a bump if a sibling branch made the same one.** Two PRs open against the same base cannot both take the next integer — the merge silently agrees with itself and one round of assets ships uncovered. The value to check is what `working-1.6` holds at *merge* time, not what it held at *branch* time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SAeGKvENjVu7eLPnijqNL