### PR TITLE
Resolve modules in three tiers, with the host's OFF beating every grant

### DIFF
--- a/packages/web/src/Assign/Resolver.php
+++ b/packages/web/src/Assign/Resolver.php
@@ -18,11 +18,15 @@ use FOG\Base\FOGBase;
 /**
  * Resolves what a host is actually assigned, host-direct plus group-granted.
  *
- * ADR 0038. A group GRANTS a snapin or a printer; it does not copy rows onto
- * whichever hosts happened to be members when a button was pressed. The grant
- * is a row keyed by group (`groupSnapinAssoc`, `groupPrinterAssoc`), and what
- * a given host ends up with is computed here, from that grant plus the host's
- * own direct associations.
+ * ADR 0038. A group GRANTS a snapin, a printer or a module; it does not copy
+ * rows onto whichever hosts happened to be members when a button was pressed.
+ * The grant is a row keyed by group (`groupSnapinAssoc`, `groupPrinterAssoc`,
+ * `groupModuleAssoc`), and what a given host ends up with is computed here,
+ * from that grant plus the host's own direct associations.
+ *
+ * Modules are the one of the three that is a SWITCH rather than a thing, so
+ * they resolve in three tiers rather than two and a host may hold one OFF
+ * against every group that grants it. resolveModules() carries the reasoning.
  *
  * ONE function answers it, for every caller -- task creation, the client's
  * printer request, and any UI preview. Three sorts in three files drift, and
@@ -246,6 +250,113 @@ class Resolver extends FOGBase
         return $resolved;
     }
 
+    /**
+     * Resolves the enabled module list for each host.
+     *
+     * MODULES ARE THE THIRD DECLARATIVE GRANT, and they are not shaped like
+     * the other two. A snapin or a printer is a thing a host either has or
+     * does not; a module is a switch, and a host is allowed to hold it OFF
+     * against every group that grants it. So this is a three-tier answer,
+     * not a two-tier union:
+     *
+     *   host row, msState = 0   the host says OFF. Beats everything.
+     *   host row, msState = 1   the host says ON.
+     *   group grant             any group the host is in says ON.
+     *   nothing anywhere        OFF.
+     *
+     * Lowest tier wins, and only the host is allowed to say OFF. A group
+     * grant is presence-only -- `groupModuleAssoc` has no state column -- so
+     * two groups can only ever union and can never contradict each other.
+     * That is the whole reason the table is shaped that way: "this group
+     * says disable, that one says enable, which wins?" is a question with no
+     * defensible answer, so the schema refuses to let it be asked.
+     *
+     * WHY "NOTHING ANYWHERE" IS OFF RATHER THAN `modules`.`default`. Before
+     * group grants, a host's rows in `moduleStatusByHost` WERE its enabled
+     * set and nothing read msState -- ServiceModule::checkPassiveModule()
+     * still computes its disabled list as array_diff(globalModules,
+     * hostRows). Absence therefore already means OFF on every existing
+     * install, and falling back to `default` here would silently switch
+     * modules on across a fleet at upgrade. `default` keeps the one job it
+     * has: seeding a newly registered host's rows.
+     *
+     * WHY msState CAN BE TRUSTED NOW. It was a varchar(1) that only ever
+     * held '1', because the only writer -- FOGController::addRemItem() --
+     * hardcodes it. Schema step 409 makes it the tinyint(1) it always was.
+     * A host row that means OFF is new, so no upgraded database has one, and
+     * this resolver returns exactly what the old code did until someone
+     * turns a module off in the UI.
+     *
+     * Order is by module id. Modules have no sequence anywhere in the
+     * schema -- unlike snapins, nothing runs them in turn -- so the order is
+     * for determinism only, and sorting by id keeps it stable across the
+     * host-direct and group-granted halves rather than exposing which half a
+     * module arrived through.
+     *
+     * @param array $hostIDs the hosts to resolve for
+     *
+     * @return array hostID => [moduleID, ...] ascending. Every host id
+     *               passed in is a key, with an empty array when it has
+     *               nothing; see resolveSnapins() for why.
+     * @throws \RuntimeException on any query failure
+     */
+    public static function resolveModules(array $hostIDs)
+    {
+        $hostIDs = self::_ids($hostIDs);
+        if (count($hostIDs) < 1) {
+            return [];
+        }
+        $resolved = [];
+        $on = [];
+        $off = [];
+        $rows = self::_rows(
+            'SELECT `msHostID`, `msModuleID`, `msState` '
+            . 'FROM `moduleStatusByHost` '
+            . 'WHERE `msHostID` IN (' . implode(',', $hostIDs) . ')'
+        );
+        foreach ($rows as $row) {
+            $hostID = (int)$row['msHostID'];
+            $moduleID = (int)$row['msModuleID'];
+            if ((int)$row['msState'] > 0) {
+                $on[$hostID][$moduleID] = true;
+                continue;
+            }
+            $off[$hostID][$moduleID] = true;
+        }
+
+        list($groupsByHost, $groupIDs) = self::_membership($hostIDs);
+        $byGroup = [];
+        if (count($groupIDs) > 0) {
+            $rows = self::_rows(
+                'SELECT `gmaGroupID`, `gmaModuleID` FROM `groupModuleAssoc` '
+                . 'WHERE `gmaGroupID` IN (' . implode(',', $groupIDs) . ')'
+            );
+            foreach ($rows as $row) {
+                $byGroup[(int)$row['gmaGroupID']][] = (int)$row['gmaModuleID'];
+            }
+        }
+
+        foreach ($hostIDs as $hostID) {
+            $out = $on[$hostID] ?? [];
+            foreach (array_keys($groupsByHost[$hostID] ?? []) as $groupID) {
+                foreach ($byGroup[$groupID] ?? [] as $moduleID) {
+                    // The host's OFF is checked here rather than by
+                    // subtracting at the end, so a module the host turned
+                    // off can never be in $out even momentarily -- there is
+                    // no ordering of the two halves that could leak it.
+                    if (isset($off[$hostID][$moduleID])) {
+                        continue;
+                    }
+                    $out[$moduleID] = true;
+                }
+            }
+            $ids = array_keys($out);
+            sort($ids);
+            $resolved[$hostID] = $ids;
+        }
+
+        return $resolved;
+    }
     /**
      * Reads group membership for a set of hosts.
      *

--- a/tests/assign-resolver.test.php
+++ b/tests/assign-resolver.test.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * Proves FOG\Assign\Resolver resolves the order ADR 0038 decision 6 promises.
+ * Proves FOG\Assign\Resolver resolves what ADR 0038 promises -- the order for
+ * snapins and printers (decision 6), and the three tiers for modules.
  *
  * The resolver is the single place that answers "what is this host actually
  * assigned". Everything it gets wrong is silent: a snapin runs in the wrong
@@ -36,6 +37,15 @@
  *        answer meaning "no printers", so a resolver that returns one on
  *        failure strips the fleet under printer mode `ar`, one machine at a
  *        time, for as long as nobody notices.
+ *   13   the saID tiebreak, pinned on the source -- see the comment there.
+ *   14-19 modules, the third grant and the only one that is a switch. A
+ *        host-direct OFF beats every group that grants the module; the same
+ *        grant still reaches a host that has not said OFF (one module, one
+ *        grant, opposite answers, so neither "OFF is global" nor "the grant
+ *        wins" survives); the union comes back ascending by module id rather
+ *        than host-then-group; a module two of a host's groups grant appears
+ *        once; a host with nothing is still a key; and a failed module read
+ *        throws for the same decision-9 reason as check 12.
  *
  * Skips without FOG_TEST_DSN, exactly as tests/schema-executes.test.php does.
  *
@@ -216,6 +226,8 @@ $need = [
     'printerAssoc',
     'groupSnapinAssoc',
     'groupPrinterAssoc',
+    'moduleStatusByHost',
+    'groupModuleAssoc',
 ];
 foreach ($need as $table) {
     if (!isset($expected[$table]['create'])) {
@@ -398,6 +410,86 @@ $check(
         $source,
         'ORDER BY `saHostID`, `saSequence`, `saID`'
     )
+);
+
+/*
+ * MODULES -- the third grant, and the only one that is a switch.
+ *
+ * The scenario is built so the three tiers are separable. Reusing the same
+ * groups keeps the membership fixture honest: host 13 has no `hosts` row at
+ * all and is in group 3, so it proves the manager-bypass property a second
+ * time on a table nobody has queried yet.
+ *
+ *   host 10  direct ON  950, direct OFF 901; in groups 1, 2, 3
+ *   host 11  no direct rows at all;          in groups 4, 5
+ *   host 12  nothing anywhere, in no group
+ *   host 13  no `hosts` row;                 in group 3
+ *
+ *   group 3 grants 901 and 902
+ *   group 1 grants 903
+ *   group 5 grants 910
+ *   group 4 grants 910 and 911
+ *
+ * 950 is deliberately the HIGHEST id in host 10's answer while being the
+ * host-direct one. A resolver that appends the group grants after the direct
+ * rows without sorting returns [950, 902, 903]; the promise is ascending by
+ * id, so the right answer is [902, 903, 950] and the two are different lists
+ * rather than the same list in a different order.
+ *
+ * 901 is the load-bearing pair. Host 10 says OFF and group 3 grants it, so
+ * host 10 must NOT have it -- and host 13, in the same group with nothing of
+ * its own to say, MUST. One module, one grant, opposite answers: a resolver
+ * that treats OFF as global, or that lets the grant win, fails one of the
+ * two whichever way it is wrong.
+ */
+$pdo->exec(
+    "INSERT INTO `moduleStatusByHost` (`msHostID`,`msModuleID`,`msState`) "
+    . "VALUES (10,950,1),(10,901,0)"
+);
+$pdo->exec(
+    "INSERT INTO `groupModuleAssoc` (`gmaGroupID`,`gmaModuleID`) VALUES "
+    . "(3,901),(3,902),(1,903),(5,910),(4,910),(4,911)"
+);
+
+$mods = \FOG\Assign\Resolver::resolveModules([10, 11, 12, 13]);
+
+$check(
+    'a host-direct OFF beats every group that grants the module',
+    !in_array(901, $mods[10] ?? [], true)
+);
+$check(
+    'the same grant still reaches a host that has not said OFF',
+    ($mods[13] ?? []) === [901, 902]
+);
+$check(
+    'host ON and group grants union, ascending by module id',
+    ($mods[10] ?? []) === [902, 903, 950]
+);
+$check(
+    'a module granted by two of a host\'s groups appears once',
+    ($mods[11] ?? []) === [910, 911]
+);
+$check(
+    'a host with nothing anywhere is still a key, with an empty list',
+    array_key_exists(12, $mods) && ($mods[12] ?? null) === []
+);
+
+// The decision-9 gate again, on the table this resolver added. Same reason:
+// under the client's module protocol an empty answer is a legitimate "all
+// modules off", so a read that fails silently switches the fleet off rather
+// than reporting anything.
+$pdo->exec('DROP TABLE `groupModuleAssoc`');
+$threw = false;
+$message = '';
+try {
+    \FOG\Assign\Resolver::resolveModules([10]);
+} catch (\RuntimeException $e) {
+    $threw = true;
+    $message = $e->getMessage();
+}
+$check(
+    'a failed module read throws rather than resolving to nothing',
+    $threw && 0 === strpos($message, 'Assignment resolution failed')
 );
 
 // 12: the decision-9 gate. A failed read must not look like "no printers".


