### PR TITLE
The host mass-edit apply endpoint

### DIFF
--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -5426,6 +5426,14 @@ msgid "Marked failed, task"
 msgstr "Laden fehlgeschlagen: %s"
 
 #, fuzzy
+msgid "Mass Edit Fail"
+msgstr "Aktualisierung der Rolle fehlgeschlagen"
+
+#, fuzzy
+msgid "Mass Edit Success"
+msgstr "Host Aktualisierung erfolgreich!"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "Aktualisierung der Rolle fehlgeschlagen"
 
@@ -5875,6 +5883,9 @@ msgstr ""
 
 msgid "No fields passed"
 msgstr "Keine Felder übergeben"
+
+msgid "No fields were set to change"
+msgstr ""
 
 msgid "No file was uploaded"
 msgstr "Keine Datei wurde hochgeladen"
@@ -10058,6 +10069,10 @@ msgstr "Ein Name ist erforderlich!"
 #, fuzzy
 msgid "Update selected"
 msgstr "ausgewählte Images hinzufügen"
+
+#, php-format
+msgid "Updated %1$d field(s) on %2$d host(s)."
+msgstr ""
 
 #, fuzzy
 msgid "Upload"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -5438,6 +5438,14 @@ msgid "Marked failed, task"
 msgstr "Load failed: %s"
 
 #, fuzzy
+msgid "Mass Edit Fail"
+msgstr "User update failed"
+
+#, fuzzy
+msgid "Mass Edit Success"
+msgstr "Install / Update Successful!"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "User update failed"
 
@@ -5887,6 +5895,9 @@ msgstr ""
 
 msgid "No fields passed"
 msgstr "No fields passed"
+
+msgid "No fields were set to change"
+msgstr ""
 
 msgid "No file was uploaded"
 msgstr "No file was uploaded"
@@ -10067,6 +10078,10 @@ msgstr "An image name is required!"
 #, fuzzy
 msgid "Update selected"
 msgstr "Remove selected printers"
+
+#, php-format
+msgid "Updated %1$d field(s) on %2$d host(s)."
+msgstr ""
 
 #, fuzzy
 msgid "Upload"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5535,6 +5535,14 @@ msgid "Marked failed, task"
 msgstr "Carga ha fallado: %s"
 
 #, fuzzy
+msgid "Mass Edit Fail"
+msgstr "actualización Valoración falló"
+
+#, fuzzy
+msgid "Mass Edit Success"
+msgstr "actualización Valoración falló"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "actualización Valoración falló"
 
@@ -5995,6 +6003,9 @@ msgstr ""
 
 msgid "No fields passed"
 msgstr "No hay campos pasaron"
+
+msgid "No fields were set to change"
+msgstr ""
 
 msgid "No file was uploaded"
 msgstr "Ningún archivo fue subido"
@@ -10225,6 +10236,10 @@ msgstr "Se requiere un nombre de imagen!"
 #, fuzzy
 msgid "Update selected"
 msgstr "Impresora"
+
+#, php-format
+msgid "Updated %1$d field(s) on %2$d host(s)."
+msgstr ""
 
 #, fuzzy
 msgid "Upload"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5427,6 +5427,14 @@ msgid "Marked failed, task"
 msgstr "Laden fehlgeschlagen: %s"
 
 #, fuzzy
+msgid "Mass Edit Fail"
+msgstr "Aktualisierung der Rolle fehlgeschlagen"
+
+#, fuzzy
+msgid "Mass Edit Success"
+msgstr "Host Aktualisierung erfolgreich!"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "Aktualisierung der Rolle fehlgeschlagen"
 
@@ -5876,6 +5884,9 @@ msgstr ""
 
 msgid "No fields passed"
 msgstr "Keine Felder übergeben"
+
+msgid "No fields were set to change"
+msgstr ""
 
 msgid "No file was uploaded"
 msgstr "Keine Datei wurde hochgeladen"
@@ -10059,6 +10070,10 @@ msgstr "Ein Name ist erforderlich!"
 #, fuzzy
 msgid "Update selected"
 msgstr "ausgewählte Images hinzufügen"
