### PR TITLE
The mass edit reaches the row-backed host settings

### DIFF
--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1223,6 +1223,10 @@ msgid "Auto Log Out Time"
 msgstr "Standard Logout-Zeit (in Minuten)"
 
 #, fuzzy
+msgid "Auto Log Out Time (in minutes)"
+msgstr "Standard Logout-Zeit (in Minuten)"
+
+#, fuzzy
 msgid "Auto Logout Settings"
 msgstr "Integritätseinstellungen"
 
@@ -3851,6 +3855,10 @@ msgid "Host Product Keys"
 msgstr "Host-Produkt-Schlüssel"
 
 msgid "Host Registration"
+msgstr "Host-Registrierung"
+
+#, fuzzy
+msgid "Host Screen Resolution"
 msgstr "Host-Registrierung"
 
 #, fuzzy

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1227,6 +1227,10 @@ msgid "Auto Log Out Time"
 msgstr "Default log out time (in minutes)"
 
 #, fuzzy
+msgid "Auto Log Out Time (in minutes)"
+msgstr "Default log out time (in minutes)"
+
+#, fuzzy
 msgid "Auto Logout Settings"
 msgstr "Settings"
 
@@ -3853,6 +3857,10 @@ msgid "Host Product Keys"
 msgstr "Host Product Key"
 
 msgid "Host Registration"
+msgstr "Host Registration"
+
+#, fuzzy
+msgid "Host Screen Resolution"
 msgstr "Host Registration"
 
 #, fuzzy

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1241,6 +1241,10 @@ msgid "Auto Log Out Time"
 msgstr "Por defecto cerrar sesión en el tiempo (en minutos)"
 
 #, fuzzy
+msgid "Auto Log Out Time (in minutes)"
+msgstr "Por defecto cerrar sesión en el tiempo (en minutos)"
+
+#, fuzzy
 msgid "Auto Logout Settings"
 msgstr "Configuración Tecla"
 
@@ -3917,6 +3921,10 @@ msgstr "Clave del producto Grupo"
 
 #, fuzzy
 msgid "Host Registration"
+msgstr "Lista de host"
+
+#, fuzzy
+msgid "Host Screen Resolution"
 msgstr "Lista de host"
 
 #, fuzzy

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1223,6 +1223,10 @@ msgid "Auto Log Out Time"
 msgstr "Standard Logout-Zeit (in Minuten)"
 
 #, fuzzy
+msgid "Auto Log Out Time (in minutes)"
+msgstr "Standard Logout-Zeit (in Minuten)"
+
+#, fuzzy
 msgid "Auto Logout Settings"
 msgstr "Integritätseinstellungen"
 
@@ -3851,6 +3855,10 @@ msgid "Host Product Keys"
 msgstr "Host-Produkt-Schlüssel"
 
 msgid "Host Registration"
+msgstr "Host-Registrierung"
+
+#, fuzzy
+msgid "Host Screen Resolution"
 msgstr "Host-Registrierung"
 
 #, fuzzy

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1228,6 +1228,10 @@ msgid "Auto Log Out Time"
 msgstr "Par défaut déconnecter le temps (en minutes)"
 
 #, fuzzy
+msgid "Auto Log Out Time (in minutes)"
+msgstr "Par défaut déconnecter le temps (en minutes)"
+
+#, fuzzy
 msgid "Auto Logout Settings"
 msgstr "Paramètres"
 
@@ -3854,6 +3858,10 @@ msgid "Host Product Keys"
 msgstr "Hôte clé de produit"
 
 msgid "Host Registration"
+msgstr "Enregistrement de l'hôte"
+
+#, fuzzy
+msgid "Host Screen Resolution"
 msgstr "Enregistrement de l'hôte"
 
 #, fuzzy

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1196,6 +1196,10 @@ msgid "Auto Log Out Time"
 msgstr "Predefinito disconnettersi tempo (in minuti)"
 
 #, fuzzy