### PR DESCRIPTION
Second modules unit, on top of #1629. `Resolver::resolveModules()`. **Nothing calls it yet** — `Host::loadModules()`, the client paths and the pages come next — so this changes no behavior on its own.

### Three tiers, not a union

Modules are the third declarative grant and the only one that is a **switch** rather than a thing, so a host is allowed to hold one OFF against every group that grants it.

| Tier | Meaning |
|---|---|
| host row, `msState = 0` | the host says OFF. **Beats everything.** |
| host row, `msState = 1` | the host says ON |
| group grant | any group the host is in says ON |
| nothing anywhere | OFF |

Only the host may say OFF. A group grant is presence-only — `groupModuleAssoc` has no state column — so two groups can only union and can never contradict each other. *"This group says disable, that one says enable, which wins?"* is a question with no defensible answer, and the schema refuses to let it be asked.

### Why "nothing anywhere" is OFF rather than `modules`.`default`

Because that is already what it means. Nothing has ever read `msState`: the only writer hardcodes `1`, and `ServiceModule::checkPassiveModule()` still computes its disabled list as `array_diff(globalModules, hostRows)`. Absence therefore means OFF on every existing install, and falling back to `default` here would silently switch modules **on** across a fleet at upgrade. `default` keeps the one job it has — seeding a newly registered host's rows.

