### PR TITLE
fix: "Tasking created for 1 hosts" and three more count messages

### DIFF
--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -115,16 +115,20 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
-msgid "%d days left"
-msgstr ""
+msgid "%d day left"
+msgid_plural "%d days left"
+msgstr[0] ""
+msgstr[1] ""
 
 #, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
-msgid "%d selected hosts"
-msgstr "Ausgewählten MAcs freigeben"
+msgid "%d selected host"
+msgid_plural "%d selected hosts"
+msgstr[0] "Ausgewählten MAcs freigeben"
+msgstr[1] "Ausgewählten MAcs freigeben"
 
 #, php-format
 msgid "%d token(s) disabled."
@@ -7787,8 +7791,10 @@ msgid "Server identity"
 msgstr "Server-Shell"
 
 #, fuzzy, php-format
-msgid "Server is only configured to run %d multicast tasks"
-msgstr "Service-Konfiguration"
+msgid "Server is only configured to run %d multicast task"
+msgid_plural "Server is only configured to run %d multicast tasks"
+msgstr[0] "Service-Konfiguration"
+msgstr[1] "Service-Konfiguration"
 
 msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
 msgstr ""
@@ -8968,9 +8974,11 @@ msgstr "Task-Typ ist nicht gültig"
 msgid "Task type update failed!"
 msgstr "Task-Typ aktualisieren fehlgeschlagen"
 
-#, php-format
-msgid "Tasking created for %d hosts"
-msgstr ""
+#, fuzzy, php-format
+msgid "Tasking created for %d host"
+msgid_plural "Tasking created for %d hosts"
+msgstr[0] "Task gestartet"
+msgstr[1] "Task gestartet"
 
 msgid "Tasks"
 msgstr "Tasks"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -120,16 +120,20 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
-msgid "%d days left"
-msgstr ""
+msgid "%d day left"
+msgid_plural "%d days left"
+msgstr[0] ""
+msgstr[1] ""
 
 #, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
-msgid "%d selected hosts"
-msgstr "Approve selected Hosts"
+msgid "%d selected host"
+msgid_plural "%d selected hosts"
+msgstr[0] "Approve selected Hosts"
+msgstr[1] "Approve selected Hosts"
 
 #, php-format
 msgid "%d token(s) disabled."
@@ -7798,8 +7802,10 @@ msgid "Server identity"
 msgstr "Server Shell"
 
 #, fuzzy, php-format
-msgid "Server is only configured to run %d multicast tasks"
-msgstr "Service Configuration"
+msgid "Server is only configured to run %d multicast task"
+msgid_plural "Server is only configured to run %d multicast tasks"
+msgstr[0] "Service Configuration"
+msgstr[1] "Service Configuration"
 
 msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
 msgstr ""
@@ -8977,9 +8983,11 @@ msgstr "Task type is not valid"
 msgid "Task type update failed!"
 msgstr "User update failed"
 
-#, php-format
-msgid "Tasking created for %d hosts"
-msgstr ""
+#, fuzzy, php-format
+msgid "Tasking created for %d host"
+msgid_plural "Tasking created for %d hosts"
+msgstr[0] "Task Started"
+msgstr[1] "Task Started"
 
 msgid "Tasks"
 msgstr "Tasks"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -118,16 +118,20 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
-msgid "%d days left"
-msgstr ""
+msgid "%d day left"
+msgid_plural "%d days left"
+msgstr[0] ""
+msgstr[1] ""
 
 #, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
-msgid "%d selected hosts"
-msgstr "retirar"
+msgid "%d selected host"
+msgid_plural "%d selected hosts"
+msgstr[0] "retirar"
+msgstr[1] "retirar"
 
 #, php-format
 msgid "%d token(s) disabled."
@@ -7928,8 +7932,10 @@ msgid "Server identity"
 msgstr "servidor TFTP"
 
 #, fuzzy, php-format
-msgid "Server is only configured to run %d multicast tasks"
-msgstr "Configuración de servicio"
+msgid "Server is only configured to run %d multicast task"
+msgid_plural "Server is only configured to run %d multicast tasks"
+msgstr[0] "Configuración de servicio"
+msgstr[1] "Configuración de servicio"
 
 msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
 msgstr ""
