### PR TITLE
The mass edit reaches every column ADR 0038 sends it

### DIFF
--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -682,6 +682,22 @@ msgstr "Aktiv"
 msgid "Active Directory"
 msgstr "Active Directory"
 
+#, fuzzy
+msgid "Active Directory Domain Name"
+msgstr "Active Directory"
+
+#, fuzzy
+msgid "Active Directory Organizational Unit"
+msgstr "Organisationseinheit"
+
+#, fuzzy
+msgid "Active Directory Password"
+msgstr "Active Directory"
+
+#, fuzzy
+msgid "Active Directory Username"
+msgstr "Active Directory"
+
 msgid "Active Multicast Tasks"
 msgstr "Aktive Multicast-Tasks"
 
@@ -3737,6 +3753,10 @@ msgid "Host EFI Exit Type"
 msgstr "Host-EFI-Exit-Typ"
 
 #, fuzzy
+msgid "Host Enforce Hostname Changes"
+msgstr "Hostname-Wechsler"
+
+#, fuzzy
 msgid "Host Group Associations"
 msgstr "zugeordneter Host"
 
@@ -3818,6 +3838,10 @@ msgstr "Druckerkonfiguration"
 #, fuzzy
 msgid "Host Printer Configuration"
 msgstr "Druckerkonfiguration"
+
+#, fuzzy
+msgid "Host Printer Management Level"
+msgstr "Keine Druckerverwaltung"
 
 msgid "Host Product Key"
 msgstr "Host Produktschlüssel"
@@ -4791,6 +4815,9 @@ msgid "It tells the client to download snapins from"
 msgstr "Es weist den Client an, Snapins vom hostdefinierten "
 
 msgid "It will operate based on the fields the area typcially requires."
+msgstr ""
+
+msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -686,6 +686,22 @@ msgstr "Active"
 msgid "Active Directory"
 msgstr "Active Directory"
 
+#, fuzzy
+msgid "Active Directory Domain Name"
+msgstr "Active Directory"
+
+#, fuzzy
+msgid "Active Directory Organizational Unit"
+msgstr "Organizational Unit"
+
+#, fuzzy
+msgid "Active Directory Password"
+msgstr "Active Directory"
+
+#, fuzzy
+msgid "Active Directory Username"
+msgstr "Active Directory"
+
 msgid "Active Multicast Tasks"
 msgstr "Active Multicast Tasks"
 
@@ -3739,6 +3755,10 @@ msgid "Host EFI Exit Type"
 msgstr "Host EFI Exit Type"
 
 #, fuzzy
+msgid "Host Enforce Hostname Changes"
+msgstr "Hostname Changer"
+
+#, fuzzy
 msgid "Host Group Associations"
 msgstr "No node associated"
 
@@ -3820,6 +3840,10 @@ msgstr "Service Configuration"
 #, fuzzy
 msgid "Host Printer Configuration"
 msgstr "Service Configuration"
+
+#, fuzzy
+msgid "Host Printer Management Level"
+msgstr "No Printer Management"
 
 msgid "Host Product Key"
 msgstr "Host Product Key"
@@ -4793,6 +4817,9 @@ msgid "It tells the client to download snapins from"
 msgstr ""
 
 msgid "It will operate based on the fields the area typcially requires."
+msgstr ""
+
+msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -692,6 +692,22 @@ msgid "Active Directory"
 msgstr "Directorio Activo"
 
 #, fuzzy
+msgid "Active Directory Domain Name"
+msgstr "Directorio Activo"
+
+#, fuzzy
+msgid "Active Directory Organizational Unit"
+msgstr "Unidad organizacional"
+
+#, fuzzy
+msgid "Active Directory Password"
+msgstr "Directorio Activo"
+
+#, fuzzy
+msgid "Active Directory Username"
+msgstr "Directorio Activo"
+
+#, fuzzy
 msgid "Active Multicast Tasks"
 msgstr "MulticastTask"
 
@@ -3793,6 +3809,10 @@ msgid "Host EFI Exit Type"
 msgstr "Grupo EFI Tipo de salida"
 
 #, fuzzy
+msgid "Host Enforce Hostname Changes"
+msgstr "nombre de host"
+
+#, fuzzy
 msgid "Host Group Associations"
 msgstr "No nodo asociado"
 
