### PR TITLE
Tell the client the resolved module list, and ask the class that has it

### DIFF
--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -3559,9 +3559,12 @@ abstract class FOGPage extends FOGBase
                 false,
                 self::$newService || self::$json
             );
+            // RESOLVED, not host-direct -- see ServiceModule. This is the
+            // list the client is told to run, so a group grant has to be in
+            // it.
             $hostModules = Route::getIds(
                 'module',
-                ['id' => self::$Host->get('modules')],
+                ['id' => self::$Host->resolvedModules()],
                 'shortName'
             );
             $hostEnabled = array_diff(

--- a/packages/web/src/Client/FOGClient.php
+++ b/packages/web/src/Client/FOGClient.php
@@ -149,8 +149,11 @@ abstract class FOGClient extends FOGBase
             ) {
                 throw new \Exception('#!ng');
             }
+            // RESOLVED, not host-direct -- see ServiceModule. A module a
+            // group grants must let the client reach its endpoint, or the
+            // grant is one the server honors and the gate refuses.
             $find = [
-                'id' => self::$Host->get('modules'),
+                'id' => self::$Host->resolvedModules(),
                 'shortName' => $this->shortName
             ];
             $hostModInfo = Route::getIds(

--- a/packages/web/src/Client/ServiceModule.php
+++ b/packages/web/src/Client/ServiceModule.php
@@ -88,9 +88,13 @@ class ServiceModule extends FOGClient
             }
             unset($en);
         }