@@ -9141,9 +9147,11 @@ msgstr "tipo de tarea no es válida"
 msgid "Task type update failed!"
 msgstr "actualización Valoración falló"
 
-#, php-format
-msgid "Tasking created for %d hosts"
-msgstr ""
+#, fuzzy, php-format
+msgid "Tasking created for %d host"
+msgid_plural "Tasking created for %d hosts"
+msgstr[0] "Nombre de la tarea"
+msgstr[1] "Nombre de la tarea"
 
 msgid "Tasks"
 msgstr "Tareas"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -115,16 +115,20 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
-msgid "%d days left"
-msgstr ""
+msgid "%d day left"
+msgid_plural "%d days left"
+msgstr[0] ""
+msgstr[1] ""
 
 #, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
-msgid "%d selected hosts"
-msgstr "Ausgewählten MAcs freigeben"
+msgid "%d selected host"
+msgid_plural "%d selected hosts"
+msgstr[0] "Ausgewählten MAcs freigeben"
+msgstr[1] "Ausgewählten MAcs freigeben"
 
 #, php-format
 msgid "%d token(s) disabled."
@@ -7788,8 +7792,10 @@ msgid "Server identity"
 msgstr "Server-Shell"
 
 #, fuzzy, php-format
-msgid "Server is only configured to run %d multicast tasks"
-msgstr "Service-Konfiguration"
+msgid "Server is only configured to run %d multicast task"
+msgid_plural "Server is only configured to run %d multicast tasks"
+msgstr[0] "Service-Konfiguration"
+msgstr[1] "Service-Konfiguration"
 
 msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
 msgstr ""
@@ -8969,9 +8975,11 @@ msgstr "Task-Typ ist nicht gültig"
 msgid "Task type update failed!"
 msgstr "Task-Typ aktualisieren fehlgeschlagen"
 
-#, php-format
-msgid "Tasking created for %d hosts"
-msgstr ""
+#, fuzzy, php-format
+msgid "Tasking created for %d host"
+msgid_plural "Tasking created for %d hosts"
+msgstr[0] "Task gestartet"
+msgstr[1] "Task gestartet"
 
 msgid "Tasks"
 msgstr "Tasks"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -121,16 +121,20 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
-msgid "%d days left"
-msgstr ""
+msgid "%d day left"
+msgid_plural "%d days left"
+msgstr[0] ""
+msgstr[1] ""
 
 #, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
-msgid "%d selected hosts"
-msgstr "Approuver hôtes sélectionnés"
+msgid "%d selected host"
+msgid_plural "%d selected hosts"
+msgstr[0] "Approuver hôtes sélectionnés"
+msgstr[1] "Approuver hôtes sélectionnés"
 
 #, php-format
 msgid "%d token(s) disabled."
@@ -7784,8 +7788,10 @@ msgid "Server identity"
 msgstr "serveur Shell"
 
 #, fuzzy, php-format
-msgid "Server is only configured to run %d multicast tasks"
-msgstr "Configuration du service"
+msgid "Server is only configured to run %d multicast task"
+msgid_plural "Server is only configured to run %d multicast tasks"
+msgstr[0] "Configuration du service"
+msgstr[1] "Configuration du service"
 
 msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
 msgstr ""
@@ -8962,9 +8968,11 @@ msgstr "Type de tâche n'est pas valide"
 msgid "Task type update failed!"
 msgstr "mise à jour de l'utilisateur a échoué"
 
-#, php-format
-msgid "Tasking created for %d hosts"
-msgstr ""
+#, fuzzy, php-format
+msgid "Tasking created for %d host"
+msgid_plural "Tasking created for %d hosts"
+msgstr[0] "Tâche Started"
+msgstr[1] "Tâche Started"
 
 msgid "Tasks"
 msgstr "les tâches"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -120,16 +120,20 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
-msgid "%d days left"
-msgstr ""
+msgid "%d day left"
+msgid_plural "%d days left"
+msgstr[0] ""
+msgstr[1] ""
 
 #, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
