### PR TITLE
The mass-edit action model, which fails closed

### DIFF
--- a/bin/psr4-scan.php
+++ b/bin/psr4-scan.php
@@ -206,6 +206,9 @@ const TABLE = [
     // agree about this column", which the group page and any mass edit over
     // a selection both need and neither owns. Not Items -- it is not a row.
     'SharedHostValues' => 'Util',
+    // Util for the same reason: reducing a submission to leave/set/clear
+    // belongs to whichever form is doing the editing, and to none of them.
+    'MassEdit' => 'Util',
     'SnapinSaveException' => 'Exception',
     'UploadException' => 'Exception',
 ];

--- a/packages/web/src/Util/MassEdit.php
+++ b/packages/web/src/Util/MassEdit.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Turns a mass-edit submission into explicit per-field instructions.
+ *
+ * PHP version 7.4+
+ *
+ * @category MassEdit
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Util;
+
+use FOG\Base\FOGBase;
+
+/**
+ * Turns a mass-edit submission into explicit per-field instructions.
+ *
+ * A form that edits many hosts at once and posts every field is a form that
+ * overwrites everything the admin did not touch. Every field therefore needs
+ * three states -- LEAVE ALONE, SET TO THIS VALUE, CLEAR -- and ADR 0038
+ * decision 11 calls this the single requirement most likely to be got wrong,
+ * "because the wrong version looks identical until somebody's images are
+ * gone". Nothing errors. The form submits, the page says it worked, and four
+ * hundred hosts quietly hold a value nobody chose.
+ *
+ * So the resolution is one function, it is out of band, and it fails closed.
+ *
+ * OUT OF BAND, meaning the ACTION IS ITS OWN CONTROL rather than a magic
+ * value inside the field. The codebase currently carries the in-band version
+ * next door: the group page reads the literal string `NULL`, case-insensitively,
+ * as "clear this" and a blank as "leave alone" (GroupManagement.php:713-720).
+ * That is rejected here for three reasons, in increasing order of weight:
+ *
+ *   - it is undiscoverable; nothing in the form says the word NULL is magic;
+ *   - it cannot express "clear" for a control with no text box, which is why
+ *     image, building and printer level had to be special-cased;
+ *   - it has no escape, so a value that is legitimately the string "NULL"
+ *     cannot be set at all.
+ *
+ * FAILS CLOSED, meaning ANYTHING NOT RECOGNIZED IS "LEAVE ALONE". A missing
+ * action, an empty one, a misspelled one, a key the caller never offered, an
+ * action array that did not arrive as an array -- every one of them resolves
+ * to LEAVE. There is no input to this function that writes to a column the
+ * submission did not explicitly ask to change, which is the property the
+ * tests exist to hold down, because it is the one whose absence is invisible.
+ *
+ * The one case worth stating rather than discovering: SET with an empty
+ * value writes empty. That is not a malformed submission being tolerated --
+ * the action control and the value control are separate, so choosing SET and
+ * leaving the box blank is a person saying "make it blank". CLEAR exists for
+ * the controls that have no box to blank.
+ *
+ * @category MassEdit
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class MassEdit extends FOGBase
+{
+    /**
+     * Leave every host's current value alone. The default, always.
+     *
+     * @var string
+     */
+    const LEAVE = 'leave';
+
+    /**
+     * Write the submitted value to every host.
+     *
+     * @var string
+     */
+    const SET = 'set';
+
+    /**
+     * Write the field's empty value to every host.
+     *
+     * @var string
+     */
+    const CLEAR = 'clear';
+
+    /**
+     * Reduces a submission to one explicit instruction per offered field.
+     *
+     * @param array $keys    the field keys the caller is willing to act on.
+     *                       Anything outside this list is discarded, so a
+     *                       submission cannot name a column the caller never
+     *                       offered.
+     * @param mixed $actions the posted action map, key => action. Not
+     *                       required to be an array: filter_input_array()
+     *                       hands back null when nothing matched, and null
+     *                       has to mean "change nothing" rather than throw.
+     * @param mixed $values  the posted value map, key => value. Same.
+     *
+     * @return array key => ['action' => one of the three, 'value' => string].
+     *               EVERY key in $keys is present. A caller -- core or a
+     *               plugin -- never has to decide what an absent key meant,
+     *               which is the ambiguity this whole class exists to remove.
+     */
+    public static function resolve(array $keys, $actions, $values)
+    {
+        $actions = is_array($actions) ? $actions : [];
+        $values = is_array($values) ? $values : [];
+        $allowed = [self::LEAVE, self::SET, self::CLEAR];
+        $resolved = [];
+        foreach ($keys as $key) {
+            $key = (string)$key;
+            $action = $actions[$key] ?? self::LEAVE;
+            // in_array with strict comparison: '0' or 0 arriving as an
+            // action must not loosely match a string constant. Everything
+            // unrecognized lands on LEAVE, which is the whole safety
+            // property -- a typo in a hand-made request changes nothing
+            // rather than clearing a column across the selection.
+            if (!is_string($action)
+                || !in_array($action, $allowed, true)
+            ) {
+                $action = self::LEAVE;
+            }
+            // SET without a value key is malformed rather than deliberate:
+            // the form pairs the two controls, so an action arriving with no
+            // box to read from is not a person choosing to blank a field. It
+            // degrades to LEAVE. A value that IS present and empty is left
+            // alone here and written as empty -- see the class docblock.
+            if (self::SET === $action && !array_key_exists($key, $values)) {
+                $action = self::LEAVE;
+            }
+            $value = '';
+            if (self::SET === $action) {
+                $raw = $values[$key];
+                // Arrays and objects are not values. A field posting
+                // key[]=a&key[]=b is either a bug or somebody probing, and
+                // casting either to string is a PHP notice and a garbage
+                // column value.
+                $value = is_scalar($raw) || null === $raw
+                    ? trim((string)$raw)
+                    : '';
+                if (!is_scalar($raw) && null !== $raw) {
+                    $action = self::LEAVE;
+                }
+            }
+            $resolved[$key] = ['action' => $action, 'value' => $value];
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Turns resolved instructions into the column map an update takes.
+     *
+     * @param array $resolved output of resolve()
+     * @param array $spec     key => ['field' => <FOGController field name>,
+     *                        'empty' => <what CLEAR writes, default ''>].
+     *                        A key absent from the spec is skipped: the spec
+     *                        is what says a key may touch a column at all.
+     *
+     * @return array field name => value, ready for a manager update(). EMPTY
+     *               when nothing was set or cleared -- and an empty map must
+     *               NOT be handed to an update, because an UPDATE with no
+     *               assignments is either a syntax error or, worse, a
+     *               statement whose WHERE is the only thing left.
+     */
+    public static function columnUpdates(array $resolved, array $spec)
+    {
+        $updates = [];
+        foreach ($resolved as $key => $instruction) {
+            if (!isset($spec[$key]['field'])) {
+                continue;
+            }
+            $action = $instruction['action'] ?? self::LEAVE;
+            if (self::SET === $action) {
+                $updates[$spec[$key]['field']] = $instruction['value'];
+            } elseif (self::CLEAR === $action) {
+                // Per field, because "empty" is not one value. A varchar
+                // column clears to '', an int foreign key to 0; writing ''
+                // into an int column stores 0 on a permissive server and
+                // errors on a strict one, so the answer belongs in the spec
+                // rather than in a cast here.
+                $updates[$spec[$key]['field']] = $spec[$key]['empty'] ?? '';
+            }
+        }
+
+        return $updates;
+    }
+
+    /**
+     * The keys a submission actually asked to change.
+     *
+     * @param array $resolved output of resolve()
+     *
+     * @return array the keys whose action is not LEAVE
+     */
+    public static function touched(array $resolved)
+    {
+        $touched = [];
+        foreach ($resolved as $key => $instruction) {
+            if (self::LEAVE !== ($instruction['action'] ?? self::LEAVE)) {
+                $touched[] = $key;
+            }
+        }
+
+        return $touched;
+    }
+}

--- a/tests/mass-edit-fails-closed.test.php
+++ b/tests/mass-edit-fails-closed.test.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * Proves FOG\Util\MassEdit never writes what it was not asked to write.
+ *
+ * ADR 0038 decision 11 calls the three-state field the single requirement
+ * most likely to be got wrong, "because the wrong version looks identical
+ * until somebody's images are gone". That is the whole difficulty: a
+ * mass-edit form that defaults wrong does not error, does not warn, and does
+ * not look different. It submits, the page says it worked, and four hundred
+ * hosts hold a value nobody chose.
+ *
+ * So the property under test is not "does it set values" -- that half is
+ * obvious and would be noticed in a day. It is the negative one: NO INPUT
+ * REACHES A COLUMN THE SUBMISSION DID NOT EXPLICITLY ASK TO CHANGE. Every
+ * case below is a way of arriving at a write without having asked for one,
+ * and each is checked to produce LEAVE:
+ *
+ *   - no action posted at all
+ *   - an action of '' , 'SET' in the wrong case, or a typo
+ *   - an action of 0 or '0', which loose comparison would match a constant
+ *   - a key the caller never offered
+ *   - actions or values arriving as null, which is what
+ *     filter_input_array() hands back when nothing matched
+ *   - SET with no corresponding value control
+ *   - SET whose value arrived as an array
+ *
+ * The positive cases are here too, because a gate that refuses everything is
+ * also broken -- it is just broken in the direction somebody notices.
+ *
+ * No database: this is pure resolution, and keeping it that way means the
+ * check runs everywhere rather than only where a server exists.
+ *
+ * Usage: php tests/mass-edit-fails-closed.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+require_once $root . '/packages/web/src/Base/FOGBase.php';
+require_once $root . '/packages/web/src/Util/MassEdit.php';
+
+use FOG\Util\MassEdit;
+
+$checks = 0;
+$failures = [];
+$check = static function ($what, $ok) use (&$checks, &$failures) {
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+};
+
+$keys = ['kernel', 'kernelArgs', 'productKey', 'image'];
+$spec = [
+    'kernel' => ['field' => 'kernel'],
+    'kernelArgs' => ['field' => 'kernelArgs'],
+    'productKey' => ['field' => 'productKey'],
+    // An int column: "empty" is 0, not ''. Writing '' into an int column
+    // stores 0 on a permissive server and errors on a strict one.
+    'image' => ['field' => 'imageID', 'empty' => 0],
+];
+
+/**
+ * Every way of failing to ask for a change. Each must resolve to LEAVE and
+ * must contribute nothing to the column map.
+ */
+$closedCases = [
+    'nothing posted at all' => [null, null],
+    'an empty actions map' => [[], []],
+    // The case that actually exercises the DEFAULT. Everything else here
+    // posts an action for `kernel`, so the `?? LEAVE` never fires and a
+    // mutation flipping that default to SET slips through -- proven, by
+    // running it. A request carrying values and no actions is also the
+    // realistic hand-made shape: it is what you get by scraping a form's
+    // inputs and dropping the controls you did not understand.
+    'values posted with no actions at all' => [
+        [],
+        ['kernel' => 'bzImage', 'kernelArgs' => 'quiet'],
+    ],
+    'an action of the empty string' => [
+        ['kernel' => ''],
+        ['kernel' => 'bzImage'],
+    ],
+    'an action in the wrong case' => [
+        ['kernel' => 'SET'],
+        ['kernel' => 'bzImage'],
+    ],
+    'a misspelled action' => [
+        ['kernel' => 'sett'],
+        ['kernel' => 'bzImage'],
+    ],
+    // The loose-comparison trap, and it is VERSION-DEPENDENT: on PHP 7.4
+    // `0 == 'leave'` is true, on PHP 8 it is false. So dropping the strict
+    // flag from the in_array() is a real defect that this case reddens only
+    // on the 7.4 arm -- verified by mutating it on 8.3, where it passes
+    // either way. The suite runs both, which is what makes the check worth
+    // keeping; anyone re-running the mutation locally on 8.x and concluding
+    // the flag is decorative is reading a false negative.
+    'an action of integer zero' => [
+        ['kernel' => 0],
+        ['kernel' => 'bzImage'],
+    ],
+    'an action of string zero' => [
+        ['kernel' => '0'],
+        ['kernel' => 'bzImage'],
+    ],
+    'an action that is itself an array' => [
+        ['kernel' => ['set']],
+        ['kernel' => 'bzImage'],
+    ],
+    'actions posted as a string rather than a map' => [
+        'set',
+        ['kernel' => 'bzImage'],
+    ],
+    'SET with no value control at all' => [
+        ['kernel' => MassEdit::SET],
+        [],
+    ],
+    'SET whose value arrived as an array' => [
+        ['kernel' => MassEdit::SET],
+        ['kernel' => ['a', 'b']],
+    ],
+];
+
+foreach ($closedCases as $label => $case) {
+    list($actions, $values) = $case;
+    $resolved = MassEdit::resolve($keys, $actions, $values);
+    $check(
+        'leaves everything alone: ' . $label,
+        MassEdit::LEAVE === ($resolved['kernel']['action'] ?? null)
+    );
+    $check(
+        'writes no column: ' . $label,
+        [] === MassEdit::columnUpdates($resolved, $spec)
+    );
+}
+
+// A key the caller never offered must not reach the resolution at all, let
+// alone a column. This is the difference between "a plugin may edit its own
+// fields" and "a submission may name any column it likes".
+$resolved = MassEdit::resolve(
+    $keys,
+    ['hostADPass' => MassEdit::SET, 'kernel' => MassEdit::LEAVE],
+    ['hostADPass' => 'hunter2']
+);
+$check(
+    'a key outside the offered list is not resolved',
+    !array_key_exists('hostADPass', $resolved)
+);
+$check(
+    'a key outside the offered list writes nothing',
+    [] === MassEdit::columnUpdates(
+        $resolved,
+        $spec + ['hostADPass' => ['field' => 'ADPass']]
+    )
+);
+
+// ...and a key that IS offered but has no spec entry still writes nothing.
+// The spec is what says a key may touch a column; being offered only says it
+// may be resolved.
+$resolved = MassEdit::resolve(
+    ['somethingElse'],
+    ['somethingElse' => MassEdit::SET],
+    ['somethingElse' => 'x']
+);
+$check(
+    'an offered key with no spec entry writes no column',
+    [] === MassEdit::columnUpdates($resolved, $spec)
+);
+
+// Every offered key comes back, so no caller has to interpret an absence.
+$resolved = MassEdit::resolve($keys, ['kernel' => MassEdit::SET], ['kernel' => 'a']);
+$check(
+    'every offered key is present in the result',
+    $keys === array_keys($resolved)
+);
+
+// The positive half.
+$resolved = MassEdit::resolve(
+    $keys,
+    [
+        'kernel' => MassEdit::SET,
+        'kernelArgs' => MassEdit::CLEAR,
+        'image' => MassEdit::CLEAR,
+        'productKey' => MassEdit::LEAVE,
+    ],
+    [
+        'kernel' => '  bzImage  ',
+        // A value posted alongside CLEAR is ignored, not written.
+        'kernelArgs' => 'quiet',
+        'productKey' => 'AAAAA-BBBBB',
+    ]
+);
+$check(
+    'SET writes the value, trimmed',
+    'bzImage' === ($resolved['kernel']['value'] ?? null)
+);
+$check(
+    'CLEAR ignores any value posted with it',
+    '' === ($resolved['kernelArgs']['value'] ?? null)
+);
+$check(
+    'LEAVE writes nothing even when a value was posted',
+    MassEdit::LEAVE === ($resolved['productKey']['action'] ?? null)
+);
+$updates = MassEdit::columnUpdates($resolved, $spec);
+$check(
+    'the column map carries exactly what was set and cleared',
+    ['kernel' => 'bzImage', 'kernelArgs' => '', 'imageID' => 0] === $updates
+);
+$check(
+    "CLEAR uses the field's own empty value, not a blanket ''",
+    array_key_exists('imageID', $updates) && 0 === $updates['imageID']
+);
+$check(
+    'touched() names only the fields that were acted on',
+    ['kernel', 'kernelArgs', 'image'] === MassEdit::touched($resolved)
+);
+
+// SET with a present but empty value is a deliberate blanking, not a
+// malformed request: the action control and the value control are separate,
+// so choosing SET and leaving the box empty is somebody saying "make it
+// empty". Stated here so the behavior is pinned rather than discovered.
+$resolved = MassEdit::resolve(
+    ['kernel'],
+    ['kernel' => MassEdit::SET],
+    ['kernel' => '']
+);
+$check(
+    'SET with a present but empty value writes empty',
+    MassEdit::SET === $resolved['kernel']['action']
+        && ['kernel' => ''] === MassEdit::columnUpdates($resolved, $spec)
+);
+
+if (count($failures)) {
+    fwrite(STDERR, "FAIL: the mass edit does not fail closed:\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    fwrite(
+        STDERR,
+        sprintf("%d of %d checks failed\n", count($failures), $checks)
+    );
+    exit(1);
+}
+
+printf("PASS  mass edit fails closed: %d checks\n", $checks);
+exit(0);


### PR DESCRIPTION
ADR 0038 decision 11 — the first slice of the mass edit. Adds `FOG\Util\MassEdit` and its test; **nothing calls it yet**, the form and apply endpoint follow. Split so this diff can be reviewed for the rule rather than for the markup.

Every field in a mass edit needs three states — leave alone / set / clear — and the decision calls this the single requirement most likely to be got wrong, *"because the wrong version looks identical until somebody's images are gone"*. Nothing errors. The form submits, the page says it worked, and four hundred hosts hold a value nobody chose.

## Out of band: the action is its own control

The in-band version lives next door today — the group page reads the literal string `NULL`, case-insensitively, as "clear this" (`GroupManagement.php:713-720`). Rejected for three reasons, increasing in weight: nothing in the form says the word `NULL` is magic; it cannot express "clear" for a control with no text box, which is why image, building and printer level had to be special-cased; and it has no escape, so a value that legitimately *is* the string `NULL` cannot be set.

## Fails closed

A missing action, an empty one, a misspelled one, one arriving as an array, a key the caller never offered, an actions map that is not a map, `SET` with no value control — all resolve to LEAVE. There is no input that writes to a column the submission did not explicitly ask to change.

## The test corrected itself twice

35 checks, nearly all of the form *"this did not write anything"*.

- **The mutation flipping the default from LEAVE to SET slipped through the first cut.** Every case posted an action for the field it asserted on, so `?? LEAVE` never fired. There is now a case posting *values with no actions at all* — which is also the realistic hand-made shape, being what you get from scraping a form's inputs and dropping the controls you did not understand.
- **Dropping the strict flag from `in_array()` also passed, and that one is a false negative.** `0 == 'leave'` is **true on PHP 7.4** and false on PHP 8, and this box runs 8.3. The suite runs both arms, so the check earns its place — and the test now says so, because the next person to mutate it locally will otherwise conclude the flag is decorative.

No database: pure resolution, so it runs everywhere rather than only where a server exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)