+
+#, php-format
+msgid "Updated %1$d field(s) on %2$d host(s)."
+msgstr ""
 
 #, fuzzy
 msgid "Upload"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -5426,6 +5426,14 @@ msgid "Marked failed, task"
 msgstr "Échec du chargement: %s"
 
 #, fuzzy
+msgid "Mass Edit Fail"
+msgstr "mise à jour de l'utilisateur a échoué"
+
+#, fuzzy
+msgid "Mass Edit Success"
+msgstr "Installation / Mise à jour réussie!"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "mise à jour de l'utilisateur a échoué"
 
@@ -5874,6 +5882,9 @@ msgstr ""
 
 msgid "No fields passed"
 msgstr "Aucun champ passé"
+
+msgid "No fields were set to change"
+msgstr ""
 
 msgid "No file was uploaded"
 msgstr "Aucun fichier a été téléchargé"
@@ -10052,6 +10063,10 @@ msgstr "Un nom de l'image est nécessaire!"
 #, fuzzy
 msgid "Update selected"
 msgstr "Imprimante"
+
+#, php-format
+msgid "Updated %1$d field(s) on %2$d host(s)."
+msgstr ""
 
 #, fuzzy
 msgid "Upload"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -5258,6 +5258,14 @@ msgid "Marked failed, task"
 msgstr "Caricamento non riuscito"
 
 #, fuzzy
+msgid "Mass Edit Fail"
+msgstr "Aggiornamento ruolo non riuscito"
+
+#, fuzzy
+msgid "Mass Edit Success"
+msgstr "Aggiornamento host completato!"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "Aggiornamento ruolo non riuscito"
 
@@ -5701,6 +5709,9 @@ msgstr ""
 
 msgid "No fields passed"
 msgstr "Nessun campo passato"
+
+msgid "No fields were set to change"
+msgstr ""
 
 msgid "No file was uploaded"
 msgstr "Nessun file è stato caricato"
@@ -9755,6 +9766,10 @@ msgstr "È richiesto un nome!"
 #, fuzzy
 msgid "Update selected"
 msgstr "Aggiungi stampanti selezionate"
+
+#, php-format
+msgid "Updated %1$d field(s) on %2$d host(s)."
+msgstr ""
 
 #, fuzzy
 msgid "Upload"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -5220,6 +5220,14 @@ msgid "Marked failed, task"
 msgstr "読み込みに失敗しました"
 
 #, fuzzy
+msgid "Mass Edit Fail"
+msgstr "ホストの更新に失敗しました"
+
+#, fuzzy
+msgid "Mass Edit Success"
+msgstr "ホストの更新に成功しました"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "ホストの更新に失敗しました"
 
@@ -5663,6 +5671,9 @@ msgstr ""
 
 msgid "No fields passed"
 msgstr "フィールドが渡されていません"
+
+msgid "No fields were set to change"
+msgstr ""
 
 msgid "No file was uploaded"
 msgstr "ファイルはアップロードされませんでした"
@@ -9699,6 +9710,10 @@ msgstr "更新は必要ありません！"
 #, fuzzy
 msgid "Update selected"
 msgstr "選択項目を削除"
+
+#, php-format
+msgid "Updated %1$d field(s) on %2$d host(s)."
+msgstr ""
 
 #, fuzzy
 msgid "Upload"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -4622,6 +4622,12 @@ msgstr ""
 msgid "Marked failed, task"
 msgstr ""
 
+msgid "Mass Edit Fail"
+msgstr ""
+
+msgid "Mass Edit Success"
+msgstr ""
+
 msgid "Mass update failed"
 msgstr ""
 
@@ -5010,6 +5016,9 @@ msgid "No external root is imported on this server."
 msgstr ""
 
 msgid "No fields passed"
+msgstr ""
+
+msgid "No fields were set to change"
 msgstr ""
 
 msgid "No file was uploaded"
@@ -8611,6 +8620,10 @@ msgid "Update not required"
 msgstr ""
 
 msgid "Update selected"
+msgstr ""
+
+#, php-format
+msgid "Updated %1$d field(s) on %2$d host(s)."
 msgstr ""
 
 msgid "Upload"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -5425,6 +5425,14 @@ msgid "Marked failed, task"
 msgstr "Carga falhou: %s"
 
 #, fuzzy
