### PR TITLE
Move Mass edit next to Delete selected, where it belongs

### DIFF
--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -1834,6 +1834,24 @@ abstract class FOGPage extends FOGBase
                         _('Delete selected'),
                         'btn btn-danger float-start'
                     );
+                    // Same seam as queueTaskActions() below: a page that can
+                    // edit its selection in bulk says so by defining the
+                    // method, and the toolbar does not learn a second node
+                    // name to do it.
+                    //
+                    // It sits on the LEFT, beside Delete selected, because
+                    // that is what it is: an action ON the rows that are
+                    // already ticked. The right-hand group is the opposite
+                    // half of the toolbar -- Queue Task, Add to group, Add
+                    // all bring something new into existence. Two floated
+                    // buttons stack in emission order, so emitting it after
+                    // Delete puts it to Delete's right; ms-2 is the gap the
+                    // btn-group gives its own children for free.
+                    if (method_exists($this, 'massEditActions')) {
+                        $mass = $this->massEditActions();
+                        $actionbox .= $mass['button'];
+                        $modals .= $mass['modal'];
+                    }
                     $actionbox .= '<div class="btn-group float-end">';
                     // Picked up the same way addModal() is, so the toolbar
                     // stays generic: a page that can task its selection says
@@ -1850,14 +1868,6 @@ abstract class FOGPage extends FOGBase
                         // own button bar, and this is what tells it which
                         // ones to draw. Empty when the page offers none.
                         $modals .= $queue['quick'] ?? '';
-                    }
-                    // Same seam, same reason: a page that can edit its
-                    // selection in bulk says so by defining the method, and
-                    // the toolbar does not learn a second node name to do it.
-                    if (method_exists($this, 'massEditActions')) {
-                        $mass = $this->massEditActions();
-                        $actionbox .= $mass['button'];
-                        $modals .= $mass['modal'];
                     }
                     if (method_exists($this, 'addModal')) {
                         if ($node == 'host') {

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -5351,13 +5351,17 @@ class HostManagement extends FOGPage
      */
     public function massEditActions()
     {
-        // Secondary, beside "Add selected to group". It changes records
-        // rather than starting work on machines, so it is deliberately not
-        // the green Queue Task shares a group with.
+        // Left half of the toolbar, immediately right of "Delete selected".
+        // Both act ON the rows already ticked, which is the distinction the
+        // toolbar is split on -- the right-hand group brings something new
+        // into existence instead. Secondary rather than danger because it
+        // edits records rather than removing them, and deliberately not the
+        // green Queue Task shares a group with: this changes records, it
+        // does not start work on machines.
         $button = self::makeButton(
             'massEditSelected',
             _('Mass edit'),
-            'btn btn-secondary'
+            'btn btn-secondary float-start ms-2'
         );
 
         $modal = self::makeModal(

--- a/tests/mass-edit-form.test.php
+++ b/tests/mass-edit-form.test.php
@@ -347,6 +347,42 @@ $check(
         )
 );
 
+// --- Where the button sits ------------------------------------------------
+//
+// The toolbar is split on a real distinction: the LEFT half acts on the rows
+// that are already ticked (Delete selected, Mass edit) and the RIGHT-hand
+// btn-group brings something new into existence (Queue Task, Add to group,
+// Add). Mass edit shipped in the right-hand group by mistake and was moved.
+//
+// Position is not something the rendering checks above can see -- they call
+// massEditActions() and get a button back with no toolbar around it -- so
+// this reads the emission order out of FOGPage::process(), which is what
+// actually decides it. Two floated buttons stack in emission order, so
+// "after deleteSelected and before the btn-group opens" IS "to the right of
+// Delete".
+$page = (string)@file_get_contents(
+    $root . '/packages/web/src/Base/FOGPage.php'
+);
+$posDelete = strpos($page, "'deleteSelected',");
+$posMass = strpos($page, "massEditActions')");
+$posGroup = strpos($page, '<div class="btn-group float-end">');
+$check(
+    'FOGPage::process() still emits all three toolbar landmarks',
+    false !== $posDelete && false !== $posMass && false !== $posGroup
+);
+$check(
+    'Mass edit is emitted after Delete selected and before the right group',
+    false !== $posDelete && false !== $posMass && false !== $posGroup
+        && $posDelete < $posMass && $posMass < $posGroup
+);
+$check(
+    'the Mass edit button floats left, so it lands beside Delete',
+    1 === preg_match(
+        "/'massEditSelected',\s*_\('Mass edit'\),\s*'[^']*\bfloat-start\b/",
+        $source
+    )
+);
+
 if (count($failures)) {
     fwrite(STDERR, "FAIL: the mass edit form is not three-state:\n");
     foreach ($failures as $f) {


### PR DESCRIPTION
Tom: *"I think the mass edit button should be to the right of Delete button instead of inline with Add, add to group, Queue Task."*

Agreed, and there is a reason it reads wrong. The host list toolbar is split on a real distinction:

| Left | Right (`btn-group float-end`) |
|---|---|
| acts **on the rows already ticked** | brings **something new into existence** |
| Delete selected | Queue Task, Add selected to group, Add |

Mass edit shipped on the right, which is the wrong half — it edits the current selection, exactly like Delete selected does.

### The change

It now floats left and is emitted immediately after Delete selected. Two floated buttons stack in emission order, so that puts it to Delete's right; `ms-2` supplies the gap the `btn-group` gives its own children for free. `.btn-actionbox` is a plain block (`margin:10px 0; overflow:visible`), so the floats behave normally inside it — no flex container to reorder them.

### The gate

Position was invisible to the existing tests: they call `massEditActions()` and get a button back with no toolbar around it. `tests/mass-edit-form.test.php` gains three checks that read the emission order out of `FOGPage::process()`, which is what actually decides it — the landmarks exist, Mass edit falls between `deleteSelected` and the right-hand group opening, and the button carries `float-start`.

Both mutations were made and confirmed red:

- moving the `massEditActions()` block back inside the right-hand group → *"Mass edit is emitted after Delete selected and before the right group"*
- dropping `float-start` from the button's classes → *"the Mass edit button floats left, so it lands beside Delete"*

### Verification

`tests/run-all.sh`: 289 passed, 0 failed. phpstan clean on both configs.