### PR TITLE
Clean it up: drop the module special case, name the auto-logout minimum

### DIFF
--- a/packages/web/src/Base/FOGController.php
+++ b/packages/web/src/Base/FOGController.php
@@ -1916,23 +1916,25 @@ abstract class FOGController extends FOGBase
             $assocstr
         ];
         $insert_values = [];
-        if ($assocstr == 'moduleID'
-            || strtolower($classCall) == 'moduleassociation'
-        ) {
-            $insert_fields[] = 'state';
-        }
-
+        // No special case for module associations any more. This used to
+        // append an explicit `state` of 1 to every module row, because
+        // `moduleStatusByHost`.`msState` was a varchar(1) NOT NULL DEFAULT
+        // '' -- an insert that omitted it wrote the empty string. Schema step
+        // 409 makes the column tinyint(1) NOT NULL DEFAULT 1, so the database
+        // supplies the same value and one generic insert covers every
+        // association table.
+        //
+        // The default is load-bearing, not cosmetic: under ADR 0038 a state
+        // of 0 is a host saying OFF, which beats every group grant. If the
+        // DEFAULT is ever dropped or changed, this insert starts writing the
+        // strongest statement in the system by accident. That pairing is
+        // pinned in tests/assign-resolver.test.php, which inserts a row
+        // omitting the column against the real DDL and reads it back.
         foreach ($diff as $id) {
-            $insert_val = [
+            $insert_values[] = [
                 $this->get('id'),
                 $id
             ];
-            if ($assocstr == 'moduleID'
-                || strtolower($classCall) == 'moduleassociation'
-            ) {
-                $insert_val[] = 1;
-            }
-            $insert_values[] = $insert_val;
         }
 
         // Perform batch insertion if there are values to insert.

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -3559,9 +3559,12 @@ abstract class FOGPage extends FOGBase
                 false,
                 self::$newService || self::$json
             );
+            // RESOLVED, not host-direct -- see ServiceModule. This is the
+            // list the client is told to run, so a group grant has to be in
+            // it.
             $hostModules = Route::getIds(
                 'module',
-                ['id' => self::$Host->get('modules')],
+                ['id' => self::$Host->resolvedModules()],
                 'shortName'
             );
             $hostEnabled = array_diff(

--- a/packages/web/src/Client/FOGClient.php
+++ b/packages/web/src/Client/FOGClient.php
@@ -149,8 +149,11 @@ abstract class FOGClient extends FOGBase
             ) {
                 throw new \Exception('#!ng');
             }
+            // RESOLVED, not host-direct -- see ServiceModule. A module a
+            // group grants must let the client reach its endpoint, or the
+            // grant is one the server honors and the gate refuses.
             $find = [
-                'id' => self::$Host->get('modules'),
+                'id' => self::$Host->resolvedModules(),
                 'shortName' => $this->shortName
             ];
             $hostModInfo = Route::getIds(

--- a/packages/web/src/Client/ServiceModule.php
+++ b/packages/web/src/Client/ServiceModule.php
@@ -88,9 +88,13 @@ class ServiceModule extends FOGClient
             }
             unset($en);
         }
