### PR TITLE
ADR 0038 decision 3 rested on a state that cannot exist

### DIFF
--- a/docs/adr/0001-group-association-state.md
+++ b/docs/adr/0001-group-association-state.md
@@ -24,6 +24,17 @@ with snapins and printers:
   **and** `msState = 1` (enabled). A disabled override (`msState = 0`) counts as
   *not having it*, so such a host pulls the item out of **All** into **Some**.
 
+  **Correction, 2026-09-01: a disabled override cannot exist.** Nothing in the
+  tree ever writes `msState = 0` — every insert path writes a literal `1`
+  (`Items/Group.php:358`, `Base/FOGController.php:1922`) — the schema deletes
+  any that survive an upgrade (`commons/schema.php:1497`, `:3352`), and the
+  client ignores the column entirely (`Items/Host.php:681`,
+  `Client/ServiceModule.php:91`). The rule above is therefore equivalent to
+  the snapin and printer rule: the row is there or it is not. Nothing about
+  this ADR's behavior changes, because every row already satisfies the
+  stricter condition. See ADR 0038 decision 3 for what the correction does
+  change, which is an argument that was built on top of it.
+
 Toggling an item to **All** writes the missing rows on every host (for modules,
 this also flips `state = 0 → 1`); toggling to **None** deletes the rows.
 

--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -209,23 +209,64 @@ page and are all absent from the trigger. So "cover the persistentgroups list"
 is a floor, not a ceiling: mass edit must cover the **union**, or retiring
 either mechanism is a regression. That union is what Decision 8 sizes against.
 
-### 3. Modules go to the imperative half, and this is the one place ADR 0001's asymmetry pays off
+### 3. Modules stay in the imperative half — but the reason first given here was wrong
 
-ADR 0001 established that a module counts as "had" only when
-`moduleStatusByHost.msState = 1`, because a module carries an enabled/disabled
-state that snapins and printers do not.
+**The original argument does not survive contact with the code, and it is
+corrected here rather than quietly dropped, because the correction reopens a
+question this decision had treated as settled.**
 
-That state is exactly why modules cannot join the declarative half. A group
-granting a module and a second group granting the same module *disabled* is a
-contradiction with no correct resolution — and unlike a snapin, where the union
-is obviously right, both readings of a module conflict are defensible. So
-modules stay a per-host value that a bulk edit writes, which is what they
-already are.
+What this section said, and what it rested on:
+
+> ADR 0001 established that a module counts as "had" only when
+> `moduleStatusByHost.msState = 1`, because a module carries an
+> enabled/disabled state that snapins and printers do not. That state is
+> exactly why modules cannot join the declarative half. A group granting a
+> module and a second group granting the same module *disabled* is a
+> contradiction with no correct resolution.
+
+**`msState` is vestigial. A disabled association cannot exist.** Verified
+across the whole tree on 2026-09-01:
+
+- Every write sets it to **1**. `Group::addModule()` inserts
+  `[$hostid, $moduleid, 1]` (`Items/Group.php:358`), and
+  `FOGController::addRemItem()` appends a literal `1` for any
+  `moduleassociation` insert (`Base/FOGController.php:1922`, `:1933`). There
+  is no code path anywhere that writes `0`.
+- The **schema deletes any that survive**: `DELETE FROM moduleStatusByHost
+  WHERE msState='0'` runs in two separate steps (`commons/schema.php:1497`,
+  `:3352`), so an upgraded database is purged of them as well.
+- The **client ignores it**. `Host::loadModules()` selects `msModuleID` with
+  no state filter (`Items/Host.php:681`), and `ServiceModule` treats presence
+  in that list as enabled (`Client/ServiceModule.php:91-103`). A `0` row, if
+  one somehow existed, would read as ON to the machine.
+- The only reader that filters on it is the group page's tri-state derivation
+  (`Pages/GroupManagement.php:3064`), where — every row being `1` — it is
+  equivalent to "a row exists".
+
+So a module association is a **two-state** thing: the row is there or it is
+not. The contradiction the original argument turned on has no way to arise.
+
+**What that means for the decision.** With `msState` out of the picture,
+modules look exactly like snapins: a set of associations with no per-source
+attribution, where a union across sources is as well-defined as it is for a
+snapin, and removing a grant from one group leaves another group's grant
+standing. The declarative reading is therefore **available**, where this
+section previously said it was impossible.
+
+**Modules nonetheless stay imperative in this ADR, and that is now a choice
+rather than a forced move.** The reasons are cost and blast radius, not
+logic: the declarative reading needs a `groupModuleAssoc` table, a schema
+step, a constraint group, a third arm on `Assign\Resolver`, and a change to
+what `ServiceModule` reads — none of which the snapin and printer work
+already pays for. Nothing here is a reason it *could not* be done later, and
+moving modules is purely additive if it is.
 
 ADR 0001's closing sentence anticipated the opposite migration ("if snapins or
 printers ever gain a per-host enabled/disabled state, they should converge on