@@ -3882,6 +3902,10 @@ msgstr "Configuración de servicio"
 #, fuzzy
 msgid "Host Printer Configuration"
 msgstr "Configuración de servicio"
+
+#, fuzzy
+msgid "Host Printer Management Level"
+msgstr "Sin administración de la impresora"
 
 #, fuzzy
 msgid "Host Product Key"
@@ -4881,6 +4905,9 @@ msgid "It tells the client to download snapins from"
 msgstr ""
 
 msgid "It will operate based on the fields the area typcially requires."
+msgstr ""
+
+msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -682,6 +682,22 @@ msgstr "Aktiv"
 msgid "Active Directory"
 msgstr "Active Directory"
 
+#, fuzzy
+msgid "Active Directory Domain Name"
+msgstr "Active Directory"
+
+#, fuzzy
+msgid "Active Directory Organizational Unit"
+msgstr "Organisationseinheit"
+
+#, fuzzy
+msgid "Active Directory Password"
+msgstr "Active Directory"
+
+#, fuzzy
+msgid "Active Directory Username"
+msgstr "Active Directory"
+
 msgid "Active Multicast Tasks"
 msgstr "Aktive Multicast-Tasks"
 
@@ -3737,6 +3753,10 @@ msgid "Host EFI Exit Type"
 msgstr "Host-EFI-Exit-Typ"
 
 #, fuzzy
+msgid "Host Enforce Hostname Changes"
+msgstr "Hostname-Wechsler"
+
+#, fuzzy
 msgid "Host Group Associations"
 msgstr "zugeordneter Host"
 
@@ -3818,6 +3838,10 @@ msgstr "Druckerkonfiguration"
 #, fuzzy
 msgid "Host Printer Configuration"
 msgstr "Druckerkonfiguration"
+
+#, fuzzy
+msgid "Host Printer Management Level"
+msgstr "Keine Druckerverwaltung"
 
 msgid "Host Product Key"
 msgstr "Host Produktschlüssel"
@@ -4792,6 +4816,9 @@ msgid "It tells the client to download snapins from"
 msgstr "Es weist den Client an, Snapins vom hostdefinierten "
 
 msgid "It will operate based on the fields the area typcially requires."
+msgstr ""
+
+msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -687,6 +687,22 @@ msgstr "actif"
 msgid "Active Directory"
 msgstr "Active Directory"
 
+#, fuzzy
+msgid "Active Directory Domain Name"
+msgstr "Active Directory"
+
+#, fuzzy
+msgid "Active Directory Organizational Unit"
+msgstr "Unité organisationnelle"
+
+#, fuzzy
+msgid "Active Directory Password"
+msgstr "Active Directory"
+
+#, fuzzy
+msgid "Active Directory Username"
+msgstr "Active Directory"
+
 msgid "Active Multicast Tasks"
 msgstr "Tâches Multicast actifs"
 
@@ -3740,6 +3756,10 @@ msgid "Host EFI Exit Type"
 msgstr "Hôte EFI Type de sortie"
 
 #, fuzzy
+msgid "Host Enforce Hostname Changes"
+msgstr "Hostname Changeur"
+
+#, fuzzy
 msgid "Host Group Associations"
 msgstr "Aucun noeud associé"
 
@@ -3821,6 +3841,10 @@ msgstr "Configuration du service"
 #, fuzzy
 msgid "Host Printer Configuration"
 msgstr "Configuration du service"
+
+#, fuzzy
+msgid "Host Printer Management Level"
+msgstr "Pas de gestion de l'imprimante"
 
 msgid "Host Product Key"
 msgstr "Hôte clé de produit"
@@ -4794,6 +4818,9 @@ msgid "It tells the client to download snapins from"
 msgstr ""
 
 msgid "It will operate based on the fields the area typcially requires."
+msgstr ""
+
+msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -672,6 +672,22 @@ msgstr "Attivo"
 msgid "Active Directory"
 msgstr "Active Directory"
 