+        // RESOLVED, not host-direct. ADR 0038: a group grants a module, so
+        // what this host actually runs is its own ON rows plus every grant
+        // from a group it is in, minus anything it has turned OFF.
+        // get('modules') is the edit view and would silently ignore grants.
         $hostModules = Route::getIds(
-            'moduleassociation',
-            ['id' => self::$Host->get('modules')],
+            'module',
+            ['id' => self::$Host->resolvedModules()],
             'shortName'
         );
         $hostEnabled = (

--- a/packages/web/src/Items/Host.php
+++ b/packages/web/src/Items/Host.php
@@ -671,19 +671,61 @@ class Host extends FOGController
         $this->set('snapins', (array)$snapins);
     }
     /**
-     * Loads any modules this host has
+     * Loads the modules this host itself has turned ON.
+     *
+     * HOST-DIRECT, NOT RESOLVED, and that is the whole point. This is the
+     * value the edit surfaces diff against -- Route's host update arm
+     * computes its add/remove lists from it, and the host page's module tab
+     * ticks it. If it returned the group-granted modules too, saving either
+     * of those would write a host row for every grant, turning a grant back
+     * into a copy: exactly what ADR 0038 exists to stop. What the client
+     * gets is resolvedModules().
+     *
+     * The `state` filter is new and changes nothing today. Every row in
+     * `moduleStatusByHost` on every existing install carries state 1,
+     * because the only writer -- FOGController::addRemItem() -- hardcodes
+     * it. A row meaning OFF is the new thing, and this is what keeps it out
+     * of the ON list once something writes one.
      *
      * @return void
      */
     protected function loadModules()
     {
-        $find = ['hostID' => $this->get('id')];
+        $find = ['hostID' => $this->get('id'), 'state' => 1];
         $modules = Route::getIds(
             'moduleassociation',
             $find,
             'moduleID'
         );
         $this->set('modules', (array)$modules);
+    }
+    /**
+     * The modules actually enabled on this host, grants included.
+     *
+     * ADR 0038: a group GRANTS a module. What a host ends up with is this
+     * host's own ON rows, plus every module granted by a group it is in,
+     * minus anything this host has explicitly turned OFF. The reasoning for
+     * the three tiers lives on Resolver::resolveModules(); this is the
+     * accessor the client protocol reads.
+     *
+     * NOT a loadX() pseudo-field. Those are cached on the object and the
+     * edit surfaces diff against them, and a value that changes when someone
+     * edits a GROUP has no business being cached on a host or being written
+     * back. Kept as an explicit call so every caller is visibly asking for
+     * the resolved answer rather than picking it up by accident.
+     *
+     * @return array module ids, ascending
+     * @throws \RuntimeException on any query failure
+     */
+    public function resolvedModules()
+    {
+        $id = (int)$this->get('id');
+        if ($id < 1) {
+            return [];
+        }
+        $resolved = Resolver::resolveModules([$id]);
+
+        return (array)($resolved[$id] ?? []);
     }
     /**
      * Loads any powermanagement tasks this host has

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -2816,7 +2816,13 @@ class HostManagement extends FOGPage
         }
         if (isset($_POST['confirmalosend'])) {
             $tme = (int)filter_input(INPUT_POST, 'tme');
-            if (!(is_numeric($tme) && $tme > 4)) {
+            // HostAutoLogout::MIN_MINUTES, not the literal it was spelled as.
+            // The same rule is stated in three other places -- the host page's
+            // own validator, the group page's constant, and the data-alo-min
+            // the group form hands the browser -- and this was the one copy
+            // that would not move if the minimum ever changed. Below the
+            // minimum means OFF, which is the existing behavior.
+            if ($tme < HostAutoLogout::MIN_MINUTES) {
                 $tme = 0;
             }
             $this->obj->setAlo($tme);

--- a/phpstan-tests-baseline.neon
+++ b/phpstan-tests-baseline.neon
@@ -319,6 +319,12 @@ parameters:
 			path: tests/hook-event-contract.test.php
 
 		-
+			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'
+			identifier: new.resultUnused
+			count: 1
+			path: tests/host-modules-are-resolved.test.php
+
+		-
 			message: '#^If condition is always false\.$#'
 			identifier: if.alwaysFalse
 			count: 1

--- a/tests/assign-resolver.test.php
+++ b/tests/assign-resolver.test.php
@@ -474,6 +474,34 @@ $check(
     array_key_exists(12, $mods) && ($mods[12] ?? null) === []
 );
 
+/*
+ * THE DEFAULT ON msState IS LOAD-BEARING.
+ *
+ * FOGController::addRemItem() used to append an explicit `state` of 1 to
+ * every module row, because the column was a varchar(1) NOT NULL DEFAULT ''
+ * and an insert that omitted it wrote the empty string. Schema step 409 made
+ * it tinyint(1) NOT NULL DEFAULT 1, so that special case was removed and the
+ * database now supplies the value.
+ *
+ * Which means the DEFAULT and the generic insert are one mechanism held in
+ * two files. Under ADR 0038 a state of 0 is a host saying OFF and beats every
+ * group grant, so if the default is ever dropped or flipped, every module
+ * added through the generic path silently becomes the strongest statement in
+ * the system -- and nothing would fail. This inserts a row the way
+ * addRemItem() now does, against the REAL DDL out of the manifest, and reads
+ * the answer back through the resolver rather than off the column: what
+ * matters is not that the column says 1, it is that the module comes out
+ * enabled.
+ */
+$pdo->exec(
+    "INSERT INTO `moduleStatusByHost` (`msHostID`,`msModuleID`) VALUES (12,960)"
+);
+$defaulted = \FOG\Assign\Resolver::resolveModules([12]);
+$check(
+    'a module row inserted without a state resolves as enabled',
+    ($defaulted[12] ?? []) === [960]
+);
+
 // The decision-9 gate again, on the table this resolver added. Same reason:
 // under the client's module protocol an empty answer is a legitimate "all
 // modules off", so a read that fails silently switches the fleet off rather

