### PR TITLE
Give modules a group grant table, and make msState mean what it says

### DIFF
--- a/docs/adr/0031-referential-integrity-is-declared-in-the-database.md
+++ b/docs/adr/0031-referential-integrity-is-declared-in-the-database.md
@@ -15,7 +15,7 @@ windowskey 2, ldap 6, oidc 8, capone 2, subnetgroup 1 -- are declared in
 core's map and applied by a step in each plugin's own `schema()` in
 `FOGProject/fog-plugins`.
 
-**105 of the map's 120 relationships are declared.** The other 15 are not
+**107 of the map's 122 relationships are declared.** The other 15 are not
 pending work: they carry action `none`, which the map's docblock defines as a
 decision rather than an omission. Nine are audit rows, which MUST NOT
 constrain the thing they record (ADR 0021, `schema.php` step 341); six are

--- a/docs/development/foreign-keys.md
+++ b/docs/development/foreign-keys.md
@@ -603,7 +603,7 @@ half-converted column.
 ## Phase D — plugins, and the direction rule
 
 18 plugin tables ship in `FOGProject/fog-plugins`. All 18 clone cleanly into
-the survey and 25 of the map's 120 relationships live in them.
+the survey and 25 of the map's 122 relationships live in them.
 
 ### Direction is the whole rule
 