-msgid "%d selected hosts"
-msgstr "Approvare MAC selezionati"
+msgid "%d selected host"
+msgid_plural "%d selected hosts"
+msgstr[0] "Approvare MAC selezionati"
+msgstr[1] "Approvare MAC selezionati"
 
 #, php-format
 msgid "%d token(s) disabled."
@@ -7561,8 +7565,10 @@ msgid "Server identity"
 msgstr "Server Shell"
 
 #, fuzzy, php-format
-msgid "Server is only configured to run %d multicast tasks"
-msgstr "Configurazione del servizio"
+msgid "Server is only configured to run %d multicast task"
+msgid_plural "Server is only configured to run %d multicast tasks"
+msgstr[0] "Configurazione del servizio"
+msgstr[1] "Configurazione del servizio"
 
 msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
 msgstr ""
@@ -8685,9 +8691,11 @@ msgstr "Tipo di attività non è valido"
 msgid "Task type update failed!"
 msgstr "Aggiornamento tipo attività fallita"
 
-#, php-format
-msgid "Tasking created for %d hosts"
-msgstr ""
+#, fuzzy, php-format
+msgid "Tasking created for %d host"
+msgid_plural "Tasking created for %d hosts"
+msgstr[0] "Attività iniziata"
+msgstr[1] "Attività iniziata"
 
 msgid "Tasks"
 msgstr "Attività"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -111,16 +111,20 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
-msgid "%d days left"
-msgstr ""
+msgid "%d day left"
+msgid_plural "%d days left"
+msgstr[0] ""
+msgstr[1] ""
 
 #, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
-msgid "%d selected hosts"
-msgstr "選択したホストを承認"
+msgid "%d selected host"
+msgid_plural "%d selected hosts"
+msgstr[0] "選択したホストを承認"
+msgstr[1] "選択したホストを承認"
 
 #, php-format
 msgid "%d token(s) disabled."
@@ -7521,8 +7525,10 @@ msgid "Server identity"
 msgstr "サーバーシェル"
 
 #, fuzzy, php-format
-msgid "Server is only configured to run %d multicast tasks"
-msgstr "サービス設定"
+msgid "Server is only configured to run %d multicast task"
+msgid_plural "Server is only configured to run %d multicast tasks"
+msgstr[0] "サービス設定"
+msgstr[1] "サービス設定"
 
 msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
 msgstr ""
@@ -8629,9 +8635,11 @@ msgstr "タスクタイプが無効です"
 msgid "Task type update failed!"
 msgstr "タスクタイプの更新に失敗しました"
 
-#, php-format
-msgid "Tasking created for %d hosts"
-msgstr ""
+#, fuzzy, php-format
+msgid "Tasking created for %d host"
+msgid_plural "Tasking created for %d hosts"
+msgstr[0] "次のタスクを開始しました"
+msgstr[1] "次のタスクを開始しました"
 
 msgid "Tasks"
 msgstr "タスク"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -96,16 +96,20 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
-msgid "%d days left"
-msgstr ""
+msgid "%d day left"
+msgid_plural "%d days left"
+msgstr[0] ""
+msgstr[1] ""
 
 #, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, php-format
-msgid "%d selected hosts"
-msgstr ""
+msgid "%d selected host"
+msgid_plural "%d selected hosts"
+msgstr[0] ""
+msgstr[1] ""
 
 #, php-format
 msgid "%d token(s) disabled."
@@ -6657,8 +6661,10 @@ msgid "Server identity"
 msgstr ""
 
 #, php-format
-msgid "Server is only configured to run %d multicast tasks"
-msgstr ""
+msgid "Server is only configured to run %d multicast task"
+msgid_plural "Server is only configured to run %d multicast tasks"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
 msgstr ""
@@ -7634,8 +7640,10 @@ msgid "Task type update failed!"
 msgstr ""
 
 #, php-format
-msgid "Tasking created for %d hosts"
-msgstr ""
+msgid "Tasking created for %d host"
+msgid_plural "Tasking created for %d hosts"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "Tasks"
 msgstr ""

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -120,16 +120,20 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
-msgid "%d days left"
-msgstr ""
+msgid "%d day left"
+msgid_plural "%d days left"
+msgstr[0] ""
+msgstr[1] ""
 
 #, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