--- a/tests/auto-logout-minimum-has-one-spelling.test.php
+++ b/tests/auto-logout-minimum-has-one-spelling.test.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * The auto-logout minimum is stated once and read everywhere.
+ *
+ * `HostAutoLogout::MIN_MINUTES` is the rule: below it, auto-logout is OFF.
+ * It is consulted from four places -- the host page's validator, the host
+ * page's own POST handler, the group page's constant, and the `data-alo-min`
+ * the group form hands the browser -- and one of them spelled it as the
+ * literal `$tme > 4`. A magic number is not wrong until the constant moves,
+ * at which point three surfaces change and one silently does not, and the
+ * symptom is a value the form accepts and the save discards.
+ *
+ * SOURCE-ANCHORED, deliberately. The behavior is identical either way while
+ * the constant is 5 -- that is the whole reason the drift is invisible -- so
+ * a behavioral assertion here would pass against the literal it exists to
+ * forbid. What can be checked is that no second spelling exists.
+ *
+ * Usage: php tests/auto-logout-minimum-has-one-spelling.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$webroot = dirname(__DIR__) . '/packages/web';
+
+$checks = 0;
+$failures = [];
+$check = static function ($what, $ok) use (&$checks, &$failures) {
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+};
+
+$item = (string)@file_get_contents(
+    $webroot . '/src/Items/HostAutoLogout.php'
+);
+$check(
+    'HostAutoLogout declares the minimum',
+    1 === preg_match('/const MIN_MINUTES = (\d+);/', $item, $m)
+        && (int)$m[1] > 0
+);
+
+/*
+ * Every comparison of a submitted auto-logout time must name the constant.
+ * `$tme` is the field name on both pages' forms, so a comparison against a
+ * bare number is the drift this file is for.
+ */
+$pages = [
+    'src/Pages/HostManagement.php',
+    'src/Pages/GroupManagement.php',
+];
+foreach ($pages as $rel) {
+    $src = (string)@file_get_contents($webroot . '/' . $rel);
+    $check(
+        basename($rel) . ' compares $tme against a named minimum, not a literal',
+        0 === preg_match('/\$tme\s*[<>]=?\s*\d/', $src)
+    );
+    $check(
+        basename($rel) . ' still gates on the auto-logout minimum at all',
+        false !== strpos($src, 'MIN_MINUTES')
+    );
+}
+
+// The group page hands the same number to the browser. A form that lets a
+// value through which the save then discards is the visible half of this
+// drift, so the attribute has to come from the constant too.
+$group = (string)@file_get_contents(
+    $webroot . '/src/Pages/GroupManagement.php'
+);
+$check(
+    'the group form gets data-alo-min from the constant',
+    1 === preg_match(
+        '/data-alo-min="\'\s*\.\s*self::ALO_MIN_MINUTES/',
+        $group
+    )
+);
+$check(
+    'the group page aliases the constant rather than restating it',
+    1 === preg_match(
+        '/const ALO_MIN_MINUTES = HostAutoLogout::MIN_MINUTES;/',
+        $group
+    )
+);
+
+if (count($failures)) {
+    fwrite(STDERR, "FAIL: the auto-logout minimum has drifted:\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    fwrite(
+        STDERR,
+        sprintf("%d of %d checks failed\n", count($failures), $checks)
+    );
+    exit(1);
+}
+
+printf(
+    "PASS  auto-logout minimum has one spelling: %d checks\n",
+    $checks
+);
+exit(0);

