### PR TITLE
Lift "what do these hosts share" out of the group page

### DIFF
--- a/bin/psr4-scan.php
+++ b/bin/psr4-scan.php
@@ -202,6 +202,10 @@ const TABLE = [
     'Timer' => 'Util',
     'FOGCron' => 'Util',
     'FOGLogPaths' => 'Util',
+    // Util because it belongs to no subsystem: it answers "do these hosts
+    // agree about this column", which the group page and any mass edit over
+    // a selection both need and neither owns. Not Items -- it is not a row.
+    'SharedHostValues' => 'Util',
     'SnapinSaveException' => 'Exception',
     'UploadException' => 'Exception',
 ];

--- a/docs/GROUP_SHARED_STATE.md
+++ b/docs/GROUP_SHARED_STATE.md
@@ -21,7 +21,7 @@ anything.
 > **⚠️ This is changing. Snapins have already changed.**
 > A group is becoming something that **grants**, rather than something that
 > copies rows onto whoever happened to be a member when a button was pressed.
-> The first half has landed: see
+> The first half has landed for **snapins and printers**: see
 > [Snapins are granted, not copied](#snapins-are-granted-not-copied) below.
 > Everything else on this page still describes the push‑to‑all model and is
 > still accurate for the page as it stands today. The reasoning, and what is
@@ -32,6 +32,7 @@ anything.
 ## Table of contents
 
 - [Snapins are granted, not copied](#snapins-are-granted-not-copied)
+  - [Printers work the same way, but are worked out live](#printers-work-the-same-way-but-are-worked-out-live)
 - [Associations (tri‑state)](#associations-tri-state)
   - [What "has it" means](#what-has-it-means)
   - [The badge and Has/Missing drill‑down](#the-badge-and-hasmissing-drill-down)
@@ -90,9 +91,25 @@ Group order is an explicit setting rather than alphabetical for one reason:
 machines.** An install that never sets it behaves alphabetically, which is the
 answer an admin can predict.
 
-> Printers have **not** moved yet, and the group Printers tab still pushes rows
-> onto member hosts as before. Nothing on the host side of printers has
-> changed.
+### Printers work the same way, but are worked out live
+
+A group can hold a **printer** grant too, and the precedence is identical: the
+host's own printers first, then what its groups grant, a printer reached both
+ways appearing once at the host's position. A **host's own default printer wins
+outright**; otherwise the default comes from the first group in order that names
+one.
+
+The difference is *when*. There is no task to attach a printer list to — the FOG
+client reconciles its printers on a schedule, and a removal has to reach the
+machine — so **the printer list is worked out fresh on every client request**.
+A change to a group's printers reaches its members on their next check-in, with
+no re-tasking.
+
+> **On printer level `ar` ("FOG Handles all printers"), the list is
+> authoritative in both directions:** the client removes every installed
+> printer that is not on it, including ones FOG did not add. That has always
+> been true of this mode; it is worth re-reading now that a group can add to
+> the list.
 
 ---
 

--- a/docs/release/1.6.0-release-notes.DRAFT.md
+++ b/docs/release/1.6.0-release-notes.DRAFT.md
@@ -227,11 +227,10 @@ pre-upgrade *dump* — it is not a schema rollback.
   disagreement is logged, so nothing is lost silently.
 - **The `accesscontrol` plugin is retired**, replaced by native RBAC. Its
   registration row is removed during the upgrade.
-- **A group's snapins are now a grant, and they are resolved when a task is
-  created.** A group no longer copies snapin rows onto whichever hosts happened
-  to be members when you pressed the button; it holds the assignment itself, so
-  a host added to the group later is covered by it and a host removed stops
-  being covered.
+- **A group's snapins and printers are now grants rather than copies.** A
+  group no longer copies rows onto whichever hosts happened to be members when
+  you pressed the button; it holds the assignment itself, so a host added to
+  the group later is covered by it and a host removed stops being covered.
 
   **The part to remember: editing a group does not change a task that is
   already queued. Re-tasking is the only way to pick a change up.** The list is
@@ -246,9 +245,23 @@ pre-upgrade *dump* — it is not a schema rollback.
   by name, so that **renaming a group cannot silently change what installs on a
   thousand machines**.
 
-  Printers have not moved yet and are unaffected in this release.
-  <!-- verified: docs/adr/0038 decisions 4, 6 and 7; FOG\Assign\Resolver;
-  docs/GROUP_SHARED_STATE.md -->
+  **Printers work the same way, with one difference: they are worked out
+  fresh on every client check-in**, not written onto a task. A change to a
+  group's printers therefore reaches its members on their next check-in with
+  no re-tasking. A host's own default printer beats a group's; otherwise the
+  default comes from the first group in order that names one.
+
+  On printer level `ar` ("FOG Handles all printers") the list the server sends
+  is authoritative in both directions -- the client removes every installed
+  printer that is not on it. That has always been true of that mode, and is
+  worth re-reading now that a group can add to the list.
+
+  The wire format has NOT changed: a host with no printers at all still
+  answers `np` exactly as before. Turning that into an ordinary empty result
+  is a separate change, deliberately not bundled with this one, so that a
+  fleet reporting missing printers has something to bisect.
+  <!-- verified: docs/adr/0038 decisions 4, 5, 6, 7 and 9; FOG\Assign\Resolver;
+  Client/PrinterClient.php; docs/GROUP_SHARED_STATE.md -->
 - **The `persistentgroups` plugin is retired**, and its database TRIGGER is
   dropped. This one matters more than a plugin removal usually would, because
   the trigger outlived the plugin's files: deleting the code never stopped it

--- a/packages/web/src/Client/PrinterClient.php
+++ b/packages/web/src/Client/PrinterClient.php
@@ -13,6 +13,7 @@
 
 namespace FOG\Client;
 
+use FOG\Assign\Resolver;
 use FOG\Router\Route;
 
 /**
@@ -65,9 +66,31 @@ class PrinterClient extends FOGClient
             'name'
         );
         @natcasesort($allPrinters);
-        $printerIDs = self::$Host->get('printers');
+        // ADR 0038 decision 5: printers resolve LIVE, on each request. There
+        // is no task to hang a snapshot on -- fog-client reconciles desired
+        // state on a schedule and a removal has to reach the machine -- so
+        // the list is computed every time rather than written down anywhere.
+        //
+        // The host's own printers plus whatever its groups GRANT, with a
+        // group grant never displacing a printer the host holds directly and
+        // a host-direct default always beating a group's.
+        $hostID = (int)self::$Host->get('id');
+        $resolved = Resolver::resolvePrinters([$hostID])[$hostID]
+            ?? ['printers' => [], 'default' => null];
+        $printerIDs = $resolved['printers'];
         $printerCount = count($printerIDs ?: []);
         if ($printerCount < 1) {
+            // STILL SPELLED `np`, and that is deliberate rather than
+            // leftover. ADR 0038 decision 9 makes this an ordinary success
+            // carrying an explicit flag instead of an error, and traces
+            // through fog-client to show it is safe -- but that trace has
+            // not been WATCHED happen on a mode-`ar` host with steady
+            // printers (UNKNOWN-4), and `np` is the single string that
+            // triggers removal-on-empty in the client. Changing where the
+            // list comes from and what the empty case means to the client
+            // in one step would leave nothing to bisect if a fleet came
+            // back with no printers. So this release changes only the
+            // source of the list; the wire format moves separately.
             return [
                 'error' => 'np',
                 'mode' => self::$_modes[$level],
@@ -76,30 +99,33 @@ class PrinterClient extends FOGClient
                 'printers' => [],
             ];
         }
-        $find = [
-            'hostID' => self::$Host->get('id'),
-            'isDefault' => 1
-        ];
-        $defaultID = Route::getIds(
-            'printerassociation',
-            $find,
-            'printerID'
-        );
-        $find = ['id' => $defaultID];
-        $defaultName = Route::getIds(
-            'printer',
-            $find,
-            'name'
-        );
-        if (count($defaultName ?: []) != 1) {
-            $default = '';
-        } else {
-            $default = array_shift($defaultName);
+        $default = '';
+        if (null !== $resolved['default']) {
+            $defaultName = Route::getIds(
+                'printer',
+                ['id' => [$resolved['default']]],
+                'name'
+            );
+            if (count($defaultName ?: []) === 1) {
+                $default = array_shift($defaultName);
+            }
         }
+        // Indexed by id, then emitted in RESOLVED order. The old loop walked
+        // the printer catalog and kept the ones the host had, so the payload
+        // came out in catalog order and the precedence the resolver just
+        // worked out was thrown away on the wire. Nothing in the client
+        // depends on the order, but a list whose order contradicts the rule
+        // that produced it is a thing somebody eventually has to explain.
         $Printers = Route::getList('printer');
-        $printers = [];
+        $byID = [];
         foreach ($Printers as $Printer) {
-            if (!in_array($Printer->id, $printerIDs)) {
+            $byID[(int)$Printer->id] = $Printer;
+        }
+        unset($Printers);
+        $printers = [];
+        foreach ($printerIDs as $printerID) {
+            $Printer = $byID[(int)$printerID] ?? null;
+            if (null === $Printer) {
                 continue;
             }
             $printers[] = [
@@ -113,7 +139,6 @@ class PrinterClient extends FOGClient
             ];
             unset($Printer);
         }
-        unset($Printers);
         return [
             'mode' => self::$_modes[$level],
             'allPrinters' => $allPrinters,

--- a/packages/web/src/Pages/GroupManagement.php
+++ b/packages/web/src/Pages/GroupManagement.php
@@ -22,6 +22,7 @@ use FOG\Items\TaskType;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 use FOG\Util\FOGCron;
+use FOG\Util\SharedHostValues;
 
 /**
  * Group management page
@@ -251,11 +252,17 @@ class GroupManagement extends FOGPage
         );
     }
     /**
-     * Reports, for each requested host column, whether every member host
-     * shares the same value and what that value is.
+     * What the member hosts hold in common, per column.
      *
-     * NULL and '' are treated as the same ("empty") for uniformity, so a
-     * field that is set on some hosts and unset on others reads as mixed.
+     * Delegates. The computation moved to FOG\\Util\\SharedHostValues so that
+     * this page and any form editing a SELECTION of hosts share one answer to
+     * "do these hosts agree" -- two copies of that would drift silently,
+     * because nothing fails when they disagree, one form just starts telling
+     * a different truth than the other about the same hosts.
+     *
+     * Kept as a wrapper rather than replacing every call site with the static:
+     * the group's membership is the only host list this page ever asks about,
+     * and threading it through thirty call sites would be noise.
      *
      * @param array $columns map of friendly key => hosts table column
      *
@@ -263,44 +270,10 @@ class GroupManagement extends FOGPage
      */
     private function _uniformHostValues($columns)
     {
-        $result = [];
-        foreach ($columns as $key => $col) {
-            $result[$key] = ['uniform' => false, 'value' => ''];
-        }
-        $hostIDs = array_map('intval', (array)$this->obj->get('hosts'));
-        if (count($hostIDs) < 1) {
-            return $result;
-        }
-        $selects = ['COUNT(*) AS `_n`'];
-        foreach ($columns as $key => $col) {
-            $safe = preg_replace('/[^A-Za-z0-9_]/', '', $key);
-            $selects[] = sprintf(
-                "COUNT(DISTINCT COALESCE(`%s`, '')) AS `d_%s`",
-                $col,
-                $safe
-            );
-            $selects[] = sprintf(
-                "MIN(COALESCE(`%s`, '')) AS `v_%s`",
-                $col,
-                $safe
-            );
-        }
-        $sql = sprintf(
-            'SELECT %s FROM `hosts` WHERE `hostID` IN (%s)',
-            implode(',', $selects),
-            implode(',', $hostIDs)
+        return SharedHostValues::forHosts(
+            (array)$this->obj->get('hosts'),
+            $columns
         );
-        $row = self::$DB->query($sql)->fetch();
-        $n = (int)$row->get('_n');
-        foreach ($columns as $key => $col) {
-            $safe = preg_replace('/[^A-Za-z0-9_]/', '', $key);
-            $distinct = (int)$row->get('d_' . $safe);
-            $result[$key] = [
-                'uniform' => ($n > 0 && $distinct <= 1),
-                'value' => (string)$row->get('v_' . $safe),
-            ];
-        }
-        return $result;
     }
     /**
      * Renders a muted "Hosts: ..." hint describing the members' shared value
@@ -312,9 +285,7 @@ class GroupManagement extends FOGPage
      */
     private function _sharedHint($info)
     {
-        return '<p class="form-text help-block-tight">'
-            . _('Hosts:') . ' ' . $this->_sharedValueText($info)
-            . '</p>';
+        return SharedHostValues::hint($info);
     }
     /**
      * The shared-state text for a _uniformHostValues() entry: the value with
@@ -326,13 +297,7 @@ class GroupManagement extends FOGPage
      */
     private function _sharedValueText($info)
     {
-        if (!$info['uniform']) {
-            return _('(varies)');
-        }
-        if ($info['value'] === '') {
-            return _('(empty on all)');
-        }
-        return \Initiator::e($info['value']) . ' ' . _('(all)');
+        return SharedHostValues::text($info);
     }
     /**
      * Summary box of the members' current Active Directory state, shown above

--- a/packages/web/src/Util/SharedHostValues.php
+++ b/packages/web/src/Util/SharedHostValues.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * What a set of hosts holds in common, per column.
+ *
+ * PHP version 7.4+
+ *
+ * @category SharedHostValues
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Util;
+
+use FOG\Base\FOGBase;
+
+/**
+ * What a set of hosts holds in common, per column.
+ *
+ * A form that edits many hosts at once has to show what they currently hold
+ * before it changes anything, and it has to be honest when they disagree.
+ * Forty hosts with six images must read as "(varies)" -- never as one of the
+ * six, which is how an admin ends up overwriting thirty-nine machines while
+ * believing they confirmed what was already there.
+ *
+ * This was private to GroupManagement, keyed off the group's own membership.
+ * It is lifted out unchanged in behavior and re-keyed on a HOST ID LIST so
+ * that the group page and any mass edit over a selection share one
+ * implementation. Two copies of "do these hosts agree" would drift silently:
+ * nothing fails when they disagree, one form just starts telling a different
+ * truth than the other about the same hosts.
+ *
+ * ONE QUERY over the whole selection, whatever the size of the column map.
+ * COUNT(DISTINCT ...) and MIN(...) per column in a single pass, rather than a
+ * read per host or per column -- the same reason the assignment resolver takes
+ * a set: a helper whose natural unit is one host becomes a query storm the
+ * first time somebody points it at four hundred of them.
+ *
+ * NULL AND '' ARE THE SAME THING HERE, deliberately. A column set on some
+ * hosts and merely blank on others is a column the hosts disagree about, and
+ * COALESCE makes both spellings collapse to one so the disagreement is
+ * visible rather than being hidden by SQL's NULL semantics -- where
+ * COUNT(DISTINCT) skips NULLs entirely and would report agreement among rows
+ * that have nothing in common.
+ *
+ * @category SharedHostValues
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class SharedHostValues extends FOGBase
+{
+    /**
+     * Computes, per column, whether the hosts agree and what they hold.
+     *
+     * @param array $hostIDs the hosts to look at
+     * @param array $columns map of friendly key => `hosts` table column
+     *
+     * @return array friendly key => ['uniform' => bool, 'value' => string].
+     *               EVERY key in $columns is present, so a caller rendering a
+     *               form never has to test for a missing entry; an empty
+     *               selection reports every column as not uniform, which
+     *               renders as "(varies)" and is the safe thing for a form
+     *               that is about to offer to overwrite them.
+     */
+    public static function forHosts(array $hostIDs, array $columns)
+    {
+        $result = [];
+        foreach ($columns as $key => $col) {
+            $result[$key] = ['uniform' => false, 'value' => ''];
+        }
+        $hostIDs = array_values(
+            array_unique(
+                array_filter(
+                    array_map('intval', $hostIDs),
+                    function ($id) {
+                        return $id > 0;
+                    }
+                )
+            )
+        );
+        if (count($hostIDs) < 1 || count($columns) < 1) {
+            return $result;
+        }
+        $selects = ['COUNT(*) AS `_n`'];
+        foreach ($columns as $key => $col) {
+            $safe = self::_alias($key);
+            $selects[] = sprintf(
+                "COUNT(DISTINCT COALESCE(`%s`, '')) AS `d_%s`",
+                $col,
+                $safe
+            );
+            // The COALESCE on the MIN is belt-and-braces and is NOT
+            // observable through the answer this returns -- proven by
+            // mutation, not assumed. `value` is only meaningful when
+            // `uniform` is true, and uniform means every coalesced value
+            // was equal; on the all-NULL selection MIN returns NULL and the
+            // string cast below flattens it to '' anyway. It stays so that
+            // both expressions describe the same value space: a reader
+            // comparing the two should not have to work out that one of
+            // them tolerates NULL and the other does not.
+            $selects[] = sprintf(
+                "MIN(COALESCE(`%s`, '')) AS `v_%s`",
+                $col,
+                $safe
+            );
+        }
+        $sql = sprintf(
+            'SELECT %s FROM `hosts` WHERE `hostID` IN (%s)',
+            implode(',', $selects),
+            implode(',', $hostIDs)
+        );
+        $row = self::$DB->query($sql)->fetch();
+        $n = (int)$row->get('_n');
+        foreach ($columns as $key => $col) {
+            $safe = self::_alias($key);
+            $distinct = (int)$row->get('d_' . $safe);
+            $result[$key] = [
+                'uniform' => ($n > 0 && $distinct <= 1),
+                'value' => (string)$row->get('v_' . $safe),
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * The text a form shows for one column's shared state.
+     *
+     * @param array $info an entry from forHosts()
+     *
+     * @return string ready-to-render, with the value HTML-escaped
+     */
+    public static function text($info)
+    {
+        if (empty($info['uniform'])) {
+            return _('(varies)');
+        }
+        if ('' === (string)$info['value']) {
+            return _('(empty on all)');
+        }
+
+        return \Initiator::e((string)$info['value']) . ' ' . _('(all)');
+    }
+
+    /**
+     * The muted "Hosts: ..." hint beneath a control.
+     *
+     * @param array $info an entry from forHosts()
+     *
+     * @return string
+     */
+    public static function hint($info)
+    {
+        return '<p class="form-text help-block-tight">'
+            . _('Hosts:') . ' ' . self::text($info)
+            . '</p>';
+    }
+
+    /**
+     * A column key reduced to something safe to use as a SQL alias.
+     *
+     * The keys are the CALLER's, so they are not trusted to be identifiers
+     * even though every caller today passes a literal. Stripping rather than
+     * quoting because an alias only has to be stable and unique within one
+     * statement, and this is read back by the same code that wrote it.
+     *
+     * @param string $key the friendly key
+     *
+     * @return string
+     */
+    private static function _alias($key)
+    {
+        return preg_replace('/[^A-Za-z0-9_]/', '', (string)$key);
+    }
+}

--- a/phpstan-tests-baseline.neon
+++ b/phpstan-tests-baseline.neon
@@ -835,6 +835,12 @@ parameters:
 			path: tests/session-provenance.test.php
 
 		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/shared-host-values.test.php
+
+		-
 			message: '#^If condition is always false\.$#'
 			identifier: if.alwaysFalse
 			count: 1

--- a/tests/printer-client-resolves.test.php
+++ b/tests/printer-client-resolves.test.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Pins the printer endpoint to the resolver, and pins `np` in place.
+ *
+ * Two separate things, and the second is the one that matters.
+ *
+ * 1. The list the client is told to install comes from the resolver, so a
+ *    group's printer grant reaches its members. ADR 0038 decision 5: printers
+ *    resolve LIVE on each request, because there is no task to hang a
+ *    snapshot on and a removal has to reach the machine.
+ *
+ * 2. THE EMPTY CASE IS STILL SPELLED `np`. Under printer level `ar` the
+ *    resolved list is authoritative in both directions -- fog-client removes
+ *    every installed printer that is not on it -- and `np`, matched
+ *    case-insensitively against ReturnCode, is the ONE string that triggers
+ *    removal-on-empty. Decision 9 turns the empty case into an ordinary
+ *    success carrying an explicit flag instead, and traces through
+ *    fog-client 0.13.0 to show that is safe. That trace has not been watched
+ *    happen on a mode-`ar` host with steady printers (UNKNOWN-4). Changing
+ *    where the list comes from AND what the empty case means to the client in
+ *    one release leaves nothing to bisect if a fleet comes back with no
+ *    printers, so this test holds the wire format still while the source of
+ *    the list moves.
+ *
+ *    When decision 9 does land, this check is expected to be REPLACED, not
+ *    deleted quietly -- by one asserting the new flag alongside `np` for the
+ *    release they overlap.
+ *
+ * Source-anchored, for the reason set out at length in
+ * tests/task-creation-resolves-assignments.test.php: the resolver's behavior
+ * is covered behaviorally against a real database, and reaching
+ * PrinterClient::json() needs a configured FOG, a host and a client session,
+ * at which point the test is an install rehearsal rather than a gate.
+ *
+ * Usage: php tests/printer-client-resolves.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+$path = $root . '/packages/web/src/Client/PrinterClient.php';
+$body = @file_get_contents($path);
+if (false === $body) {
+    fwrite(STDERR, "FAIL: cannot read $path\n");
+    exit(1);
+}
+$body = (string)$body;
+
+$checks = 0;
+$failures = [];
+$check = static function ($what, $ok) use (&$checks, &$failures) {
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+};
+
+$check(
+    'the printer endpoint resolves through the resolver',
+    false !== strpos(
+        $body,
+        "\$resolved = Resolver::resolvePrinters([\$hostID])[\$hostID]"
+    )
+);
+$check(
+    'PrinterClient imports the resolver',
+    false !== strpos($body, 'use FOG\Assign\Resolver;')
+);
+$check(
+    'the list sent to the client is the resolved one',
+    false !== strpos($body, "\$printerIDs = \$resolved['printers'];")
+);
+$check(
+    'the endpoint no longer sends the host-direct printers alone',
+    false === strpos($body, "\$printerIDs = self::\$Host->get('printers');")
+);
+$check(
+    'the default sent is the resolved default',
+    false !== strpos($body, "if (null !== \$resolved['default']) {")
+);
+
+// The `np` guard. Anchored as the whole return, and required to sit inside
+// the empty-list branch: an `np` string surviving somewhere else in the file
+// would satisfy a bare search while the empty case had quietly stopped
+// emitting it.
+$emptyBranch = "if (\$printerCount < 1) {";
+$emptyAt = strpos($body, $emptyBranch);
+$npAt = strpos($body, "'error' => 'np',");
+$check(
+    'the empty case is still reached by a count check',
+    false !== $emptyAt
+);
+$check(
+    'the empty case still answers `np`',
+    false !== $npAt && false !== $emptyAt && $npAt > $emptyAt
+);
+$check(
+    'nothing else in the endpoint answers `np`',
+    1 === substr_count($body, "'np'")
+);
+
+if (count($failures)) {
+    fwrite(STDERR, "FAIL: the printer endpoint changed in a way that matters:\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    fwrite(
+        STDERR,
+        sprintf("%d of %d checks failed\n", count($failures), $checks)
+    );
+    exit(1);
+}
+
+printf("PASS  printer endpoint resolves: %d checks\n", $checks);
+exit(0);

--- a/tests/shared-host-values.test.php
+++ b/tests/shared-host-values.test.php
@@ -1,0 +1,383 @@
+<?php
+/**
+ * Proves FOG\Util\SharedHostValues is honest about disagreement, and cheap.
+ *
+ * Two properties, and the first is the one that costs people machines.
+ *
+ * 1. HOSTS THAT DISAGREE MUST READ AS DISAGREEING. A form editing forty hosts
+ *    with six images shows "(varies)", never one of the six. Showing one is
+ *    how an admin confirms what they believe is already set and overwrites
+ *    thirty-nine machines. The trap is SQL's own NULL semantics: COUNT(DISTINCT)
+ *    SKIPS NULLs, so a column that is set on some hosts and NULL on the rest
+ *    counts one distinct value and reports agreement among rows that have
+ *    nothing in common. COALESCE is what stops that, and cases 3 and 4 exist
+ *    to make sure it is still there.
+ *
+ * 2. ONE QUERY, whatever the size of the column map or the selection. The DB
+ *    stub COUNTS statements, so a rewrite that reads per column or per host --
+ *    the natural shape, and a query storm at four hundred hosts -- fails
+ *    rather than merely getting slower where nobody is watching.
+ *
+ * Skips without FOG_TEST_DSN, exactly as tests/schema-executes.test.php does.
+ *
+ * Usage: FOG_TEST_DSN=... php tests/shared-host-values.test.php
+ * Exit status 0 = pass or skip, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$dsn = getenv('FOG_TEST_DSN');
+if ($dsn === false || $dsn === '') {
+    echo "SKIP  no FOG_TEST_DSN set; shared host values not checked on a server\n";
+    exit(0);
+}
+if (!in_array('mysql', \PDO::getAvailableDrivers(), true)) {
+    fwrite(STDERR, "FAIL: FOG_TEST_DSN is set but the pdo_mysql driver is missing.\n");
+    exit(1);
+}
+
+$user = getenv('FOG_TEST_USER');
+$pass = getenv('FOG_TEST_PASS');
+$user = ($user === false) ? 'root' : $user;
+$pass = ($pass === false) ? '' : $pass;
+
+$root = dirname(__DIR__);
+$webroot = $root . '/packages/web';
+
+// A scratch database, never the one the DSN names.
+$db = 'fog_shared_host_values_test';
+
+$tmp = sys_get_temp_dir() . '/fog-shared-host-values-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
+register_shutdown_function(
+    function () use ($tmp) {
+        if (!is_dir($tmp)) {
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($tmp, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $f) {
+            $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+        }
+        @rmdir($tmp);
+    }
+);
+if (!defined('FOG_CACHE_DIR')) {
+    define('FOG_CACHE_DIR', $tmp . '/cache');
+}
+if (!defined('FOG_LOG_DIR')) {
+    define('FOG_LOG_DIR', $tmp . '/log');
+}
+if (!defined('FOG_PLUGIN_DIR')) {
+    define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+}
+
+$init = $webroot . '/commons/init.php';
+if (!is_readable($init)) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+require_once $init;
+new Initiator();
+
+$checks = 0;
+$failures = [];
+$check = static function ($what, $ok) use (&$checks, &$failures) {
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+};
+
+try {
+    $pdo = new \PDO(
+        $dsn,
+        $user,
+        $pass,
+        [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]
+    );
+} catch (\PDOException $e) {
+    fwrite(STDERR, 'FAIL: cannot connect: ' . $e->getMessage() . "\n");
+    exit(1);
+}
+
+/**
+ * The statement counter, kept in $GLOBALS rather than on the stub.
+ *
+ * Not stylistic. The increment happens inside SharedHostValues, through a
+ * $DB static analysis cannot connect back to the stub object, so a property
+ * -- instance OR static -- is seen as assigned zero and never touched, and
+ * every assertion about the count is reported as always-false. Analysis does
+ * not track $GLOBALS, so this is the one shape that lets the count be
+ * asserted at all. Both were tried; the note is here so the next person does
+ * not retry them.
+ */
+function svCountQuery()
+{
+    $GLOBALS['sv_queries'] = (int)($GLOBALS['sv_queries'] ?? 0) + 1;
+}
+
+/**
+ * Reads the counter and clears it, so each case counts only its own call.
+ *
+ * @return int statements run since the last call
+ */
+function svTakeQueryCount()
+{
+    $n = (int)($GLOBALS['sv_queries'] ?? 0);
+    $GLOBALS['sv_queries'] = 0;
+    return $n;
+}
+
+/**
+ * A `self::$DB` over real PDO that COUNTS the statements it is asked to run.
+ *
+ * The count is the point. "One query per call" is a design property that
+ * nothing else can observe -- a per-column rewrite returns identical answers
+ * and is simply slower, which is invisible until somebody points the form at
+ * four hundred hosts.
+ */
+class SharedValuesTestDB
+{
+    /** @var \PDO */
+    public $pdo;
+
+
+    /** @var string|bool */
+    public $error = false;
+
+    /** @var \PDOStatement|null */
+    private $_stmt = null;
+
+    public function __construct(\PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function query($sql = null, $data = [], $params = [])
+    {
+        svCountQuery();
+        $this->error = false;
+        try {
+            $this->_stmt = $this->pdo->prepare((string)$sql);
+            $this->_stmt->execute($params ?: null);
+        } catch (\PDOException $e) {
+            $this->_stmt = null;
+            $this->error = $e->getMessage();
+        }
+        return $this;
+    }
+
+    public function fetch($type = null, $fetchType = null, $params = false)
+    {
+        return $this;
+    }
+
+    /**
+     * SharedHostValues reads columns off the row by name, so get($key)
+     * has to answer per column rather than hand back the whole row.
+     */
+    public function get($key = null)
+    {
+        if (null === $this->_stmt) {
+            return null;
+        }
+        static $row = null;
+        if (null === $key) {
+            return null;
+        }
+        $row = $this->_row ?? ($this->_row = $this->_stmt->fetch(\PDO::FETCH_ASSOC));
+        return $row[$key] ?? null;
+    }
+
+    /** @var array|false|null */
+    private $_row = null;
+
+    public function resetRow()
+    {
+        $this->_row = null;
+    }
+}
+
+$pdo->exec("DROP DATABASE IF EXISTS `$db`");
+$pdo->exec("CREATE DATABASE `$db`");
+register_shutdown_function(
+    function () use ($pdo, $db) {
+        try {
+            $pdo->exec("DROP DATABASE IF EXISTS `$db`");
+        } catch (\PDOException $e) {
+            // best effort; the scratch database is named, not guessed
+        }
+    }
+);
+$pdo->exec("USE `$db`");
+
+// Not the real `hosts` table: this one needs columns that are NULLABLE, and
+// the shipped table declares almost everything NOT NULL. The point under test
+// is how NULL and '' are collapsed, which the real schema cannot express, so
+// the fixture is deliberately more permissive than production rather than
+// less.
+$pdo->exec(
+    'CREATE TABLE `hosts` ('
+    . '`hostID` int(11) NOT NULL, '
+    . '`hostImage` varchar(50) NULL, '
+    . '`hostKernel` varchar(255) NULL, '
+    . '`hostDesc` varchar(255) NULL, '
+    . '`hostAD` varchar(50) NULL, '
+    . 'PRIMARY KEY (`hostID`)'
+    . ') ENGINE=InnoDB'
+);
+$pdo->exec(
+    "INSERT INTO `hosts` (`hostID`,`hostImage`,`hostKernel`,`hostDesc`,`hostAD`) VALUES "
+    // 1 and 2 agree on the image, disagree on the kernel.
+    . "(1,'ubuntu','bzImage','shared','yes'), "
+    . "(2,'ubuntu','vmlinuz','shared','yes'), "
+    // 3 agrees on the image; its kernel is NULL while 1 and 2 have values,
+    // and its description is '' while theirs is 'shared'. Both are the
+    // COALESCE trap -- without it, COUNT(DISTINCT) skips the NULL and 1/2/3
+    // read as agreeing about a kernel they do not share.
+    . "(3,'ubuntu',NULL,'',NULL), "
+    // 4 and 5 hold NULL and '' for the image: different spellings of the same
+    // nothing, which must read as agreement on "empty".
+    . "(4,NULL,NULL,NULL,NULL), "
+    . "(5,'',NULL,NULL,NULL)"
+);
+
+$stub = new SharedValuesTestDB($pdo);
+$dbProp = new \ReflectionProperty(\FOG\Base\FOGBase::class, 'DB');
+$dbProp->setAccessible(true);
+$dbProp->setValue(null, $stub);
+
+$columns = [
+    'image' => 'hostImage',
+    'kernel' => 'hostKernel',
+    'desc' => 'hostDesc',
+    'ad' => 'hostAD',
+];
+
+svTakeQueryCount();
+$stub->resetRow();
+$got = \FOG\Util\SharedHostValues::forHosts([1, 2, 3], $columns);
+
+$check(
+    'hosts agreeing on a column report it, with the value',
+    true === ($got['image']['uniform'] ?? null)
+        && 'ubuntu' === ($got['image']['value'] ?? null)
+);
+$check(
+    'hosts holding different values report as not uniform',
+    false === ($got['kernel']['uniform'] ?? null)
+);
+// THE COALESCE GUARD, and the only case that actually tests it. Hosts 1 and 2
+// hold 'yes'; host 3 holds NULL. COUNT(DISTINCT) SKIPS NULLs, so without the
+// COALESCE it counts ONE distinct value and reports that all three agree about
+// a setting one of them does not have -- and MIN() skips it too, so the form
+// would show 'yes (all)'. The kernel column above cannot catch this: 1 and 2
+// already disagree there, so the answer is "not uniform" either way.
+$check(
+    'a value on some hosts and NULL on others is a disagreement',
+    false === ($got['ad']['uniform'] ?? null)
+);
+// The same guard from the '' side: host 3's description is '', 1 and 2 hold
+// 'shared'.
+$check(
+    'an empty string among real values is a disagreement',
+    false === ($got['desc']['uniform'] ?? null)
+);
+$check(
+    'the whole answer takes ONE query, whatever the column count',
+    1 === svTakeQueryCount()
+);
+
+svTakeQueryCount();
+$stub->resetRow();
+$got = \FOG\Util\SharedHostValues::forHosts([4, 5], $columns);
+// NULL and '' are two spellings of the same nothing, so these hosts DO agree.
+$check(
+    'NULL and the empty string count as the same value',
+    true === ($got['image']['uniform'] ?? null)
+        && '' === ($got['image']['value'] ?? null)
+);
+$check(
+    'a column that is empty everywhere is uniform and empty',
+    true === ($got['desc']['uniform'] ?? null)
+        && '' === ($got['desc']['value'] ?? null)
+);
+$check(
+    'a second selection is still one query',
+    1 === svTakeQueryCount()
+);
+
+// An empty selection must still answer for every column, and must answer
+// "not uniform" -- which renders as (varies) and is the safe thing for a form
+// about to offer to overwrite them.
+svTakeQueryCount();
+$stub->resetRow();
+$got = \FOG\Util\SharedHostValues::forHosts([], $columns);
+$check(
+    'an empty selection reports every column, none uniform',
+    ['image', 'kernel', 'desc', 'ad'] === array_keys($got)
+        && false === $got['image']['uniform']
+        && false === $got['kernel']['uniform']
+);
+$check(
+    'an empty selection runs no query at all',
+    0 === svTakeQueryCount()
+);
+
+// A host id that does not exist must not be treated as agreement with
+// nothing: no rows means no agreement.
+svTakeQueryCount();
+$stub->resetRow();
+$got = \FOG\Util\SharedHostValues::forHosts([9999], $columns);
+$check(
+    'a selection matching no rows is not uniform',
+    false === $got['image']['uniform']
+);
+
+// The rendering half.
+$check(
+    'mixed values render as (varies)',
+    _('(varies)') === \FOG\Util\SharedHostValues::text(
+        ['uniform' => false, 'value' => 'ubuntu']
+    )
+);
+$check(
+    'an agreed empty renders as (empty on all)',
+    _('(empty on all)') === \FOG\Util\SharedHostValues::text(
+        ['uniform' => true, 'value' => '']
+    )
+);
+$check(
+    'an agreed value renders with (all), HTML-escaped',
+    false !== strpos(
+        \FOG\Util\SharedHostValues::text(
+            ['uniform' => true, 'value' => '<b>x</b>']
+        ),
+        '&lt;b&gt;'
+    )
+);
+
+if (count($failures)) {
+    fwrite(STDERR, "FAIL: shared host values are not telling the truth:\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    fwrite(
+        STDERR,
+        sprintf("%d of %d checks failed\n", count($failures), $checks)
+    );
+    exit(1);
+}
+
+printf("PASS  shared host values: %d checks\n", $checks);
+exit(0);


### PR DESCRIPTION
**Stacked on #1616 → #1612 → #1611** — merge in that order.

`FOG\Util\SharedHostValues`, keyed on a **host id list** rather than on a group's own membership, so the group page and a mass edit over a selection share one answer to "do these hosts agree". Behavior unchanged; the group page delegates. Done on its own so the mass edit's diff is the mass edit.

## Why one implementation and not two

Two copies of that rule drift the way this codebase documents elsewhere: nothing fails when they disagree, one form just starts telling a different truth than the other about the same hosts.

## The honesty requirement is the whole point

Forty hosts holding six images must read as **(varies)**, never as one of the six — showing one is how an admin confirms what they believe is already set and overwrites thirty-nine machines.

SQL fights this: **`COUNT(DISTINCT)` skips NULLs**, so a column set on some hosts and NULL on the rest counts one distinct value and reports agreement among rows sharing nothing. `COALESCE` is what stops it.

## Building the test corrected two things

| | |
|---|---|
| The first fixture **could not catch** the COALESCE being dropped | Its NULL row sat in a column whose other rows already disagreed, so the answer was "not uniform" either way. There is now a column where two hosts agree and a third is NULL — the only shape where losing COALESCE claims a *false agreement*. |
| The COALESCE on the `MIN` is **not observable** | Proven by mutating it, not assumed. `value` is only read when `uniform` is true, and the string cast flattens NULL anyway. It stays, and now says in the code that it is there for symmetry rather than for a reachable case. |

## It also counts statements

"One query whatever the column count" is a design property nothing else can observe — a per-column rewrite returns identical answers and is merely slower, which is invisible until somebody points the form at four hundred hosts.

The counter lives in `$GLOBALS`, and the comment says why: an instance *or* static property is seen as assigned zero and never touched, because the increment happens inside the class under test through a `$DB` static analysis cannot connect back to the stub — every assertion about the count is then reported as always-false. Both were tried; the note is there so the next person does not retry them.

14 checks, 5 mutations, full suite green, both phpstan configs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)