-msgid "%d selected hosts"
-msgstr "Aprovar Hosts selecionados"
+msgid "%d selected host"
+msgid_plural "%d selected hosts"
+msgstr[0] "Aprovar Hosts selecionados"
+msgstr[1] "Aprovar Hosts selecionados"
 
 #, php-format
 msgid "%d token(s) disabled."
@@ -7785,8 +7789,10 @@ msgid "Server identity"
 msgstr "Shell servidor"
 
 #, fuzzy, php-format
-msgid "Server is only configured to run %d multicast tasks"
-msgstr "Configuração de serviço"
+msgid "Server is only configured to run %d multicast task"
+msgid_plural "Server is only configured to run %d multicast tasks"
+msgstr[0] "Configuração de serviço"
+msgstr[1] "Configuração de serviço"
 
 msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
 msgstr ""
@@ -8964,9 +8970,11 @@ msgstr "tipo de tarefa não é válido"
 msgid "Task type update failed!"
 msgstr "atualização do utilizador falhou"
 
-#, php-format
-msgid "Tasking created for %d hosts"
-msgstr ""
+#, fuzzy, php-format
+msgid "Tasking created for %d host"
+msgid_plural "Tasking created for %d hosts"
+msgstr[0] "tarefa iniciada"
+msgstr[1] "tarefa iniciada"
 
 msgid "Tasks"
 msgstr "tarefas"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -120,16 +120,20 @@ msgid "%d certificates in this file"
 msgstr ""
 
 #, php-format
-msgid "%d days left"
-msgstr ""
+msgid "%d day left"
+msgid_plural "%d days left"
+msgstr[0] ""
+msgstr[1] ""
 
 #, php-format
 msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
-msgid "%d selected hosts"
-msgstr "批准选定主机"
+msgid "%d selected host"
+msgid_plural "%d selected hosts"
+msgstr[0] "批准选定主机"
+msgstr[1] "批准选定主机"
 
 #, php-format
 msgid "%d token(s) disabled."
@@ -7785,8 +7789,10 @@ msgid "Server identity"
 msgstr "服务器外壳"
 
 #, fuzzy, php-format
-msgid "Server is only configured to run %d multicast tasks"
-msgstr "服务配置"
+msgid "Server is only configured to run %d multicast task"
+msgid_plural "Server is only configured to run %d multicast tasks"
+msgstr[0] "服务配置"
+msgstr[1] "服务配置"
 
 msgid "Server paging bounds. Also published as x-fog-paging at the root of this document."
 msgstr ""
@@ -8964,9 +8970,11 @@ msgstr "任务类型无效"
 msgid "Task type update failed!"
 msgstr "用户更新失败"
 
-#, php-format
-msgid "Tasking created for %d hosts"
-msgstr ""
+#, fuzzy, php-format
+msgid "Tasking created for %d host"
+msgid_plural "Tasking created for %d hosts"
+msgstr[0] "任务开始"
+msgstr[1] "任务开始"
 
 msgid "Tasks"
 msgstr "任务"

--- a/packages/web/src/Items/MulticastSession.php
+++ b/packages/web/src/Items/MulticastSession.php
@@ -189,7 +189,15 @@ class MulticastSession extends FOGController
         if ($max > 0 && self::activeCount() >= $max) {
             throw new \Exception(
                 sprintf(
-                    _('Server is only configured to run %d multicast tasks'),
+                    // FOG_MULTICAST_MAX_SESSIONS of 1 is a normal setting on
+                    // a small server, and it is the one value this sentence
+                    // used to get wrong: "run 1 multicast tasks".
+                    /* translators: %d is a number of concurrent sessions */
+                    ngettext(
+                        'Server is only configured to run %d multicast task',
+                        'Server is only configured to run %d multicast tasks',
+                        $max
+                    ),
                     $max
                 )
             );

--- a/packages/web/src/Pages/FOGConfigurationPage.php
+++ b/packages/web/src/Pages/FOGConfigurationPage.php
@@ -615,7 +615,10 @@ class FOGConfigurationPage extends FOGPage
             // 30 days is the window every ACME client renews inside, so a
             // certificate still amber here is one nothing is renewing.
             $out .= '<br><span class="badge bg-warning">' . sprintf(
-                _('%d days left'),
+                // One day left is precisely when somebody reads this badge,
+                // so it is the case worth getting right.
+                /* translators: %d is a number of days */
+                ngettext('%d day left', '%d days left', $days),
                 $days
             ) . '</span>';
         }

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -4839,7 +4839,11 @@ class HostManagement extends FOGPage
                     'name',
                     sprintf(
                         /* translators: %d is a number of hosts */
-                        _('%d selected hosts'),
+                        ngettext(
+                            '%d selected host',
+                            '%d selected hosts',
+                            count($hosts)
+                        ),
                         count($hosts)
                     )
                 )
