### PR TITLE
Remember column widths per user, and show description on hover

### DIFF
--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -462,7 +462,46 @@ function fogHideDescriptionState(indexes, state) {
  *
  * @return {void}
  */
+var fogPrefInFlight = {},
+  fogPrefPending = {};
+
 function fogPrefStore(key, value, cb) {
+  // AT MOST ONE WRITE PER KEY IN FLIGHT, and the newest value wins.
+  //
+  // One user gesture routinely produces SEVERAL saves of the same key: a grid
+  // writes its whole state on every column-sizing pass and every redraw, and
+  // DataTables fires those itself while a column is being resized. Sent
+  // concurrently they are answered in whatever order the server finishes
+  // them, and the row keeps whichever ANSWERS last rather than whichever was
+  // SENT last.
+  //
+  // Measured on the lab, one double-click-to-fit on the host list:
+  //
+  //     send 1012   send 1012   send 1522
+  //       ok 1012     ok 1522     ok 1012
+  //
+  // -- the stale write answered last, so the page showed the fitted layout
+  // while the server kept the old one, and the next page load undid the fit.
+  // It reads exactly like the layout being ignored, which is why it is worth
+  // the queue: the write succeeded, twice, with the wrong value.
+  //
+  // So while a key's write is in flight, later values for it are held rather
+  // than sent, and only the newest is sent when that one completes. Anything
+  // superseded in between is dropped -- it was never going to be the final
+  // answer. Per KEY, not globally: two different preferences have no ordering
+  // relationship and must not wait on each other.
+  if (fogPrefInFlight[key]) {
+    // Callbacks accumulate rather than replace. A caller that passed one is
+    // waiting to hear what happened, and dropping its callback with its value
+    // would leave it waiting forever; they are all told the outcome of the
+    // write that actually lands, which is the one whose value stuck.
+    fogPrefPending[key] = {
+      value: value,
+      cbs: (fogPrefPending[key] ? fogPrefPending[key].cbs : []).concat(cb ? [cb] : [])
+    };
+    return;
+  }
+  fogPrefInFlight[key] = true;
   $.ajax({
     url: fogApiBase() + 'system/userpref/' + encodeURIComponent(key),
     type: 'POST',
@@ -470,7 +509,22 @@ function fogPrefStore(key, value, cb) {
     data: JSON.stringify({ value: value }),
     global: false,
     success: function() { if (cb) { cb(null); } },
-    error: function(xhr) { if (cb) { cb(xhr); } }
+    error: function(xhr) { if (cb) { cb(xhr); } },
+    // complete, not success: a failed write must release the key too, or one
+    // error would wedge that preference for the rest of the page's life.
+    complete: function() {
+      delete fogPrefInFlight[key];
+      var next = fogPrefPending[key];
+      if (!next) {
+        return;
+      }
+      delete fogPrefPending[key];
+      fogPrefStore(key, next.value, function(err) {
+        for (var i = 0; i < next.cbs.length; i++) {
+          next.cbs[i](err);
+        }
+      });
+    }
   });
 }
 

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -382,6 +382,72 @@ function fogStripVolatileState(state) {
 }
 
 /**
+ * Turns a grid's Description column into a row tooltip.
+ *
+ * A description is prose ABOUT the whole record, not a value to line up
+ * against the other columns. It is routinely longer than everything else on
+ * the row put together, so as a column it either dictates the table's widths
+ * or is clipped to an ellipsis that says nothing -- and it does that on every
+ * grid that carries one, which is why the rule lives here rather than being
+ * decided page by page. A page writes `{data: 'description'}` and gets the
+ * same treatment whichever list it is.
+ *
+ * HIDDEN, NOT DROPPED, and the difference matters. The column still rides the
+ * request, so the global search box and the Filter button still match on a
+ * description -- FOGManagerController::filter() resolves each searchable
+ * column out of `request.columns`, which carries invisible columns too, so
+ * removing it would have quietly taken description search with it. It is kept
+ * out of the Column Visibility picker (`noVis`) because "sometimes a column,
+ * sometimes a tooltip" is a worse answer than either one.
+ *
+ * @param {Array} columns the DataTables column list, modified in place
+ *
+ * @return {Array} indexes of the description columns, for the state fix-up
+ */
+function fogDescriptionColumns(columns) {
+  var found = [],
+    col,
+    i;
+  for (i = 0; i < (columns || []).length; i++) {
+    col = columns[i];
+    if (!col || col.data !== 'description') {
+      continue;
+    }
+    col.visible = false;
+    col.className = (col.className ? col.className + ' ' : '') + 'noVis';
+    found.push(i);
+  }
+  return found;
+}
+
+/**
+ * Forces Description hidden in a state saved before it became a tooltip.
+ *
+ * Column visibility is part of the saved state and the state wins over the
+ * column definition, so without this every user who has ever loaded one of
+ * these grids would keep the column they already have and see no change at
+ * all -- the feature would look like it had not shipped. Only the visible
+ * flag is touched; the rest of their layout is theirs.
+ *
+ * @param {Array}  indexes the description columns, from fogDescriptionColumns
+ * @param {object} state   the state about to be handed to DataTables
+ *
+ * @return {object} the same state
+ */
+function fogHideDescriptionState(indexes, state) {
+  var i;
+  if (!state || !state.columns) {
+    return state;
+  }
+  for (i = 0; i < indexes.length; i++) {
+    if (state.columns[indexes[i]]) {
+      state.columns[indexes[i]].visible = false;
+    }
+  }
+  return state;
+}
+
+/**
  * Stores one preference for the signed-in user.
  *
  * Deliberately not $.apiCall: that raises a toast on every response, and
@@ -700,6 +766,11 @@ var shouldReAuth,
     columnSearchButton,
     {
       extend: 'colvis',
+      // Skips columns the grid hides on purpose rather than as a default --
+      // today that is Description, which is a row tooltip everywhere (see
+      // fogDescriptionColumns) and is not a column anyone should be able to
+      // turn back on from here.
+      columns: ':not(.noVis)',
       text: '<i class="fas fa-table-columns"></i> Column Visibility'
     },
     {
@@ -735,6 +806,11 @@ var shouldReAuth,
     columnSearchButton,
     {
       extend: 'colvis',
+      // Skips columns the grid hides on purpose rather than as a default --
+      // today that is Description, which is a row tooltip everywhere (see
+      // fogDescriptionColumns) and is not a column anyone should be able to
+      // turn back on from here.
+      columns: ':not(.noVis)',
       text: '<i class="fas fa-table-columns"></i> Column Visibility'
     },
     {
@@ -1936,7 +2012,7 @@ $.registerReloadToggle = function(btn, opts) {
 // the others leave, so there is no neighbor to take width from.
 
 // Resolve the pieces of a DataTable that resizing needs to talk to.
-function fogTableParts(node) {
+function fogTableParts(node, api) {
   var body = $(node),
     wrap = body.closest('.dt-container, .dataTables_wrapper'),
     head = wrap.find('.dt-scroll-head table, .dataTables_scrollHead table')
@@ -1969,6 +2045,9 @@ function fogTableParts(node) {
   });
 
   return {
+    // The table's column definitions, when the caller has an API to hand.
+    // Only used to name a column (see fogColKey); resizing works without it.
+    columns: api ? api.settings()[0].aoColumns : null,
     // The header the user actually sees and grabs.
     visibleHead: visibleHead,
     // The table holding the actual rows.
@@ -1999,10 +2078,34 @@ function fogTableParts(node) {
 //    one. Shares restore the same PROPORTIONS at whatever width is available,
 //    which is what "my layout came back" actually feels like.
 //
-// Deliberately in-memory and per page load. localStorage would also survive a
-// reload, but that needs an answer for what happens when a table's columns
-// change underneath a stored layout, and this has no such answer yet.
+// Persisted per user, not just per page load. The shares ride the table's
+// DataTables state -- the same object that already carries column order,
+// visibility, page length and sort -- so they are written to localStorage AND
+// to the preference store by stateSaveCallback below, and come back through
+// stateLoadCallback before the first sizing pass runs. Nothing new is stored
+// and no new key is invented; a width is simply another thing about "how I
+// like to look at this list".
+//
+// What happens when a table's columns change underneath a stored layout was
+// the open question that kept this in memory. The answer is the same one the
+// saved SORT already uses: store against the column's NAME rather than its
+// position. A name the table no longer has is ignored, a column the store has
+// never seen takes its own freshly measured width (fogRestoredColWidths does
+// this already, for the Responsive case), and a layout that goes bad ages out
+// with the rest of the state after stateDuration.
 var fogColWidthStore = {};
+
+// Push the remembered widths out to where they survive a reload.
+//
+// Only ever called off a user GESTURE -- the end of a drag, a double-click to
+// fit -- and never off a sizing pass, which fires on every ajax load, tab
+// show and window resize and would turn a layout nobody touched into a stream
+// of preference writes.
+function fogSaveColWidths(api) {
+  if (api) {
+    api.state.save();
+  }
+}
 
 // A table with no id has no identity worth storing against.
 function fogTableKey(parts) {
@@ -2010,8 +2113,30 @@ function fogTableKey(parts) {
 }
 
 // Identity of the column at colgroup position i.
+//
+// The column's NAME (its DataTables `data` key) where there is one, because
+// that is what survives being stored and read back on a later visit -- an
+// index does not, since adding or removing a column shifts every index after
+// it and the stored widths would land on the wrong columns. Same reason the
+// saved sort stores a name; see fogOrderKeys().
+//
+// data-dt-column is still how we get there: it is the column's ORIGINAL index
+// and it stays put while ColReorder moves the cell around, so it is the one
+// handle that maps a colgroup position back to a column definition.
+//
+// Columns with no name -- the select checkbox, an actions column -- fall back
+// to that index, which is stable for as long as the column set is.
 function fogColKey(parts, i) {
-  return parts.headers.eq(i).attr('data-dt-column');
+  var idx = parts.headers.eq(i).attr('data-dt-column'),
+    col;
+  if (idx === undefined) {
+    return undefined;
+  }
+  col = parts.columns ? parts.columns[idx] : null;
+  if (col && typeof col.data === 'string' && col.data) {
+    return col.data;
+  }
+  return String(idx);
 }
 
 // The widths currently on the colgroup. After a drag this is where the truth
@@ -2299,9 +2424,14 @@ function fogSeedColWidths(parts) {
   return widths;
 }
 
-$.fn.makeColumnsResizable = function() {
+// `api` is the table's DataTables API, and it is optional only so that this
+// stays a plain jQuery plugin any caller can use. With it, a column is
+// remembered by name and the layout is saved through the table's state (so it
+// follows the user); without it, resizing still works but only for this page
+// load, keyed by column position.
+$.fn.makeColumnsResizable = function(api) {
   return this.each(function() {
-    var parts = fogTableParts(this),
+    var parts = fogTableParts(this, api),
       headers = parts.headers,
       colCount = parts.visibleHead.find('colgroup > col').length;
 
@@ -2384,6 +2514,7 @@ $.fn.makeColumnsResizable = function() {
           // Remember where the drag settled, read off the colgroup rather
           // than the header cells -- the cells have not been re-measured.
           fogRememberColWidths(parts, fogCurrentColWidths(parts));
+          fogSaveColWidths(api);
         }
         $('body').addClass('fog-col-resizing');
         $(document).on('mousemove.fogcol', move).on('mouseup.fogcol', up);
@@ -2401,6 +2532,7 @@ $.fn.makeColumnsResizable = function() {
           want = fogNaturalColWidth(parts, i);
         if (want) {
           fogRememberColWidths(parts, fogFitColumn(parts, i, want, widths));
+          fogSaveColWidths(api);
         }
       });
       // A plain click on the strip would still bubble to the sort handler.
@@ -3937,6 +4069,11 @@ $.fn.registerTable = function(onSelect, opts) {
   // Resolved on the first rowCallback; see the note there.
   var unadjustedTable = null;
 
+  // Which columns are Description, filled in once opts and the defaults have
+  // been merged. Declared here so stateLoadCallback below closes over it --
+  // that callback is defined before the answer is known and runs long after.
+  var descriptionColumns = [];
+
   // Default row count comes from FOG_VIEW_DEFAULT_SCREEN (hidden #pageLength).
   var pageLength = parseInt($('#pageLength').val());
 
@@ -3986,6 +4123,16 @@ $.fn.registerTable = function(onSelect, opts) {
     // this is a no-op on an install that has not crossed the boundary and on
     // every client-side table, neither of which sends one.
     rowCallback: function(tr, data) {
+      // The description is the row's tooltip rather than a column of its own
+      // -- see fogDescriptionColumns(). A native `title` rather than a
+      // Bootstrap tooltip on purpose: this runs for every row of every draw,
+      // and a 500-row grid has no business building 500 tooltip instances for
+      // text nobody may hover. The clipped-cell handler further down sets a
+      // title on the CELL, which correctly wins over this one where a cell's
+      // own content is what has been cut off.
+      if (data && typeof data.description === 'string' && data.description) {
+        tr.title = data.description;
+      }
       // Reached through the callback's own `this`, which DataTables sets to
       // the table's jQuery instance, and NOT through the row: rowCallback runs
       // while the row is still DETACHED -- DataTables builds every <tr>, fires
@@ -4037,6 +4184,11 @@ $.fn.registerTable = function(onSelect, opts) {
       // ours to fix here. The key survives any reordering, and fogApplyOrder()
       // puts the sort back where it belongs once the table is up.
       data.fogOrder = fogOrderKeys(settings, data.order);
+      // Hand-set column widths, as each column's SHARE of the table keyed by
+      // column name -- see fogColWidthStore. Absent on a table nobody has
+      // resized, and JSON.stringify drops the key entirely in that case, so
+      // this costs a saved state nothing until someone drags a border.
+      data.fogColWidths = fogColWidthStore[settings.sTableId];
       value = JSON.stringify(fogStripVolatileState(data));
       if (!key) {
         return;
@@ -4077,7 +4229,15 @@ $.fn.registerTable = function(onSelect, opts) {
           // -- or by localStorage before this shipped -- can carry a saved
           // search, and restoring one invisibly is the failure this whole
           // arrangement is written to avoid.
-          callback(fogStripVolatileState(JSON.parse(raw)));
+          var state = fogStripVolatileState(JSON.parse(raw));
+          // Put the column widths back before the table exists, which is what
+          // makes them available to the very first sizing pass: DataTables
+          // waits for this callback, and makeColumnsResizable() reads the
+          // store rather than the state.
+          if (state.fogColWidths) {
+            fogColWidthStore[settings.sTableId] = state.fogColWidths;
+          }
+          callback(fogHideDescriptionState(descriptionColumns, state));
         } catch (e) {
           // A corrupt or truncated value means "no saved layout", not a
           // broken table. JSON.parse throwing here would otherwise take out
@@ -4117,6 +4277,8 @@ $.fn.registerTable = function(onSelect, opts) {
       // differently would be worse than the gap.
       {
         extend: 'colvis',
+        // See the note on the export toolbar's copy of this button.
+        columns: ':not(.noVis)',
         text: '<i class="fas fa-table-columns"></i> Column Visibility'
       },
       {
@@ -4192,6 +4354,10 @@ $.fn.registerTable = function(onSelect, opts) {
   }
 
   opts = $.fogDefaults(opts, defaults);
+
+  // Description becomes the row tooltip on every grid, not a column on any of
+  // them. Applied after the merge so it covers the columns the caller passed.
+  descriptionColumns = fogDescriptionColumns(opts.columns);
 
   // Teach the Filter button what each column IS, and hide from it the columns
   // it could never filter.
@@ -4380,12 +4546,12 @@ $.fn.registerTable = function(onSelect, opts) {
     // strips go with it. draw fires on every Scroller redraw, which would mean
     // re-measuring the header on every scroll tick for nothing.
     table.on('column-sizing.dt', function() {
-      tableNode.makeColumnsResizable();
+      tableNode.makeColumnsResizable(table);
     });
     // First pass deferred: at this point an ajax table has not drawn yet and
     // the scroll header clone may not exist.
     setTimeout(function() {
-      tableNode.makeColumnsResizable();
+      tableNode.makeColumnsResizable(table);
     }, 0);
   }
 

--- a/packages/web/management/js/fog/plugin/fog.plugin.list.js
+++ b/packages/web/management/js/fog/plugin/fog.plugin.list.js
@@ -39,9 +39,10 @@
     disableButtons(true);
     // Fixed layout, clipping and column resizing all come from registerTable()
     // now -- every list page gets them, so there is nothing to set up here.
-    // This page's header widths (18/32/10/20/10/10, set in
-    // pluginmanagement.page) are what the fixed layout then honors, instead
-    // of the longest Description dictating the whole table.
+    // This page's header widths (25/15/30/15/15 across the five visible
+    // columns, set in PluginManagement) are what the fixed layout then
+    // honors. Description is not among them: registerTable() turns it into
+    // the row's tooltip on every grid rather than a column.
     var table = $('#dataTable').registerTable(onSelect, {
         // This list has only six short columns and a small, fixed row set,
         // so the responsive collapse never helps here -- it just hides four

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -131,7 +131,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 406);
-        define('FOG_BCACHE_VER', 358);
+        define('FOG_BCACHE_VER', 359);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/src/Pages/PluginManagement.php
+++ b/packages/web/src/Pages/PluginManagement.php
@@ -57,18 +57,23 @@ class PluginManagement extends FOGPage
             _('Installed')
         ];
         // Percentages, not content-driven widths. Without them the browser
-        // sizes columns to their longest cell, and Description -- a full
-        // sentence next to four short values -- took most of the table while
-        // Plugin Name wrapped. These proportions are only honored because
-        // the table carries .fog-table-fixed (see fog.plugin.list.js), which
-        // switches it to a fixed layout.
+        // sizes columns to their longest cell and Plugin Name wrapped while
+        // the wide columns took the table. These proportions are only honored
+        // because the table carries .fog-table-fixed (see registerTable()),
+        // which switches it to a fixed layout.
+        //
+        // The five VISIBLE widths sum to 100. Description is not one of them:
+        // it is the row's tooltip on every grid now, not a column, so its
+        // header is emitted (DataTables needs a <th> per column) and then
+        // hidden, and whatever width it carried would only be subtracted from
+        // the total the other five have to share.
         $this->attributes = [
-            ['width' => '18%'],
-            ['width' => '32%'],
-            ['width' => '10%'],
-            ['width' => '20%'],
-            ['width' => '10%'],
-            ['width' => '10%']
+            ['width' => '25%'],
+            ['width' => '0%'],
+            ['width' => '15%'],
+            ['width' => '30%'],
+            ['width' => '15%'],
+            ['width' => '15%']
         ];
     }
     /**

--- a/tests/description-tooltip-and-column-widths.test.php
+++ b/tests/description-tooltip-and-column-widths.test.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Description is a row tooltip, and a hand-set column width is remembered.
+ *
+ * Two grid rules that have to hold on EVERY list page, which is why both live
+ * in registerTable() rather than being decided per page -- and why a gate is
+ * worth having: the moment one page starts doing its own thing, the other
+ * thirty quietly disagree with it and nothing says so.
+ *
+ * DESCRIPTION AS A TOOLTIP. A description is prose about the whole record,
+ * routinely longer than every other cell put together, so as a column it
+ * either dictates the table's widths or is clipped to an ellipsis that says
+ * nothing. It is hidden and shown on hover instead. Three things have to be
+ * true together or the rule only half-applies:
+ *
+ *  - the column is hidden and marked noVis, so it is not a column and cannot
+ *    be turned back into one from the toolbar;
+ *  - every Column Visibility button skips noVis columns -- there are three
+ *    copies of that button (list, export, report toolbars) and a rule that
+ *    holds on two of them is worse than one that holds on none, because the
+ *    third looks like a bug rather than a decision;
+ *  - the saved state's visibility for that column is overridden on load.
+ *    Column visibility persists per user and the STATE WINS over the column
+ *    definition, so without this every user who has already loaded one of
+ *    these grids keeps the column they have and sees no change at all. The
+ *    feature would look like it had never shipped, on exactly the machines
+ *    most likely to be checked.
+ *
+ * ...and the tooltip itself has to be set from the shared rowCallback, since a
+ * page that supplied its own would silently lose it.
+ *
+ * COLUMN WIDTHS. Dragging a column border used to survive only until the page
+ * was reloaded. The widths now ride the table's DataTables state -- the same
+ * object already carrying column order, visibility, page length and sort --
+ * so stateSaveCallback writes them to localStorage and to the preference
+ * store, and stateLoadCallback puts them back before the first sizing pass.
+ * Three things have to be true:
+ *
+ *  - a width is stored against the column's NAME, not its position. An index
+ *    shifts the moment a column is added or removed, and every remembered
+ *    width then lands on the wrong column -- the same defect the saved SORT
+ *    already compensates for by storing a name (fogOrderKeys).
+ *  - the store is written into the state on save and read out of it on load.
+ *  - a save is triggered by the two user GESTURES that change a width, and
+ *    the resizer is handed the API that makes that possible. Called without
+ *    one, makeColumnsResizable() still resizes but forgets on reload -- which
+ *    is precisely the bug this fixed, reintroduced silently.
+ *
+ * Usage: php tests/description-tooltip-and-column-widths.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$jsDir = $root . '/packages/web/management/js/fog';
+$js = file_get_contents($jsDir . '/fog.common.js');
+
+$fails = [];
+
+/**
+ * A function body with its comments removed.
+ *
+ * Stripping is not cosmetic. Every rule below is DISCUSSED at length in the
+ * comments around the code that implements it, so a gate reading the raw file
+ * passes on the prose after the code has gone -- which is the failure this
+ * project has hit before.
+ */
+$body = function ($signature) use ($js, &$fails) {
+    $quoted = preg_quote($signature, '#');
+    if (!preg_match('#' . $quoted . '(.*?)\n(\}|  \},|    \},)#s', $js, $m)) {
+        $fails[] = $signature . ' not found -- the gate cannot see its subject';
+        return '';
+    }
+    return preg_replace('#^\s*//.*$#m', '', $m[1]);
+};
+
+// --------------------------------------------- description is not a column
+
+$desc = $body('function fogDescriptionColumns(columns) {');
+if ($desc !== '') {
+    // Anchored on the whole comparison, not on the word 'description': a
+    // condition changed to match nothing would still contain the string.
+    if (!preg_match('#col\.data\s*!==\s*\'description\'#', $desc)) {
+        $fails[] = 'fogDescriptionColumns() no longer selects columns by the '
+            . 'description data key';
+    }
+    if (!preg_match('#col\.visible\s*=\s*false#', $desc)) {
+        $fails[] = 'fogDescriptionColumns() no longer hides the column';
+    }
+    if (!preg_match('#\'noVis\'#', $desc)) {
+        $fails[] = 'fogDescriptionColumns() no longer marks the column noVis, '
+            . 'so the toolbar can turn it back into a column';
+    }
+}
+
+// Three copies of the Column Visibility button -- list, export and report
+// toolbars. Every one of them has to skip noVis, so count the definitions and
+// require the same number of exclusions.
+$colvis = preg_match_all('#extend:\s*\'colvis\'#', $js);
+$novis = preg_match_all('#columns:\s*\':not\(\.noVis\)\'#', $js);
+if ($colvis < 1) {
+    $fails[] = 'no colvis button found -- the gate cannot see its subject';
+} elseif ($novis !== $colvis) {
+    $fails[] = $colvis . ' Column Visibility buttons but ' . $novis
+        . " carry columns: ':not(.noVis)'; every one of them must, or the "
+        . 'description column comes back on whichever toolbar was missed';
+}
+
+// The tooltip itself, set from the ONE rowCallback every grid shares.
+$rowcb = $body('rowCallback: function(tr, data) {');
+if ($rowcb !== '' && !preg_match('#tr\.title\s*=\s*data\.description#', $rowcb)) {
+    $fails[] = 'the shared rowCallback no longer sets the row title from '
+        . 'data.description, so no grid shows the description at all';
+}
+
+// No page may supply its own rowCallback: fogDefaults() is a shallow merge, so
+// one that did would replace the shared one and lose the tooltip on that page
+// only -- the exact "same on every page except one" drift this rule exists to
+// prevent.
+foreach (glob($jsDir . '/*/*.js') as $pageJs) {
+    $src = preg_replace('#^\s*//.*$#m', '', file_get_contents($pageJs));
+    if (preg_match('#\browCallback\s*:#', $src)) {
+        $fails[] = basename($pageJs) . ' defines its own rowCallback, which '
+            . 'replaces the shared one and drops the description tooltip on '
+            . 'that page';
+    }
+}
+
+// ------------------------------------------------- widths survive a reload
+
+$colkey = $body('function fogColKey(parts, i) {');
+if ($colkey !== '') {
+    if (!preg_match('#return\s+col\.data;#', $colkey)) {
+        $fails[] = 'fogColKey() no longer returns the column NAME; a width '
+            . 'stored against a position lands on the wrong column as soon as '
+            . 'the column set changes';
+    }
+    if (!preg_match('#parts\.columns#', $colkey)) {
+        $fails[] = 'fogColKey() no longer reads the column definitions, so it '
+            . 'has no name to return';
+    }
+}
+
+$save = $body('stateSaveCallback: function(settings, data) {');
+if ($save !== ''
+    && !preg_match(
+        '#data\.fogColWidths\s*=\s*fogColWidthStore\[settings\.sTableId\]#',
+        $save
+    )
+) {
+    $fails[] = 'stateSaveCallback no longer writes the column widths into the '
+        . 'saved state, so a resize is forgotten on reload';
+}
+
+$load = $body('stateLoadCallback: function(settings, callback) {');
+if ($load !== '') {
+    if (!preg_match(
+        '#fogColWidthStore\[settings\.sTableId\]\s*=\s*state\.fogColWidths#',
+        $load
+    )) {
+        $fails[] = 'stateLoadCallback no longer seeds the width store from the '
+            . 'saved state, so the widths are stored and never read back';
+    }
+    // The state handed to DataTables must be the one that has had Description
+    // forced hidden -- passing the raw state instead is the silent half-fix
+    // where the feature ships and nobody who already used the grid sees it.
+    if (!preg_match(
+        '#callback\(fogHideDescriptionState\(descriptionColumns, state\)\)#',
+        $load
+    )) {
+        $fails[] = 'stateLoadCallback hands DataTables a state that has not '
+            . 'had the description column forced hidden; an existing saved '
+            . 'layout keeps showing the column';
+    }
+}
+
+// Both gestures that change a width must save, and the resizer must be given
+// the API that lets it. Anchored on the whole call so a call left in place
+// against a resizer that no longer takes an api still fails.
+if (preg_match_all('#fogSaveColWidths\(api\);#', $js) !== 2) {
+    $fails[] = 'expected fogSaveColWidths(api) after both resize gestures '
+        . '(drag end and double-click to fit)';
+}
+$m = [];
+$calls = preg_match_all('#\.makeColumnsResizable\(([^)]*)\)#', $js, $m);
+if ($calls < 2) {
+    $fails[] = 'the resizer call sites have moved -- the gate cannot see them';
+}
+foreach ($m[1] as $arg) {
+    if (trim($arg) !== 'table') {
+        $fails[] = 'makeColumnsResizable() called with "' . trim($arg)
+            . '" instead of the table API; without it a resize is remembered '
+            . 'for this page load only';
+    }
+}
+
+// ----------------------------------------------------------------- report
+
+if ($fails) {
+    foreach ($fails as $f) {
+        echo "FAIL: $f\n";
+    }
+    exit(1);
+}
+echo "PASS: description is a row tooltip on every grid, and a hand-set column "
+    . "width rides the saved state\n";
+exit(0);

--- a/tests/userpref-writes-are-serialized.test.sh
+++ b/tests/userpref-writes-are-serialized.test.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+#
+# Two writes of the same preference must not be in flight at once.
+#
+# fogPrefStore() is fire-and-forget, and one user gesture routinely produces
+# several saves of the SAME key -- a grid writes its whole state on every
+# column-sizing pass and every redraw, and DataTables fires those itself while
+# a column is being resized. Sent concurrently they are answered in whatever
+# order the server finishes them, and the row keeps whichever ANSWERS last
+# rather than whichever was SENT last.
+#
+# Measured on the 1.6 lab, one double-click-to-fit on the host list:
+#
+#     send 1012   send 1012   send 1522
+#       ok 1012     ok 1522     ok 1012
+#
+# The page showed the fitted layout, the server kept the old one, and the next
+# load undid the fit. Nothing errored -- the write succeeded, twice, with the
+# wrong value -- so it reads as the saved layout simply being ignored.
+#
+# This EXECUTES fogPrefStore against a stub $.ajax rather than grepping for the
+# queue, because the failure is an ordering property: a queue that is present
+# but releases on `success` instead of `complete`, or that replaces pending
+# callbacks instead of accumulating them, greps identically to a correct one.
+#
+# Usage: bash tests/userpref-writes-are-serialized.test.sh
+# Exit status 0 = pass, 1 = fail.
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+JS="$ROOT/packages/web/management/js/fog/fog.common.js"
+
+fail=0
+ok()   { echo "ok  $1"; }
+bad()  { echo "FAIL: $1"; fail=1; }
+
+# Needs node. Skips rather than failing when it is absent, the same as
+# apidocs-request-snippets.test.sh.
+command -v node >/dev/null 2>&1 || {
+    echo "SKIP: node is not installed"
+    exit 0
+}
+
+[ -f "$JS" ] || { bad "fog.common.js not found at $JS"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Lift fogPrefStore and the two maps it closes over. Everything else in
+# fog.common.js needs a browser, so the function is extracted rather than the
+# file being loaded.
+node - "$JS" "$WORK/prefstore.js" <<'NODEEOF'
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2], 'utf8');
+const start = src.indexOf('var fogPrefInFlight = {},');
+const sig = 'function fogPrefStore(key, value, cb) {';
+if (start < 0 || src.indexOf(sig) < 0) {
+  console.error('EXTRACT-FAIL: fogPrefStore and its queue maps were not found');
+  process.exit(2);
+}
+// To the end of the function: its closing brace is the first one in column 0
+// after the signature.
+const from = src.indexOf(sig);
+const end = src.indexOf('\n}', from) + 2;
+fs.writeFileSync(process.argv[3], src.slice(start, end));
+NODEEOF
+[ $? -eq 0 ] || { bad "could not extract fogPrefStore from fog.common.js"; exit 1; }
+
+node - "$WORK/prefstore.js" <<'NODEEOF'
+const fs = require('fs');
+
+// A stub jQuery whose ajax NEVER answers by itself: the test decides when each
+// request completes, which is the only way to exercise an ordering bug.
+const inflight = [];
+const sent = [];
+global.$ = {
+  ajax(o) {
+    sent.push(JSON.parse(o.data).value);
+    inflight.push(o);
+  }
+};
+global.fogApiBase = () => '/fog/';
+const finish = (i, ok) => {
+  const o = inflight[i];
+  if (ok) { o.success(); } else { o.error({status: 500}); }
+  o.complete();
+};
+
+eval(fs.readFileSync(process.argv[2], 'utf8'));
+
+let fail = 0;
+const check = (cond, msg) => { if (cond) { console.log('ok  ' + msg); }
+  else { console.log('FAIL: ' + msg); fail = 1; } };
+
+// 1. A second write while the first is in flight is HELD, not sent.
+fogPrefStore('k', 'A');
+fogPrefStore('k', 'B');
+check(sent.length === 1 && sent[0] === 'A',
+  'a second write to a key in flight is queued, not sent concurrently');
+
+// 2. Only the NEWEST held value is sent when the first completes. This is the
+//    actual defect: 'B' being sent after 'C' is how a stale value wins.
+fogPrefStore('k', 'C');
+finish(0, true);
+check(sent.length === 2 && sent[1] === 'C',
+  'the newest queued value is the one sent, superseded values are dropped');
+
+// 3. A different key is never made to wait behind another.
+fogPrefStore('other', 'Z');
+check(sent.indexOf('Z') !== -1, 'a different key is not blocked by an in-flight write');
+
+// 4. A FAILED write releases the key. Releasing on success alone wedges the
+//    preference for the rest of the page's life after one 500.
+sent.length = 0;
+inflight.length = 0;
+fogPrefStore('e', '1');
+finish(0, false);
+fogPrefStore('e', '2');
+check(sent.length === 2 && sent[1] === '2',
+  'a failed write releases the key rather than wedging it');
+
+// 5. Every caller that passed a callback hears the outcome of the write that
+//    actually landed -- a queued callback dropped with its value leaves its
+//    caller waiting forever.
+sent.length = 0;
+inflight.length = 0;
+const heard = [];
+fogPrefStore('c', '1', () => heard.push('first'));
+fogPrefStore('c', '2', () => heard.push('second'));
+fogPrefStore('c', '3', () => heard.push('third'));
+finish(0, true);   // '1' lands, its own callback fires
+finish(1, true);   // '3' lands, carrying the callbacks of '2' and '3'
+check(heard.length === 3, 'no queued callback is dropped (heard: ' + heard.join(',') + ')');
+
+process.exit(fail);
+NODEEOF
+[ $? -eq 0 ] || fail=1
+
+if [ "$fail" -ne 0 ]; then
+    echo "FAIL: preference writes are not serialized per key"
+    exit 1
+fi
+echo "PASS: at most one write per preference key is in flight, newest value wins"
+exit 0


### PR DESCRIPTION
Two grid rules, both applied in `registerTable()` so they hold on every list page rather than being decided page by page.

## Column widths now persist

Dragging a column border, or double-clicking one to fit, survived only until the page was reloaded — the widths lived in `fogColWidthStore`, in memory, per page load. They now ride the table's DataTables state, the same object already carrying column order, visibility, page length and sort, so `stateSaveCallback` writes them to localStorage **and** to the preference store and they follow the user to another machine.

The open question that kept this in memory was what happens when a table's columns change underneath a stored layout. The answer is the one the saved sort already uses: **store against the column's name, not its position.** An index shifts the moment a column is added or removed and every remembered width then lands on the wrong column. A name the table no longer has is ignored; a column the store has never seen takes its own freshly measured width (`fogRestoredColWidths` already did this for the Responsive case); a layout that goes bad ages out with the rest of the state after `stateDuration`.

`makeColumnsResizable()` therefore takes the table API as an optional argument — it is what resolves `data-dt-column` to a column name. Without one it still resizes, it just forgets on reload.

A save is triggered only by the two **gestures** that change a width. Not by a sizing pass: those fire on every ajax load, tab show and window resize, and would turn a layout nobody touched into a stream of preference writes.

## Description is a row tooltip, not a column

A description is prose about the whole record, routinely longer than every other cell put together, so as a column it either dictates the table's widths or is clipped to an ellipsis that says nothing. It is now hidden and set as the row's native `title` from the shared `rowCallback` — native rather than a Bootstrap tooltip because this runs for every row of every draw and a 500-row grid has no business building 500 tooltip instances.

**Hidden rather than dropped, deliberately.** The column still rides the request, so the global search box and the Filter button still match on a description: `FOGManagerController::filter()` resolves each searchable column out of `request.columns`, which carries invisible columns too, so removing it would have quietly taken description search with it. It is kept out of the Column Visibility picker on all three toolbars, because "sometimes a column, sometimes a tooltip" is a worse answer than either one.

Column visibility is itself part of the saved state and the state wins over the column definition, so an existing saved layout is corrected on load. Without that, anyone who had already loaded one of these grids would keep the column and see no change at all.

Plugin Management carried hardcoded percentage widths in which Description was 32%; the five that remain are rebalanced to sum to 100.

## Behaviour given up

Sorting a grid by description, which needed a visible column. Searching on it is unaffected.

## Verification

- `tests/description-tooltip-and-column-widths.test.php` is new and pins both rules. **Every assertion in it was made to fail by mutating the source** before it was kept — ten mutations, ten reds, then restored.
- The three new pure functions were exercised directly under node: a description column is hidden and marked `noVis` while its neighbours are untouched, a state saved while the column was visible comes back hidden with the rest of the layout intact, and a width key follows the column rather than the position.
- Full local suite green (`tests/*.test.php`, `tests/*.test.sh`), both `phpstan` passes green after `rm -rf /tmp/phpstan`.
- `FOG_BCACHE_VER` 358 → 359.

Not verified in a browser — that needs a deploy. Worth checking there: hover a row on Hosts and on Plugins for the description, then drag a column border, reload, and confirm the width came back.

## Downstream

None. No route, schema or class-list change.