### PR TITLE
The mass edit form, and the plugin seam that has no sentinel

### DIFF
--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -720,12 +720,21 @@ serialize through conflicts anyway.
 | A | Steps 402-405 | `commons/schema.php`, `schema-expected.php`, `schema-constraints.php` | nothing; rehearsed on the 1.5-origin dump first | **merged** (#1604, #1610) |
 | B | `saveGroup` security + permission split | `Auth/Authorization.php`, the one method | nothing; these are live bugs today (§5, UNKNOWN-6) | **merged** (#1598) |
 | C1 | `FOG\Assign\Resolver` + its tests, wired to nothing | new `src/Assign/`, `bin/psr4-scan.php` | A | **merged** (#1611) |
-| C2 | Snapin resolution at task creation + docs | `Items/Group.php`, `Items/Host.php`, `docs/GROUP_SHARED_STATE.md` | C1 | open (#1612) |
+| C2 | Snapin resolution at task creation + docs | `Items/Group.php`, `Items/Host.php`, `docs/GROUP_SHARED_STATE.md` | C1 | **merged** (#1612) |
 | C3 | `persistentgroups` deletion from `fog-plugins` | `fog-plugins` | C2 | open (fog-plugins #35) |
-| C4 | Printer resolution in `PrinterClient` | `Client/PrinterClient.php` | C2, and UNKNOWN-4 observed | not started |
-| C5 | Mass edit + `HOST_MASSEDIT_*` | `Pages/HostManagement.php`, `docs/plugin-development.md` | B (same method) | not started |
+| C4 | Printer resolution in `PrinterClient` | `Client/PrinterClient.php` | C2, and UNKNOWN-4 observed | **merged** (#1616, #1621) |
+| C5a | The three-state action model (`FOG\Util\MassEdit`) | new `src/Util/MassEdit.php` | B | **merged** (#1622) |
+| C5b | The apply endpoint | `Pages/HostManagement.php` | C5a | **merged** (#1623) |
+| C5c | Every `hosts` column ADR 0038 sends to mass edit | `Pages/HostManagement.php` | C5b | **merged** (#1625) |
+| C5d | The row-backed settings + composite values | `Util/MassEdit.php`, `Items/HostAutoLogout.php` | C5c | open (#1626) |
+| C5e | The form, the modal, and `HOST_MASSEDIT_FIELDS` | `Pages/HostManagement.php`, `Base/FOGPage.php`, `Util/SharedHostValues.php`, `fog.host.list.js`, `docs/plugin-development.md` | C5d | open |
 | D | Presentation: groups column + filter, bulk add/remove, group list "grants" | `Router/Route.php`, `Base/FOGManagerController.php`, `Pages/HostManagement.php`, JS | C5 | not started |
 | E | Group page rework + removal of the imperative tabs | `Pages/GroupManagement.php`, JS | **C5 proven** (Decision 10), D | not started |
+
+C5 split into five as it was built. The split is by what each piece can be
+tested against on its own -- the action model with no endpoint, the endpoint
+with no form, the form over a field set that is already complete -- and not
+by file, which is why three of them touch the same method.
 
 A and B are independent of everything and of each other, so they went first and
 in parallel. E is last by Decision 10 and is the only unit that removes

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -1070,9 +1070,85 @@ fire for page routes too: `docs/adr/0006-site-object-scope-boundary.md`.
 | `API_SERVER_OWNED_FIELDS` | refuse API writes to columns your own code maintains — see §8 |
 | `<NODE>_ADD_FIELDS` / `_GENERAL_FIELDS` | let others extend your forms |
 | `<NODE>_ADD_POST` / `_EDIT_POST` / `_ADD_SUCCESS` / `_ADD_FAIL` | extension points around your saves |
+| `HOST_MASSEDIT_FIELDS` / `HOST_MASSEDIT_APPLY` | change one of your own values across a whole host selection — see §9b |
 
 Fire your own events with `&`‑by‑reference args so listeners can mutate them
 (see the example's `HELLOWORLD_*` events).
+
+### 9b. Changing a value across many hosts — `HOST_MASSEDIT_*`
+
+Every other editing extension point a plugin has is a **per-object** edit with
+a loop behind it. The ABI has a bulk *read* seam (`API_MASSDATA_MAPPING`) and a
+bulk *delete* seam (`DELETEMASS_API`), and between them sat the operation
+neither covers: changing a value across a set. `HOST_MASSEDIT_*` is that seam
+(ADR 0038 decision 13).
+
+It is why `location` and `ou` each shipped a whole second hook file whose only
+job was to set one value across a group's members — and those files always
+clobbered, because there was no way to say *leave this host alone*.
+
+**Contribute a field** — fired when the Mass Edit form is built, and again
+when it is applied, with the same arguments both times so the two can never
+disagree about which keys exist:
+
+```php
+public function massEditFields($arguments)
+{
+    $hostIDs = $arguments['hostIDs'];   // the selection, for your hint
+    $arguments['fields']['myplugin_thing'] = [
+        'label' => _('My Thing'),
+        'input' => '<input class="form-control" '
+            . 'name="value[myplugin_thing]" value=""/>',
+        'hint'  => $this->sharedHint($hostIDs),
+    ];
+}
+```
+
+Three things about that array:
+
+- **`name="value[<your key>]"`.** That is what the resolver reads.
+- **Render it EMPTY.** There is no read path in this form. A control
+  pre-filled from a selection has to answer *"pre-filled with which host's
+  value"*, and there is no honest answer when they differ. Say what the hosts
+  hold in the `hint` instead, where *(varies)* is sayable —
+  `FOG\Util\SharedHostValues` computes exactly that in one query.
+- **Do not draw an action control.** Core draws it. A plugin that drew its own
+  could ship a two-state field, and a two-state field in a mass edit is the
+  defect this whole design is about: it looks identical to a correct one until
+  somebody's values are gone.
+
+**Apply it** — you receive the host ids and the **resolved** instructions for
+your own keys only, already reduced to one of three states:
+
+```php
+public function massEditApply($arguments)
+{
+    foreach ($arguments['actions'] as $key => $instruction) {
+        switch ($instruction['action']) {
+            case 'leave':                       // the default, always
+                break;
+            case 'set':
+                $this->writeAll($arguments['hostIDs'], $instruction['value']);
+                break;
+            case 'clear':
+                $this->clearAll($arguments['hostIDs']);
+                break;
+        }
+    }
+}
+```
+
+You never parse a sentinel, because there is no sentinel. Anything the request
+got wrong — a missing action, a misspelled one, a key you never offered, a
+value that arrived as an array — has already resolved to `leave` before you
+see it. `FOG\Util\MassEdit` fails closed, and *leave alone* is what closed
+means.
+
+**Write in one statement, not a loop.** The core half sends one
+`UPDATE ... WHERE hostID IN (...)` for four hundred hosts, and the row-backed
+half is one delete plus one `insertBatch`. A `foreach` calling `save()` per
+host is the shape the group page had, and it is what ADR 0038 exists to
+remove.
 
 ### 9a. Naming your report
 

--- a/docs/release/1.6.0-release-notes.DRAFT.md
+++ b/docs/release/1.6.0-release-notes.DRAFT.md
@@ -268,6 +268,40 @@ pre-upgrade *dump* — it is not a schema rollback.
   `noPrinters` over `error == "np"` from now on.
   <!-- verified: docs/adr/0038 decisions 4, 5, 6, 7 and 9; FOG\Assign\Resolver;
   Client/PrinterClient.php; docs/GROUP_SHARED_STATE.md -->
+- **Mass edit on the host list**, and it asks before it overwrites. Tick any
+  set of hosts, press **Mass edit**, and every field is paired with its own
+  *No change / Set on all / Clear on all* control. Nothing is written unless
+  you say so, per field.
+
+  This replaces the group page's convention, which was that a **blank** box
+  meant "leave alone" and the literal string **`NULL`** meant "clear". Nothing
+  in that form said the word `NULL` was magic; it could not express "clear" at
+  all for a dropdown; and a value that genuinely *was* the string `NULL` could
+  not be set. If you have documentation or a runbook telling people to type
+  `NULL` into a group field, it stops being true.
+
+  Beside every control the form tells you what the selection currently holds:
+  `Hosts: bzImage (all)`, `Hosts: (varies)`, `Hosts: (empty on all)`. Forty
+  hosts with six images say **(varies)** -- the form never quietly picks one of
+  the six and shows it to you as though it were the answer.
+
+  The Active Directory password is **set-only**. It renders empty, there is no
+  read path, and its hint says `(set on all)` rather than the password. The
+  group page's 32-asterisk placeholder is gone.
+
+  The fields it covers are the ones the group page pushed: image, kernel,
+  kernel arguments, primary disk, init, BIOS and EFI exit type, product key,
+  printer management level, the AD settings, hostname enforcement, auto-logout
+  and screen resolution.
+
+  **For plugin authors:** `HOST_MASSEDIT_FIELDS` and `HOST_MASSEDIT_APPLY` let
+  a plugin put its own field in that form with the same three states, and
+  receive the resolved instruction rather than parsing anything. That is a new
+  seam -- the ABI had a bulk *read* and a bulk *delete* extension point and no
+  bulk *edit* one, which is why `location` and `ou` each shipped a second hook
+  file that could only ever clobber. See `docs/plugin-development.md` §9b.
+  <!-- verified: docs/adr/0038 decisions 8, 11, 12 and 13; FOG\Util\MassEdit;
+  FOG\Util\SharedHostValues; Pages/HostManagement::massEditFormPost() -->
 - **The `persistentgroups` plugin is retired**, and its database TRIGGER is
   dropped. This one matters more than a plugin removal usually would, because
   the trigger outlived the plugin's files: deleting the code never stopped it

--- a/packages/web/management/js/fog/host/fog.host.list.js
+++ b/packages/web/management/js/fog/host/fog.host.list.js
@@ -1,6 +1,11 @@
 (function($) {
     var addToGroup = $('#addSelectedToGroup'),
         deleteSelected = $('#deleteSelected'),
+        massEdit = $('#massEditSelected'),
+        massEditModal = $('#massEditModal'),
+        massEditHolder = $('#massedit-form-holder'),
+        massEditCount = $('.massedit-host-count'),
+        massEditSend = $('#massEditSend'),
         queueTask = $('#queueTask'),
         queueTaskModal = $('#queueTaskModal'),
         groupModal = $('#addToGroupModal'),
@@ -18,6 +23,7 @@
     function disableButtons(disable) {
         addToGroup.prop('disabled', disable);
         deleteSelected.prop('disabled', disable);
+        massEdit.prop('disabled', disable);
         queueTask.prop('disabled', disable);
     }
     disableButtons(true);
@@ -647,6 +653,93 @@
                     }
                     $('#queueTaskModal .modal-dialog').setLoading(false);
                     queueTaskModal.modal('hide');
+                    $.notifyFromAPI(jqXHR.responseJSON, jqXHR);
+                }
+            });
+        });
+    });
+
+    // Mass edit. The form is fetched by POST rather than GET because its
+    // "Hosts: (varies)" hints are computed over the actual selection, and
+    // several hundred ids do not go in a query string.
+    massEdit.on('click', function() {
+        var hosts = $.getSelectedIds(table);
+        if (hosts.length < 1) {
+            return;
+        }
+
+        massEditCount.text(' - ' + hosts.length);
+        massEditHolder.html('Loading, please wait...');
+        massEditSend.addClass('d-none');
+        massEditModal.modal('show');
+        $('#massEditModal .modal-dialog').setLoading(true);
+
+        Pace.track(function() {
+            $.ajax({
+                type: 'post',
+                url: '../management/index.php?node=host&sub=masseditform',
+                data: {hosts: hosts},
+                dataType: 'json',
+                success: function(data) {
+                    $('#massEditModal .modal-dialog').setLoading(false);
+                    massEditHolder.html($.parseHTML(data.msg));
+
+                    var form = $('#host-massedit-form');
+
+                    // A value control is inert until its action says SET.
+                    // The disabled state is the form SAYING the three
+                    // states out loud -- without it the boxes all look
+                    // live and "leave alone" reads as "I forgot to fill
+                    // this in".
+                    function applyActionState() {
+                        var action = $(this),
+                            key = action.data('massedit-key'),
+                            enable = action.val() === 'set',
+                            // Exact name, plus the composite's parts. A
+                            // ^= on 'value[key]' alone would also catch
+                            // 'value[keyOther]', which is a bug waiting
+                            // for the first pair of keys that share a
+                            // prefix.
+                            sel = '[name="value[' + key + ']"],'
+                                + '[name^="value[' + key + ']["]';
+                        $(sel, form).prop('disabled', !enable);
+                    }
+                    $('.massedit-action', form)
+                        .on('change', applyActionState)
+                        .each(applyActionState);
+
+                    massEditSend.removeClass('d-none').off('click').on(
+                        'click',
+                        function(e) {
+                            e.stopImmediatePropagation();
+                            // Read the selection again HERE, for the same
+                            // reason the Queue Task modal does: the grid is
+                            // still live behind the modal, and the ids in
+                            // the form are the ones the server writes.
+                            var current = $.getSelectedIds(table);
+                            $('input[name="hosts[]"]', form).remove();
+                            $.each(current, function(i, id) {
+                                $('<input>').attr({
+                                    type: 'hidden',
+                                    name: 'hosts[]'
+                                }).val(id).appendTo(form);
+                            });
+                            form.processForm(function(err) {
+                                if (err) {
+                                    return;
+                                }
+                                massEditModal.modal('hide');
+                                table.ajax.reload(null, false);
+                            });
+                        }
+                    );
+                },
+                error: function(jqXHR, textStatus) {
+                    if (textStatus == 'abort') {
+                        return;
+                    }
+                    $('#massEditModal .modal-dialog').setLoading(false);
+                    massEditModal.modal('hide');
                     $.notifyFromAPI(jqXHR.responseJSON, jqXHR);
                 }
             });

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -245,6 +245,9 @@ msgstr ""
 msgid "(none on all)"
 msgstr ""
 
+msgid "(set on all)"
+msgstr ""
+
 msgid "(varies)"
 msgstr ""
 
@@ -1708,6 +1711,9 @@ msgstr "frei"
 msgid "Clear Fields"
 msgstr "Felder leeren"
 
+msgid "Clear on all"
+msgstr ""
+
 msgid "Clear one of your preferences"
 msgstr ""
 
@@ -2568,6 +2574,14 @@ msgstr "Snapins exportieren"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "Snapins exportieren"
+
+#, fuzzy
+msgid "Edit selected hosts"
+msgstr "Ausgewählten MAcs freigeben"
+
+#, php-format
+msgid "Editing %d selected hosts. Every field is left alone unless you choose otherwise."
+msgstr ""
 
 #, fuzzy
 msgid "Editing Capone ID"
@@ -3641,6 +3655,10 @@ msgstr ""
 #, php-format
 msgid "Header is missing the required \"%s\" column"
 msgstr ""
+
+#, fuzzy
+msgid "Height"
+msgstr "Mitternacht"
 
 msgid "Height must be 120 pixels."
 msgstr "Höhe muss 120 Pixel betragen"
@@ -5469,6 +5487,18 @@ msgid "Mass Edit Success"
 msgstr "Host Aktualisierung erfolgreich!"
 
 #, fuzzy
+msgid "Mass edit"
+msgstr "Aktualisierung der Rolle fehlgeschlagen"
+
+#, fuzzy
+msgid "Mass edit form fail"
+msgstr "Aktualisierung der Rolle fehlgeschlagen"
+
+#, fuzzy
+msgid "Mass edit form success"
+msgstr "Host Aktualisierung erfolgreich!"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "Aktualisierung der Rolle fehlgeschlagen"
 
@@ -7222,6 +7252,10 @@ msgid "Redirect URI"
 msgstr ""
 
 #, fuzzy
+msgid "Refresh"
+msgstr "Standard-Bildwiederholrate"
+
+#, fuzzy
 msgid "Refresh Settings Cache"
 msgstr "Service-Status"
 
@@ -7943,6 +7977,10 @@ msgstr "Name der Speichergruppe"
 
 #, fuzzy
 msgid "Set failed"
+msgstr "Service-Update fehlgeschlagen"
+
+#, fuzzy
+msgid "Set on all"
 msgstr "Service-Update fehlgeschlagen"
 
 #, fuzzy
@@ -10527,6 +10565,9 @@ msgid "Who a filter can be shared with"
 msgstr ""
 
 msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
+msgstr ""
+
+msgid "Width"
 msgstr ""
 
 msgid "Width must be 650 pixels."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -250,6 +250,9 @@ msgstr ""
 msgid "(none on all)"
 msgstr ""
 
+msgid "(set on all)"
+msgstr ""
+
 msgid "(varies)"
 msgstr ""
 
@@ -1710,6 +1713,9 @@ msgstr "Clear"
 msgid "Clear Fields"
 msgstr ""
 
+msgid "Clear on all"
+msgstr ""
+
 msgid "Clear one of your preferences"
 msgstr ""
 
@@ -2571,6 +2577,14 @@ msgstr "Export Snapins"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "Export Snapins"
+
+#, fuzzy
+msgid "Edit selected hosts"
+msgstr "Approve selected Hosts"
+
+#, php-format
+msgid "Editing %d selected hosts. Every field is left alone unless you choose otherwise."
+msgstr ""
 
 #, fuzzy
 msgid "Editing Capone ID"
@@ -3643,6 +3657,10 @@ msgstr ""
 #, php-format
 msgid "Header is missing the required \"%s\" column"
 msgstr ""
+
+#, fuzzy
+msgid "Height"
+msgstr "Midnight"
 
 msgid "Height must be 120 pixels."
 msgstr ""
@@ -5481,6 +5499,18 @@ msgid "Mass Edit Success"
 msgstr "Install / Update Successful!"
 
 #, fuzzy
+msgid "Mass edit"
+msgstr "User update failed"
+
+#, fuzzy
+msgid "Mass edit form fail"
+msgstr "User update failed"
+
+#, fuzzy
+msgid "Mass edit form success"
+msgstr "Install / Update Successful!"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "User update failed"
 
@@ -7233,6 +7263,10 @@ msgid "Redirect URI"
 msgstr ""
 
 #, fuzzy
+msgid "Refresh"
+msgstr "Default Refresh Rate"
+
+#, fuzzy
 msgid "Refresh Settings Cache"
 msgstr "Service Status"
 
@@ -7954,6 +7988,10 @@ msgstr "Storage Group Name"
 
 #, fuzzy
 msgid "Set failed"
+msgstr "Service update failed"
+
+#, fuzzy
+msgid "Set on all"
 msgstr "Service update failed"
 
 #, fuzzy
@@ -10535,6 +10573,9 @@ msgid "Who a filter can be shared with"
 msgstr ""
 
 msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
+msgstr ""
+
+msgid "Width"
 msgstr ""
 
 msgid "Width must be 650 pixels."

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -248,6 +248,9 @@ msgstr ""
 msgid "(none on all)"
 msgstr ""
 
+msgid "(set on all)"
+msgstr ""
+
 msgid "(varies)"
 msgstr ""
 
@@ -1728,6 +1731,9 @@ msgstr "Tareas"
 msgid "Clear Fields"
 msgstr ""
 
+msgid "Clear on all"
+msgstr ""
+
 msgid "Clear one of your preferences"
 msgstr ""
 
@@ -2603,6 +2609,14 @@ msgstr "snapins"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "snapins"
+
+#, fuzzy
+msgid "Edit selected hosts"
+msgstr "retirar"
+
+#, php-format
+msgid "Editing %d selected hosts. Every field is left alone unless you choose otherwise."
+msgstr ""
 
 #, fuzzy
 msgid "Editing Capone ID"
@@ -3694,6 +3708,10 @@ msgstr ""
 #, php-format
 msgid "Header is missing the required \"%s\" column"
 msgstr ""
+
+#, fuzzy
+msgid "Height"
+msgstr "Medianoche"
 
 msgid "Height must be 120 pixels."
 msgstr ""
@@ -5578,6 +5596,18 @@ msgid "Mass Edit Success"
 msgstr "actualización Valoración falló"
 
 #, fuzzy
+msgid "Mass edit"
+msgstr "actualización Valoración falló"
+
+#, fuzzy
+msgid "Mass edit form fail"
+msgstr "actualización Valoración falló"
+
+#, fuzzy
+msgid "Mass edit form success"
+msgstr "actualización Valoración falló"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "actualización Valoración falló"
 
@@ -7358,6 +7388,10 @@ msgid "Redirect URI"
 msgstr ""
 
 #, fuzzy
+msgid "Refresh"
+msgstr "Frecuencia de actualización predeterminado"
+
+#, fuzzy
 msgid "Refresh Settings Cache"
 msgstr "Estado del servicio"
 
@@ -8086,6 +8120,10 @@ msgstr "Nombre del grupo de almacenamiento"
 
 #, fuzzy
 msgid "Set failed"
+msgstr "actualización de servicio no pudo"
+
+#, fuzzy
+msgid "Set on all"
 msgstr "actualización de servicio no pudo"
 
 #, fuzzy
@@ -10697,6 +10735,9 @@ msgid "Who a filter can be shared with"
 msgstr ""
 
 msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
+msgstr ""
+
+msgid "Width"
 msgstr ""
 
 msgid "Width must be 650 pixels."

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -245,6 +245,9 @@ msgstr ""
 msgid "(none on all)"
 msgstr ""
 
+msgid "(set on all)"
+msgstr ""
+
 msgid "(varies)"
 msgstr ""
 
@@ -1708,6 +1711,9 @@ msgstr "frei"
 msgid "Clear Fields"
 msgstr "Felder leeren"
 
+msgid "Clear on all"
+msgstr ""
+
 msgid "Clear one of your preferences"
 msgstr ""
 
@@ -2568,6 +2574,14 @@ msgstr "Snapins exportieren"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "Snapins exportieren"
+
+#, fuzzy
+msgid "Edit selected hosts"
+msgstr "Ausgewählten MAcs freigeben"
+
+#, php-format
+msgid "Editing %d selected hosts. Every field is left alone unless you choose otherwise."
+msgstr ""
 
 #, fuzzy
 msgid "Editing Capone ID"
@@ -3641,6 +3655,10 @@ msgstr ""
 #, php-format
 msgid "Header is missing the required \"%s\" column"
 msgstr ""
+
+#, fuzzy
+msgid "Height"
+msgstr "Mitternacht"
 
 msgid "Height must be 120 pixels."
 msgstr "Höhe muss 120 Pixel betragen"
@@ -5470,6 +5488,18 @@ msgid "Mass Edit Success"
 msgstr "Host Aktualisierung erfolgreich!"
 
 #, fuzzy
+msgid "Mass edit"
+msgstr "Aktualisierung der Rolle fehlgeschlagen"
+
+#, fuzzy
+msgid "Mass edit form fail"
+msgstr "Aktualisierung der Rolle fehlgeschlagen"
+
+#, fuzzy
+msgid "Mass edit form success"
+msgstr "Host Aktualisierung erfolgreich!"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "Aktualisierung der Rolle fehlgeschlagen"
 
@@ -7223,6 +7253,10 @@ msgid "Redirect URI"
 msgstr ""
 
 #, fuzzy
+msgid "Refresh"
+msgstr "Standard-Bildwiederholrate"
+
+#, fuzzy
 msgid "Refresh Settings Cache"
 msgstr "Service-Status"
 
@@ -7944,6 +7978,10 @@ msgstr "Name der Speichergruppe"
 
 #, fuzzy
 msgid "Set failed"
+msgstr "Service-Update fehlgeschlagen"
+
+#, fuzzy
+msgid "Set on all"
 msgstr "Service-Update fehlgeschlagen"
 
 #, fuzzy
@@ -10528,6 +10566,9 @@ msgid "Who a filter can be shared with"
 msgstr ""
 
 msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
+msgstr ""
+
+msgid "Width"
 msgstr ""
 
 msgid "Width must be 650 pixels."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -251,6 +251,9 @@ msgstr ""
 msgid "(none on all)"
 msgstr ""
 
+msgid "(set on all)"
+msgstr ""
+
 msgid "(varies)"
 msgstr ""
 
@@ -1712,6 +1715,9 @@ msgstr "Clair"
 msgid "Clear Fields"
 msgstr "clairement toute l'histoire"
 
+msgid "Clear on all"
+msgstr ""
+
 msgid "Clear one of your preferences"
 msgstr ""
 
@@ -2572,6 +2578,14 @@ msgstr "Export SnapIns"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "Export SnapIns"
+
+#, fuzzy
+msgid "Edit selected hosts"
+msgstr "Approuver hôtes sélectionnés"
+
+#, php-format
+msgid "Editing %d selected hosts. Every field is left alone unless you choose otherwise."
+msgstr ""
 
 #, fuzzy
 msgid "Editing Capone ID"
@@ -3644,6 +3658,10 @@ msgstr ""
 #, php-format
 msgid "Header is missing the required \"%s\" column"
 msgstr ""
+
+#, fuzzy
+msgid "Height"
+msgstr "Minuit"
 
 msgid "Height must be 120 pixels."
 msgstr ""
@@ -5469,6 +5487,18 @@ msgid "Mass Edit Success"
 msgstr "Installation / Mise à jour réussie!"
 
 #, fuzzy
+msgid "Mass edit"
+msgstr "mise à jour de l'utilisateur a échoué"
+
+#, fuzzy
+msgid "Mass edit form fail"
+msgstr "mise à jour de l'utilisateur a échoué"
+
+#, fuzzy
+msgid "Mass edit form success"
+msgstr "Installation / Mise à jour réussie!"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "mise à jour de l'utilisateur a échoué"
 
@@ -7220,6 +7250,10 @@ msgid "Redirect URI"
 msgstr ""
 
 #, fuzzy
+msgid "Refresh"
+msgstr "Par défaut Taux de rafraîchissement"
+
+#, fuzzy
 msgid "Refresh Settings Cache"
 msgstr "État du service"
 
@@ -7940,6 +7974,10 @@ msgstr "Nom du groupe de stockage"
 
 #, fuzzy
 msgid "Set failed"
+msgstr "mise à jour du service n'a pas"
+
+#, fuzzy
+msgid "Set on all"
 msgstr "mise à jour du service n'a pas"
 
 #, fuzzy
@@ -10520,6 +10558,9 @@ msgid "Who a filter can be shared with"
 msgstr ""
 
 msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
+msgstr ""
+
+msgid "Width"
 msgstr ""
 
 msgid "Width must be 650 pixels."

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -250,6 +250,9 @@ msgstr ""
 msgid "(none on all)"
 msgstr ""
 
+msgid "(set on all)"
+msgstr ""
+
 msgid "(varies)"
 msgstr ""
 
@@ -1665,6 +1668,9 @@ msgstr "Pulire"
 msgid "Clear Fields"
 msgstr "Cancellare campi"
 
+msgid "Clear on all"
+msgstr ""
+
 msgid "Clear one of your preferences"
 msgstr ""
 
@@ -2504,6 +2510,14 @@ msgstr "Export Snapins"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "Export Snapins"
+
+#, fuzzy
+msgid "Edit selected hosts"
+msgstr "Approvare MAC selezionati"
+
+#, php-format
+msgid "Editing %d selected hosts. Every field is left alone unless you choose otherwise."
+msgstr ""
 
 #, fuzzy
 msgid "Editing Capone ID"
@@ -3548,6 +3562,10 @@ msgstr ""
 #, php-format
 msgid "Header is missing the required \"%s\" column"
 msgstr ""
+
+#, fuzzy
+msgid "Height"
+msgstr "Mezzanotte"
 
 msgid "Height must be 120 pixels."
 msgstr "Altezza deve essere di 120 pixel."
@@ -5301,6 +5319,18 @@ msgid "Mass Edit Success"
 msgstr "Aggiornamento host completato!"
 
 #, fuzzy
+msgid "Mass edit"
+msgstr "Aggiornamento ruolo non riuscito"
+
+#, fuzzy
+msgid "Mass edit form fail"
+msgstr "Aggiornamento ruolo non riuscito"
+
+#, fuzzy
+msgid "Mass edit form success"
+msgstr "Aggiornamento host completato!"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "Aggiornamento ruolo non riuscito"
 
@@ -7012,6 +7042,10 @@ msgid "Redirect URI"
 msgstr ""
 
 #, fuzzy
+msgid "Refresh"
+msgstr "Predefinito: frequenza aggiornamento"
+
+#, fuzzy
 msgid "Refresh Settings Cache"
 msgstr "Stato servizio"
 
@@ -7715,6 +7749,10 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr "Nome gruppo di archiviazione"
 
 msgid "Set failed"
+msgstr "Fallita impostazione"
+
+#, fuzzy
+msgid "Set on all"
 msgstr "Fallita impostazione"
 
 #, fuzzy
@@ -10207,6 +10245,9 @@ msgid "Who a filter can be shared with"
 msgstr ""
 
 msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
+msgstr ""
+
+msgid "Width"
 msgstr ""
 
 msgid "Width must be 650 pixels."

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -242,6 +242,9 @@ msgstr ""
 msgid "(none on all)"
 msgstr ""
 
+msgid "(set on all)"
+msgstr ""
+
 msgid "(varies)"
 msgstr ""
 
@@ -1649,6 +1652,10 @@ msgstr "クリア"
 msgid "Clear Fields"
 msgstr "フィールドをクリア"
 
+#, fuzzy
+msgid "Clear on all"
+msgstr "すべてのフィールドをクリアしますか？"
+
 msgid "Clear one of your preferences"
 msgstr ""
 
@@ -2489,6 +2496,14 @@ msgstr "ノードを編集"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "ノードを編集"
+
+#, fuzzy
+msgid "Edit selected hosts"
+msgstr "選択したホストを承認"
+
+#, php-format
+msgid "Editing %d selected hosts. Every field is left alone unless you choose otherwise."
+msgstr ""
 
 #, fuzzy
 msgid "Editing Capone ID"
@@ -3522,6 +3537,10 @@ msgstr "ホストはアクセス用にロックされていません"
 #, php-format
 msgid "Header is missing the required \"%s\" column"
 msgstr ""
+
+#, fuzzy
+msgid "Height"
+msgstr "午前 0 時"
 
 msgid "Height must be 120 pixels."
 msgstr "高さは 120 ピクセルである必要があります。"
@@ -5263,6 +5282,18 @@ msgid "Mass Edit Success"
 msgstr "ホストの更新に成功しました"
 
 #, fuzzy
+msgid "Mass edit"
+msgstr "ホストの更新に失敗しました"
+
+#, fuzzy
+msgid "Mass edit form fail"
+msgstr "ホストの更新に失敗しました"
+
+#, fuzzy
+msgid "Mass edit form success"
+msgstr "ホストの更新に成功しました"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "ホストの更新に失敗しました"
 
@@ -6980,6 +7011,9 @@ msgstr ""
 msgid "Redirect URI"
 msgstr ""
 
+msgid "Refresh"
+msgstr ""
+
 msgid "Refresh Settings Cache"
 msgstr ""
 
@@ -7674,6 +7708,10 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr "ストレージグループの説明"
 
 msgid "Set failed"
+msgstr "設定に失敗しました"
+
+#, fuzzy
+msgid "Set on all"
 msgstr "設定に失敗しました"
 
 #, fuzzy
@@ -10156,6 +10194,9 @@ msgstr ""
 msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
 msgstr ""
 
+msgid "Width"
+msgstr ""
+
 msgid "Width must be 650 pixels."
 msgstr "幅は 650 ピクセルである必要があります。"
 
@@ -11561,9 +11602,6 @@ msgstr ""
 
 #~ msgid "City/State/Zip"
 #~ msgstr "市区町村/都道府県/郵便番号"
-
-#~ msgid "Clear all fields?"
-#~ msgstr "すべてのフィールドをクリアしますか？"
 
 #~ msgid "Clear all history"
 #~ msgstr "すべての履歴をクリア"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -226,6 +226,9 @@ msgstr ""
 msgid "(none on all)"
 msgstr ""
 
+msgid "(set on all)"
+msgstr ""
+
 msgid "(varies)"
 msgstr ""
 
@@ -1471,6 +1474,9 @@ msgstr ""
 msgid "Clear Fields"
 msgstr ""
 
+msgid "Clear on all"
+msgstr ""
+
 msgid "Clear one of your preferences"
 msgstr ""
 
@@ -2202,6 +2208,13 @@ msgid "Edit Capone"
 msgstr ""
 
 msgid "Edit Capone ID"
+msgstr ""
+
+msgid "Edit selected hosts"
+msgstr ""
+
+#, php-format
+msgid "Editing %d selected hosts. Every field is left alone unless you choose otherwise."
 msgstr ""
 
 msgid "Editing Capone ID"
@@ -3122,6 +3135,9 @@ msgstr ""
 
 #, php-format
 msgid "Header is missing the required \"%s\" column"
+msgstr ""
+
+msgid "Height"
 msgstr ""
 
 msgid "Height must be 120 pixels."
@@ -4655,6 +4671,15 @@ msgstr ""
 msgid "Mass Edit Success"
 msgstr ""
 
+msgid "Mass edit"
+msgstr ""
+
+msgid "Mass edit form fail"
+msgstr ""
+
+msgid "Mass edit form success"
+msgstr ""
+
 msgid "Mass update failed"
 msgstr ""
 
@@ -6162,6 +6187,9 @@ msgstr ""
 msgid "Redirect URI"
 msgstr ""
 
+msgid "Refresh"
+msgstr ""
+
 msgid "Refresh Settings Cache"
 msgstr ""
 
@@ -6786,6 +6814,9 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr ""
 
 msgid "Set failed"
+msgstr ""
+
+msgid "Set on all"
 msgstr ""
 
 msgid "Setting"
@@ -9017,6 +9048,9 @@ msgid "Who a filter can be shared with"
 msgstr ""
 
 msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
+msgstr ""
+
+msgid "Width"
 msgstr ""
 
 msgid "Width must be 650 pixels."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -250,6 +250,9 @@ msgstr ""
 msgid "(none on all)"
 msgstr ""
 
+msgid "(set on all)"
+msgstr ""
+
 msgid "(varies)"
 msgstr ""
 
@@ -1711,6 +1714,9 @@ msgstr "Claro"
 msgid "Clear Fields"
 msgstr "Limpar histórico"
 
+msgid "Clear on all"
+msgstr ""
+
 msgid "Clear one of your preferences"
 msgstr ""
 
@@ -2571,6 +2577,14 @@ msgstr "exportação Snapins"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "exportação Snapins"
+
+#, fuzzy
+msgid "Edit selected hosts"
+msgstr "Aprovar Hosts selecionados"
+
+#, php-format
+msgid "Editing %d selected hosts. Every field is left alone unless you choose otherwise."
+msgstr ""
 
 #, fuzzy
 msgid "Editing Capone ID"
@@ -3643,6 +3657,10 @@ msgstr ""
 #, php-format
 msgid "Header is missing the required \"%s\" column"
 msgstr ""
+
+#, fuzzy
+msgid "Height"
+msgstr "meia-noite"
 
 msgid "Height must be 120 pixels."
 msgstr ""
@@ -5468,6 +5486,18 @@ msgid "Mass Edit Success"
 msgstr "Instalar / Atualizar sucesso!"
 
 #, fuzzy
+msgid "Mass edit"
+msgstr "atualização do utilizador falhou"
+
+#, fuzzy
+msgid "Mass edit form fail"
+msgstr "atualização do utilizador falhou"
+
+#, fuzzy
+msgid "Mass edit form success"
+msgstr "Instalar / Atualizar sucesso!"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "atualização do utilizador falhou"
 
@@ -7220,6 +7250,10 @@ msgid "Redirect URI"
 msgstr ""
 
 #, fuzzy
+msgid "Refresh"
+msgstr "Padrão Refresh Rate"
+
+#, fuzzy
 msgid "Refresh Settings Cache"
 msgstr "status do serviço"
 
@@ -7941,6 +7975,10 @@ msgstr "Nome do grupo de armazenamento"
 
 #, fuzzy
 msgid "Set failed"
+msgstr "atualização do Service falhou"
+
+#, fuzzy
+msgid "Set on all"
 msgstr "atualização do Service falhou"
 
 #, fuzzy
@@ -10522,6 +10560,9 @@ msgid "Who a filter can be shared with"
 msgstr ""
 
 msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
+msgstr ""
+
+msgid "Width"
 msgstr ""
 
 msgid "Width must be 650 pixels."

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -250,6 +250,9 @@ msgstr ""
 msgid "(none on all)"
 msgstr ""
 
+msgid "(set on all)"
+msgstr ""
+
 msgid "(varies)"
 msgstr ""
 
@@ -1711,6 +1714,9 @@ msgstr "明确"
 msgid "Clear Fields"
 msgstr "清除所有历史"
 
+msgid "Clear on all"
+msgstr ""
+
 msgid "Clear one of your preferences"
 msgstr ""
 
@@ -2571,6 +2577,14 @@ msgstr "出口Snapins"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "出口Snapins"
+
+#, fuzzy
+msgid "Edit selected hosts"
+msgstr "批准选定主机"
+
+#, php-format
+msgid "Editing %d selected hosts. Every field is left alone unless you choose otherwise."
+msgstr ""
 
 #, fuzzy
 msgid "Editing Capone ID"
@@ -3643,6 +3657,10 @@ msgstr ""
 #, php-format
 msgid "Header is missing the required \"%s\" column"
 msgstr ""
+
+#, fuzzy
+msgid "Height"
+msgstr "午夜"
 
 msgid "Height must be 120 pixels."
 msgstr ""
@@ -5468,6 +5486,18 @@ msgid "Mass Edit Success"
 msgstr "安装/升级成功！"
 
 #, fuzzy
+msgid "Mass edit"
+msgstr "用户更新失败"
+
+#, fuzzy
+msgid "Mass edit form fail"
+msgstr "用户更新失败"
+
+#, fuzzy
+msgid "Mass edit form success"
+msgstr "安装/升级成功！"
+
+#, fuzzy
 msgid "Mass update failed"
 msgstr "用户更新失败"
 
@@ -7220,6 +7250,10 @@ msgid "Redirect URI"
 msgstr ""
 
 #, fuzzy
+msgid "Refresh"
+msgstr "默认刷新频率"
+
+#, fuzzy
 msgid "Refresh Settings Cache"
 msgstr "服务状态"
 
@@ -7941,6 +7975,10 @@ msgstr "存储组名称"
 
 #, fuzzy
 msgid "Set failed"
+msgstr "服务更新失败"
+
+#, fuzzy
+msgid "Set on all"
 msgstr "服务更新失败"
 
 #, fuzzy
@@ -10522,6 +10560,9 @@ msgid "Who a filter can be shared with"
 msgstr ""
 
 msgid "Why the caller can see it, most specific grant first. A filter reachable several ways is still returned once and reports only the most specific reason."
+msgstr ""
+
+msgid "Width"
 msgstr ""
 
 msgid "Width must be 650 pixels."

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -1851,6 +1851,14 @@ abstract class FOGPage extends FOGBase
                         // ones to draw. Empty when the page offers none.
                         $modals .= $queue['quick'] ?? '';
                     }
+                    // Same seam, same reason: a page that can edit its
+                    // selection in bulk says so by defining the method, and
+                    // the toolbar does not learn a second node name to do it.
+                    if (method_exists($this, 'massEditActions')) {
+                        $mass = $this->massEditActions();
+                        $actionbox .= $mass['button'];
+                        $modals .= $mass['modal'];
+                    }
                     if (method_exists($this, 'addModal')) {
                         if ($node == 'host') {
                             $actionbox .= self::makeButton(

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -30,6 +30,7 @@ use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 use FOG\Util\FOGCron;
 use FOG\Util\MassEdit;
+use FOG\Util\SharedHostValues;
 
 /**
  * Host management page
@@ -4079,6 +4080,39 @@ class HostManagement extends FOGPage
         );
     }
     /**
+     * The posted host selection, normalized once.
+     *
+     * Shared by the form and the apply so the two cannot disagree about what
+     * "the selection" is -- a form rendered over one set of ids and a write
+     * bounded by another is a scope check answering the wrong question.
+     *
+     * @return array int host ids, deduplicated, zeroes dropped
+     *
+     * @throws \Exception when nothing usable was posted
+     */
+    private function massEditSelection()
+    {
+        $hosts = filter_input(
+            INPUT_POST,
+            'hosts',
+            FILTER_DEFAULT,
+            FILTER_REQUIRE_ARRAY
+        );
+        $hosts = array_values(
+            array_unique(
+                array_filter(
+                    array_map('intval', (array)$hosts)
+                )
+            )
+        );
+        if (count($hosts) < 1) {
+            throw new \Exception(_('No hosts are selected'));
+        }
+
+        return $hosts;
+    }
+
+    /**
      * The core host fields a mass edit may change.
      *
      * The set is every `hosts` column ADR 0038's disposition table sends to
@@ -4350,18 +4384,434 @@ class HostManagement extends FOGPage
      * value across many hosts, always clobbering, unable to express "leave
      * alone" at all.
      *
-     * @return array key => ['label' => ..., 'input' => <html>]
+     * The selection is passed because a plugin's mixed-value hint has to be
+     * computed over it -- "(varies)" is a statement about THESE hosts. Both
+     * the form and the apply call this with the same ids, so the two can
+     * never see different field sets: a key offered by the form and absent
+     * from the apply would be a control that silently does nothing.
+     *
+     * @param array $hostIDs the selected host ids
+     *
+     * @return array key => ['label' => ..., 'input' => <html>,
+     *               'hint' => <html>, 'kind' => ...]
      */
-    private function massEditPluginFields()
+    private function massEditPluginFields(array $hostIDs = [])
     {
         $fields = [];
         self::$HookManager->processEvent(
             'HOST_MASSEDIT_FIELDS',
-            ['fields' => &$fields]
+            [
+                'fields' => &$fields,
+                'hostIDs' => &$hostIDs
+            ]
         );
 
         return $fields;
     }
+    /**
+     * The `hosts` columns behind the core field keys, for the shared-value
+     * hints.
+     *
+     * The map is derived from the manager's own field map rather than
+     * restated in massEditCoreFields(). Restating it would be a second place
+     * that has to agree with `Host::$databaseFields`, and the failure when it
+     * did not agree would be a hint quietly describing the wrong column --
+     * which reads as a true statement about the selection and is not one.
+     *
+     * getColumns() also drops any field whose column is not actually on the
+     * table, which is the state a server sits in between deploying new code
+     * and running the schema updater. Such a field renders with no hint
+     * rather than taking the whole form down with a SQL error.
+     *
+     * @param array $spec massEditCoreFields()
+     *
+     * @return array field key => `hosts` column name
+     */
+    private function massEditColumnMap(array $spec)
+    {
+        $map = self::getClass('HostManager')->getColumns();
+        $columns = [];
+        foreach ($spec as $key => $entry) {
+            $field = $entry['field'] ?? '';
+            if (isset($map[$field])) {
+                $columns[$key] = $map[$field];
+            }
+        }
+
+        return $columns;
+    }
+
+    /**
+     * The action control. Core renders it, never the field's owner.
+     *
+     * ADR 0038 decision 11: a plugin that drew its own could ship a
+     * two-state field, and a two-state field in a mass edit is the defect
+     * that decision is entirely about -- it looks identical to a correct one
+     * until somebody's images are gone.
+     *
+     * A boolean is offered LEAVE and SET only. Its value control is already
+     * a yes/no, so a CLEAR that wrote 0 would be a second spelling of "set
+     * to No" sitting next to the first, and two controls that mean the same
+     * thing is how a person picks the wrong one.
+     *
+     * @param string $key  the field key
+     * @param array  $spec that field's entry
+     *
+     * @return string
+     */
+    private function massEditActionControl($key, array $spec)
+    {
+        $id = self::massEditControlId('action', $key);
+        $options = [MassEdit::LEAVE => _('No change')];
+        $options[MassEdit::SET] = _('Set on all');
+        if ('bool' !== ($spec['kind'] ?? 'text')) {
+            $options[MassEdit::CLEAR] = _('Clear on all');
+        }
+        $html = '<select class="form-control massedit-action"'
+            . ' name="action[' . \Initiator::e($key) . ']"'
+            . ' id="' . $id . '"'
+            . ' data-massedit-key="' . \Initiator::e($key) . '"'
+            . ' autocomplete="off">';
+        foreach ($options as $value => $label) {
+            $html .= '<option value="' . $value . '">'
+                . \Initiator::e($label)
+                . '</option>';
+        }
+
+        return $html . '</select>';
+    }
+
+    /**
+     * The value control for one field, by kind.
+     *
+     * Every control is rendered EMPTY. There is no read path in this form --
+     * not for the credentials, which is decision 11's requirement, and not
+     * for anything else either, because a control pre-filled from a
+     * selection has to answer "pre-filled with which host's value" and there
+     * is no honest answer when they differ. What the hosts currently hold is
+     * reported by the hint beside it instead, where "(varies)" is sayable.
+     *
+     * @param string $key  the field key
+     * @param array  $spec that field's entry
+     *
+     * @return string
+     */
+    private function massEditValueControl($key, array $spec)
+    {
+        $name = 'value[' . $key . ']';
+        $id = self::massEditControlId('value', $key);
+        $kind = $spec['kind'] ?? 'text';
+        switch ($kind) {
+            case 'image':
+                return self::getClass('ImageManager')
+                    ->buildSelectBox('', $name, 'name', '', false, 'id', $id);
+            case 'biosexit':
+            case 'efiexit':
+                return Setting::buildExitSelector($name, '', true, $id);
+            case 'printerlevel':
+                return self::massEditSelect(
+                    $name,
+                    $id,
+                    [
+                        '0' => _('No Printer Management'),
+                        '1' => _('Add/Remove Managed Printers'),
+                        '2' => _('All Printers'),
+                    ]
+                );
+            case 'bool':
+                return self::massEditSelect(
+                    $name,
+                    $id,
+                    ['1' => _('Yes'), '0' => _('No')]
+                );
+            case 'password':
+                // autocomplete off and no value: the browser must not offer
+                // to fill a field that writes to four hundred hosts.
+                return self::makeInput(
+                    'form-control',
+                    $name,
+                    '',
+                    'password',
+                    $id,
+                    '',
+                    false,
+                    false
+                );
+            case 'number':
+                return self::makeInput(
+                    'form-control',
+                    $name,
+                    '',
+                    'number',
+                    $id,
+                    '',
+                    false,
+                    false,
+                    -1,
+                    -1,
+                    'min="0"'
+                );
+            case 'resolution':
+                // One instruction, three parts. The names are the array HTTP
+                // already gives -- value[resolution][x] and friends -- so
+                // MassEdit::resolveComposite() reads them without parsing
+                // anything. See that method for why this is not one string.
+                $part = function ($sub, $placeholder) use ($name, $id) {
+                    return '<div class="col-4">'
+                        . self::makeInput(
+                            'form-control',
+                            $name . '[' . $sub . ']',
+                            $placeholder,
+                            'number',
+                            $id . '-' . $sub,
+                            '',
+                            false,
+                            false,
+                            -1,
+                            -1,
+                            'min="0"'
+                        )
+                        . '</div>';
+                };
+                return '<div class="row g-1">'
+                    . $part('x', _('Width'))
+                    . $part('y', _('Height'))
+                    . $part('r', _('Refresh'))
+                    . '</div>';
+        }
+
+        return self::makeInput('form-control', $name, '', 'text', $id);
+    }
+
+    /**
+     * A plain select whose options are a value => label map.
+     *
+     * @param string $name    the control name
+     * @param string $id      the control id
+     * @param array  $options value => label
+     *
+     * @return string
+     */
+    private static function massEditSelect($name, $id, array $options)
+    {
+        $html = '<select class="form-control" name="' . $name . '"'
+            . ' id="' . $id . '" autocomplete="off">';
+        foreach ($options as $value => $label) {
+            $html .= '<option value="' . \Initiator::e((string)$value) . '">'
+                . \Initiator::e($label)
+                . '</option>';
+        }
+
+        return $html . '</select>';
+    }
+
+    /**
+     * A control id from a field key.
+     *
+     * The keys are core's and the plugins', so they are not trusted to be
+     * HTML identifiers even though every one today is. Stripping rather than
+     * escaping, because an id with a bracket in it is a selector nobody
+     * writes correctly on the first try.
+     *
+     * @param string $kind 'action' or 'value'
+     * @param string $key  the field key
+     *
+     * @return string
+     */
+    private static function massEditControlId($kind, $key)
+    {
+        return 'massedit-' . $kind . '-'
+            . preg_replace('/[^A-Za-z0-9_-]/', '', (string)$key);
+    }
+
+    /**
+     * What the selection currently holds, per field, ready to render.
+     *
+     * Mixed values are SHOWN, never resolved (ADR 0038 decision 11): forty
+     * hosts holding six images render as "(varies)", not as one of the six.
+     *
+     * @param array $hostIDs the selected host ids
+     * @param array $core    massEditCoreFields()
+     *
+     * @return array field key => hint HTML
+     */
+    private function massEditHints(array $hostIDs, array $core)
+    {
+        $hints = [];
+        $shared = SharedHostValues::forHosts(
+            $hostIDs,
+            $this->massEditColumnMap($core)
+        );
+        foreach ($core as $key => $spec) {
+            if (!isset($shared[$key])) {
+                continue;
+            }
+            // A credential reports agreement and not the value. Both
+            // secrets here match Redaction::CREDENTIAL_PATTERN, and a form
+            // editing hundreds of hosts at once is the last place either
+            // should be rendered back out.
+            $hints[$key] = SharedHostValues::hint(
+                $shared[$key],
+                !empty($spec['secret'])
+            );
+        }
+
+        $alo = SharedHostValues::forHostRows(
+            $hostIDs,
+            'hostAutoLogOut',
+            'haloHostID',
+            ['autologout' => 'haloTime']
+        );
+        $hints['autologout'] = SharedHostValues::hint($alo['autologout']);
+
+        // Three columns, one answer. The resolution is uniform only when
+        // every part agrees AND every selected host has a row -- which is
+        // what forHostRows() means by uniform -- so the parts are combined
+        // rather than reported one by one. Three hints reading "(all)",
+        // "(varies)", "(all)" would describe a resolution nobody has.
+        $disp = SharedHostValues::forHostRows(
+            $hostIDs,
+            'hostScreenSettings',
+            'hssHostID',
+            ['x' => 'hssWidth', 'y' => 'hssHeight', 'r' => 'hssRefresh']
+        );
+        $uniform = !empty($disp['x']['uniform'])
+            && !empty($disp['y']['uniform'])
+            && !empty($disp['r']['uniform']);
+        $hints['resolution'] = SharedHostValues::hint(
+            [
+                'uniform' => $uniform,
+                'value' => $uniform
+                    ? sprintf(
+                        '%sx%s@%s',
+                        $disp['x']['value'],
+                        $disp['y']['value'],
+                        $disp['r']['value']
+                    )
+                    : ''
+            ]
+        );
+
+        return $hints;
+    }
+
+    /**
+     * Builds the mass edit form for a selection of hosts.
+     *
+     * A POST rather than a GET, and that is not incidental. The hints beside
+     * every control describe THIS selection, so the endpoint needs the ids to
+     * render at all -- and several hundred of them do not go in a query
+     * string. deployMulti() gets away with a GET because it only needs a
+     * count.
+     *
+     * @return void
+     */
+    public function massEditFormPost()
+    {
+        self::checkAuthAndCSRF();
+        header('Content-type: application/json');
+
+        try {
+            $hosts = $this->massEditSelection();
+            // The form reports what these hosts hold, so it is a read of
+            // them and takes the same boundary the write does.
+            Authorization::requirePageObjectScopeMass('host', $hosts);
+
+            $core = $this->massEditCoreFields();
+            $rows = $this->massEditRowFields();
+            $hints = $this->massEditHints($hosts, $core);
+
+            $labelClass = 'col-sm-3 col-form-label';
+            $fields = [];
+            foreach (array_merge($core, $rows) as $key => $spec) {
+                $fields[
+                    self::makeLabel(
+                        $labelClass,
+                        self::massEditControlId('value', $key),
+                        $spec['label'] ?? $key
+                    )
+                ] = '<div class="row g-2">'
+                    . '<div class="col-sm-4">'
+                    . $this->massEditActionControl($key, $spec)
+                    . '</div>'
+                    . '<div class="col-sm-8">'
+                    . $this->massEditValueControl($key, $spec)
+                    . ($hints[$key] ?? '')
+                    . '</div>'
+                    . '</div>';
+            }
+
+            // The plugin half. A plugin supplies the label, the value
+            // control and its own hint over the selection; core keeps the
+            // action control. Same call the apply path makes, so the two
+            // cannot see different field sets -- a plugin whose key appears
+            // in the form and not in the apply would offer a control that
+            // silently does nothing.
+            $pluginFields = $this->massEditPluginFields($hosts);
+            foreach ($pluginFields as $key => $spec) {
+                $fields[
+                    self::makeLabel(
+                        $labelClass,
+                        self::massEditControlId('value', $key),
+                        $spec['label'] ?? $key
+                    )
+                ] = '<div class="row g-2">'
+                    . '<div class="col-sm-4">'
+                    . $this->massEditActionControl($key, $spec)
+                    . '</div>'
+                    . '<div class="col-sm-8">'
+                    . ($spec['input'] ?? '')
+                    . ($spec['hint'] ?? '')
+                    . '</div>'
+                    . '</div>';
+            }
+
+            $rendered = self::formFields($fields);
+            unset($fields);
+
+            ob_start();
+            echo self::makeFormTag(
+                '',
+                'host-massedit-form',
+                '../management/index.php?node=host&sub=massedit',
+                'post',
+                'application/x-www-form-urlencoded',
+                true
+            );
+            echo '<p class="form-text">';
+            printf(
+                /* translators: %d is the number of selected hosts */
+                _('Editing %d selected hosts. Every field is left alone '
+                . 'unless you choose otherwise.'),
+                count($hosts)
+            );
+            echo '</p>';
+            echo $rendered;
+            foreach ($hosts as $hostID) {
+                echo '<input type="hidden" name="hosts[]" value="'
+                    . (int)$hostID . '"/>';
+            }
+            echo '</form>';
+
+            $msg = json_encode(
+                [
+                    'msg' => ob_get_clean(),
+                    'title' => _('Mass edit form success')
+                ]
+            );
+            $code = HTTPResponseCodes::HTTP_SUCCESS;
+        } catch (\Exception $e) {
+            $msg = json_encode(
+                [
+                    'error' => $e->getMessage(),
+                    'title' => _('Mass edit form fail')
+                ]
+            );
+            $code = HTTPResponseCodes::HTTP_BAD_REQUEST;
+        }
+        $this->jsonSend($code, $msg);
+    }
+
     /**
      * Applies a three-state edit to a selection of hosts.
      *
@@ -4386,22 +4836,7 @@ class HostManagement extends FOGPage
         header('Content-type: application/json');
 
         try {
-            $hosts = filter_input(
-                INPUT_POST,
-                'hosts',
-                FILTER_DEFAULT,
-                FILTER_REQUIRE_ARRAY
-            );
-            $hosts = array_values(
-                array_unique(
-                    array_filter(
-                        array_map('intval', (array)$hosts)
-                    )
-                )
-            );
-            if (count($hosts) < 1) {
-                throw new \Exception(_('No hosts are selected'));
-            }
+            $hosts = $this->massEditSelection();
             // Airtight: one id outside the caller's site scope denies the
             // whole request rather than quietly editing the rest. The ids
             // come from the browser, so this is the only place they are
@@ -4411,7 +4846,7 @@ class HostManagement extends FOGPage
 
             $coreFields = $this->massEditCoreFields();
             $rowFields = $this->massEditRowFields();
-            $pluginFields = $this->massEditPluginFields();
+            $pluginFields = $this->massEditPluginFields($hosts);
             // Core wins a key collision. A plugin cannot capture `image` and
             // quietly redirect what the Image control writes, which it could
             // if the arrays were merged the other way round.
@@ -4900,6 +5335,56 @@ class HostManagement extends FOGPage
         echo '</div>';
         echo '</div>';
     }
+    /**
+     * The Mass Edit control for the host list: one button, one modal.
+     *
+     * Picked up by FOGPage::process() through method_exists, the same seam
+     * queueTaskActions() uses, so the generic list toolbar does not learn a
+     * second node name.
+     *
+     * The modal ships EMPTY. Its body is fetched on click, by POST, because
+     * the hints beside every control describe the current selection and
+     * several hundred host ids do not go in a query string. Rendering it
+     * with the page would mean rendering it before anything is ticked.
+     *
+     * @return array ['button' => string, 'modal' => string]
+     */
+    public function massEditActions()
+    {
+        // Secondary, beside "Add selected to group". It changes records
+        // rather than starting work on machines, so it is deliberately not
+        // the green Queue Task shares a group with.
+        $button = self::makeButton(
+            'massEditSelected',
+            _('Mass edit'),
+            'btn btn-secondary'
+        );
+
+        $modal = self::makeModal(
+            'massEditModal',
+            '<h4 class="card-title">'
+            . _('Edit selected hosts')
+            . '<span class="massedit-host-count"></span></h4>',
+            '<div id="massedit-form-holder"></div>',
+            self::makeButton(
+                'massEditClose',
+                _('Cancel'),
+                'btn btn-outline-secondary float-start',
+                'data-bs-dismiss="modal"'
+            )
+            . self::makeButton(
+                'massEditSend',
+                _('Update'),
+                'btn btn-primary float-end d-none'
+            ),
+            '',
+            'secondary',
+            'modal-lg'
+        );
+
+        return ['button' => $button, 'modal' => $modal];
+    }
+
     /**
      * The Queue Task control for the host list: one button, one modal.
      *

--- a/packages/web/src/Util/SharedHostValues.php
+++ b/packages/web/src/Util/SharedHostValues.php
@@ -127,19 +127,111 @@ class SharedHostValues extends FOGBase
     }
 
     /**
+     * forHosts() for a table holding at most one row per host.
+     *
+     * Auto-logout and screen resolution are not `hosts` columns -- each is a
+     * row in its own table, and a host with no row is a host with no
+     * override. That asymmetry is the whole reason this is a second method
+     * rather than a parameter: "every host agrees" has to mean every SELECTED
+     * host, not every host that happens to have a row. A selection where
+     * thirty hosts share a value and ten have no row at all is NOT uniform,
+     * and a query that only counted the thirty would confidently say it was.
+     *
+     * So the row count is compared against the selection size, not against
+     * itself.
+     *
+     * @param array  $hostIDs the selected host ids
+     * @param string $table   the table holding one row per host
+     * @param string $hostCol the column in it naming the host
+     * @param array  $columns map of friendly key => column in that table
+     *
+     * @return array friendly key => ['uniform' => bool, 'value' => string]
+     */
+    public static function forHostRows(
+        array $hostIDs,
+        $table,
+        $hostCol,
+        array $columns
+    ) {
+        $result = [];
+        foreach ($columns as $key => $col) {
+            $result[$key] = ['uniform' => false, 'value' => ''];
+        }
+        $hostIDs = array_values(
+            array_unique(
+                array_filter(
+                    array_map('intval', $hostIDs),
+                    function ($id) {
+                        return $id > 0;
+                    }
+                )
+            )
+        );
+        if (count($hostIDs) < 1 || count($columns) < 1) {
+            return $result;
+        }
+        $selects = ['COUNT(*) AS `_n`'];
+        foreach ($columns as $key => $col) {
+            $safe = self::_alias($key);
+            $selects[] = sprintf(
+                "COUNT(DISTINCT COALESCE(`%s`, '')) AS `d_%s`",
+                $col,
+                $safe
+            );
+            $selects[] = sprintf(
+                "MIN(COALESCE(`%s`, '')) AS `v_%s`",
+                $col,
+                $safe
+            );
+        }
+        $sql = sprintf(
+            'SELECT %s FROM `%s` WHERE `%s` IN (%s)',
+            implode(',', $selects),
+            $table,
+            $hostCol,
+            implode(',', $hostIDs)
+        );
+        $row = self::$DB->query($sql)->fetch();
+        $n = (int)$row->get('_n');
+        // The line this method exists for. Every selected host must have a
+        // row before the values in those rows can be called uniform.
+        $everyHostHasOne = ($n === count($hostIDs));
+        foreach ($columns as $key => $col) {
+            $safe = self::_alias($key);
+            $distinct = (int)$row->get('d_' . $safe);
+            $result[$key] = [
+                'uniform' => ($everyHostHasOne && $n > 0 && $distinct <= 1),
+                'value' => (string)$row->get('v_' . $safe),
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
      * The text a form shows for one column's shared state.
      *
-     * @param array $info an entry from forHosts()
+     * @param array $info   an entry from forHosts() or forHostRows()
+     * @param bool  $redact  report agreement without reporting the value
      *
      * @return string ready-to-render, with the value HTML-escaped
      */
-    public static function text($info)
+    public static function text($info, $redact = false)
     {
         if (empty($info['uniform'])) {
             return _('(varies)');
         }
         if ('' === (string)$info['value']) {
             return _('(empty on all)');
+        }
+        // A credential's shared state is still worth reporting -- "they all
+        // have the same one" is what an admin needs to know before changing
+        // it across four hundred hosts -- but the VALUE is not. ADR 0038
+        // decision 11: ADPass and productKey both match
+        // Redaction::CREDENTIAL_PATTERN, and a form editing hundreds of them
+        // at once is the last place either should be rendered.
+        if ($redact) {
+            return _('(set on all)');
         }
 
         return \Initiator::e((string)$info['value']) . ' ' . _('(all)');
@@ -148,14 +240,15 @@ class SharedHostValues extends FOGBase
     /**
      * The muted "Hosts: ..." hint beneath a control.
      *
-     * @param array $info an entry from forHosts()
+     * @param array $info   an entry from forHosts() or forHostRows()
+     * @param bool  $redact  report agreement without reporting the value
      *
      * @return string
      */
-    public static function hint($info)
+    public static function hint($info, $redact = false)
     {
         return '<p class="form-text help-block-tight">'
-            . _('Hosts:') . ' ' . self::text($info)
+            . _('Hosts:') . ' ' . self::text($info, $redact)
             . '</p>';
     }
 

--- a/phpstan-tests-baseline.neon
+++ b/phpstan-tests-baseline.neon
@@ -337,6 +337,12 @@ parameters:
 			path: tests/lockout-guard-is-unscoped.test.php
 
 		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/mass-edit-form.test.php
+
+		-
 			message: '#^Access to an undefined static property FOG\\Route\:\:\$rows\.$#'
 			identifier: staticProperty.notFound
 			count: 3

--- a/tests/mass-edit-form.test.php
+++ b/tests/mass-edit-form.test.php
@@ -1,0 +1,363 @@
+<?php
+/**
+ * The mass edit form renders three states, and never a credential.
+ *
+ * The apply endpoint fails closed no matter what arrives
+ * (tests/mass-edit-fails-closed.test.php). This is about the other half of
+ * ADR 0038 decision 11, which is a claim about what the FORM does:
+ *
+ *   - every field is paired with an ACTION control that core renders, so a
+ *     plugin cannot ship a two-state field;
+ *   - a boolean is offered LEAVE and SET only, because its value control is
+ *     already a yes/no and a CLEAR beside it would be a second spelling of
+ *     "set to No";
+ *   - every value control is EMPTY -- there is no read path -- and its name
+ *     is `value[<key>]` so MassEdit sees it;
+ *   - the AD password in particular renders with no value and no 32-asterisk
+ *     placeholder, and its hint reports agreement without reporting the
+ *     secret.
+ *
+ * These are checked by RENDERING, not by grepping: the control builders are
+ * pure string functions, so the object is constructed without its
+ * constructor and the private methods are called through reflection. That is
+ * real evidence about the markup a browser receives, which a source scan is
+ * not.
+ *
+ * The kinds that need a database (`image`, and the two exit selectors, which
+ * read settings) are deliberately not exercised here -- they are the shared
+ * builders every other FOG form already uses, and standing a schema up to
+ * watch them work would make this an install rehearsal.
+ *
+ * Usage: php tests/mass-edit-form.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+$webroot = $root . '/packages/web';
+$init = $webroot . '/commons/init.php';
+if (!is_readable($init)) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+
+$tmp = sys_get_temp_dir() . '/fog-mass-edit-form-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
+register_shutdown_function(
+    function () use ($tmp) {
+        if (!is_dir($tmp)) {
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($tmp, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $f) {
+            $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+        }
+        @rmdir($tmp);
+    }
+);
+if (!defined('FOG_CACHE_DIR')) {
+    define('FOG_CACHE_DIR', $tmp . '/cache');
+}
+if (!defined('FOG_LOG_DIR')) {
+    define('FOG_LOG_DIR', $tmp . '/log');
+}
+if (!defined('FOG_PLUGIN_DIR')) {
+    define('FOG_PLUGIN_DIR', $tmp . '/plugins');
+}
+
+require_once $init;
+new Initiator();
+
+$checks = 0;
+$failures = [];
+$check = static function ($what, $ok) use (&$checks, &$failures) {
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+};
+
+$class = \FOG\Pages\HostManagement::class;
+if (!class_exists($class, true)) {
+    fwrite(STDERR, "FAIL: HostManagement does not resolve\n");
+    exit(1);
+}
+
+// No constructor: it wants a configured server. The control builders are
+// pure, so an uninitialized instance is enough to call them, and calling
+// them is the whole point -- this test asserts on rendered markup.
+$page = (new \ReflectionClass($class))->newInstanceWithoutConstructor();
+$call = static function ($method, array $args = []) use ($class, $page) {
+    $m = new \ReflectionMethod($class, $method);
+    $m->setAccessible(true);
+    return $m->invokeArgs($page, $args);
+};
+
+$core = $call('massEditCoreFields');
+$rows = $call('massEditRowFields');
+$check('the core field spec is reachable', is_array($core) && count($core) > 0);
+$check('the row field spec is reachable', is_array($rows) && count($rows) > 0);
+
+// --- The action control ---------------------------------------------------
+
+$action = $call('massEditActionControl', ['kernel', $core['kernel']]);
+$check(
+    'the action control posts as action[<key>]',
+    false !== strpos($action, 'name="action[kernel]"')
+);
+$check(
+    'a text field is offered all three states',
+    false !== strpos($action, 'value="leave"')
+        && false !== strpos($action, 'value="set"')
+        && false !== strpos($action, 'value="clear"')
+);
+$check(
+    'leave is the first option, so it is what an untouched control submits',
+    strpos($action, 'value="leave"') < strpos($action, 'value="set"')
+);
+$check(
+    'the action control names its key for the script that disables the value',
+    false !== strpos($action, 'data-massedit-key="kernel"')
+);
+
+$boolAction = $call('massEditActionControl', ['useAD', $core['useAD']]);
+$check(
+    'a boolean is offered leave and set only',
+    false !== strpos($boolAction, 'value="leave"')
+        && false !== strpos($boolAction, 'value="set"')
+        && false === strpos($boolAction, 'value="clear"')
+);
+
+// Every field core and the row half offer must get an action control, and
+// core must be the one drawing it. A plugin drawing its own could ship a
+// two-state field, which is the defect decision 11 is entirely about.
+$missing = [];
+foreach (array_merge($core, $rows) as $key => $spec) {
+    $html = $call('massEditActionControl', [$key, $spec]);
+    if (false === strpos($html, 'name="action[' . $key . ']"')
+        || false === strpos($html, 'value="leave"')
+    ) {
+        $missing[] = $key;
+    }
+}
+$check(
+    'every offered field gets a core-rendered action control ('
+    . implode(', ', $missing) . ')',
+    0 === count($missing)
+);
+
+// --- Value controls -------------------------------------------------------
+
+$text = $call('massEditValueControl', ['kernel', $core['kernel']]);
+$check(
+    'a text value posts as value[<key>]',
+    false !== strpos($text, 'name="value[kernel]"')
+);
+$check(
+    'a text value renders empty -- there is no read path',
+    false !== strpos($text, 'value=""')
+);
+
+$pass = $call('massEditValueControl', ['ADPass', $core['ADPass']]);
+$check(
+    'the AD password is a password input',
+    false !== strpos($pass, 'type="password"')
+);
+$check(
+    'the AD password renders empty',
+    false !== strpos($pass, 'value=""')
+);
+$check(
+    'the AD password carries no 32-asterisk placeholder',
+    false === strpos($pass, '****')
+);
+$check(
+    'the AD password does not invite the browser to fill it',
+    false !== strpos($pass, 'autocomplete="off"')
+);
+
+$bool = $call('massEditValueControl', ['useAD', $core['useAD']]);
+$check(
+    'a boolean value control is a yes/no select',
+    false !== strpos($bool, 'name="value[useAD]"')
+        && false !== strpos($bool, 'value="1"')
+        && false !== strpos($bool, 'value="0"')
+);
+
+$level = $call('massEditValueControl', ['printerLevel', $core['printerLevel']]);
+$check(
+    'the printer level offers all three levels',
+    false !== strpos($level, 'value="0"')
+        && false !== strpos($level, 'value="1"')
+        && false !== strpos($level, 'value="2"')
+);
+
+// The composite. Its parts must arrive as an ARRAY under one key, which is
+// what lets MassEdit::resolveComposite() read them without parsing anything
+// -- and is why there is no 1024x768@60 string anywhere in this form.
+$res = $call('massEditValueControl', ['resolution', $rows['resolution']]);
+$check(
+    'the resolution posts three parts under one key',
+    false !== strpos($res, 'name="value[resolution][x]"')
+        && false !== strpos($res, 'name="value[resolution][y]"')
+        && false !== strpos($res, 'name="value[resolution][r]"')
+);
+$check(
+    'the resolution is not encoded into one string field',
+    false === strpos($res, 'name="value[resolution]"')
+);
+
+// --- Control ids ----------------------------------------------------------
+
+$check(
+    'a control id is a usable HTML id, whatever the key',
+    'massedit-value-weirdkey' === $call(
+        'massEditControlId',
+        ['value', 'weird[key]']
+    )
+);
+
+// --- What the whitelist promises the form ---------------------------------
+
+$noKind = [];
+foreach (array_merge($core, $rows) as $key => $spec) {
+    if (!isset($spec['label'])) {
+        $noKind[] = $key;
+    }
+}
+$check(
+    'every offered field carries a label to render ('
+    . implode(', ', $noKind) . ')',
+    0 === count($noKind)
+);
+
+// --- The endpoint's own wiring --------------------------------------------
+
+$source = (string)@file_get_contents(
+    $root . '/packages/web/src/Pages/HostManagement.php'
+);
+$methodBody = static function ($src, $signature) {
+    $start = strpos($src, $signature);
+    if (false === $start) {
+        return null;
+    }
+    $open = strpos($src, '{', $start);
+    if (false === $open) {
+        return null;
+    }
+    $depth = 0;
+    $len = strlen($src);
+    for ($i = $open; $i < $len; $i++) {
+        if ('{' === $src[$i]) {
+            $depth++;
+        } elseif ('}' === $src[$i]) {
+            $depth--;
+            if (0 === $depth) {
+                return substr($src, $open, $i - $open + 1);
+            }
+        }
+    }
+    return null;
+};
+$body = $methodBody($source, 'public function massEditFormPost()');
+$check('massEditFormPost() is still findable', null !== $body);
+$body = (string)$body;
+
+// The form reports what the selection holds, so fetching it is a read of
+// those hosts and takes the same boundary the write does.
+$auth = strpos($body, 'checkAuthAndCSRF');
+$scope = strpos($body, 'requirePageObjectScopeMass');
+$hints = strpos($body, 'massEditHints(');
+$check('the form endpoint checks auth and CSRF', false !== $auth);
+$check('the form endpoint bounds the selection to the site scope', false !== $scope);
+$check(
+    'the scope check runs before anything is read about the hosts',
+    false !== $scope && false !== $hints && $scope < $hints
+);
+
+// The form posts to the APPLY sub, not to itself.
+$check(
+    'the form submits to the apply endpoint',
+    false !== strpos($body, 'sub=massedit')
+        && false === strpos($body, 'sub=masseditform&')
+);
+$check(
+    'the selection rides in the form as hidden host ids',
+    false !== strpos($body, 'name="hosts[]"')
+);
+
+// The plugin half goes through the same call the apply path makes, so the
+// two cannot see different field sets.
+$check(
+    'the form gets its plugin fields from massEditPluginFields()',
+    false !== strpos($body, 'massEditPluginFields($hosts)')
+);
+
+$plugin = $methodBody($source, 'private function massEditPluginFields(');
+$check(
+    'HOST_MASSEDIT_FIELDS carries the selection to the plugin',
+    null !== $plugin
+        && false !== strpos((string)$plugin, "'hostIDs' => &\$hostIDs")
+);
+
+// The credential hint. A secret reports agreement, never the value.
+$hintBody = $methodBody($source, 'private function massEditHints(');
+$check('massEditHints() is still findable', null !== $hintBody);
+$check(
+    'a secret field gets a redacted hint',
+    null !== $hintBody
+        && 1 === preg_match(
+            '/SharedHostValues::hint\(\s*\$shared\[\$key\],\s*'
+            . '!empty\(\$spec\[.secret.\]\)/s',
+            (string)$hintBody
+        )
+);
+
+// The row-backed hints ask their own tables, and the resolution's three
+// columns are combined into one answer rather than reported separately.
+$check(
+    'the auto-logout hint reads its own table',
+    null !== $hintBody
+        && false !== strpos((string)$hintBody, "'hostAutoLogOut'")
+);
+$check(
+    'the resolution hint reads its own table',
+    null !== $hintBody
+        && false !== strpos((string)$hintBody, "'hostScreenSettings'")
+);
+$check(
+    'the resolution is uniform only when all three parts agree',
+    null !== $hintBody
+        && 1 === preg_match(
+            '/\$uniform = !empty\(\$disp\[.x.\]\[.uniform.\]\)\s*'
+            . '&& !empty\(\$disp\[.y.\]\[.uniform.\]\)\s*'
+            . '&& !empty\(\$disp\[.r.\]\[.uniform.\]\)/s',
+            (string)$hintBody
+        )
+);
+
+if (count($failures)) {
+    fwrite(STDERR, "FAIL: the mass edit form is not three-state:\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    fwrite(
+        STDERR,
+        sprintf("%d of %d checks failed\n", count($failures), $checks)
+    );
+    exit(1);
+}
+
+printf("PASS  mass edit form: %d checks\n", $checks);
+exit(0);

--- a/tests/shared-host-values.test.php
+++ b/tests/shared-host-values.test.php
@@ -367,6 +367,150 @@ $check(
     )
 );
 
+// --- Redaction ------------------------------------------------------------
+//
+// ADPass and productKey both match Redaction::CREDENTIAL_PATTERN, and the
+// mass edit form renders a hint beside every control. Agreement is worth
+// reporting; the value is not.
+$check(
+    'a redacted agreed value reports agreement, never the value',
+    _('(set on all)') === \FOG\Util\SharedHostValues::text(
+        ['uniform' => true, 'value' => 'hunter2'],
+        true
+    )
+);
+$check(
+    'redaction does not leak the value into the hint markup',
+    false === strpos(
+        \FOG\Util\SharedHostValues::hint(
+            ['uniform' => true, 'value' => 'hunter2'],
+            true
+        ),
+        'hunter2'
+    )
+);
+$check(
+    'redaction still distinguishes varies from set-on-all',
+    _('(varies)') === \FOG\Util\SharedHostValues::text(
+        ['uniform' => false, 'value' => 'hunter2'],
+        true
+    )
+);
+$check(
+    'redaction still distinguishes empty-on-all',
+    _('(empty on all)') === \FOG\Util\SharedHostValues::text(
+        ['uniform' => true, 'value' => ''],
+        true
+    )
+);
+
+// --- Row-backed tables ----------------------------------------------------
+//
+// Auto-logout and screen resolution are one row per host, and a host with no
+// row is a host with no override. The property that matters, and the one a
+// naive query gets wrong, is that "every host agrees" must mean every
+// SELECTED host -- not every host that happens to have a row.
+$pdo->exec(
+    'CREATE TABLE `hostAutoLogOut` ('
+    . '`haloID` int(11) NOT NULL AUTO_INCREMENT, '
+    . '`haloHostID` int(11) NOT NULL, '
+    . '`haloTime` varchar(6) NULL, '
+    . 'PRIMARY KEY (`haloID`)'
+    . ') ENGINE=InnoDB'
+);
+$pdo->exec(
+    "INSERT INTO `hostAutoLogOut` (`haloHostID`,`haloTime`) VALUES "
+    // 1 and 2 agree. 3 has NO ROW AT ALL -- the case the whole method is
+    // about. 4 disagrees. 5 and 6 both HAVE rows and 6's value is NULL,
+    // which is the COALESCE trap: COUNT(DISTINCT) skips NULLs, so without
+    // the COALESCE the pair counts as one distinct value and reports
+    // agreement on a time that host 6 does not have.
+    . "(1,'15'), (2,'15'), (4,'30'), (5,'15'), (6,NULL)"
+);
+
+$stub->resetRow();
+$got = \FOG\Util\SharedHostValues::forHostRows(
+    [1, 2],
+    'hostAutoLogOut',
+    'haloHostID',
+    ['alo' => 'haloTime']
+);
+$check(
+    'row-backed hosts that all have a row and agree are uniform',
+    true === ($got['alo']['uniform'] ?? null)
+        && '15' === ($got['alo']['value'] ?? null)
+);
+
+$stub->resetRow();
+$got = \FOG\Util\SharedHostValues::forHostRows(
+    [1, 2, 3],
+    'hostAutoLogOut',
+    'haloHostID',
+    ['alo' => 'haloTime']
+);
+// THE ONE THAT MATTERS. Hosts 1 and 2 hold '15'; host 3 has no row. A query
+// that only compared the rows it found would report agreement on a value one
+// of the three does not have, and the form would say "15 (all)" over a
+// selection where a third of the hosts have no auto-logout at all.
+$check(
+    'a selected host with NO ROW breaks uniformity',
+    false === ($got['alo']['uniform'] ?? null)
+);
+
+$stub->resetRow();
+$got = \FOG\Util\SharedHostValues::forHostRows(
+    [1, 4],
+    'hostAutoLogOut',
+    'haloHostID',
+    ['alo' => 'haloTime']
+);
+$check(
+    'row-backed hosts holding different values are not uniform',
+    false === ($got['alo']['uniform'] ?? null)
+);
+
+$stub->resetRow();
+svTakeQueryCount();
+$got = \FOG\Util\SharedHostValues::forHostRows(
+    [1, 2, 3, 4],
+    'hostAutoLogOut',
+    'haloHostID',
+    ['alo' => 'haloTime']
+);
+$check(
+    'the row-backed answer also takes ONE query',
+    1 === svTakeQueryCount()
+);
+
+$stub->resetRow();
+$got = \FOG\Util\SharedHostValues::forHostRows(
+    [5, 6],
+    'hostAutoLogOut',
+    'haloHostID',
+    ['alo' => 'haloTime']
+);
+// The COALESCE guard for the row-backed side, and the only case that tests
+// it. Both hosts HAVE rows -- so the every-host-has-a-row rule above is
+// satisfied and cannot be what answers this -- but one holds NULL.
+// COUNT(DISTINCT) skips NULLs, so without the COALESCE this counts one
+// distinct value and the form says "15 (all)" over a host with no
+// auto-logout time at all.
+$check(
+    'a NULL value among rows that exist is a disagreement',
+    false === ($got['alo']['uniform'] ?? null)
+);
+
+$got = \FOG\Util\SharedHostValues::forHostRows(
+    [],
+    'hostAutoLogOut',
+    'haloHostID',
+    ['alo' => 'haloTime']
+);
+$check(
+    'an empty selection is not uniform and asks nothing',
+    false === ($got['alo']['uniform'] ?? null)
+);
+
 if (count($failures)) {
     fwrite(STDERR, "FAIL: shared host values are not telling the truth:\n");
     foreach ($failures as $f) {


### PR DESCRIPTION
The last piece of C5. #1622/#1623/#1625/#1626 built a write path with no way to reach it — this is the form, the modal on the host list, and the `HOST_MASSEDIT_FIELDS` half of the ABI gap [ADR 0038](../blob/working-1.6/docs/adr/0038-a-group-grants-it-does-not-copy.md) decision 13 named.

## Three states, out of band

Every field is paired with its own action control — **No change / Set on all / Clear on all** — and the value control is disabled until the action says SET.

That is more markup than the group page has and it is the correct amount. The group page's convention is a blank box meaning *leave alone* and the literal string **`NULL`** meaning *clear*:

- it is undiscoverable — nothing in the form says the word `NULL` is magic;
- it cannot express *clear* for a control with no text box, which is why image, building and printer level had to be special-cased;
- it has no escape, so a value that legitimately **is** the string `NULL` cannot be set.

**Core renders the action control, never the field's owner.** A plugin that drew its own could ship a two-state field, and a two-state field in a mass edit is the defect decision 11 is entirely about: it looks identical to a correct one until somebody's images are gone.

A boolean is offered LEAVE and SET only. Its value control is already a yes/no, so a CLEAR beside it would be a second spelling of *"set to No"* — and two controls that mean the same thing is how a person picks the wrong one.

## Every control renders empty

There is no read path. Not for the credentials, which is decision 11's requirement — and not for anything else either, because a control pre-filled from a selection has to answer *"pre-filled with which host's value"* and there is no honest answer when they differ.

What the hosts hold goes in the hint beside it, where *(varies)* is sayable:

```
Image                [No change ▾]  [ubuntu-22 ▾]
                                    Hosts: (varies)
Host Kernel          [Set on all ▾] [bzImage        ]
                                    Hosts: (empty on all)
AD Password          [No change ▾]  [•••••••••      ]
                                    Hosts: (set on all)
```

## `SharedHostValues` gains the two things that needs

**`forHostRows()`** answers the same question for a table holding one row per host. Its whole point is one line — the row count compared against the **selection** size:

> thirty hosts sharing a value and ten with no row at all is **not** uniform, and a query that only compared the thirty would say confidently that it was.

**`text()`/`hint()` gain a `redact` flag** so a credential reports agreement without reporting the value. `ADPass` and `productKey` both match `Redaction::CREDENTIAL_PATTERN`, and the group page's 32-asterisk placeholder is not carried over.

## Why the form is a POST

Not incidental. The hints describe **this** selection, so the endpoint needs the ids to render at all, and several hundred do not go in a query string. `deployMulti()` gets away with a GET because it only needs a count.

Scope is checked **before anything is read about the hosts** — the form reports what they hold, so fetching it is a read of them and takes the same boundary the write does.

## Wiring

The toolbar picks the button up through `method_exists` on `massEditActions`, the same seam `queueTaskActions` uses, so `FOGPage` does not learn a second node name.

`HOST_MASSEDIT_FIELDS` now carries the selection, and the form and the apply make the **same call** — a key offered by one and absent from the other would be a control that silently does nothing.

`docs/plugin-development.md` §9b documents both events, with the three-state contract and the reason a plugin must not draw its own action control.

## Tests

`tests/mass-edit-form.test.php` **renders** the controls rather than grepping for them: the builders are pure string functions, so the page is constructed without its constructor and the private methods are called through reflection. That is real evidence about the markup a browser receives.

33 checks, eight mutations, each reddening the intended one:

| Mutation | What went red |
|---|---|
| a Clear option on a boolean | the two-state assertion |
| `set` listed before `leave` | the default-option assertion |
| the 32-asterisk placeholder returning | the empty-password assertions |
| the resolution collapsed into one string field | the composite-name assertions |
| the scope check moved after the read | the ordering assertion |
| the secret hint unredacted | the redaction assertion |
| the plugin hook losing the selection | the hook-payload assertion |
| the resolution called uniform on one part agreeing | the all-three-parts assertion |

`shared-host-values` gains ten checks and four mutations. The row-backed COALESCE guard needed a fixture where **both** hosts have rows and one holds NULL before it was observable at all — the first cut passed with the guard removed, so the fixture was fixed rather than the finding written up as covered.

Full PHP and shell suites green (with a live MariaDB, so the DB-backed tests actually ran rather than skipping); both phpstan passes clean.

## Still to come

Unit D (the groups column and filter on the host list) and unit E (the group page rework), which is gated on this being **proven in use**, not merely merged — decision 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)