+#, fuzzy
+msgid "Active Directory Domain Name"
+msgstr "Active Directory"
+
+#, fuzzy
+msgid "Active Directory Organizational Unit"
+msgstr "Unità organizzativa"
+
+#, fuzzy
+msgid "Active Directory Password"
+msgstr "Active Directory"
+
+#, fuzzy
+msgid "Active Directory Username"
+msgstr "Active Directory"
+
 msgid "Active Multicast Tasks"
 msgstr "Compiti multicast attivi"
 
@@ -3642,6 +3658,10 @@ msgid "Host EFI Exit Type"
 msgstr "Host EFI Tipo Exit"
 
 #, fuzzy
+msgid "Host Enforce Hostname Changes"
+msgstr "Nome host Changer"
+
+#, fuzzy
 msgid "Host Group Associations"
 msgstr "Host associato"
 
@@ -3722,6 +3742,10 @@ msgstr "Configurazione della stampante"
 #, fuzzy
 msgid "Host Printer Configuration"
 msgstr "Configurazione della stampante"
+
+#, fuzzy
+msgid "Host Printer Management Level"
+msgstr "No Printer Management"
 
 msgid "Host Product Key"
 msgstr "Host Product Key"
@@ -4653,6 +4677,9 @@ msgid "It tells the client to download snapins from"
 msgstr "indica al client di scaricare gli snapins da"
 
 msgid "It will operate based on the fields the area typcially requires."
+msgstr ""
+
+msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -658,6 +658,22 @@ msgstr "有効"
 msgid "Active Directory"
 msgstr "Active Directory"
 
+#, fuzzy
+msgid "Active Directory Domain Name"
+msgstr "Active Directory"
+
+#, fuzzy
+msgid "Active Directory Organizational Unit"
+msgstr "組織単位"
+
+#, fuzzy
+msgid "Active Directory Password"
+msgstr "Active Directory"
+
+#, fuzzy
+msgid "Active Directory Username"
+msgstr "Active Directory"
+
 msgid "Active Multicast Tasks"
 msgstr "実行中のマルチキャストタスク"
 
@@ -3616,6 +3632,10 @@ msgid "Host EFI Exit Type"
 msgstr "ホスト EFI 終了方法"
 
 #, fuzzy
+msgid "Host Enforce Hostname Changes"
+msgstr "ホスト名変更"
+
+#, fuzzy
 msgid "Host Group Associations"
 msgstr "グループの関連付け"
 
@@ -3694,6 +3714,10 @@ msgstr "プリンターの関連付け"
 #, fuzzy
 msgid "Host Printer Configuration"
 msgstr "ホストプリンター設定"
+
+#, fuzzy
+msgid "Host Printer Management Level"
+msgstr "プリンター管理なし"
 
 msgid "Host Product Key"
 msgstr "ホスト プロダクトキー"
@@ -4616,6 +4640,10 @@ msgstr "クライアントに次の場所からスナップインをダウンロ
 #, fuzzy
 msgid "It will operate based on the fields the area typcially requires."
 msgstr "通常その領域で必要とされるフィールドに基づいて動作します"
+
+#, fuzzy
+msgid "Join Domain after image task"
+msgstr "展開後にドメイン参加"
 
 msgid "Kbps"
 msgstr ""
@@ -12276,9 +12304,6 @@ msgstr ""
 
 #~ msgid "Job Create Date"
 #~ msgstr "ジョブ作成日"
-
-#~ msgid "Join Domain after deploy"
-#~ msgstr "展開後にドメイン参加"
 
 #~ msgid "Kernel Name"
 #~ msgstr "カーネル名"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -599,6 +599,18 @@ msgstr ""
 msgid "Active Directory"
 msgstr ""
 
+msgid "Active Directory Domain Name"
+msgstr ""
+
+msgid "Active Directory Organizational Unit"
+msgstr ""
+
+msgid "Active Directory Password"
+msgstr ""
+
+msgid "Active Directory Username"
+msgstr ""
+
 msgid "Active Multicast Tasks"
 msgstr ""
 
@@ -3202,6 +3214,9 @@ msgstr ""
 msgid "Host EFI Exit Type"
 msgstr ""
 
+msgid "Host Enforce Hostname Changes"
+msgstr ""
+
 msgid "Host Group Associations"
 msgstr ""
 