+msgid "Auto Log Out Time (in minutes)"
+msgstr "Predefinito disconnettersi tempo (in minuti)"
+
+#, fuzzy
 msgid "Auto Logout Settings"
 msgstr "Impostazioni di integrità"
 
@@ -3754,6 +3758,10 @@ msgid "Host Product Keys"
 msgstr "Tasti del prodotto host"
 
 msgid "Host Registration"
+msgstr "registrazione Host"
+
+#, fuzzy
+msgid "Host Screen Resolution"
 msgstr "registrazione Host"
 
 #, fuzzy

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1181,6 +1181,10 @@ msgid "Auto Log Out Time"
 msgstr "自動ログアウト時間（分）"
 
 #, fuzzy
+msgid "Auto Log Out Time (in minutes)"
+msgstr "既定のログアウト時間（分）"
+
+#, fuzzy
 msgid "Auto Logout Settings"
 msgstr "整合性設定"
 
@@ -3727,6 +3731,9 @@ msgstr "ホスト プロダクトキー"
 
 msgid "Host Registration"
 msgstr "ホスト登録"
+
+msgid "Host Screen Resolution"
+msgstr "ホスト画面解像度"
 
 #, fuzzy
 msgid "Host Snapin Associations"
@@ -11638,9 +11645,6 @@ msgstr ""
 #~ msgid "Date of checkout"
 #~ msgstr "貸出日"
 
-#~ msgid "Default log out time (in minutes)"
-#~ msgstr "既定のログアウト時間（分）"
-
 #~ msgid "Delayed Start"
 #~ msgstr "遅延開始"
 
@@ -12059,9 +12063,6 @@ msgstr ""
 
 #~ msgid "Host Printers"
 #~ msgstr "ホスト プリンター"
-
-#~ msgid "Host Screen Resolution"
-#~ msgstr "ホスト画面解像度"
 
 #~ msgid "Host Site"
 #~ msgstr "ホスト サイト"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1054,6 +1054,9 @@ msgstr ""
 msgid "Auto Log Out Time"
 msgstr ""
 
+msgid "Auto Log Out Time (in minutes)"
+msgstr ""
+
 msgid "Auto Logout Settings"
 msgstr ""
 
@@ -3296,6 +3299,9 @@ msgid "Host Product Keys"
 msgstr ""
 
 msgid "Host Registration"
+msgstr ""
+
+msgid "Host Screen Resolution"
 msgstr ""
 
 msgid "Host Snapin Associations"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1227,6 +1227,10 @@ msgid "Auto Log Out Time"
 msgstr "Padrão log out tempo (em minutos)"
 
 #, fuzzy
+msgid "Auto Log Out Time (in minutes)"
+msgstr "Padrão log out tempo (em minutos)"
+
+#, fuzzy
 msgid "Auto Logout Settings"
 msgstr "Configurações"
 
@@ -3853,6 +3857,10 @@ msgid "Host Product Keys"
 msgstr "Hospedar de Chave de Produto"
 
 msgid "Host Registration"
+msgstr "Registro de acolhimento"
+
+#, fuzzy
+msgid "Host Screen Resolution"
 msgstr "Registro de acolhimento"
 
 #, fuzzy

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1227,6 +1227,10 @@ msgid "Auto Log Out Time"
 msgstr "默认注销时间（分钟）"
 
 #, fuzzy
+msgid "Auto Log Out Time (in minutes)"
+msgstr "默认注销时间（分钟）"
+
+#, fuzzy
 msgid "Auto Logout Settings"
 msgstr "设置"
 
@@ -3853,6 +3857,10 @@ msgid "Host Product Keys"
 msgstr "主机产品密钥"
 
 msgid "Host Registration"
+msgstr "主机注册"
+
+#, fuzzy
+msgid "Host Screen Resolution"
 msgstr "主机注册"
 
 #, fuzzy