@@ -4876,8 +4880,17 @@ class HostManagement extends FOGPage
             $msg = json_encode(
                 [
                     'msg' => sprintf(
+                        // ngettext, not _(): a single-host tasking is by
+                        // far the commonest thing this method does, and it
+                        // used to answer "Tasking created for 1 hosts".
+                        // The count is passed twice on purpose -- once to
+                        // choose the form, once for sprintf to interpolate.
                         /* translators: %d is a number of hosts */
-                        _('Tasking created for %d hosts'),
+                        ngettext(
+                            'Tasking created for %d host',
+                            'Tasking created for %d hosts',
+                            count($hosts)
+                        ),
                         count($hosts)
                     ),
                     'title' => _('Create Task Success')


### PR DESCRIPTION
## The bug

Reported against the new host list quick tasks — tasking a single host answers **"Tasking created for 1 hosts"**.

Four messages interpolate a count and then hardcode a plural noun, and each is wrong at exactly the count somebody is most likely to see:

| Where | Renders at n=1 |
|---|---|
| `deployMultiPost()` toast | `Tasking created for 1 hosts` |
| `deployMultiPost()` — the unsaved `Group`'s name, which is what the multicast session ends up called | `1 selected hosts` |
| `MulticastSession::assertCapacity()` | `Server is only configured to run 1 multicast tasks` — `FOG_MULTICAST_MAX_SESSIONS = 1` is a normal small-server setting |
| Certificate expiry badge | `1 days left` — and one day left is precisely when that badge gets read |

## The fix

All four become `ngettext()`. That is **new to this codebase** — there were no prior uses — so two things were checked rather than assumed:

- **Extraction.** The pre-commit hook's `xgettext` call passes no `--keyword`, so PHP's defaults apply and `ngettext:1,2` is picked up for free. Confirmed by running the hook's exact flags over a scratch file and getting a real `msgid_plural` entry back, not by reading the manual.
- **The untranslated path.** With no textdomain bound — every English install — PHP's `ngettext` returns the singular for `n == 1` and the plural otherwise. Verified: `n=0 → 0 hosts`, `n=1 → 1 host`, `n=2 → 2 hosts`, `n=25 → 25 hosts`. So this works before a single catalog is regenerated.

The count is passed twice at each site: once to choose the form, once for `sprintf` to interpolate.

## Deliberately not changed

- **`%d certificates in this file`** reads like the same bug and is not — it sits inside `if ($count > 1)` and can never render the singular. Caught by reading it rather than by pattern-matching, which is also the reason for the next point.
- **Ten `%d token(s) revoked` / `%d host(s)` style messages.** The `(s)` form is ugly but not *wrong*, and rewriting ten strings across four pages nobody complained about is a bigger diff than the bug justifies. Happy to sweep them separately if wanted.
- **No lint gate for this class.** The obvious heuristic — a `_()` string where `%d` precedes a word ending in `s` — flags the certificates message above, which is correct code. So it needs a human read per hit and an allowlist that would start out mostly false positives. Five real instances in the tree's whole history is not a drift rate that earns that.

No `FOG_BCACHE_VER` bump: PHP only, no JS or CSS.

Note the `regenerate` job will have real work here — the msgids changed, so it will push a catalog commit and the suite will re-run against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SAeGKvENjVu7eLPnijqNL