@@ -3269,6 +3284,9 @@ msgid "Host Printer Associations"
 msgstr ""
 
 msgid "Host Printer Configuration"
+msgstr ""
+
+msgid "Host Printer Management Level"
 msgstr ""
 
 msgid "Host Product Key"
@@ -4090,6 +4108,9 @@ msgid "It tells the client to download snapins from"
 msgstr ""
 
 msgid "It will operate based on the fields the area typcially requires."
+msgstr ""
+
+msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -686,6 +686,22 @@ msgstr "Ativo"
 msgid "Active Directory"
 msgstr "Active Directory"
 
+#, fuzzy
+msgid "Active Directory Domain Name"
+msgstr "Active Directory"
+
+#, fuzzy
+msgid "Active Directory Organizational Unit"
+msgstr "Unidade organizacional"
+
+#, fuzzy
+msgid "Active Directory Password"
+msgstr "Active Directory"
+
+#, fuzzy
+msgid "Active Directory Username"
+msgstr "Active Directory"
+
 msgid "Active Multicast Tasks"
 msgstr "Tarefas Multicast ativos"
 
@@ -3739,6 +3755,10 @@ msgid "Host EFI Exit Type"
 msgstr "Hospedar EFI Tipo Exit"
 
 #, fuzzy
+msgid "Host Enforce Hostname Changes"
+msgstr "hostname Changer"
+
+#, fuzzy
 msgid "Host Group Associations"
 msgstr "No nó associado"
 
@@ -3820,6 +3840,10 @@ msgstr "Configuração de serviço"
 #, fuzzy
 msgid "Host Printer Configuration"
 msgstr "Configuração de serviço"
+
+#, fuzzy
+msgid "Host Printer Management Level"
+msgstr "Sem gerenciamento de impressoras"
 
 msgid "Host Product Key"
 msgstr "Hospedar de Chave de Produto"
@@ -4793,6 +4817,9 @@ msgid "It tells the client to download snapins from"
 msgstr ""
 
 msgid "It will operate based on the fields the area typcially requires."
+msgstr ""
+
+msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -686,6 +686,22 @@ msgstr "活性"
 msgid "Active Directory"
 msgstr "活动目录"
 
+#, fuzzy
+msgid "Active Directory Domain Name"
+msgstr "活动目录"
+
+#, fuzzy
+msgid "Active Directory Organizational Unit"
+msgstr "组织单位"
+
+#, fuzzy
+msgid "Active Directory Password"
+msgstr "活动目录"
+
+#, fuzzy
+msgid "Active Directory Username"
+msgstr "活动目录"
+
 msgid "Active Multicast Tasks"
 msgstr "活动组播任务"
 
@@ -3739,6 +3755,10 @@ msgid "Host EFI Exit Type"
 msgstr "主持人EFI退出类型"
 
 #, fuzzy
+msgid "Host Enforce Hostname Changes"
+msgstr "换主机名"
+
+#, fuzzy
 msgid "Host Group Associations"
 msgstr "无关联的节点"
 
@@ -3820,6 +3840,10 @@ msgstr "服务配置"
 #, fuzzy
 msgid "Host Printer Configuration"
 msgstr "服务配置"
+
+#, fuzzy
+msgid "Host Printer Management Level"
+msgstr "没有打印机管理"
 
 msgid "Host Product Key"
 msgstr "主机产品密钥"
@@ -4793,6 +4817,9 @@ msgid "It tells the client to download snapins from"
 msgstr ""
 
 msgid "It will operate based on the fields the area typcially requires."