+        // RESOLVED, not host-direct. ADR 0038: a group grants a module, so
+        // what this host actually runs is its own ON rows plus every grant
+        // from a group it is in, minus anything it has turned OFF.
+        // get('modules') is the edit view and would silently ignore grants.
         $hostModules = Route::getIds(
-            'moduleassociation',
-            ['id' => self::$Host->get('modules')],
+            'module',
+            ['id' => self::$Host->resolvedModules()],
             'shortName'
         );
         $hostEnabled = (

--- a/packages/web/src/Items/Host.php
+++ b/packages/web/src/Items/Host.php
@@ -671,19 +671,61 @@ class Host extends FOGController
         $this->set('snapins', (array)$snapins);
     }
     /**
-     * Loads any modules this host has
+     * Loads the modules this host itself has turned ON.
+     *
+     * HOST-DIRECT, NOT RESOLVED, and that is the whole point. This is the
+     * value the edit surfaces diff against -- Route's host update arm
+     * computes its add/remove lists from it, and the host page's module tab
+     * ticks it. If it returned the group-granted modules too, saving either
+     * of those would write a host row for every grant, turning a grant back
+     * into a copy: exactly what ADR 0038 exists to stop. What the client
+     * gets is resolvedModules().
+     *
+     * The `state` filter is new and changes nothing today. Every row in
+     * `moduleStatusByHost` on every existing install carries state 1,
+     * because the only writer -- FOGController::addRemItem() -- hardcodes
+     * it. A row meaning OFF is the new thing, and this is what keeps it out
+     * of the ON list once something writes one.
      *
      * @return void
      */
     protected function loadModules()
     {
-        $find = ['hostID' => $this->get('id')];
+        $find = ['hostID' => $this->get('id'), 'state' => 1];
         $modules = Route::getIds(
             'moduleassociation',
             $find,
             'moduleID'
         );
         $this->set('modules', (array)$modules);
+    }
+    /**
+     * The modules actually enabled on this host, grants included.
+     *
+     * ADR 0038: a group GRANTS a module. What a host ends up with is this
+     * host's own ON rows, plus every module granted by a group it is in,
+     * minus anything this host has explicitly turned OFF. The reasoning for
+     * the three tiers lives on Resolver::resolveModules(); this is the
+     * accessor the client protocol reads.
+     *
+     * NOT a loadX() pseudo-field. Those are cached on the object and the
+     * edit surfaces diff against them, and a value that changes when someone
+     * edits a GROUP has no business being cached on a host or being written
+     * back. Kept as an explicit call so every caller is visibly asking for
+     * the resolved answer rather than picking it up by accident.
+     *
+     * @return array module ids, ascending
+     * @throws \RuntimeException on any query failure
+     */
+    public function resolvedModules()
+    {
+        $id = (int)$this->get('id');
+        if ($id < 1) {
+            return [];
+        }
+        $resolved = Resolver::resolveModules([$id]);
+
+        return (array)($resolved[$id] ?? []);
     }
     /**
      * Loads any powermanagement tasks this host has

--- a/phpstan-tests-baseline.neon
+++ b/phpstan-tests-baseline.neon
@@ -319,6 +319,12 @@ parameters:
 			path: tests/hook-event-contract.test.php
 
 		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/host-modules-are-resolved.test.php
+
+		-
 			message: '#^If condition is always false\.$#'
 			identifier: if.alwaysFalse
 			count: 1

--- a/tests/host-modules-are-resolved.test.php
+++ b/tests/host-modules-are-resolved.test.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * The client is told the RESOLVED module list, and short names come from the
+ * class that has them.
+ *
+ * TWO FAILURES, one new and one that has been live for the whole of 1.6.
+ *
+ * 1. ADR 0038: a group GRANTS a module. `Host::get('modules')` is the
+ *    host-direct list -- the value the edit surfaces diff against -- so a
+ *    client path that reads it ignores every grant. The three client-facing
+ *    readers must call `Host::resolvedModules()` instead.
+ *
+ * 2. `ServiceModule::checkPassiveModule()` asked `moduleassociation` for
+ *    `shortName`. `ModuleAssociation` has four fields -- id, hostID,
+ *    moduleID, state -- and `shortName` is not one of them, so the projection
+ *    could never resolve and the call returned an empty list on every server.
+ *    `$hostDisabled` is `array_diff($globalModules, $hostEnabled)`, so an
+ *    empty $hostEnabled makes EVERY module disabled for EVERY host and the
+ *    endpoint answers `#!nh` unconditionally. Confirmed against a real
+ *    MariaDB before the fix: `Route::getIds('moduleassociation', ['id' =>
+ *    [2,3]], 'shortName')` returned [] with an "Undefined array key
+ *    shortName" notice, while the `module` spelling returned
+ *    ["greenfog","printermanager"].
+ *
+ * WHAT IS ASSERTED, AND HOW. The class-name fact is read off the MODELS
+ * themselves -- `Module` declares `shortName`, `ModuleAssociation` does not
+ * -- through reflection on `$databaseFields`. That is the property that makes
+ * the old call impossible to answer, and it goes red the moment either model
+ * changes. A FakeDB was tried first and rejected: a fake that answers every
+ * query with a row keyed by the columns the SELECT named cannot tell the two
+ * spellings apart (both came back with a value), so it would have measured
+ * the fixture rather than the fix.
+ *
+ * The rest is source-anchored. Which of two accessors a call site uses is not
+ * observable from outside without standing up the whole client protocol, a
+ * Host row and a session; the BEHAVIOR both accessors feed is covered by
+ * tests/assign-resolver.test.php, which drives the resolver against a real
+ * database. What is left here is the wiring, and the wiring is a fact about
+ * the source.
+ *
+ * Usage: php tests/host-modules-are-resolved.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+$webroot = $root . '/packages/web';
+$init = $webroot . '/commons/init.php';
+if (!is_readable($init)) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+
+$tmp = sys_get_temp_dir() . '/fog-host-modules-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
+register_shutdown_function(
+    function () use ($tmp) {
+        if (!is_dir($tmp)) {
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($tmp, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $f) {
+            $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+        }
+        @rmdir($tmp);
+    }
+);
+foreach (
+    [
+        'FOG_CACHE_DIR' => $tmp . '/cache',
+        'FOG_LOG_DIR' => $tmp . '/log',
+        'FOG_PLUGIN_DIR' => $tmp . '/plugins',
+    ] as $const => $value
+) {
+    if (!defined($const)) {
+        define($const, $value);
+    }
+}
+// FOGBase::_writeLog() stamps the schema version into every line; a real
+// install gets this from the generated config.class.php, which a test has not.
+if (!defined('FOG_SCHEMA')) {
+    define('FOG_SCHEMA', 0);
+}
+
+require_once $init;
+new Initiator();
+
+$checks = 0;
+$failures = [];
+$check = static function ($what, $ok) use (&$checks, &$failures) {
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+};
+
+/*
+ * 1-2. The class-name fact, read off the models. `Module` has a shortName to
+ * project; `ModuleAssociation` has four fields and none of them is it, which
+ * is why the old call site could never answer and returned an empty list on
+ * every server.
+ */
+$fields = static function ($class) {
+    $prop = new \ReflectionProperty($class, 'databaseFields');
+    $prop->setAccessible(true);
+    $obj = (new \ReflectionClass($class))->newInstanceWithoutConstructor();
+
+    return array_keys((array)$prop->getValue($obj));
+};
+$check(
+    'the module class declares shortName, so it can be projected',
+    in_array('shortName', $fields(\FOG\Items\Module::class), true)
+);
+$check(
+    'the moduleassociation class does not -- there is nothing to project',
+    !in_array('shortName', $fields(\FOG\Items\ModuleAssociation::class), true)
+);
+
+/*
+ * 3-6. The wiring. Every client-facing reader asks for the RESOLVED list,
+ * and asks the class that can answer.
+ */
+$readers = [
+    'src/Client/ServiceModule.php' => 'checkPassiveModule',
+    'src/Client/FOGClient.php' => 'the client endpoint gate',
+    'src/Base/FOGPage.php' => 'the servicemodule-active response',
+];
+foreach ($readers as $file => $what) {
+    $src = (string)@file_get_contents($webroot . '/' . $file);
+    $check(
+        "$what reads the resolved module list, not the host-direct one",
+        false !== strpos($src, "self::\$Host->resolvedModules()")
+            && false === strpos($src, "self::\$Host->get('modules')")
+    );
+}
+$svc = (string)@file_get_contents($webroot . '/src/Client/ServiceModule.php');
+$check(
+    'checkPassiveModule() asks the module class for its short names',
+    1 === preg_match(
+        "/getIds\(\s*'module',\s*\[\s*'id' => self::\\\$Host->resolvedModules/s",
+        $svc
+    )
+);
+
+/*
+ * 7-8. The other half of the split: the host-direct list stays host-direct,
+ * and it stops at the rows the host has turned ON. Route's host update arm
+ * diffs against get('modules'), so a resolved value there would write a host
+ * row for every grant -- turning a grant back into a copy, which is the one
+ * thing ADR 0038 exists to prevent.
+ */
+$host = (string)@file_get_contents($webroot . '/src/Items/Host.php');
+$check(
+    'loadModules() filters to the rows the host has turned ON',
+    1 === preg_match(
+        "/protected function loadModules\(\).*?"
+        . "\\\$find = \['hostID' => \\\$this->get\('id'\), 'state' => 1\]/s",
+        $host
+    )
+);
+$check(
+    'resolvedModules() is a separate public accessor, not a cached field',
+    1 === preg_match(
+        '/public function resolvedModules\(\).*?'
+        . 'Resolver::resolveModules\(\[\$id\]\)/s',
+        $host
+    )
+    && false === strpos($host, "'modulesResolved'")
+);
+
+if (count($failures)) {
+    fwrite(STDERR, "FAIL: the module read path is wrong:\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    fwrite(
+        STDERR,
+        sprintf("%d of %d checks failed\n", count($failures), $checks)
+    );
+    exit(1);
+}
+
+printf("PASS  host modules are resolved: %d checks\n", $checks);
+exit(0);


