### PR TITLE
Send an explicit noPrinters flag alongside np

### DIFF
--- a/docs/release/1.6.0-release-notes.DRAFT.md
+++ b/docs/release/1.6.0-release-notes.DRAFT.md
@@ -256,10 +256,16 @@ pre-upgrade *dump* — it is not a schema rollback.
   printer that is not on it. That has always been true of that mode, and is
   worth re-reading now that a group can add to the list.
 
-  The wire format has NOT changed: a host with no printers at all still
-  answers `np` exactly as before. Turning that into an ordinary empty result
-  is a separate change, deliberately not bundled with this one, so that a
-  fleet reporting missing printers has something to bisect.
+  **Existing clients are unaffected by the wire format.** A host with no
+  printers at all still answers `np` exactly as before, so a client that has
+  not been updated behaves identically. Alongside it the response now carries
+  an explicit `noPrinters` boolean, present on every response rather than only
+  the empty one, which is what a future client will read instead. `np` is
+  removed only in a later release, once that has been watched working on a
+  host running printer level `ar`.
+
+  If you maintain something that consumes `/service/Printers.php`, prefer
+  `noPrinters` over `error == "np"` from now on.
   <!-- verified: docs/adr/0038 decisions 4, 5, 6, 7 and 9; FOG\Assign\Resolver;
   Client/PrinterClient.php; docs/GROUP_SHARED_STATE.md -->
 - **The `persistentgroups` plugin is retired**, and its database TRIGGER is