+msgstr ""
+
+msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -4080,23 +4080,38 @@ class HostManagement extends FOGPage
     /**
      * The core host fields a mass edit may change.
      *
-     * The set is deliberately the one the group page pushes today through
-     * its in-band `NULL` sentinel (GroupManagement.php:713-720) -- these are
-     * the fields that convention was invented for, so they are the ones the
-     * three-state replacement has to cover before anything can be taken away
-     * from the group page (ADR 0038 decision 10).
+     * The set is every `hosts` column ADR 0038's disposition table sends to
+     * mass edit -- the General tab's fields, the AD tab's, the Enforce tab's
+     * and the printer level. Those are the ones the group page pushes today
+     * through its in-band `NULL` sentinel and its tri-state selects, so they
+     * are the ones the three-state replacement has to cover before anything
+     * can be taken away from the group page (ADR 0038 decision 10).
+     *
+     * `hostBuilding` is deliberately NOT here. The `persistentgroups` trigger
+     * copies it and both field maps declare it, but nothing in the tree ever
+     * writes it and the only place it is read is an always-hidden export
+     * column. Carrying a dead column into a new form would make it look
+     * alive.
      *
      * `empty` is per field because "empty" is not one value: a varchar
      * clears to '', an image reference clears to 0. Writing '' into an int
      * column stores 0 on a permissive server and errors on a strict one, so
      * the answer belongs here rather than in a cast at the write.
      *
+     * `kind` tells the form which control to draw. It carries no authority --
+     * the apply path reads `field` and `empty` only -- but it lives here so
+     * that the form and the whitelist cannot disagree about which fields
+     * exist. `secret` marks a field the form must render EMPTY with no read
+     * path: ADR 0038 decision 11 rejects the 32-asterisk placeholder the
+     * group page uses, because a fake value rendered into a form has to be
+     * pattern-matched back out at every call site that ever touches it.
+     *
      * A field ABSENT from this map cannot be written by a mass edit at all,
      * whatever a request asks for -- FOG\Util\MassEdit::columnUpdates()
      * skips what the spec does not name. That is the map's second job and
      * the reason it is a whitelist rather than a blacklist.
      *
-     * @return array key => ['field' => ..., 'empty' => ..., 'label' => ...]
+     * @return array key => ['field', 'empty', 'label', 'kind', 'secret']
      */
     private function massEditCoreFields()
     {
@@ -4104,42 +4119,113 @@ class HostManagement extends FOGPage
             'image' => [
                 'field' => 'imageID',
                 'empty' => 0,
-                'label' => _('Image')
+                'label' => _('Image'),
+                'kind' => 'image'
             ],
             'kernel' => [
                 'field' => 'kernel',
                 'empty' => '',
-                'label' => _('Host Kernel')
+                'label' => _('Host Kernel'),
+                'kind' => 'text'
             ],
             'kernelArgs' => [
                 'field' => 'kernelArgs',
                 'empty' => '',
-                'label' => _('Host Kernel Arguments')
+                'label' => _('Host Kernel Arguments'),
+                'kind' => 'text'
             ],
             'kernelDevice' => [
                 'field' => 'kernelDevice',
                 'empty' => '',
-                'label' => _('Host Primary Disk')
+                'label' => _('Host Primary Disk'),
+                'kind' => 'text'
             ],
             'init' => [
                 'field' => 'init',
                 'empty' => '',
-                'label' => _('Host Init')
+                'label' => _('Host Init'),
+                'kind' => 'text'
             ],
             'biosexit' => [
                 'field' => 'biosexit',
                 'empty' => '',
-                'label' => _('Host BIOS Exit Type')
+                'label' => _('Host BIOS Exit Type'),
+                'kind' => 'biosexit'
             ],
             'efiexit' => [
                 'field' => 'efiexit',
                 'empty' => '',
-                'label' => _('Host EFI Exit Type')
+                'label' => _('Host EFI Exit Type'),
+                'kind' => 'efiexit'
             ],
             'productKey' => [
                 'field' => 'productKey',
                 'empty' => '',
-                'label' => _('Product Key')
+                'label' => _('Product Key'),
+                'kind' => 'text',
+                'secret' => true
+            ],
+            // Printer level is a `hosts` column and so belongs to the
+            // imperative half (ADR 0038 decision 1) even though the printers
+            // it governs are becoming group-owned. Clearing it means level 0,
+            // "no printer management", which is a real setting rather than an
+            // absence -- so CLEAR and "set to 0" land on the same value on
+            // purpose.
+            'printerLevel' => [
+                'field' => 'printerLevel',
+                'empty' => 0,
+                'label' => _('Host Printer Management Level'),
+                'kind' => 'printerlevel'
+            ],
+            // The two booleans. A boolean has no meaningful "clear", so the
+            // form draws them as No change / Enable on all / Disable on all
+            // -- the shape the group page already gets right
+            // (GroupManagement.php:1405, :1519) -- which lands here as SET
+            // with '1' or '0'. `empty` is 0 so that a request that does ask
+            // to clear one gets the safe answer rather than an error.
+            'useAD' => [
+                'field' => 'useAD',
+                'empty' => 0,
+                'label' => _('Join Domain after image task'),
+                'kind' => 'bool'
+            ],
+            'enforce' => [
+                'field' => 'enforce',
+                'empty' => 0,
+                'label' => _('Host Enforce Hostname Changes'),
+                'kind' => 'bool'
+            ],
+            'ADDomain' => [
+                'field' => 'ADDomain',
+                'empty' => '',
+                'label' => _('Active Directory Domain Name'),
+                'kind' => 'text'
+            ],
+            'ADOU' => [
+                'field' => 'ADOU',
+                'empty' => '',
+                'label' => _('Active Directory Organizational Unit'),
+                'kind' => 'text'
+            ],
+            'ADUser' => [
+                'field' => 'ADUser',
+                'empty' => '',
+                'label' => _('Active Directory Username'),
+                'kind' => 'text'
+            ],
+            // Set-only. There is no read path and there is deliberately no
+            // 32-asterisk placeholder: the form renders an empty password
+            // input whose action defaults to LEAVE, and typing into it is
+            // what selects SET. ADPass matches Redaction::CREDENTIAL_PATTERN,
+            // so it is already redacted from the audit trail -- displaying it
+            // back into a form editing four hundred hosts at once would be
+            // the one place it leaked.
+            'ADPass' => [
+                'field' => 'ADPass',
+                'empty' => '',
+                'label' => _('Active Directory Password'),
+                'kind' => 'password',
+                'secret' => true
             ],
         ];
     }