### PR DESCRIPTION
Third modules unit, on top of #1632. Two fixes — one new, and one that has been live for the whole of 1.6.

### 1. The client paths ignored group grants

ADR 0038: a group **grants** a module. `Host::get('modules')` is the host-direct list — the value the edit surfaces diff against — so a client path that reads it ignores every grant. The three client-facing readers now call `Host::resolvedModules()`:

- `ServiceModule::checkPassiveModule()`
- the `FOGClient` endpoint gate
- `FOGPage`'s `servicemodule-active` response

`get('modules')` deliberately **stays** host-direct, and `loadModules()` now filters to `msState = 1`. Route's host update arm diffs against it, so a resolved value there would write a host row for every grant — turning a grant back into a copy, which is the one thing ADR 0038 exists to prevent. The state filter changes nothing today: every row on every existing install carries state 1, because the only writer hardcodes it.

`resolvedModules()` is an explicit call rather than a `loadX()` pseudo-field. A value that changes when someone edits a *group* has no business being cached on a host or written back, and an explicit call means every caller is visibly asking for the resolved answer rather than picking it up by accident.

### 2. `checkPassiveModule()` has never worked

It asked `moduleassociation` for `shortName`. `ModuleAssociation` has four fields — `id`, `hostID`, `moduleID`, `state` — and `shortName` is not one of them, so the projection could never resolve and the call returned an empty list **on every server**. `$hostDisabled` is `array_diff($globalModules, $hostEnabled)`, so an empty `$hostEnabled` made every module disabled for every host, and `servicemodule-active.php` answered `#!nh` unconditionally.

It now asks `module` — which is what `FOGPage` already did for the same lookup.

Confirmed against a real MariaDB before the fix:

```
Route::getIds('moduleassociation', ['id' => [2,3]], 'shortName')
  -> []  with an "Undefined array key shortName" notice
Route::getIds('module',            ['id' => [2,3]], 'shortName')
  -> ["greenfog","printermanager"]
```

### The gate

`tests/host-modules-are-resolved.test.php`, 8 checks. The class-name fact is read off the **models** through reflection on `$databaseFields`, which is the property that makes the old call impossible to answer.

A FakeDB was tried first and rejected, and the docblock records why: a fake that answers every query with a row keyed by the columns the SELECT named cannot tell the two spellings apart — both came back with a value — so it would have measured the fixture rather than the fix.

Mutations run and confirmed red:

| Mutation | Check that went red |
|---|---|
| give `ModuleAssociation` a `shortName` field | "there is nothing to project" |
| revert ServiceModule to both old spellings | two checks |
| revert the FOGClient gate | "the client endpoint gate reads the resolved list" |
| drop `loadModules()`' state filter | "filters to the rows the host has turned ON" |

### Verification

`tests/run-all.sh`: 290 passed, 0 failed. phpstan clean on both configs.