--- a/tests/host-modules-are-resolved.test.php
+++ b/tests/host-modules-are-resolved.test.php
@@ -179,6 +179,32 @@ $check(
     && false === strpos($host, "'modulesResolved'")
 );
 
+/*
+ * 9. The generic association insert stays generic. addRemItem() used to
+ * append an explicit `state` of 1 for module rows, because the column was a
+ * varchar(1) NOT NULL DEFAULT '' and an omitted value wrote the empty
+ * string. Schema step 409 made it tinyint(1) NOT NULL DEFAULT 1, so the
+ * database supplies it and the special case is gone.
+ *
+ * Pinned on the source because the BEHAVIOR is indistinguishable: writing 1
+ * explicitly and letting the default write 1 produce the same row. What this
+ * catches is the special case coming back with a different value in it --
+ * and under ADR 0038, 0 is a host saying OFF and beats every group grant.
+ * That the default itself is 1 is pinned behaviorally, against the real DDL,
+ * in tests/assign-resolver.test.php.
+ */
+$controller = (string)@file_get_contents(
+    $webroot . '/src/Base/FOGController.php'
+);
+$check(
+    'addRemItem() has no module special case left',
+    false === strpos($controller, "\$assocstr == 'moduleID'")
+        && false === strpos(
+            $controller,
+            "strtolower(\$classCall) == 'moduleassociation'"
+        )
+);
+
 if (count($failures)) {
     fwrite(STDERR, "FAIL: the module read path is wrong:\n");
     foreach ($failures as $f) {

--- a/tests/host-modules-are-resolved.test.php
+++ b/tests/host-modules-are-resolved.test.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * The client is told the RESOLVED module list, and short names come from the
+ * class that has them.
+ *
+ * TWO FAILURES, one new and one that has been live for the whole of 1.6.
+ *
+ * 1. ADR 0038: a group GRANTS a module. `Host::get('modules')` is the
+ *    host-direct list -- the value the edit surfaces diff against -- so a
+ *    client path that reads it ignores every grant. The three client-facing
+ *    readers must call `Host::resolvedModules()` instead.
+ *
+ * 2. `ServiceModule::checkPassiveModule()` asked `moduleassociation` for
+ *    `shortName`. `ModuleAssociation` has four fields -- id, hostID,
+ *    moduleID, state -- and `shortName` is not one of them, so the projection
+ *    could never resolve and the call returned an empty list on every server.
+ *    `$hostDisabled` is `array_diff($globalModules, $hostEnabled)`, so an
+ *    empty $hostEnabled makes EVERY module disabled for EVERY host and the
+ *    endpoint answers `#!nh` unconditionally. Confirmed against a real
+ *    MariaDB before the fix: `Route::getIds('moduleassociation', ['id' =>
+ *    [2,3]], 'shortName')` returned [] with an "Undefined array key
+ *    shortName" notice, while the `module` spelling returned
+ *    ["greenfog","printermanager"].
+ *
+ * WHAT IS ASSERTED, AND HOW. The class-name fact is read off the MODELS
+ * themselves -- `Module` declares `shortName`, `ModuleAssociation` does not
+ * -- through reflection on `$databaseFields`. That is the property that makes
+ * the old call impossible to answer, and it goes red the moment either model
+ * changes. A FakeDB was tried first and rejected: a fake that answers every
+ * query with a row keyed by the columns the SELECT named cannot tell the two
+ * spellings apart (both came back with a value), so it would have measured
+ * the fixture rather than the fix.
+ *
+ * The rest is source-anchored. Which of two accessors a call site uses is not
+ * observable from outside without standing up the whole client protocol, a
+ * Host row and a session; the BEHAVIOR both accessors feed is covered by
+ * tests/assign-resolver.test.php, which drives the resolver against a real
+ * database. What is left here is the wiring, and the wiring is a fact about
+ * the source.
+ *
+ * Usage: php tests/host-modules-are-resolved.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+$webroot = $root . '/packages/web';
+$init = $webroot . '/commons/init.php';
+if (!is_readable($init)) {
+    fwrite(STDERR, "FAIL: cannot read $init\n");
+    exit(1);
+}
+
+$tmp = sys_get_temp_dir() . '/fog-host-modules-test-' . getmypid();
+@mkdir($tmp . '/cache', 0700, true);
+@mkdir($tmp . '/log', 0700, true);
+register_shutdown_function(
+    function () use ($tmp) {
+        if (!is_dir($tmp)) {
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($tmp, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $f) {
+            $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+        }
+        @rmdir($tmp);
+    }
+);
+foreach (
+    [
+        'FOG_CACHE_DIR' => $tmp . '/cache',
+        'FOG_LOG_DIR' => $tmp . '/log',
+        'FOG_PLUGIN_DIR' => $tmp . '/plugins',
+    ] as $const => $value
+) {
+    if (!defined($const)) {
+        define($const, $value);
+    }
+}
+// FOGBase::_writeLog() stamps the schema version into every line; a real
+// install gets this from the generated config.class.php, which a test has not.
+if (!defined('FOG_SCHEMA')) {
+    define('FOG_SCHEMA', 0);
+}
+
+require_once $init;
+new Initiator();
+
+$checks = 0;
+$failures = [];
+$check = static function ($what, $ok) use (&$checks, &$failures) {
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+};
+
+/*
+ * 1-2. The class-name fact, read off the models. `Module` has a shortName to
+ * project; `ModuleAssociation` has four fields and none of them is it, which
+ * is why the old call site could never answer and returned an empty list on
+ * every server.
+ */
+$fields = static function ($class) {
+    $prop = new \ReflectionProperty($class, 'databaseFields');
+    $prop->setAccessible(true);
+    $obj = (new \ReflectionClass($class))->newInstanceWithoutConstructor();
+
+    return array_keys((array)$prop->getValue($obj));
+};
+$check(
+    'the module class declares shortName, so it can be projected',
+    in_array('shortName', $fields(\FOG\Items\Module::class), true)
+);
+$check(
+    'the moduleassociation class does not -- there is nothing to project',
+    !in_array('shortName', $fields(\FOG\Items\ModuleAssociation::class), true)
+);
+
+/*
+ * 3-6. The wiring. Every client-facing reader asks for the RESOLVED list,
+ * and asks the class that can answer.
+ */
+$readers = [
+    'src/Client/ServiceModule.php' => 'checkPassiveModule',
+    'src/Client/FOGClient.php' => 'the client endpoint gate',
+    'src/Base/FOGPage.php' => 'the servicemodule-active response',
+];
+foreach ($readers as $file => $what) {
+    $src = (string)@file_get_contents($webroot . '/' . $file);
+    $check(
+        "$what reads the resolved module list, not the host-direct one",
+        false !== strpos($src, "self::\$Host->resolvedModules()")
+            && false === strpos($src, "self::\$Host->get('modules')")
+    );
+}
+$svc = (string)@file_get_contents($webroot . '/src/Client/ServiceModule.php');
+$check(
+    'checkPassiveModule() asks the module class for its short names',
+    1 === preg_match(
+        "/getIds\(\s*'module',\s*\[\s*'id' => self::\\\$Host->resolvedModules/s",
+        $svc
+    )
+);
+
+/*
+ * 7-8. The other half of the split: the host-direct list stays host-direct,
+ * and it stops at the rows the host has turned ON. Route's host update arm
+ * diffs against get('modules'), so a resolved value there would write a host
+ * row for every grant -- turning a grant back into a copy, which is the one
+ * thing ADR 0038 exists to prevent.
+ */
+$host = (string)@file_get_contents($webroot . '/src/Items/Host.php');
+$check(
+    'loadModules() filters to the rows the host has turned ON',
+    1 === preg_match(
+        "/protected function loadModules\(\).*?"
+        . "\\\$find = \['hostID' => \\\$this->get\('id'\), 'state' => 1\]/s",
+        $host
+    )
+);
+$check(
+    'resolvedModules() is a separate public accessor, not a cached field',
+    1 === preg_match(
+        '/public function resolvedModules\(\).*?'
+        . 'Resolver::resolveModules\(\[\$id\]\)/s',
+        $host
+    )
+    && false === strpos($host, "'modulesResolved'")
+);
+
+if (count($failures)) {
+    fwrite(STDERR, "FAIL: the module read path is wrong:\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    fwrite(
+        STDERR,
+        sprintf("%d of %d checks failed\n", count($failures), $checks)
+    );
+    exit(1);
+}
+
+printf("PASS  host modules are resolved: %d checks\n", $checks);
+exit(0);


### PR DESCRIPTION
The *"clean it up"* half of the modules work, on top of #1633 (whose commit rides along until that merges). Two duplications, both now removable because something else changed underneath them.

### 1. `addRemItem()`'s module special case

`FOGController::addRemItem()` appended an explicit `state` of 1 to every module association it inserted — spelled **twice** in the same method, behind two conditions that mean the same thing. It existed because `moduleStatusByHost.msState` was a `varchar(1) NOT NULL DEFAULT ''`, so an insert that omitted the column wrote the empty string. Schema step 409 (#1629) made it `tinyint(1) NOT NULL DEFAULT 1`, so the database supplies the value and one generic insert now covers every association table.

**That default is load-bearing, not cosmetic.** Under ADR 0038 a state of 0 is a host saying OFF, which beats every group grant — so if the `DEFAULT` is ever dropped or flipped, this insert starts writing the strongest statement in the system by accident, and nothing would fail.

`tests/assign-resolver.test.php` now inserts a row the way `addRemItem()` does, against the **real DDL out of the manifest**, and reads the answer back *through the resolver*: what matters is not that the column says 1, it is that the module comes out enabled. Flipping the manifest's `DEFAULT` to 0 turns it red.

### 2. The auto-logout minimum, spelled four ways

`hostModulePost()` had `$tme > 4`. The same rule is stated in three other places — the host page's validator, the group page's `ALO_MIN_MINUTES`, and the `data-alo-min` the group form hands the browser — all of which read `HostAutoLogout::MIN_MINUTES`. This was the one copy that would not move if the minimum changed, and the symptom of that drift is *a value the form accepts and the save discards*, which is why the form attribute is pinned too.

`tests/auto-logout-minimum-has-one-spelling.test.php`, 7 checks. Source-anchored on purpose, and the docblock says why: while the constant is 5 the literal behaves identically — that is exactly what makes the drift invisible — so a behavioral assertion would pass against the thing it exists to forbid.

### Mutations, all run and confirmed red

| Mutation | Check |
|---|---|
| manifest `DEFAULT` flipped to 0 | "a module row inserted without a state resolves as enabled" |
| module special case put back | "addRemItem() has no module special case left" |
| literal restored in `hostModulePost()` | "compares `$tme` against a named minimum" |
| group page restates the number | "aliases the constant rather than restating it" |

### Verification

`tests/run-all.sh`: 291 passed, 0 failed. phpstan clean on both configs.