--- a/packages/web/src/Items/HostAutoLogout.php
+++ b/packages/web/src/Items/HostAutoLogout.php
@@ -27,6 +27,21 @@ use FOG\Base\FOGController;
 class HostAutoLogout extends FOGController
 {
     /**
+     * The shortest auto-logout the client honors; anything below this saves
+     * as 0 (disabled).
+     *
+     * It lives on the model rather than on a page because three places have
+     * to agree about it and none of them owns it: the group page enforces it
+     * on save and hands it to its JS so the readout can predict the result
+     * without a round trip, and the host mass edit enforces the same rule on
+     * the same column. It was on GroupManagement while that was the only
+     * writer; the mass edit is the second, and ADR 0038 decision 10 removes
+     * the first.
+     *
+     * @var int
+     */
+    const MIN_MINUTES = 5;
+    /**
      * The host auto logout table.
      *
      * @var string

--- a/packages/web/src/Pages/GroupManagement.php
+++ b/packages/web/src/Pages/GroupManagement.php
@@ -17,6 +17,7 @@ namespace FOG\Pages;
 
 use FOG\Auth\Authorization;
 use FOG\Base\FOGPage;
+use FOG\Items\HostAutoLogout;
 use FOG\Items\Setting;
 use FOG\Items\TaskType;
 use FOG\Router\HTTPResponseCodes;
@@ -52,9 +53,14 @@ class GroupManagement extends FOGPage
      * left as a literal -- folding it in would change the gettext msgid and
      * strand every existing translation of it.
      *
+     * The value itself now lives on HostAutoLogout, because the host mass
+     * edit enforces the same rule on the same column and ADR 0038 decision 10
+     * removes this page's tab. Kept as an alias so the two references below
+     * and the JS data attribute do not have to change with it.
+     *
      * @var int
      */
-    const ALO_MIN_MINUTES = 5;
+    const ALO_MIN_MINUTES = HostAutoLogout::MIN_MINUTES;
     /**
      * Initializes the group page
      *

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -22,6 +22,7 @@ use FOG\Boot\SecureBootState;
 use FOG\Items\Architecture;
 use FOG\Items\Group;
 use FOG\Items\Host;
+use FOG\Items\HostAutoLogout;
 use FOG\Items\MACAddress;
 use FOG\Items\Setting;
 use FOG\Items\TaskType;
@@ -4230,6 +4231,104 @@ class HostManagement extends FOGPage
         ];
     }
     /**
+     * The host settings a mass edit may change that are NOT `hosts` columns.
+     *
+     * Auto-logout and screen resolution live one row per host in their own
+     * tables, and the group page writes each by deleting every member's row
+     * and inserting a fresh one (`Group::setAlo()`, `Group::setDisp()`). That
+     * shape maps onto the three states exactly: SET is delete-then-insert,
+     * CLEAR is the delete on its own -- no row IS the absence of an override
+     * -- and LEAVE touches nothing.
+     *
+     * `composite` marks the one field whose value is more than one number.
+     * A resolution is width, height and refresh written as a single row, so
+     * "set the width and leave the height" has no meaning at the storage
+     * layer; it is one instruction carrying three parts, resolved through
+     * MassEdit::resolveComposite(). See that method for why it is not a
+     * `1024x768@60` string.
+     *
+     * Deliberately separate from massEditCoreFields(): nothing here can ever
+     * be a column update, and keeping the two lists apart is what stops one
+     * from being handed to columnUpdates() by accident.
+     *
+     * @return array key => ['label', 'kind', 'composite']
+     */
+    private function massEditRowFields()
+    {
+        return [
+            'autologout' => [
+                'label' => _('Auto Log Out Time (in minutes)'),
+                'kind' => 'number'
+            ],
+            'resolution' => [
+                'label' => _('Host Screen Resolution'),
+                'kind' => 'resolution',
+                'composite' => true
+            ],
+        ];
+    }
+
+    /**
+     * Applies the row-backed instructions, and says how many hosts it wrote.
+     *
+     * Each arm is delete-then-insert over the whole selection rather than a
+     * loop, so it is two statements per field regardless of how many hosts
+     * were picked -- the same reason the column half is one UPDATE.
+     *
+     * @param array $resolved the resolved row-backed instructions
+     * @param array $hostIDs  the selected host ids, already scope-checked
+     *
+     * @return int the number of hosts written, 0 if nothing was asked for
+     */
+    private function massEditApplyRows(array $resolved, array $hostIDs)
+    {
+        $wrote = 0;
+        $alo = $resolved['autologout'] ?? null;
+        if (null !== $alo && MassEdit::LEAVE !== $alo['action']) {
+            Route::deletemass('hostautologout', ['hostID' => $hostIDs]);
+            if (MassEdit::SET === $alo['action']) {
+                // Below the minimum means "off", which is how the group
+                // page has always read it. A blank SET is therefore 0 rather
+                // than an error, and CLEAR -- the delete with no insert -- is
+                // the same outcome expressed as an absent row.
+                $minutes = (int)$alo['value'];
+                if ($minutes < HostAutoLogout::MIN_MINUTES) {
+                    $minutes = 0;
+                }
+                $rows = [];
+                foreach ($hostIDs as $hostID) {
+                    $rows[] = [$hostID, $minutes];
+                }
+                self::getClass('HostAutoLogoutManager')
+                    ->insertBatch(['hostID', 'time'], $rows);
+            }
+            $wrote = count($hostIDs);
+        }
+
+        $res = $resolved['resolution'] ?? null;
+        if (null !== $res && MassEdit::LEAVE !== $res['action']) {
+            Route::deletemass('hostscreensetting', ['hostID' => $hostIDs]);
+            if (MassEdit::SET === $res['action']) {
+                $x = (int)($res['value']['x'] ?? 0);
+                $y = (int)($res['value']['y'] ?? 0);
+                $r = (int)($res['value']['r'] ?? 0);
+                $rows = [];
+                foreach ($hostIDs as $hostID) {
+                    $rows[] = [$hostID, $x, $y, $r];
+                }
+                self::getClass('HostScreenSettingManager')
+                    ->insertBatch(
+                        ['hostID', 'width', 'height', 'refresh'],
+                        $rows
+                    );
+            }
+            $wrote = count($hostIDs);
+        }
+
+        return $wrote;
+    }
+
+    /**
      * The plugin-contributed field keys a mass edit may act on.
      *
      * HOST_MASSEDIT_FIELDS is the CONTRIBUTION seam: a plugin adds a key, a
@@ -4311,6 +4410,7 @@ class HostManagement extends FOGPage
             Authorization::requirePageObjectScopeMass('host', $hosts);
 
             $coreFields = $this->massEditCoreFields();
+            $rowFields = $this->massEditRowFields();
             $pluginFields = $this->massEditPluginFields();
             // Core wins a key collision. A plugin cannot capture `image` and
             // quietly redirect what the Image control writes, which it could
@@ -4323,6 +4423,18 @@ class HostManagement extends FOGPage
                     )
                 )
             );
+            // The row-backed fields are resolved separately by shape, not
+            // merged into $keys: the composite one has an array value, and
+            // resolve()'s safety property is that an array is never a value.
+            $scalarRows = [];
+            $compositeRows = [];
+            foreach ($rowFields as $key => $rowSpec) {
+                if (!empty($rowSpec['composite'])) {
+                    $compositeRows[] = $key;
+                } else {
+                    $scalarRows[] = $key;
+                }
+            }
 
             $flags = ['flags' => FILTER_REQUIRE_ARRAY];
             $posted = filter_input_array(
@@ -4334,7 +4446,22 @@ class HostManagement extends FOGPage
                 $posted['action'] ?? null,
                 $posted['value'] ?? null
             );
-            $touched = MassEdit::touched($resolved);
+            $resolvedRows = array_merge(
+                MassEdit::resolve(
+                    $scalarRows,
+                    $posted['action'] ?? null,
+                    $posted['value'] ?? null
+                ),
+                MassEdit::resolveComposite(
+                    $compositeRows,
+                    $posted['action'] ?? null,
+                    $posted['value'] ?? null
+                )
+            );
+            $touched = array_merge(
+                MassEdit::touched($resolved),
+                MassEdit::touched($resolvedRows)
+            );
             if (count($touched) < 1) {
                 // Refused rather than treated as a no-op success. A form
                 // that reports "12 hosts updated" having changed nothing is
@@ -4353,6 +4480,11 @@ class HostManagement extends FOGPage
                     ->update(['id' => $hosts], '', $updates);
                 $affected = count($hosts);
             }
+            // Row-backed fields count toward the same affectedCount: one
+            // authorized action is one audit header (ADR 0021 decision 11),
+            // and a submission that only changed the resolution still
+            // changed every selected host.
+            $affected = max($affected, $this->massEditApplyRows($resolvedRows, $hosts));
 
             // The plugin half receives the RESOLVED actions for its own keys
             // only, already reduced to leave/set/clear. A plugin never parses

--- a/packages/web/src/Util/MassEdit.php
+++ b/packages/web/src/Util/MassEdit.php
@@ -148,6 +148,84 @@ class MassEdit extends FOGBase
     }
 
     /**
+     * resolve() for fields whose value is more than one number.
+     *
+     * Screen resolution is one setting made of three values -- width, height
+     * and refresh -- written as one row. It cannot be three independent
+     * fields, because the row is deleted and re-inserted whole, so "set the
+     * width and leave the height" has no meaning at the storage layer. And
+     * it must not be one string like `1024x768@60`, because that is an
+     * in-band encoding, which is the exact shape ADR 0038 decision 11 threw
+     * out: undiscoverable, unescapable, and a second format to remember at
+     * every call site.
+     *
+     * So the value arrives the way HTTP already gives it -- `value[key][x]`,
+     * `value[key][y]`, `value[key][r]` -- and stays an array all the way to
+     * the arm that writes it. Nothing parses anything.
+     *
+     * This is a SEPARATE function rather than a flag on resolve() on
+     * purpose. resolve()'s safety property is "an array is never a value,
+     * because a field posting key[]=a&key[]=b is either a bug or somebody
+     * probing". Adding a parameter that suspends that rule for some keys
+     * would make the property conditional on the caller passing the right
+     * list. Here it stays literally true of resolve(), and asking for a
+     * composite is an explicit choice of which function to call.
+     *
+     * Fails closed the same way in both directions: a composite key posting
+     * a scalar resolves to LEAVE, and so does one posting an array with a
+     * non-scalar in it.
+     *
+     * @param array $keys    the composite field keys the caller offers
+     * @param mixed $actions the posted action map, key => action
+     * @param mixed $values  the posted value map, key => array of scalars
+     *
+     * @return array key => ['action' => ..., 'value' => array of strings].
+     *               EVERY key in $keys is present, as with resolve().
+     */
+    public static function resolveComposite(array $keys, $actions, $values)
+    {
+        $actions = is_array($actions) ? $actions : [];
+        $values = is_array($values) ? $values : [];
+        $allowed = [self::LEAVE, self::SET, self::CLEAR];
+        $resolved = [];
+        foreach ($keys as $key) {
+            $key = (string)$key;
+            $action = $actions[$key] ?? self::LEAVE;
+            if (!is_string($action)
+                || !in_array($action, $allowed, true)
+            ) {
+                $action = self::LEAVE;
+            }
+            if (self::SET === $action && !array_key_exists($key, $values)) {
+                $action = self::LEAVE;
+            }
+            $value = [];
+            if (self::SET === $action) {
+                $raw = $values[$key];
+                if (!is_array($raw)) {
+                    $action = self::LEAVE;
+                } else {
+                    foreach ($raw as $part => $sub) {
+                        if (!is_scalar($sub) && null !== $sub) {
+                            // One bad part discards the whole instruction.
+                            // A composite half-written is a row half-right,
+                            // and there is no way for the arm downstream to
+                            // tell that from a deliberate blank.
+                            $action = self::LEAVE;
+                            $value = [];
+                            break;
+                        }
+                        $value[(string)$part] = trim((string)$sub);
+                    }
+                }
+            }
+            $resolved[$key] = ['action' => $action, 'value' => $value];
+        }
+
+        return $resolved;
+    }
+
+    /**
      * Turns resolved instructions into the column map an update takes.
      *
      * @param array $resolved output of resolve()
@@ -171,6 +249,14 @@ class MassEdit extends FOGBase
             }
             $action = $instruction['action'] ?? self::LEAVE;
             if (self::SET === $action) {
+                // A composite instruction can never be a column update: its
+                // value is an array and a column takes one value. Guarded
+                // here rather than left to the spec, because the spec is
+                // partly written by plugins and a plugin naming `field` on a
+                // composite key would otherwise write "Array" into a column.
+                if (is_array($instruction['value'])) {
+                    continue;
+                }
                 $updates[$spec[$key]['field']] = $instruction['value'];
             } elseif (self::CLEAR === $action) {
                 // Per field, because "empty" is not one value. A varchar

--- a/tests/mass-edit-endpoint-is-gated.test.php
+++ b/tests/mass-edit-endpoint-is-gated.test.php
@@ -270,6 +270,99 @@ $check(
         && false === strpos($body, '*{32}')
 );
 
+// --- The row-backed half --------------------------------------------------
+//
+// Auto-logout and screen resolution are not `hosts` columns; they are one row
+// per host in their own tables, written delete-then-insert. Two properties
+// have to hold and neither is visible from a passing request: the row fields
+// must be resolved SEPARATELY from the column fields (so a row key can never
+// reach columnUpdates()), and the composite one must go through
+// resolveComposite() rather than resolve(), whose safety rule is that an
+// array is never a value.
+$rows = $methodBody($source, 'private function massEditRowFields()');
+$check('massEditRowFields() is still findable', null !== $rows);
+$rows = (string)$rows;
+$check(
+    'the row-backed fields are auto-logout and resolution',
+    false !== strpos($rows, "'autologout' => [")
+        && false !== strpos($rows, "'resolution' => [")
+);
+$check(
+    'the resolution is declared composite',
+    1 === preg_match(
+        "/'resolution' => \[[^\]]*'composite' => true/s",
+        $rows
+    )
+);
+
+$rowKeys = strpos($body, 'massEditRowFields()');
+$colUpdates = strpos($body, 'columnUpdates(');
+$composite = strpos($body, 'resolveComposite(');
+$applyRows = strpos($body, 'massEditApplyRows(');
+$check('the endpoint asks for the row-backed fields', false !== $rowKeys);
+$check('the endpoint resolves the composite one', false !== $composite);
+$check('the endpoint applies the row-backed half', false !== $applyRows);
+
+// The load-bearing one: columnUpdates() is handed $coreFields, and the row
+// fields are never merged into the key list it resolves from. If a row key
+// ever reached the column spec the write would be an UPDATE against a column
+// that does not exist.
+$check(
+    'row-backed keys are never merged into the column key list',
+    1 === preg_match(
+        '/\$keys = array_values\(\s*array_unique\(\s*array_merge\(\s*'
+        . 'array_keys\(\$coreFields\),\s*array_keys\(\$pluginFields\)/s',
+        $body
+    )
+);
+
+// Scope is checked before the row-backed write too, not only before the
+// UPDATE. Two separate write paths, one boundary.
+$check(
+    'the row-backed write happens after the scope check',
+    false !== $scope && false !== $applyRows && $scope < $applyRows
+);
+
+// A row-backed-only submission must still count as work. Without this the
+// "nothing was set to change" refusal fires on a resolution-only edit and
+// the operator is told their submission was empty when it was not.
+$check(
+    'the touched list includes the row-backed instructions',
+    1 === preg_match(
+        '/\$touched = array_merge\(\s*MassEdit::touched\(\$resolved\),'
+        . '\s*MassEdit::touched\(\$resolvedRows\)/s',
+        $body
+    )
+);
+
+$apply = $methodBody($source, 'private function massEditApplyRows(');
+$check('massEditApplyRows() is still findable', null !== $apply);
+$apply = (string)$apply;
+
+// CLEAR is the delete with no insert -- no row IS the absence of an override.
+// The tell that this is wrong is an insert that runs unconditionally, which
+// would turn CLEAR into "set to zero" for auto-logout and "set to 0x0" for
+// the resolution.
+$check(
+    'the row arms insert only on SET',
+    2 === substr_count($apply, 'MassEdit::SET === ')
+        && 2 === substr_count($apply, 'insertBatch(')
+);
+$check(
+    'the row arms delete on both SET and CLEAR',
+    2 === substr_count($apply, 'Route::deletemass(')
+        && 2 === substr_count($apply, 'MassEdit::LEAVE !== ')
+);
+
+// One statement per field regardless of selection size, same reason the
+// column half is one UPDATE. A per-host loop here is the shape ADR 0038
+// decision 4 is about.
+$check(
+    'the row arms do not write one host at a time',
+    false === strpos($apply, '->save()')
+        && false === strpos($apply, 'foreach ($resolved')
+);
+
 if (count($failures)) {
     fwrite(STDERR, "FAIL: the mass-edit endpoint lost a gate:\n");
     foreach ($failures as $f) {

--- a/tests/mass-edit-fails-closed.test.php
+++ b/tests/mass-edit-fails-closed.test.php
@@ -239,6 +239,80 @@ $check(
         && ['kernel' => ''] === MassEdit::columnUpdates($resolved, $spec)
 );
 
+// --- Composite values -----------------------------------------------------
+//
+// resolveComposite() exists because a screen resolution is three numbers
+// written as one row, and "set the width, leave the height" has no meaning at
+// the storage layer. It must fail closed in BOTH directions: a composite key
+// posting a scalar, and a composite key posting an array with something
+// unusable in it.
+
+$resolved = MassEdit::resolveComposite(
+    ['resolution'],
+    ['resolution' => MassEdit::SET],
+    ['resolution' => ['x' => ' 1024 ', 'y' => '768', 'r' => '60']]
+);
+$check(
+    'a composite SET keeps its parts, trimmed',
+    MassEdit::SET === $resolved['resolution']['action']
+        && ['x' => '1024', 'y' => '768', 'r' => '60']
+            === $resolved['resolution']['value']
+);
+
+$resolved = MassEdit::resolveComposite(
+    ['resolution'],
+    ['resolution' => MassEdit::SET],
+    ['resolution' => '1024x768@60']
+);
+$check(
+    'a composite posting a scalar falls back to LEAVE',
+    MassEdit::LEAVE === $resolved['resolution']['action']
+);
+
+$resolved = MassEdit::resolveComposite(
+    ['resolution'],
+    ['resolution' => MassEdit::SET],
+    ['resolution' => ['x' => '1024', 'y' => ['nested'], 'r' => '60']]
+);
+$check(
+    'one unusable part discards the whole composite instruction',
+    MassEdit::LEAVE === $resolved['resolution']['action']
+        && [] === $resolved['resolution']['value']
+);
+
+$resolved = MassEdit::resolveComposite(
+    ['resolution'],
+    ['resolution' => MassEdit::CLEAR],
+    []
+);
+$check(
+    'a composite CLEAR needs no value',
+    MassEdit::CLEAR === $resolved['resolution']['action']
+);
+
+$resolved = MassEdit::resolveComposite(['resolution'], null, null);
+$check(
+    'a composite with nothing posted is LEAVE and still present',
+    array_key_exists('resolution', $resolved)
+        && MassEdit::LEAVE === $resolved['resolution']['action']
+);
+
+// A composite can never become a column update, even if a spec names a field
+// for it. The spec is partly written by plugins, and writing the string
+// "Array" into a column is the failure this guard prevents.
+$resolved = MassEdit::resolveComposite(
+    ['resolution'],
+    ['resolution' => MassEdit::SET],
+    ['resolution' => ['x' => '1024', 'y' => '768', 'r' => '60']]
+);
+$check(
+    'a composite is never turned into a column update',
+    [] === MassEdit::columnUpdates(
+        $resolved,
+        ['resolution' => ['field' => 'kernel', 'empty' => '']]
+    )
+);
+
 if (count($failures)) {
     fwrite(STDERR, "FAIL: the mass edit does not fail closed:\n");
     foreach ($failures as $f) {


### PR DESCRIPTION
The last two entries in [ADR 0038](../blob/working-1.6/docs/adr/0038-a-group-grants-it-does-not-copy.md)'s disposition table that the mass edit did not cover. Follows #1623 (the endpoint) and #1625 (the columns).

## Why these two are different

Neither is a `hosts` column. Auto-logout and screen resolution are each one row per host in their own table, and the group page writes them by deleting every member's row and inserting a fresh one (`Group::setAlo()`, `Group::setDisp()`).

That shape maps onto the three states exactly, which is the point:

| Action | What happens |
|---|---|
| `LEAVE` | nothing |
| `SET` | delete then insert |
| `CLEAR` | the delete on its own — **no row is the absence of an override** |

Two statements per field regardless of how many hosts were picked, for the same reason the column half is one `UPDATE`.

## The composite value

A screen resolution is three numbers written as one row, so *"set the width and leave the height"* has no meaning at the storage layer. It cannot be three independent fields.

It also must not be a `1024x768@60` string. That is an in-band encoding — undiscoverable, unescapable, and a second format to remember at every call site — which is the exact shape decision 11 threw out when it removed the `NULL` sentinel. Replacing one in-band encoding with another would be a strange way to close that decision.

So `MassEdit` gains `resolveComposite()`, and the value arrives the way HTTP already gives it — `value[resolution][x]`, `[y]`, `[r]` — staying an array all the way to the arm that writes it. **Nothing parses anything.**

### Why it is a separate function and not a flag on `resolve()`

`resolve()`'s safety property is *"an array is never a value, because a field posting `key[]=a&key[]=b` is either a bug or somebody probing."* A parameter that suspends that rule for some keys would make the property conditional on the caller passing the right list — and this is a seam plugins write against.

Here it stays literally true of `resolve()`, and asking for a composite is an explicit choice of which function to call. `columnUpdates()` refuses an array value outright as well, because the spec is partly written by plugins and a plugin naming `field` on a composite key would otherwise write the string `Array` into a column.

## `ALO_MIN_MINUTES` moves to the model

Three places now have to agree that "below five minutes means off" and none of them owns it: the group page enforces it on save, hands it to its JS so the readout can predict the result without a round trip, and the mass edit enforces the same rule on the same column — and decision 10 removes the first of those.

It becomes `HostAutoLogout::MIN_MINUTES`. `GroupManagement::ALO_MIN_MINUTES` stays as an alias, so its two uses and the `data-alo-min` attribute are untouched.

## Tests

Eleven new checks across the two files (36 + 41), each reddened by mutation before being trusted:

| Mutation | What went red |
|---|---|
| a scalar accepted as a composite | scalar → LEAVE |
| the good parts of a bad composite kept | one bad part discards the whole |
| the trim dropped | parts are trimmed |
| the `columnUpdates` composite guard dropped | a composite is never a column update |
| a composite CLEAR degraded to LEAVE | CLEAR needs no value |
| row keys merged into the column key list | the key-list assertion |
| the rows applied *before* the scope check | the ordering assertion |
| the rows dropped from the touched list | the touched-list assertion |
| the insert made unconditional (CLEAR → 0x0) | insert-only-on-SET |
| the composite resolved through `resolve()` | the composite-resolution assertion |
| the `composite` flag removed | the spec assertion |

Full PHP and shell suites green; both phpstan passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)