+msgid "Mass Edit Fail"
+msgstr "atualização do utilizador falhou"
+
+#, fuzzy
+msgid "Mass Edit Success"
+msgstr "Instalar / Atualizar sucesso!"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "atualização do utilizador falhou"
 
@@ -5874,6 +5882,9 @@ msgstr ""
 
 msgid "No fields passed"
 msgstr "Nenhum campo passado"
+
+msgid "No fields were set to change"
+msgstr ""
 
 msgid "No file was uploaded"
 msgstr "Nenhum arquivo foi transferido"
@@ -10054,6 +10065,10 @@ msgstr "Um nome de imagem é necessário!"
 #, fuzzy
 msgid "Update selected"
 msgstr "Impressora"
+
+#, php-format
+msgid "Updated %1$d field(s) on %2$d host(s)."
+msgstr ""
 
 #, fuzzy
 msgid "Upload"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -5425,6 +5425,14 @@ msgid "Marked failed, task"
 msgstr "加载失败： %s"
 
 #, fuzzy
+msgid "Mass Edit Fail"
+msgstr "用户更新失败"
+
+#, fuzzy
+msgid "Mass Edit Success"
+msgstr "安装/升级成功！"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "用户更新失败"
 
@@ -5874,6 +5882,9 @@ msgstr ""
 
 msgid "No fields passed"
 msgstr "否字段通过"
+
+msgid "No fields were set to change"
+msgstr ""
 
 msgid "No file was uploaded"
 msgstr "没有文件被上传"
@@ -10054,6 +10065,10 @@ msgstr "图像名是必需的！"
 #, fuzzy
 msgid "Update selected"
 msgstr "打印机"
+
+#, php-format
+msgid "Updated %1$d field(s) on %2$d host(s)."
+msgstr ""
 
 #, fuzzy
 msgid "Upload"

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -15,6 +15,7 @@
 
 namespace FOG\Pages;
 
+use FOG\Audit\Audit;
 use FOG\Auth\Authorization;
 use FOG\Base\FOGPage;
 use FOG\Boot\SecureBootState;