--- a/packages/web/src/Client/PrinterClient.php
+++ b/packages/web/src/Client/PrinterClient.php
@@ -80,19 +80,39 @@ class PrinterClient extends FOGClient
         $printerIDs = $resolved['printers'];
         $printerCount = count($printerIDs ?: []);
         if ($printerCount < 1) {
-            // STILL SPELLED `np`, and that is deliberate rather than
-            // leftover. ADR 0038 decision 9 makes this an ordinary success
-            // carrying an explicit flag instead of an error, and traces
-            // through fog-client to show it is safe -- but that trace has
-            // not been WATCHED happen on a mode-`ar` host with steady
-            // printers (UNKNOWN-4), and `np` is the single string that
-            // triggers removal-on-empty in the client. Changing where the
-            // list comes from and what the empty case means to the client
-            // in one step would leave nothing to bisect if a fleet came
-            // back with no printers. So this release changes only the
-            // source of the list; the wire format moves separately.
+            // BOTH SPELLINGS, on purpose. ADR 0038 decision 9 turns "this
+            // host has no printers" into an ordinary success carrying an
+            // explicit flag instead of an error, and its shipping order is
+            // to send `np` ALONGSIDE the new flag for a release before
+            // dropping it.
+            //
+            // The two halves need different evidence, which is why they are
+            // separated rather than done together:
+            //
+            //   - ADDING `noPrinters` needs none. The shipped client's
+            //     printer contract (fog-client 0.13.0,
+            //     Modules/DataContracts/PrinterManager.cs) declares Mode,
+            //     Printers and AllPrinters and nothing else, yet this
+            //     endpoint has always sent `default` too -- which that
+            //     contract has no member for and which the separate
+            //     DefaultPrinterManager module reads from its own endpoint.
+            //     So an unknown top-level key is not merely assumed safe;
+            //     the endpoint has been proving it every poll for years.
+            //
+            //   - REMOVING `np` needs the observation nobody has made yet
+            //     (UNKNOWN-4). `np`, matched case-insensitively against
+            //     ReturnCode, is the single string that triggers
+            //     removal-on-empty in the client, so dropping it changes
+            //     what an old client does with this response. It stays
+            //     until a mode-`ar` host with steady printers has been
+            //     watched through a poll cycle.
+            //
+            // A client can only USE the flag if it is present in both
+            // branches -- an absent key would be indistinguishable from an
+            // older server -- so the success return below carries it too.
             return [
                 'error' => 'np',
+                'noPrinters' => true,
                 'mode' => self::$_modes[$level],
                 'allPrinters' => $allPrinters,
                 'default' => '',
@@ -140,6 +160,11 @@ class PrinterClient extends FOGClient
             unset($Printer);
         }
         return [
+            // Always present, never only on the empty branch: a client
+            // testing `noPrinters` has to be able to tell "this server says
+            // no" from "this server is too old to say", and a key that
+            // appears only in one case cannot express that.
+            'noPrinters' => false,
             'mode' => self::$_modes[$level],
             'allPrinters' => $allPrinters,
             'default' => $default,

--- a/tests/printer-client-resolves.test.php
+++ b/tests/printer-client-resolves.test.php
@@ -9,22 +9,28 @@
  *    resolve LIVE on each request, because there is no task to hang a
  *    snapshot on and a removal has to reach the machine.
  *
- * 2. THE EMPTY CASE IS STILL SPELLED `np`. Under printer level `ar` the
+ * 2. THE EMPTY CASE CARRIES BOTH SPELLINGS. Under printer level `ar` the
  *    resolved list is authoritative in both directions -- fog-client removes
  *    every installed printer that is not on it -- and `np`, matched
  *    case-insensitively against ReturnCode, is the ONE string that triggers
  *    removal-on-empty. Decision 9 turns the empty case into an ordinary
- *    success carrying an explicit flag instead, and traces through
- *    fog-client 0.13.0 to show that is safe. That trace has not been watched
- *    happen on a mode-`ar` host with steady printers (UNKNOWN-4). Changing
- *    where the list comes from AND what the empty case means to the client in
- *    one release leaves nothing to bisect if a fleet comes back with no
- *    printers, so this test holds the wire format still while the source of
- *    the list moves.
+ *    success carrying an explicit flag instead, and its shipping order is to
+ *    send `np` ALONGSIDE that flag for a release before dropping it. Both are
+ *    sent now, and this file pins both halves:
  *
- *    When decision 9 does land, this check is expected to be REPLACED, not
- *    deleted quietly -- by one asserting the new flag alongside `np` for the
- *    release they overlap.
+ *      - `noPrinters` must appear in BOTH returns. A client cannot use a flag
+ *        that shows up only when it is true, because an absent key is
+ *        indistinguishable from a server too old to send it. The check counts
+ *        occurrences rather than looking for one, because a single one would
+ *        be satisfied by the empty branch alone -- the version nothing can
+ *        consume.
+ *      - `np` must stay until UNKNOWN-4 is observed. Dropping it changes what
+ *        an OLD client does with this response, and no mode-`ar` host with
+ *        steady printers has been watched through a poll cycle yet.
+ *
+ *    So the `np` check is not permanent, and is not to be deleted quietly
+ *    either: when that observation exists it is REPLACED by one asserting the
+ *    empty case no longer carries an `error` at all.
  *
  * Source-anchored, for the reason set out at length in
  * tests/task-creation-resolves-assignments.test.php: the resolver's behavior
@@ -104,6 +110,22 @@ $check(
 $check(
     'nothing else in the endpoint answers `np`',
     1 === substr_count($body, "'np'")
+);
+
+// The flag, and specifically that it is in BOTH returns. Counting is what
+// makes that assertion real: a single occurrence would be satisfied by the
+// empty branch alone, which is the version a client cannot consume.
+$check(
+    'the empty case also carries the explicit noPrinters flag',
+    false !== strpos($body, "'noPrinters' => true,")
+);
+$check(
+    'the success case carries it too, so a client can tell it apart',
+    false !== strpos($body, "'noPrinters' => false,")
+);
+$check(
+    'the flag appears exactly twice -- once per return',
+    2 === substr_count($body, "'noPrinters' =>")
 );
 
 if (count($failures)) {


### PR DESCRIPTION
Finishes what #1616 left half-done. Decision 9's shipping order is `np` **alongside** the new flag for a release, then `np` goes — #1616 sent neither half, because I held the whole thing behind UNKNOWN-4 and UNKNOWN-4 only gates one half.

## The two halves need different evidence

**Adding the flag needs none.** The shipped client's printer contract (fog-client 0.13.0, `Modules/DataContracts/PrinterManager.cs`) declares `Mode`, `Printers` and `AllPrinters` and nothing else — yet this endpoint has always sent `default` as well, which that contract has no member for, and which is read by the *separate* `DefaultPrinterManager` module from its own endpoint. So "an unknown top-level key is ignored" is not an assumption about the deserializer: this endpoint has been demonstrating it every poll for years.

**Removing `np` needs the observation nobody has made.** It is the single string that triggers removal-on-empty in the client, so dropping it changes what an *unupdated* client does with this response. It stays until a mode-`ar` host with steady printers has been watched through a poll cycle.

## The flag is on both returns

A client testing `noPrinters` has to tell "this server says no printers" from "this server is too old to say", and a key present only when true cannot express that. The check **counts occurrences** rather than looking for one, because a single occurrence would be satisfied by exactly the useless version.

Existing clients are unaffected: the empty case still carries `error: np` and behaves identically.

3 mutations — the flag on either branch alone, and `np` dropped now that the flag exists — each turn the test red. 11 checks. Full suite green, both phpstan configs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)