--- a/packages/web/commons/schema-constraints.php
+++ b/packages/web/commons/schema-constraints.php
@@ -299,6 +299,15 @@ return [
     ['child' => 'groupSnapinAssoc', 'column' => 'gsaSnapinID', 'parent' => 'snapins', 'pcolumn' => 'sID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 9],
     ['child' => 'groupPrinterAssoc', 'column' => 'gpaGroupID', 'parent' => 'groups', 'pcolumn' => 'groupID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 9],
     ['child' => 'groupPrinterAssoc', 'column' => 'gpaPrinterID', 'parent' => 'printers', 'pcolumn' => 'pID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 9],
+    // ADR 0038 decision 3, revised. Group 10, created empty by step 407 so
+    // there is nothing to sweep before the flip.
+    //
+    // Both CASCADE, for the reason group 9 gives: a grant is meaningless once
+    // either end is gone, and an orphan row would offer a grant against an id
+    // that has since been reused -- here, a host silently gaining whichever
+    // module inherited the number.
+    ['child' => 'groupModuleAssoc', 'column' => 'gmaGroupID', 'parent' => 'groups', 'pcolumn' => 'groupID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 10],
+    ['child' => 'groupModuleAssoc', 'column' => 'gmaModuleID', 'parent' => 'modules', 'pcolumn' => 'id', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 10],
     ['child' => 'ldapUserGrant', 'column' => 'lugTargetID', 'parent' => '(lugTargetType)', 'pcolumn' => '-', 'class' => 'poly', 'action' => 'none'],
     ['child' => 'oidcUserGrant', 'column' => 'ougTargetID', 'parent' => '(ougTargetType)', 'pcolumn' => '-', 'class' => 'poly', 'action' => 'none'],
 ];

--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -82,15 +82,6 @@ return [
         ],
     ],
     'tables' => [
-        'architectures' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `architectures` ( `archID` mediumint(9) NOT NULL AUTO_INCREMENT, `archName` varchar(16) NOT NULL, `archDescription` varchar(255) NOT NULL DEFAULT \'\', `archIsAccess` enum(\'both\',\'host\',\'image\') NOT NULL DEFAULT \'both\', PRIMARY KEY (`archID`), UNIQUE KEY `archName` (`archName`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
-            'columns' => [
-                'archID' => 'mediumint(9) NOT NULL',
-                'archName' => 'varchar(16) NOT NULL',
-                'archDescription' => 'varchar(255) NOT NULL DEFAULT \'\'',
-                'archIsAccess' => 'enum(\'both\',\'host\',\'image\') NOT NULL DEFAULT \'both\'',
-            ],
-        ],
         'apiTokens' => [
             'create' => 'CREATE TABLE IF NOT EXISTS `apiTokens` ( `atID` int(11) NOT NULL AUTO_INCREMENT, `atUserID` int(11) NOT NULL DEFAULT 0, `atName` varchar(255) NOT NULL DEFAULT \'\', `atHash` char(64) NOT NULL DEFAULT \'\', `atEnabled` tinyint(1) NOT NULL DEFAULT 1, `atCreatedTime` datetime NOT NULL DEFAULT current_timestamp(), `atCreatedBy` varchar(255) NOT NULL DEFAULT \'\', `atLastUsed` datetime DEFAULT NULL, PRIMARY KEY (`atID`), UNIQUE KEY `atHash` (`atHash`), KEY `atUserID` (`atUserID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
@@ -102,6 +93,15 @@ return [
                 'atCreatedTime' => 'datetime NOT NULL DEFAULT current_timestamp()',
                 'atCreatedBy' => 'varchar(255) NOT NULL DEFAULT \'\'',
                 'atLastUsed' => 'datetime DEFAULT NULL',
+            ],
+        ],
+        'architectures' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `architectures` ( `archID` mediumint(9) NOT NULL AUTO_INCREMENT, `archName` varchar(16) NOT NULL, `archDescription` varchar(255) NOT NULL DEFAULT \'\', `archIsAccess` enum(\'both\',\'host\',\'image\') NOT NULL DEFAULT \'both\', PRIMARY KEY (`archID`), UNIQUE KEY `archName` (`archName`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'archID' => 'mediumint(9) NOT NULL',
+                'archName' => 'varchar(16) NOT NULL',
+                'archDescription' => 'varchar(255) NOT NULL DEFAULT \'\'',
+                'archIsAccess' => 'enum(\'both\',\'host\',\'image\') NOT NULL DEFAULT \'both\'',
             ],
         ],
         'auditChange' => [
@@ -206,6 +206,14 @@ return [
                 'gmGroupID' => 'int(11) NOT NULL',
             ],
         ],
+        'groupModuleAssoc' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `groupModuleAssoc` ( `gmaID` int(11) NOT NULL AUTO_INCREMENT, `gmaGroupID` int(11) NOT NULL, `gmaModuleID` int(11) NOT NULL, PRIMARY KEY (`gmaID`), UNIQUE KEY `gmaGroupModule` (`gmaGroupID`,`gmaModuleID`), KEY `gmaModuleID` (`gmaModuleID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'gmaID' => 'int(11) NOT NULL',
+                'gmaGroupID' => 'int(11) NOT NULL',
+                'gmaModuleID' => 'int(11) NOT NULL',
+            ],
+        ],
         'groupPrinterAssoc' => [
             'create' => 'CREATE TABLE IF NOT EXISTS `groupPrinterAssoc` ( `gpaID` int(11) NOT NULL AUTO_INCREMENT, `gpaGroupID` int(11) NOT NULL, `gpaPrinterID` int(11) NOT NULL, `gpaIsDefault` tinyint(1) NOT NULL DEFAULT 0, PRIMARY KEY (`gpaID`), UNIQUE KEY `gpaGroupPrinter` (`gpaGroupID`,`gpaPrinterID`), KEY `gpaPrinterID` (`gpaPrinterID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
@@ -213,15 +221,6 @@ return [
                 'gpaGroupID' => 'int(11) NOT NULL',
                 'gpaPrinterID' => 'int(11) NOT NULL',
                 'gpaIsDefault' => 'tinyint(1) NOT NULL DEFAULT 0',
-            ],
-        ],
-        'groupSnapinAssoc' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `groupSnapinAssoc` ( `gsaID` int(11) NOT NULL AUTO_INCREMENT, `gsaGroupID` int(11) NOT NULL, `gsaSnapinID` int(11) NOT NULL, `gsaSequence` int(11) NOT NULL DEFAULT 0, PRIMARY KEY (`gsaID`), UNIQUE KEY `gsaGroupSnapin` (`gsaGroupID`,`gsaSnapinID`), KEY `gsaSnapinID` (`gsaSnapinID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
-            'columns' => [
-                'gsaID' => 'int(11) NOT NULL',
-                'gsaGroupID' => 'int(11) NOT NULL',
-                'gsaSnapinID' => 'int(11) NOT NULL',
-                'gsaSequence' => 'int(11) NOT NULL DEFAULT 0',
             ],
         ],
         'groups' => [
@@ -238,6 +237,15 @@ return [
                 'groupPrimaryDisk' => 'varchar(255) NOT NULL DEFAULT \'\'',
                 'groupInit' => 'longtext NOT NULL DEFAULT \'\'',
                 'groupOrder' => 'int(11) NOT NULL DEFAULT 0',
+            ],
+        ],
+        'groupSnapinAssoc' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `groupSnapinAssoc` ( `gsaID` int(11) NOT NULL AUTO_INCREMENT, `gsaGroupID` int(11) NOT NULL, `gsaSnapinID` int(11) NOT NULL, `gsaSequence` int(11) NOT NULL DEFAULT 0, PRIMARY KEY (`gsaID`), UNIQUE KEY `gsaGroupSnapin` (`gsaGroupID`,`gsaSnapinID`), KEY `gsaSnapinID` (`gsaSnapinID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'gsaID' => 'int(11) NOT NULL',
+                'gsaGroupID' => 'int(11) NOT NULL',
+                'gsaSnapinID' => 'int(11) NOT NULL',
+                'gsaSequence' => 'int(11) NOT NULL DEFAULT 0',
             ],
         ],
         'history' => [
@@ -464,12 +472,12 @@ return [
             ],
         ],
         'moduleStatusByHost' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `moduleStatusByHost` ( `msID` int(11) NOT NULL AUTO_INCREMENT, `msHostID` int(11) NOT NULL, `msModuleID` int(11) NOT NULL, `msState` varchar(1) NOT NULL DEFAULT \'\', PRIMARY KEY (`msID`), UNIQUE KEY `msHostID` (`msHostID`,`msModuleID`), UNIQUE KEY `msHostID_2` (`msHostID`,`msModuleID`), KEY `new_index` (`msHostID`), KEY `new_index2` (`msModuleID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'create' => 'CREATE TABLE IF NOT EXISTS `moduleStatusByHost` ( `msID` int(11) NOT NULL AUTO_INCREMENT, `msHostID` int(11) NOT NULL, `msModuleID` int(11) NOT NULL, `msState` tinyint(1) NOT NULL DEFAULT 1, PRIMARY KEY (`msID`), UNIQUE KEY `msHostID` (`msHostID`,`msModuleID`), UNIQUE KEY `msHostID_2` (`msHostID`,`msModuleID`), KEY `new_index` (`msHostID`), KEY `new_index2` (`msModuleID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
                 'msID' => 'int(11) NOT NULL',
                 'msHostID' => 'int(11) NOT NULL',
                 'msModuleID' => 'int(11) NOT NULL',
-                'msState' => 'varchar(1) NOT NULL DEFAULT \'\'',
+                'msState' => 'tinyint(1) NOT NULL DEFAULT 1',
             ],
         ],
         'multicastSessions' => [
@@ -685,6 +693,43 @@ return [
                 'rugName' => 'varchar(60) NOT NULL DEFAULT \'\'',
                 'rugGroupID' => 'int(11) NOT NULL',
                 'rugRoleID' => 'int(11) NOT NULL',
+            ],
+        ],
+        'savedFilterGroupAssoc' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `savedFilterGroupAssoc` ( `sfgaID` int(11) NOT NULL AUTO_INCREMENT, `sfgaFilterID` int(11) NOT NULL, `sfgaUserGroupID` int(11) NOT NULL, PRIMARY KEY (`sfgaID`), UNIQUE KEY `sfgaFilterGroup` (`sfgaFilterID`,`sfgaUserGroupID`), KEY `sfgaUserGroupID` (`sfgaUserGroupID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'sfgaID' => 'int(11) NOT NULL',
+                'sfgaFilterID' => 'int(11) NOT NULL',
+                'sfgaUserGroupID' => 'int(11) NOT NULL',
+            ],
+        ],
+        'savedFilterRoleAssoc' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `savedFilterRoleAssoc` ( `sfraID` int(11) NOT NULL AUTO_INCREMENT, `sfraFilterID` int(11) NOT NULL, `sfraRoleID` int(11) NOT NULL, PRIMARY KEY (`sfraID`), UNIQUE KEY `sfraFilterRole` (`sfraFilterID`,`sfraRoleID`), KEY `sfraRoleID` (`sfraRoleID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'sfraID' => 'int(11) NOT NULL',
+                'sfraFilterID' => 'int(11) NOT NULL',
+                'sfraRoleID' => 'int(11) NOT NULL',
+            ],
+        ],
+        'savedFilters' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `savedFilters` ( `sfID` int(11) NOT NULL AUTO_INCREMENT, `sfUserID` int(11) DEFAULT NULL, `sfCreatorID` int(11) DEFAULT NULL, `sfTable` varchar(128) NOT NULL DEFAULT \'\', `sfName` varchar(64) NOT NULL DEFAULT \'\', `sfValue` longtext DEFAULT NULL, `sfCreatedTime` datetime NOT NULL DEFAULT current_timestamp(), `sfModifiedTime` datetime DEFAULT NULL, PRIMARY KEY (`sfID`), UNIQUE KEY `sfOwnerTableName` (`sfUserID`,`sfTable`,`sfName`), KEY `sfTable` (`sfTable`), KEY `sfCreatorID` (`sfCreatorID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'sfID' => 'int(11) NOT NULL',
+                'sfUserID' => 'int(11) DEFAULT NULL',
+                'sfCreatorID' => 'int(11) DEFAULT NULL',
+                'sfTable' => 'varchar(128) NOT NULL DEFAULT \'\'',
+                'sfName' => 'varchar(64) NOT NULL DEFAULT \'\'',
+                'sfValue' => 'longtext DEFAULT NULL',
+                'sfCreatedTime' => 'datetime NOT NULL DEFAULT current_timestamp()',
+                'sfModifiedTime' => 'datetime DEFAULT NULL',
+            ],
+        ],
+        'savedFilterUserAssoc' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `savedFilterUserAssoc` ( `sfuaID` int(11) NOT NULL AUTO_INCREMENT, `sfuaFilterID` int(11) NOT NULL, `sfuaUserID` int(11) NOT NULL, PRIMARY KEY (`sfuaID`), UNIQUE KEY `sfuaFilterUser` (`sfuaFilterID`,`sfuaUserID`), KEY `sfuaUserID` (`sfuaUserID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'sfuaID' => 'int(11) NOT NULL',
+                'sfuaFilterID' => 'int(11) NOT NULL',
+                'sfuaUserID' => 'int(11) NOT NULL',
             ],
         ],
         'scheduledTasks' => [
@@ -954,54 +999,6 @@ return [
                 'uaPasswordHash' => 'varchar(255) NOT NULL DEFAULT \'\'',
             ],
         ],
-        'userPrefs' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `userPrefs` ( `upID` int(11) NOT NULL AUTO_INCREMENT, `upUserID` int(11) NOT NULL DEFAULT 0, `upKey` varchar(190) NOT NULL DEFAULT \'\', `upValue` longtext DEFAULT NULL, `upCreatedTime` datetime NOT NULL DEFAULT current_timestamp(), `upModifiedTime` datetime DEFAULT NULL, PRIMARY KEY (`upID`), UNIQUE KEY `upUserKey` (`upUserID`,`upKey`), KEY `upUserID` (`upUserID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
-            'columns' => [
-                'upID' => 'int(11) NOT NULL',
-                'upUserID' => 'int(11) NOT NULL DEFAULT 0',
-                'upKey' => 'varchar(190) NOT NULL DEFAULT \'\'',
-                'upValue' => 'longtext DEFAULT NULL',
-                'upCreatedTime' => 'datetime NOT NULL DEFAULT current_timestamp()',
-                'upModifiedTime' => 'datetime DEFAULT NULL',
-            ],
-        ],
-        'savedFilters' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `savedFilters` ( `sfID` int(11) NOT NULL AUTO_INCREMENT, `sfUserID` int(11) DEFAULT NULL, `sfCreatorID` int(11) DEFAULT NULL, `sfTable` varchar(128) NOT NULL DEFAULT \'\', `sfName` varchar(64) NOT NULL DEFAULT \'\', `sfValue` longtext DEFAULT NULL, `sfCreatedTime` datetime NOT NULL DEFAULT current_timestamp(), `sfModifiedTime` datetime DEFAULT NULL, PRIMARY KEY (`sfID`), UNIQUE KEY `sfOwnerTableName` (`sfUserID`,`sfTable`,`sfName`), KEY `sfTable` (`sfTable`), KEY `sfCreatorID` (`sfCreatorID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
-            'columns' => [
-                'sfID' => 'int(11) NOT NULL',
-                'sfUserID' => 'int(11) DEFAULT NULL',
-                'sfCreatorID' => 'int(11) DEFAULT NULL',
-                'sfTable' => 'varchar(128) NOT NULL DEFAULT \'\'',
-                'sfName' => 'varchar(64) NOT NULL DEFAULT \'\'',
-                'sfValue' => 'longtext DEFAULT NULL',
-                'sfCreatedTime' => 'datetime NOT NULL DEFAULT current_timestamp()',
-                'sfModifiedTime' => 'datetime DEFAULT NULL',
-            ],
-        ],
-        'savedFilterUserAssoc' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `savedFilterUserAssoc` ( `sfuaID` int(11) NOT NULL AUTO_INCREMENT, `sfuaFilterID` int(11) NOT NULL, `sfuaUserID` int(11) NOT NULL, PRIMARY KEY (`sfuaID`), UNIQUE KEY `sfuaFilterUser` (`sfuaFilterID`,`sfuaUserID`), KEY `sfuaUserID` (`sfuaUserID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
-            'columns' => [
-                'sfuaID' => 'int(11) NOT NULL',
-                'sfuaFilterID' => 'int(11) NOT NULL',
-                'sfuaUserID' => 'int(11) NOT NULL',
-            ],
-        ],
-        'savedFilterGroupAssoc' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `savedFilterGroupAssoc` ( `sfgaID` int(11) NOT NULL AUTO_INCREMENT, `sfgaFilterID` int(11) NOT NULL, `sfgaUserGroupID` int(11) NOT NULL, PRIMARY KEY (`sfgaID`), UNIQUE KEY `sfgaFilterGroup` (`sfgaFilterID`,`sfgaUserGroupID`), KEY `sfgaUserGroupID` (`sfgaUserGroupID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
-            'columns' => [
-                'sfgaID' => 'int(11) NOT NULL',
-                'sfgaFilterID' => 'int(11) NOT NULL',
-                'sfgaUserGroupID' => 'int(11) NOT NULL',
-            ],
-        ],
-        'savedFilterRoleAssoc' => [
-            'create' => 'CREATE TABLE IF NOT EXISTS `savedFilterRoleAssoc` ( `sfraID` int(11) NOT NULL AUTO_INCREMENT, `sfraFilterID` int(11) NOT NULL, `sfraRoleID` int(11) NOT NULL, PRIMARY KEY (`sfraID`), UNIQUE KEY `sfraFilterRole` (`sfraFilterID`,`sfraRoleID`), KEY `sfraRoleID` (`sfraRoleID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
-            'columns' => [
-                'sfraID' => 'int(11) NOT NULL',
-                'sfraFilterID' => 'int(11) NOT NULL',
-                'sfraRoleID' => 'int(11) NOT NULL',
-            ],
-        ],
         'userCleanup' => [
             'create' => 'CREATE TABLE IF NOT EXISTS `userCleanup` ( `ucID` int(11) NOT NULL AUTO_INCREMENT, `ucName` varchar(254) NOT NULL DEFAULT \'\', PRIMARY KEY (`ucID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [
@@ -1026,6 +1023,17 @@ return [
                 'ugDesc' => 'longtext NOT NULL DEFAULT \'\'',
                 'ugCreatedBy' => 'varchar(40) NOT NULL DEFAULT \'\'',
                 'ugCreatedTime' => 'timestamp NOT NULL DEFAULT current_timestamp()',
+            ],
+        ],
+        'userPrefs' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `userPrefs` ( `upID` int(11) NOT NULL AUTO_INCREMENT, `upUserID` int(11) NOT NULL DEFAULT 0, `upKey` varchar(190) NOT NULL DEFAULT \'\', `upValue` longtext DEFAULT NULL, `upCreatedTime` datetime NOT NULL DEFAULT current_timestamp(), `upModifiedTime` datetime DEFAULT NULL, PRIMARY KEY (`upID`), UNIQUE KEY `upUserKey` (`upUserID`,`upKey`), KEY `upUserID` (`upUserID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'upID' => 'int(11) NOT NULL',
+                'upUserID' => 'int(11) NOT NULL DEFAULT 0',
+                'upKey' => 'varchar(190) NOT NULL DEFAULT \'\'',
+                'upValue' => 'longtext DEFAULT NULL',
+                'upCreatedTime' => 'datetime NOT NULL DEFAULT current_timestamp()',
+                'upModifiedTime' => 'datetime DEFAULT NULL',
             ],
         ],
         'users' => [

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -10496,3 +10496,81 @@ $this->schema[] = [
     // (vHostMAC -> hostMAC.hmMAC) was class 'poly' and applied nothing.
     Schema::dropTable('virus'),
 ];
+
+// 407
+$this->schema[] = [
+    // ADR 0038 decision 3, revised: modules become the third declarative
+    // grant, beside snapins and printers.
+    //
+    // The original decision kept them imperative on the grounds that a module
+    // carries an enabled/disabled state a snapin does not, so two groups
+    // granting the same module -- one enabled, one disabled -- would be a
+    // contradiction with no correct answer. That argument did not survive
+    // reading the code: nothing ever wrote `msState = 0`, two earlier schema
+    // steps DELETE any that exist, and the client ignores the column outright,
+    // so the disabled state it turned on was not reachable.
+    //
+    // The revision keeps the state AND makes it real, with an order of
+    // precedence rather than a contradiction: the most specific writer wins.
+    // A host row saying 0 is an explicit "not on this machine" and beats every
+    // group grant. A host row saying 1 is a host-direct enable. NO row is the
+    // host expressing nothing, which is what lets a group grant reach it.
+    //
+    // Empty on creation and nothing migrated, exactly as step 403 did for the
+    // other two (decision 18). A group's module tab today is derived from its
+    // members' own rows, so migrating it would be inventing grants out of a
+    // display. Every host keeps precisely the modules it has.
+    "CREATE TABLE IF NOT EXISTS `groupModuleAssoc` ( "
+    . "`gmaID` int(11) NOT NULL AUTO_INCREMENT, "
+    . "`gmaGroupID` int(11) NOT NULL, "
+    . "`gmaModuleID` int(11) NOT NULL, "
+    . "PRIMARY KEY (`gmaID`), "
+    . "UNIQUE KEY `gmaGroupModule` (`gmaGroupID`,`gmaModuleID`), "
+    . "KEY `gmaModuleID` (`gmaModuleID`) "
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC",
+];
+
+// 408
+// The foreign keys for the table step 407 just created, per ADR 0031.
+//
+// Group 10, and like groups 7, 8 and 9 it has nothing to sweep first: a table
+// created empty one step earlier cannot hold an orphan.
+//
+// Both CASCADE. A grant is meaningless once either end is gone, and leaving
+// the row would offer a grant against an id that has since been reused -- a
+// host would silently gain whichever module inherited the number.
+$this->schema[] =
+    function () {
+        \FOG\Db\SchemaReconciler::applyConstraints(10);
+
+        return true;
+    };
+
+// 409
+$this->schema[] = [
+    // `msState` stops being decoration and starts being the precedence rule,
+    // so it is converted to the boolean it always described. ADR 0028: a
+    // boolean is tinyint(1), and tests/booleans-are-tinyint.test.php refuses
+    // anything else for a column that holds one.
+    //
+    // A DIRECT MODIFY is correct here and the ENUM caution on step 368 does
+    // not apply. That step's three-statement dance exists because converting
+    // an ENUM straight to tinyint converts BY INDEX -- '0' becomes 1 and '1'
+    // becomes 2, both truthy, silently. This column is already varchar(1), so
+    // the conversion is by VALUE and '1' becomes 1.
+    //
+    // The UPDATE first, because varchar can hold things tinyint cannot. Every
+    // row on every server should already read '1' -- that is the finding this
+    // whole revision rests on -- but '' is what the column DEFAULTS to, so an
+    // insert that omitted it would reach the ALTER as an empty string and
+    // fail the upgrade. Anything that is not an explicit '0' is normalized to
+    // '1', which is the meaning it has had since the column was created:
+    // present means enabled.
+    "UPDATE `moduleStatusByHost` SET `msState` = '1' WHERE `msState` <> '0'",
+    // DEFAULT 1, not 0. A writer that forgets the column is asking for the
+    // behavior this column has always had, and 0 is now the strongest
+    // statement in the system -- it overrides every group. Defaulting to it
+    // would let an omission silently switch a module off across a fleet.
+    "ALTER TABLE `moduleStatusByHost` MODIFY `msState` tinyint(1) "
+    . "NOT NULL DEFAULT 1",
+];

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -130,7 +130,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 406);
+        define('FOG_SCHEMA', 409);
         define('FOG_BCACHE_VER', 358);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -129,7 +129,7 @@ parameters:
 		-
 			message: '#^Variable \$this might not be defined\.$#'
 			identifier: variable.undefined
-			count: 376
+			count: 379
 			path: packages/web/commons/schema.php
 
 		-

--- a/tests/fixtures/upgrade-rehearsal-baseline.txt
+++ b/tests/fixtures/upgrade-rehearsal-baseline.txt
@@ -1,5 +1,5 @@
-  constraints declared and applicable here: 80
-  constraints actually present:             78
+  constraints declared and applicable here: 82
+  constraints actually present:             80
   MISSING:                                  2
     fk_hostMAC_hmHostID                      CASCADE     orphan rows: 0
     fk_nfsGroupMembers_ngmGroupID            RESTRICT    orphan rows: 1

--- a/tests/foreign-key-map.test.php
+++ b/tests/foreign-key-map.test.php
@@ -64,6 +64,11 @@ $notAReference = [
     // The user tier (0 mobile, 1 admin, 2 api). No table of user types
     // exists; Authorization reads the integer directly.
     'users.uType',
+    // Whether the host has this module on or off -- a boolean, not a
+    // reference to taskStates like the other *State columns. It was a
+    // varchar(1) until schema step 409 made it the tinyint(1) it had always
+    // held, which is what brought it into this check's sights.
+    'moduleStatusByHost.msState',
 ];
 
 $validActions = ['CASCADE', 'RESTRICT', 'SET NULL', 'none'];
@@ -341,6 +346,10 @@ $expected = [
     'groupSnapinAssoc.gsaSnapinID',
     'groupPrinterAssoc.gpaGroupID',
     'groupPrinterAssoc.gpaPrinterID',
+    // Group 10 -- modules, the third declarative grant. Same CASCADE
+    // reasoning as group 9.
+    'groupModuleAssoc.gmaGroupID',
+    'groupModuleAssoc.gmaModuleID',
     // Plugin groups, named for the plugin rather than numbered. Each
     // lands in that plugin's own repo, in an appended step of its
     // manager's schema(); see fog-plugins tests/foreign-keys.test.php,

--- a/tests/virus-scan-is-removed.test.php
+++ b/tests/virus-scan-is-removed.test.php
@@ -47,15 +47,29 @@ $manifest = include $web . '/commons/schema-expected.php';
 $constraints = include $web . '/commons/schema-constraints.php';
 
 /*
- * 1. The step exists and is the last one. That FOG_SCHEMA matches the
- * step count is already pinned by tests/schema-gate.test.php.
+ * 1. The step exists and is still numbered 406. It was written as "406 and
+ * nothing after it", which asserted that no schema step would ever be
+ * appended again -- so it went red on the first one that was (step 407,
+ * groupModuleAssoc). A gate that fails on every future schema commit is one
+ * nobody can act on. What this file is actually for is that step 406 is not
+ * REWRITTEN: schema.php is an append-only replay log, so the number and the
+ * contents of the step are the thing to pin, not its position at the end.
+ * That FOG_SCHEMA matches the step count is already pinned by
+ * tests/schema-gate.test.php.
  */
 $t->check(
     'the removal is schema step 406',
     false !== strpos($schema, "\n// 406\n")
-    && false === strpos($schema, "\n// 407\n")
 );
-$step = substr($schema, (int)strpos($schema, "\n// 406\n"));
+// Bounded at the next step marker. While 406 was the last step, running to
+// the end of the file was the same thing; now that steps follow it, an
+// unbounded slice would let a later step satisfy -- or break -- a check that
+// is about this one.
+$stepStart = (int)strpos($schema, "\n// 406\n");
+$stepEnd = strpos($schema, "\n// 407\n", $stepStart);
+$step = false === $stepEnd
+    ? substr($schema, $stepStart)
+    : substr($schema, $stepStart, $stepEnd - $stepStart);
 
 /*
  * 2. The delete order. Both children come before the parent, or an upgrade


### PR DESCRIPTION
Schema-only first step of putting modules on the same footing as snapins and printers under ADR 0038. **Nothing reads the new table yet** — the resolver, the pages and the API arms follow in their own PRs.

### Why modules were excluded, and why that was wrong

ADR 0038 decision 3 kept modules imperative on the strength of a claim in ADR 0001 that a host's module rows carry a real *disabled* state, which would make "group A says enabled, group B says disabled" unanswerable. Reading the data says otherwise: `moduleStatusByHost.msState` is a `varchar(1)` that nothing has ever written anything but `'1'` to. The conflict the decision avoided cannot occur.

A group grant is **presence-only**: a group either grants a module or says nothing about it. Two groups can only ever union, so they can never disagree. Only a host can say *disabled*, and that beats every grant — lowest tier wins.

### The steps

| Step | What |
|---|---|
| 407 | Creates `groupModuleAssoc`. No state column, by design. Empty on creation, nothing migrated — same as step 403 for printers. |
| 408 | Constraint group 10, both ends CASCADE. Same reasoning as group 9: a grant is meaningless once either end is gone, and an orphan row would offer a grant against a reused id. |
| 409 | Converts `msState` to the `tinyint(1)` it has always held. `DEFAULT 1`, not 0 — with group grants, 0 becomes the strongest statement in the system, so a row that appears without an explicit value must not read as one. |

Step 368's three-statement ENUM dance does not apply: this column is already `varchar(1)`, so the conversion is by value.

### Carried along

- `schema-expected.php` regenerated. **Table order moves** because the generator sorts by name and the committed file predated that; the only *content* changes are `groupModuleAssoc` and `msState`, verified by an order-independent comparison.
- `tests/foreign-key-map.test.php` — group 10 added to the expected set, and `moduleStatusByHost.msState` recorded as not-a-reference. It is a boolean, unlike the other `*State` columns which point at `taskStates`; becoming a tinyint is what brought it into that check's sights.
- `tests/virus-scan-is-removed.test.php` asserted step 406 was the **last** step — i.e. that no schema step would ever be appended again — so it went red on the first one that was. It now pins the number and the contents of 406 (which is what the file is actually for: schema.php is append-only, so a *rewrite* is the failure), and the slice it reads is bounded to that step rather than running to EOF. Both mutations — gutting 406, renumbering its marker — were made and confirmed red.
- FK counts in ADR 0031 and `docs/development/foreign-keys.md`, and the upgrade-rehearsal baseline, all move by the two new keys.

### Verification

- Full fresh replay against MariaDB 11.8: 409 steps, 1025 statements, **0 failures**, 78 tables, 82 foreign keys.
- `tests/run-all.sh`: 288 passed, 0 failed.
- phpstan, both configs, clean (the schema.php baseline count moves 376 → 379 for the three new `$this->schema[]` lines).