@@ -27,6 +28,7 @@ use FOG\Items\TaskType;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 use FOG\Util\FOGCron;
+use FOG\Util\MassEdit;
 
 /**
  * Host management page
@@ -4074,6 +4076,252 @@ class HostManagement extends FOGPage
                 }
             }
         );
+    }
+    /**
+     * The core host fields a mass edit may change.
+     *
+     * The set is deliberately the one the group page pushes today through
+     * its in-band `NULL` sentinel (GroupManagement.php:713-720) -- these are
+     * the fields that convention was invented for, so they are the ones the
+     * three-state replacement has to cover before anything can be taken away
+     * from the group page (ADR 0038 decision 10).
+     *
+     * `empty` is per field because "empty" is not one value: a varchar
+     * clears to '', an image reference clears to 0. Writing '' into an int
+     * column stores 0 on a permissive server and errors on a strict one, so
+     * the answer belongs here rather than in a cast at the write.
+     *
+     * A field ABSENT from this map cannot be written by a mass edit at all,
+     * whatever a request asks for -- FOG\Util\MassEdit::columnUpdates()
+     * skips what the spec does not name. That is the map's second job and
+     * the reason it is a whitelist rather than a blacklist.
+     *
+     * @return array key => ['field' => ..., 'empty' => ..., 'label' => ...]
+     */
+    private function massEditCoreFields()
+    {
+        return [
+            'image' => [
+                'field' => 'imageID',
+                'empty' => 0,
+                'label' => _('Image')
+            ],
+            'kernel' => [
+                'field' => 'kernel',
+                'empty' => '',
+                'label' => _('Host Kernel')
+            ],
+            'kernelArgs' => [
+                'field' => 'kernelArgs',
+                'empty' => '',
+                'label' => _('Host Kernel Arguments')
+            ],
+            'kernelDevice' => [
+                'field' => 'kernelDevice',
+                'empty' => '',
+                'label' => _('Host Primary Disk')
+            ],
+            'init' => [
+                'field' => 'init',
+                'empty' => '',
+                'label' => _('Host Init')
+            ],
+            'biosexit' => [
+                'field' => 'biosexit',
+                'empty' => '',
+                'label' => _('Host BIOS Exit Type')
+            ],
+            'efiexit' => [
+                'field' => 'efiexit',
+                'empty' => '',
+                'label' => _('Host EFI Exit Type')
+            ],
+            'productKey' => [
+                'field' => 'productKey',
+                'empty' => '',
+                'label' => _('Product Key')
+            ],
+        ];
+    }
+    /**
+     * The plugin-contributed field keys a mass edit may act on.
+     *
+     * HOST_MASSEDIT_FIELDS is the CONTRIBUTION seam: a plugin adds a key, a
+     * label and a value control, and core renders the three-state action
+     * control around it. The action control is core's on purpose -- a plugin
+     * that rendered its own could ship a two-state field, and a two-state
+     * field in a mass edit is the defect ADR 0038 decision 11 is entirely
+     * about.
+     *
+     * This is also what makes the apply side safe: a key is actionable only
+     * because a plugin declared it here, so a request cannot name one that
+     * nothing offered.
+     *
+     * The wider point (decision 13): the ABI already has a bulk READ seam
+     * (API_MASSDATA_MAPPING) and a bulk DELETE seam (DELETEMASS_API) and no
+     * bulk EDIT seam. Between them sat the operation neither covers --
+     * changing a value across a set -- and its absence is why `location` and
+     * `ou` each ship a whole second hook file whose only job is to set one
+     * value across many hosts, always clobbering, unable to express "leave
+     * alone" at all.
+     *
+     * @return array key => ['label' => ..., 'input' => <html>]
+     */
+    private function massEditPluginFields()
+    {
+        $fields = [];
+        self::$HookManager->processEvent(
+            'HOST_MASSEDIT_FIELDS',
+            ['fields' => &$fields]
+        );
+
+        return $fields;
+    }
+    /**
+     * Applies a three-state edit to a selection of hosts.
+     *
+     * ADR 0038 decisions 11 and 12. The three-state resolution itself lives
+     * in FOG\Util\MassEdit and fails closed; this is the endpoint around it.
+     *
+     * ONE STATEMENT, ONE AUDIT ROW. The host columns go out as a single
+     * UPDATE ... WHERE hostID IN (...), so four hundred hosts is one
+     * statement rather than four hundred: it succeeds or fails whole, and
+     * "a 400-row loop that times out" is not a risk this path has. Per ADR
+     * 0021 decision 11 that is ONE authorized action and therefore one audit
+     * header with affectedCount, never a header per host. And per ADR 0021
+     * decision 5 it carries NO auditChange rows, because a bulk update has
+     * no before/after to record -- that gap is named in the ADR rather than
+     * being a bug here.
+     *
+     * @return void
+     */
+    public function massEditPost()
+    {
+        self::checkAuthAndCSRF();
+        header('Content-type: application/json');
+
+        try {
+            $hosts = filter_input(
+                INPUT_POST,
+                'hosts',
+                FILTER_DEFAULT,
+                FILTER_REQUIRE_ARRAY
+            );
+            $hosts = array_values(
+                array_unique(
+                    array_filter(
+                        array_map('intval', (array)$hosts)
+                    )
+                )
+            );
+            if (count($hosts) < 1) {
+                throw new \Exception(_('No hosts are selected'));
+            }
+            // Airtight: one id outside the caller's site scope denies the
+            // whole request rather than quietly editing the rest. The ids
+            // come from the browser, so this is the only place they are
+            // bounded -- same stance, and the same call, as
+            // deployMultiPost() and saveGroup().
+            Authorization::requirePageObjectScopeMass('host', $hosts);
+
+            $coreFields = $this->massEditCoreFields();
+            $pluginFields = $this->massEditPluginFields();
+            // Core wins a key collision. A plugin cannot capture `image` and
+            // quietly redirect what the Image control writes, which it could
+            // if the arrays were merged the other way round.
+            $keys = array_values(
+                array_unique(
+                    array_merge(
+                        array_keys($coreFields),
+                        array_keys($pluginFields)
+                    )
+                )
+            );
+
+            $flags = ['flags' => FILTER_REQUIRE_ARRAY];
+            $posted = filter_input_array(
+                INPUT_POST,
+                ['action' => $flags, 'value' => $flags]
+            );
+            $resolved = MassEdit::resolve(
+                $keys,
+                $posted['action'] ?? null,
+                $posted['value'] ?? null
+            );
+            $touched = MassEdit::touched($resolved);
+            if (count($touched) < 1) {
+                // Refused rather than treated as a no-op success. A form
+                // that reports "12 hosts updated" having changed nothing is
+                // how somebody concludes the edit landed and moves on.
+                throw new \Exception(_('No fields were set to change'));
+            }
+
+            $updates = MassEdit::columnUpdates($resolved, $coreFields);
+            $affected = 0;
+            if (count($updates) > 0) {
+                // One statement over the whole selection. Guarded on being
+                // non-empty because an UPDATE with no assignments is either
+                // a syntax error or, worse, a statement whose WHERE is the
+                // only part left.
+                self::getClass('HostManager')
+                    ->update(['id' => $hosts], '', $updates);
+                $affected = count($hosts);
+            }
+
+            // The plugin half receives the RESOLVED actions for its own keys
+            // only, already reduced to leave/set/clear. A plugin never parses
+            // a sentinel, because there is no sentinel to parse.
+            $forPlugins = array_intersect_key(
+                $resolved,
+                $pluginFields
+            );
+            if (count($forPlugins) > 0) {
+                self::$HookManager->processEvent(
+                    'HOST_MASSEDIT_APPLY',
+                    [
+                        'hostIDs' => &$hosts,
+                        'actions' => &$forPlugins
+                    ]
+                );
+            }
+
+            Audit::record(
+                [
+                    'type' => 'host.massedit',
+                    'subjectType' => 'host',
+                    'subjectLabel' => implode(', ', $touched),
+                    'permission' => 'host.edit',
+                    'affectedCount' => $affected,
+                    'renderable' => 1
+                ]
+            );
+
+            $code = HTTPResponseCodes::HTTP_ACCEPTED;
+            $msg = json_encode(
+                [
+                    'msg' => sprintf(
+                        _('Updated %1$d field(s) on %2$d host(s).'),
+                        count($touched),
+                        count($hosts)
+                    ),
+                    'title' => _('Mass Edit Success')
+                ]
+            );
+        } catch (\Exception $e) {
+            // Always a 400. Every throw above is a bad request -- no hosts,
+            // nothing to change, or a scope refusal -- so there is no
+            // server-fault branch to carry. deployMultiPost() has one
+            // because it can fail on a task type the server is missing;
+            // this cannot.
+            $code = HTTPResponseCodes::HTTP_BAD_REQUEST;
+            $msg = json_encode(
+                [
+                    'error' => $e->getMessage(),
+                    'title' => _('Mass Edit Fail')
+                ]
+            );
+        }
+        $this->jsonSend($code, $msg);
     }
     /**
      * Saves host to a selected or new group depending on action.

--- a/tests/mass-edit-endpoint-is-gated.test.php
+++ b/tests/mass-edit-endpoint-is-gated.test.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Pins the mass-edit endpoint's gates, in order.
+ *
+ * A handler that edits an arbitrary set of hosts in one statement is the
+ * shape where a missing check is worth the most: the same request that
+ * changes twelve hosts changes four hundred, and a scope bound that is
+ * merely LATE is a scope bound that never ran on the request that mattered.
+ *
+ * Four gates, and the order between them is the assertion, not just their
+ * presence:
+ *
+ *   1. checkAuthAndCSRF() -- saveGroup was reachable with a session cookie
+ *      alone, from any origin, because the router's CSRF gate keys off a
+ *      *Post/*Ajax suffix and that method had neither (ADR 0038 decision
+ *      16a). This one is named massEditPost, so the router covers it too,
+ *      and the explicit call is the belt to that braces.
+ *   2. requirePageObjectScopeMass('host', ...) -- BEFORE any write. One id
+ *      outside the caller's sites denies the whole request rather than
+ *      quietly editing the rest.
+ *   3. The resolution runs through MassEdit, which fails closed. The
+ *      endpoint must not do its own reading of the posted actions.
+ *   4. columnUpdates() is given the CORE spec, which is the whitelist. A
+ *      key the spec does not name cannot reach a column whatever the
+ *      request says, and passing the merged core+plugin map here instead
+ *      would hand plugin keys direct write access to `hosts`.
+ *
+ * Plus the two invariants ADR 0021 decision 11 fixes for a bulk action: one
+ * audit header rather than one per host, and a guard against issuing an
+ * UPDATE with no assignments.
+ *
+ * Source-anchored, for the reason set out in
+ * tests/task-creation-resolves-assignments.test.php: MassEdit's behavior is
+ * covered directly by tests/mass-edit-fails-closed.test.php, and reaching
+ * massEditPost() needs a configured FOG, a session, a CSRF token and a
+ * schema, at which point the test is an install rehearsal rather than a
+ * gate. What is left is exactly what source text can answer -- is the check
+ * there, and is it before the write.
+ *
+ * Usage: php tests/mass-edit-endpoint-is-gated.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+$path = $root . '/packages/web/src/Pages/HostManagement.php';
+$source = @file_get_contents($path);
+if (false === $source) {
+    fwrite(STDERR, "FAIL: cannot read $path\n");
+    exit(1);
+}
+$source = (string)$source;
+
+$checks = 0;
+$failures = [];
+$check = static function ($what, $ok) use (&$checks, &$failures) {
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+};
+
+/**
+ * The body of one method, so an assertion about what massEditPost() does
+ * cannot be satisfied by an identical line in a neighboring handler -- of
+ * which this file has many, several carrying the very calls being checked.
+ */
+$methodBody = static function ($src, $signature) {
+    $start = strpos($src, $signature);
+    if (false === $start) {
+        return null;
+    }
+    $open = strpos($src, '{', $start);
+    if (false === $open) {
+        return null;
+    }
+    $depth = 0;
+    $len = strlen($src);
+    for ($i = $open; $i < $len; $i++) {
+        if ('{' === $src[$i]) {
+            $depth++;
+        } elseif ('}' === $src[$i]) {
+            $depth--;
+            if (0 === $depth) {
+                return substr($src, $open, $i - $open + 1);
+            }
+        }
+    }
+    return null;
+};
+
+$body = $methodBody($source, 'public function massEditPost()');
+$check('massEditPost() is still findable', null !== $body);
+if (null === $body) {
+    fwrite(STDERR, "FAIL: massEditPost() moved or was renamed; this test is\n");
+    fwrite(STDERR, "      pinning nothing until its signature is updated.\n");
+    exit(1);
+}
+
+$at = static function ($needle) use ($body) {
+    return strpos($body, $needle);
+};
+
+$auth = $at('self::checkAuthAndCSRF();');
+$scope = $at("Authorization::requirePageObjectScopeMass('host', \$hosts);");
+$resolve = $at('$resolved = MassEdit::resolve(');
+$write = $at("->update(['id' => \$hosts], '', \$updates);");
+$hook = $at("'HOST_MASSEDIT_APPLY',");
+
+$check('it checks auth and CSRF', false !== $auth);
+$check('it bounds the hosts to the caller\'s site scope', false !== $scope);
+$check('it resolves through MassEdit', false !== $resolve);
+$check('it writes the host columns in one statement', false !== $write);
+
+// The ORDER is the point. A scope check after the write is not a scope
+// check; it is an audit trail for damage already done.
+$check(
+    'the scope bound comes before the write',
+    false !== $scope && false !== $write && $scope < $write
+);
+$check(
+    'the scope bound comes before the plugin apply hook',
+    false !== $scope && false !== $hook && $scope < $hook
+);
+$check(
+    'auth and CSRF come before everything',
+    false !== $auth && false !== $scope && $auth < $scope
+);
+
+// The whitelist. columnUpdates() must be handed the CORE spec: handing it
+// the merged core+plugin map would let a plugin key write straight into a
+// `hosts` column, which is exactly what HOST_MASSEDIT_APPLY exists to avoid.
+$check(
+    'only core fields can reach a hosts column',
+    false !== strpos(
+        $body,
+        'MassEdit::columnUpdates($resolved, $coreFields)'
+    )
+);
+$check(
+    'plugins get their own keys only, already resolved',
+    false !== strpos($body, '$forPlugins = array_intersect_key(')
+);
+
+// An UPDATE with no assignments is either a syntax error or a statement
+// whose WHERE is the only part left. The guard is not decoration.
+$check(
+    'the write is guarded on there being something to write',
+    false !== strpos($body, 'if (count($updates) > 0) {')
+);
+// A submission that changes nothing is refused rather than reported as a
+// success: a form that says "12 hosts updated" having changed nothing is
+// how somebody concludes the edit landed and moves on.
+$check(
+    'a submission that touches no field is refused',
+    false !== strpos($body, 'if (count($touched) < 1) {')
+);
+
+// ADR 0021 decision 11: ONE header for one authorized action, with
+// affectedCount -- never a header per host.
+$check(
+    'it records exactly one audit header',
+    1 === substr_count($body, 'Audit::record(')
+);
+$check(
+    'the audit header carries affectedCount',
+    false !== strpos($body, "'affectedCount' => \$affected,")
+);
+$check(
+    'the audit record is not inside a loop over hosts',
+    false === strpos($body, 'foreach ($hosts')
+);
+
+// The endpoint must not re-read the posted actions itself: MassEdit is the
+// only thing that decides what an action means, and a second reader is how
+// the sentinel comes back.
+$check(
+    'the endpoint does not interpret posted actions itself',
+    false === stripos($body, "'NULL'")
+        && false === strpos($body, "strcasecmp")
+);
+
+if (count($failures)) {
+    fwrite(STDERR, "FAIL: the mass-edit endpoint lost a gate:\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    fwrite(
+        STDERR,
+        sprintf("%d of %d checks failed\n", count($failures), $checks)
+    );
+    exit(1);
+}
+
+printf("PASS  mass-edit endpoint is gated: %d checks\n", $checks);
+exit(0);