--- a/tests/mass-edit-endpoint-is-gated.test.php
+++ b/tests/mass-edit-endpoint-is-gated.test.php
@@ -187,6 +187,89 @@ $check(
         && false === strpos($body, "strcasecmp")
 );
 
+// --- The whitelist itself -------------------------------------------------
+//
+// massEditCoreFields() is what decides which columns a mass edit can reach,
+// so the shape of its entries is a gate too: a spec missing `field` is
+// silently skipped by columnUpdates(), and a spec missing `empty` clears an
+// int column to '' -- which stores 0 on a permissive server and errors on a
+// strict one. Neither shows up as a failing request.
+$spec = $methodBody($source, 'private function massEditCoreFields()');
+$check('massEditCoreFields() is still findable', null !== $spec);
+$spec = (string)$spec;
+
+// Every column ADR 0038's disposition table sends to mass edit. Named one by
+// one rather than counted, because "there are 14 of them" stays green when
+// the wrong 14 are present.
+$expected = [
+    'image', 'kernel', 'kernelArgs', 'kernelDevice', 'init', 'biosexit',
+    'efiexit', 'productKey', 'printerLevel', 'useAD', 'enforce', 'ADDomain',
+    'ADOU', 'ADUser', 'ADPass',
+];
+$missing = [];
+foreach ($expected as $key) {
+    if (false === strpos($spec, "'" . $key . "' => [")) {
+        $missing[] = $key;
+    }
+}
+$check(
+    'the whitelist carries every column ADR 0038 sends to mass edit ('
+    . implode(', ', $missing) . ')',
+    0 === count($missing)
+);
+
+// hostBuilding is copied by the persistentgroups trigger and written by
+// nothing. It must not be revived by being listed in a new form.
+$check(
+    'the dead `building` column is not in the whitelist',
+    false === strpos($spec, "'building'")
+);
+
+// Each entry must be complete. Counting the parts is what catches an entry
+// added by copy-paste with a key renamed and an `empty` left behind.
+$entries = preg_match_all("/'[A-Za-z]+' => \[/", $spec);
+$fields = substr_count($spec, "'field' =>");
+$empties = substr_count($spec, "'empty' =>");
+$labels = substr_count($spec, "'label' =>");
+$kinds = substr_count($spec, "'kind' =>");
+$check(
+    'every whitelist entry declares field, empty, label and kind',
+    $entries > 0
+        && $fields === $entries
+        && $empties === $entries
+        && $labels === $entries
+        && $kinds === $entries
+);
+
+// The credential fields must be marked, because the form reads `secret` to
+// decide it has no read path. ADPass and productKey both match
+// Redaction::CREDENTIAL_PATTERN, so an unmarked one would be rendered back
+// into a form that is editing hundreds of hosts at once.
+$check(
+    'the AD password is marked secret',
+    1 === preg_match(
+        "/'ADPass' => \[[^\]]*'secret' => true/s",
+        $spec
+    )
+);
+$check(
+    'the product key is marked secret',
+    1 === preg_match(
+        "/'productKey' => \[[^\]]*'secret' => true/s",
+        $spec
+    )
+);
+
+// No 32-asterisk placeholder anywhere near the mass edit. That is the group
+// page's pattern (GroupManagement.php:878) and ADR 0038 decision 11 rejects
+// it: a fake value rendered into a form has to be matched back out at every
+// call site that ever touches it.
+$check(
+    'the mass edit does not use the 32-asterisk password placeholder',
+    false === strpos($spec, '*{32}')
+        && false === strpos($body, '*{32}')
+);
+
 if (count($failures)) {
     fwrite(STDERR, "FAIL: the mass-edit endpoint lost a gate:\n");
     foreach ($failures as $f) {


### PR DESCRIPTION
Follows #1623, which shipped the apply endpoint with the General tab's fields. This completes the imperative half of [ADR 0038](../blob/working-1.6/docs/adr/0038-a-group-grants-it-does-not-copy.md)'s disposition table for `hosts` columns.

## Added

| Field | Was | Now |
|---|---|---|
| `useAD` | AD tab, tri-state select | mass edit, `bool` |
| `ADDomain` / `ADOU` / `ADUser` | AD tab, `NULL` sentinel | mass edit, `text` |
| `ADPass` | AD tab, 32-asterisk sentinel | mass edit, **set-only** |
| `enforce` | its own tri-state tab | mass edit, `bool` |
| `printerLevel` | Printers tab | mass edit, `printerlevel` |

## The booleans need no new machinery

A boolean has no meaningful *clear*, so the form draws them as **No change / Enable on all / Disable on all** — the shape the group page already gets right (`GroupManagement.php:1405`, `:1519`) — and that lands here as `SET` with `'1'` or `'0'`. `empty` is `0` so that a request which *does* ask to clear one gets the safe answer rather than an error.

## The AD password is set-only, and there is no placeholder

The group page renders a 32-asterisk fake value into its form and pattern-matches it back out on save (`GroupManagement.php:878`). It works. It also has to be re-remembered at every call site that ever touches the field, which is exactly the kind of thing that gets forgotten once.

Here the form renders an **empty** password input whose action defaults to *leave alone*; typing into it is what selects *set*. There is no read path.

`ADPass` and `productKey` both match `Redaction::CREDENTIAL_PATTERN` (`Auth/Redaction.php:93` — `PASS` and `KEY` respectively, verified rather than assumed), so both are marked `secret` and the form is required to honor that.

## `hostBuilding` is deliberately absent

The `persistentgroups` trigger copies it and both field maps declare it, but nothing in the tree writes it and its only reader is an always-hidden export column (`fog.host.export.js:8`). The test asserts its absence out loud, because listing it in a new form would make a dead column look alive — and the next person would have no way to tell.

## `kind`

Added per entry for the form that follows. It carries **no authority** — the apply path still reads `field` and `empty` only — but it lives in the whitelist so that the form and the whitelist cannot disagree about which fields exist.

## Tests

Five new checks in `tests/mass-edit-endpoint-is-gated.test.php` (23 total), each reddened by mutation before being trusted:

| Mutation | What went red |
|---|---|
| `ADPass` renamed out of the whitelist | the column list, and the secret marking |
| `productKey` unmarked as secret | the secret marking |
| an entry with its `empty` removed | the entry-completeness count |
| `building` added back | the dead-column assertion |
| a `*{32}` placeholder reintroduced | the placeholder assertion |

The completeness check counts `field`/`empty`/`label`/`kind` against the number of entries rather than asserting a total, so an entry added by copy-paste with the key renamed and an `empty` left behind fails rather than passing on arithmetic.

Full PHP and shell suites green; both phpstan passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)