### PR TITLE
docs: record that the upgrade rehearsal is a required check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,15 +161,23 @@ jobs:
     # suite is running is the useful thing for this segment to say.
     #
     # THESE NAMES ARE NOW LOAD-BEARING. The ruleset "working-1.6 pull request
-    # gate" (active since 2026-08-26) requires all seven of `fogproject / tests
+    # gate" (active since 2026-08-26) requires all eight of `fogproject / tests
     # (PHP 7.4)`, `fogproject / tests (PHP 8.3)`, `fogproject / vendor matches
     # composer.lock`, `fogproject / schema on mariadb:10.5`, `fogproject /
-    # schema on mariadb:11.8`, `fogproject / schema on mysql:8.0` and
-    # `fogproject / release pins resolve` -- plus `phpstan`, which is an inline
-    # job below and so carries no prefix. Renaming this job, or a job inside
-    # fogproject-tests.yml, silently orphans a required context and parks every
-    # pull request on "Expected -- waiting for status to be reported". Update
-    # the ruleset in the same change.
+    # schema on mariadb:11.8`, `fogproject / schema on mysql:8.0`, `fogproject /
+    # release pins resolve` and `fogproject / upgrade rehearsal` -- plus
+    # `phpstan`, which is an inline job below and so carries no prefix.
+    # Renaming this job, or a job inside fogproject-tests.yml, silently orphans
+    # a required context and parks every pull request on "Expected -- waiting
+    # for status to be reported". Update the ruleset in the same change.
+    #
+    # `fogproject / upgrade rehearsal` joined on 2026-09-01. It had been
+    # reporting since 2026-08-31 and was simply never added -- the ruleset was
+    # last edited the day before the job landed -- so it was an omission rather
+    # than a decision, and it showed: #1604 merged with that check RED, because
+    # a required-context list is the only thing the merge queue consults. Its
+    # own docblock in fog-workflows argues the case ("a gate nobody can fail is
+    # the thing these jobs exist to stop"); it is now one that can be failed.
     name: fogproject
     needs: regen
 
@@ -225,7 +233,7 @@ jobs:
   #
   # A REQUIRED CONTEXT since 2026-08-28, after four consecutive green pull
   # requests (#1437, #1438, #1439, #1440). The ruleset "working-1.6 pull
-  # request gate" now requires eight checks: the seven `fogproject / ...` ones
+  # request gate" now requires nine checks: the eight `fogproject / ...` ones
   # the `suite:` comment lists, and this one.
   #
   # THE CONTEXT IS `phpstan` -- exactly that, with no prefix. Verified against

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,9 +144,15 @@ there is not a plain `git push`:
   base + the entry and tests that. So the queue is not a version-bump
   mechanism — the version left git in GH-1510/GH-1513 — it is the thing that
   now catches a pull request whose base moved under it;
-- **eight checks must pass**: the seven `fogproject / …` contexts plus
+- **nine checks must pass**: the eight `fogproject / …` contexts plus
   `phpstan`. `regenerate / …` is deliberately *not* required: it is skipped on
   fork PRs, and requiring it would leave those unmergeable.
+  `fogproject / upgrade rehearsal` was added on 2026-09-01, having reported
+  since the day it landed without ever being required — the ruleset was last
+  edited the day before. That gap is not academic: #1604 merged with the
+  rehearsal RED, because the required-context list is the only thing the merge
+  queue consults, and the stale baseline it left behind then failed every
+  branch that came after it.
 - **the price is two full suite runs per pull request.** The required contexts
   have to be reported against the merge-group ref as well, so `tests.yml`
   triggers on both `pull_request` and `merge_group` and there is no way to


### PR DESCRIPTION
`fogproject / upgrade rehearsal` was added to the **working-1.6 pull request gate** ruleset today, taking the required contexts from eight to nine. Three passages still described the old set; this corrects them.

### Why it was missing

The job began reporting on 2026-08-31 (`602489a20`). The ruleset had last been edited on 2026-08-30 — the day before — so the context was simply never added. An omission, not a decision.

It showed. **#1604 merged with `upgrade rehearsal` RED**, because a required-context list is the only thing the merge queue consults. The stale baseline that merge left behind then failed the rehearsal on every branch that came after it, until `f550a404c` moved the numbers.

That is the outcome the job's own docblock in fog-workflows argues against:

> NOT `continue-on-error`. […] a gate nobody can fail is the thing these jobs exist to stop.

It is now one that can be failed.

### What changed

| File | |
|---|---|
| `.github/workflows/tests.yml` | the `suite:` job's load-bearing context list — seven → eight `fogproject / …` names, with `upgrade rehearsal` spelled out |
| `.github/workflows/tests.yml` | the `phpstan` job's count — eight → nine |
| `CLAUDE.md` | the ruleset section's count, plus why the context was late |

Documentation only; no workflow logic, no job names, no ruleset changes in this PR — the ruleset was updated directly and verified against the API (nine contexts, everything else byte-identical).

### Verified

- `tests/run-all.sh` — 283 passed, 0 failed
- `.github/workflows/tests.yml` parses as YAML
- no remaining occurrence of the old wording anywhere in the tree