-the module rule"). This decision takes the other fork and the reason is the
-same fact: an item with a tri-state cannot be rolled up.
+the module rule"). That fork is now moot in the direction it named — the
+module rule's distinguishing state is not real — and ADR 0001's own
+description of it (`docs/adr/0001-group-association-state.md:24`) should be
+read with this section beside it.
 
 ### 4. Snapins resolve at task creation, and the snapshot already exists
 


### PR DESCRIPTION
Docs only. **This one reopens a decision, so it wants a read rather than a rubber stamp.**

## What decision 3 said

> ADR 0001 established that a module counts as "had" only when `moduleStatusByHost.msState = 1`, because a module carries an enabled/disabled state that snapins and printers do not. That state is exactly why modules cannot join the declarative half. A group granting a module and a second group granting the same module *disabled* is a contradiction with no correct resolution.

## `msState` is vestigial. A disabled association cannot exist.

Verified across the whole tree — `packages/web/src`, `service/`, `management/`, `commons/`, `packages/service/`, and the JS:

| | |
|---|---|
| **Every write sets it to `1`** | `Group::addModule()` inserts `[$hostid, $moduleid, 1]` (`Items/Group.php:358`); `FOGController::addRemItem()` appends a literal `1` for any `moduleassociation` insert (`Base/FOGController.php:1922`, `:1933`). Nothing writes `0`. |
| **The schema deletes any that survive** | `DELETE FROM moduleStatusByHost WHERE msState='0'` in two separate steps (`commons/schema.php:1497`, `:3352`), so upgraded databases are purged too. |
| **The client ignores it** | `Host::loadModules()` selects `msModuleID` with no state filter (`Items/Host.php:681`) and `ServiceModule` treats presence in that list as enabled (`Client/ServiceModule.php:91-103`) — a `0` row, if one could exist, would read as **ON** to the machine. |
| **One reader filters on it** | the group page's tri-state derivation (`Pages/GroupManagement.php:3064`), where every row being `1` makes it equivalent to *"a row exists"*. |

So a module association is **two-state**: the row is there or it is not. The contradiction the argument turned on has no way to arise.

## What that changes

With `msState` out of the picture, modules look exactly like snapins — no per-source attribution, a well-defined union, removal from one group leaving another group's grant standing. **The declarative reading is available**, where decision 3 said it was impossible.

## What I did about it

**Modules still stay imperative in this ADR**, and the mass edit work in flight is unaffected. But that is now a *choice on cost* rather than a forced move, and the ADR says so:

- a `groupModuleAssoc` table, a schema step, a constraint group,
- a third arm on `Assign\Resolver`,
- a change to what `ServiceModule` reads.

None of it is paid for by the snapin and printer work, and moving modules later is purely additive. I have not built any of it — this PR only makes the ADR say what is true, so the next person does not build on the false premise.

ADR 0001 carries the same correction beside its own statement of the rule, since that is where the claim originates. Its behavior does not change: every existing row already satisfies the stricter condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)