### PR DESCRIPTION
ADR 0038 decision 6. A group grants, it does not copy — so the group page stops pushing values into its hosts, and the ability to change one field across many hosts moves to where the hosts are actually selected: the host list.

This is the **write** half. The form follows in the next PR.

## What it does

`HostManagement::massEditPost()`:

- reads the three-state actions (`leave` / `set` / `clear`) through `MassEdit::resolve()` from #1622,
- turns the core ones into **one** `HostManager->update()` over the selected ids,
- hands the plugin-owned ones to `HOST_MASSEDIT_APPLY`,
- refuses a submission that changes nothing, rather than reporting it as a success.

That last one matters more than it looks: without it an operator who ticks nothing gets a green toast and believes hundreds of hosts were changed.

## Order, which is the security-relevant part

`checkAuthAndCSRF()` → `Authorization::requirePageObjectScopeMass('host', $hosts)` → the write.

The scope check runs over every id **before** anything is changed, never per row afterwards. A user with a site scope cannot reach a host outside it, and cannot partially modify a set before being stopped.

## Auditing

One header per authorized action carrying `affectedCount`, listing the fields touched — ADR 0021 decisions 5 and 11. Not one header per host, and no `auditChange` rows for a bulk update.

## The core whitelist

Deliberately the set the group page pushes today through its `NULL` sentinel: image, kernel, kernel args, kernel device, init, bios exit, efi exit, product key. Nothing new is being made mass-editable here; the same capability is being moved to a surface that does not lie about ownership.

Plugin fields arrive through `HOST_MASSEDIT_FIELDS` and are never allowed into the column update — `columnUpdates()` is given the core spec alone, so a plugin cannot name `imageID` and write it.

## Tests

`tests/mass-edit-endpoint-is-gated.test.php` — 16 checks, source-anchored with a brace matcher so a neighbouring handler cannot satisfy an assertion. The *behaviour* of the action model is covered behaviourally in `mass-edit-fails-closed.test.php`; "the scope check runs before the write" is a question about this source, so it is asserted against this source.

Every check was reddened by mutation before being trusted:

| Mutation | What went red |
|---|---|
| scope line deleted | presence |
| scope call **moved** after the UPDATE | ordering (the deletion alone did not prove this) |
| plugin keys allowed into `columnUpdates` | the core-spec assertion |
| empty-update guard removed | the guard assertion |
| no-op submission reported as success | the refusal assertion |
| CSRF check dropped | the auth assertion |

Full PHP and shell suites green; both phpstan passes clean at 2G.

🤖 Generated with [Claude Code](https://claude.com/claude-code)