So this resolver returns exactly what the old code did until someone turns a module off in the UI: no upgraded database has a state-0 row, and `groupModuleAssoc` ships empty.

Order is by module id. Modules have no sequence anywhere in the schema, so the order is for determinism only, and sorting by id keeps it stable rather than exposing which half a module arrived through.

### The tests

Six cases added to `tests/assign-resolver.test.php`. The load-bearing one is **module 901**: host 10 says OFF and group 3 grants it, while host 13 is in that same group with nothing of its own to say. One module, one grant, opposite answers — so neither "OFF is global" nor "the grant wins" survives. **Module 950** is the host-direct one *and* the highest id in the answer, so an unsorted append returns a different **list** (`[950, 902, 903]`) rather than the same list reordered.

Every mutation was run and confirmed red:

| Mutation | Checks that went red |
|---|---|
| drop the host-OFF check | OFF-beats-grant, union-ascending |
| drop the `sort()` | union-ascending |
| read `msState` 0 as ON | OFF-beats-grant, union-ascending |
| omit empty hosts from the result | host-with-nothing-is-still-a-key |
| neuter the group read | three of the grant checks |

### Verification

`tests/run-all.sh`: 288 passed, 0 failed. With a DSN, `assign-resolver`: 19 checks (was 13). phpstan clean on both configs.