### PR TITLE
Record the modules reversal in the documents that argued the other way

### DIFF
--- a/docs/GROUP_SHARED_STATE.md
+++ b/docs/GROUP_SHARED_STATE.md
@@ -18,14 +18,20 @@ anything.
 > **no‑clobber**: a blank field leaves each host's value alone, so you only
 > change what you intend to.
 
-> **⚠️ This is changing. Snapins have already changed.**
+> **⚠️ This is changing. Snapins, printers and modules have already changed.**
 > A group is becoming something that **grants**, rather than something that
 > copies rows onto whoever happened to be a member when a button was pressed.
-> The first half has landed for **snapins and printers**: see
+> The first half has landed for **snapins, printers and modules**: see
 > [Snapins are granted, not copied](#snapins-are-granted-not-copied) below.
 > Everything else on this page still describes the push‑to‑all model and is
 > still accurate for the page as it stands today. The reasoning, and what is
 > left to move, are in [ADR 0038](adr/0038-a-group-grants-it-does-not-copy.md).
+>
+> **Modules carry one extra rule.** They are a *switch*, not a thing, so a
+> host is allowed to hold one OFF against every group that grants it — lowest
+> tier wins. A group grant is presence‑only: a group either grants a module or
+> says nothing about it, and can never say "disabled", so two groups can only
+> ever union. See ADR 0038 decision 3.
 
 ---
 
@@ -159,6 +165,13 @@ All   --click-->  None       (remove from every host)
 
 So an indeterminate item resolves to *All* first; the destructive
 remove‑from‑all only happens on a second click through the checked state.
+
+> **The module line above is on notice.** "Flip a disabled override back to
+> enabled" was harmless while a disabled override could not exist — nothing
+> ever wrote one. Under ADR 0038 decision 3 a disabled module row is a
+> deliberate host‑level statement that beats every group grant, so a group‑wide
+> toggle overriding it is wrong. The tab keeps this behavior until the group
+> page rework (unit E) replaces it with a grant.
 
 ---
 

--- a/docs/adr/0001-group-association-state.md
+++ b/docs/adr/0001-group-association-state.md
@@ -24,19 +24,39 @@ with snapins and printers:
   **and** `msState = 1` (enabled). A disabled override (`msState = 0`) counts as
   *not having it*, so such a host pulls the item out of **All** into **Some**.
 
-  **Correction, 2026-09-01: a disabled override cannot exist.** Nothing in the
-  tree ever writes `msState = 0` — every insert path writes a literal `1`
-  (`Items/Group.php:358`, `Base/FOGController.php:1922`) — the schema deletes
-  any that survive an upgrade (`commons/schema.php:1497`, `:3352`), and the
-  client ignores the column entirely (`Items/Host.php:681`,
-  `Client/ServiceModule.php:91`). The rule above is therefore equivalent to
-  the snapin and printer rule: the row is there or it is not. Nothing about
-  this ADR's behavior changes, because every row already satisfies the
-  stricter condition. See ADR 0038 decision 3 for what the correction does
-  change, which is an argument that was built on top of it.
+  **Correction, 2026-09-01: a disabled override could not exist — and now
+  it is the point.** When this ADR was written, nothing in the tree ever
+  wrote `msState = 0`: every insert path wrote a literal `1`
+  (`Items/Group.php`, `Base/FOGController.php`), the schema deleted any that
+  survived an upgrade (schema steps 34 and 231 — both historical, since a
+  numbered step replays once), and the client ignored the column entirely.
+  The rule above was therefore *equivalent* to the snapin and printer rule:
+  the row is there or it is not. Nothing about this ADR's behavior changed,
+  because every row already satisfied the stricter condition.
+
+  What that finding did change was the argument built on top of it. ADR 0038
+  decision 3 had kept modules out of the declarative half **because** of this
+  asymmetry, and the asymmetry was not real. That decision was reversed:
+  modules are now the third group grant, and `msState = 0` has a meaning for
+  the first time — a host saying OFF, which beats every group grant. A group
+  grant carries no state at all (`groupModuleAssoc` has no state column), so
+  two groups can only ever union.
+
+  So the rule stated above is now correct as written, for a reason it did not
+  have when it was written. What is no longer true is the sentence below it:
+  toggling an item to **All** cannot mean "flip `state = 0 → 1`" once 0 is a
+  deliberate host-level statement, and the group page's own module tab is
+  scheduled for rework in ADR 0038's unit E. Read this section with ADR 0038
+  decision 3 beside it.
 
 Toggling an item to **All** writes the missing rows on every host (for modules,
 this also flips `state = 0 → 1`); toggling to **None** deletes the rows.
+
+**Superseded for modules by ADR 0038 decision 3.** Once `state = 0` is a host
+saying OFF, flipping it to 1 on a group-wide toggle overrides a deliberate
+per-host statement, and deleting the row means "unstated" rather than "off".
+The group module tab keeps this behavior until unit E replaces it with a
+grant; the correction note above has the detail.
 
 Per-host configuration *shared values* (Active Directory, auto-logout,
 force-reboot, the printer **default** flag) are explicitly **out of scope** for

--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -158,15 +158,21 @@ two groups". The group is only ever a *selection mechanism* for writing them,
 and the write is legitimately one-shot. This half **leaves the group entirely**
 and becomes mass edit driven from the host list (Decision 8).
 
-**Declarative half — snapins and printers.** These are set membership. A host
-can hold any number, from any number of sources, and the union is meaningful.
-These **stay with the group**, in new group-owned association tables, and are
-**evaluated, never copied**.
+**Declarative half — snapins, printers and modules.** These are set
+membership. A host can hold any number, from any number of sources, and the
+union is meaningful. These **stay with the group**, in new group-owned
+association tables, and are **evaluated, never copied**. Modules were
+originally put in the imperative half here; Decision 3 records why that was
+wrong and how they joined.
 
 The test that separates them is not "is it a column or a row". `hostPrinterLevel`
 is a column and belongs to the imperative half; `moduleStatusByHost` is a row
-and also belongs to the imperative half (Decision 3). The test is whether two
-sources granting the same thing can be combined without one of them losing.
+and belongs to the declarative one. The test is whether two sources granting
+the same thing can be combined without one of them losing.
+
+Modules pass that test with one extra rule, and it is worth stating here
+because it is what makes a *switch* safe to grant: only a HOST may say OFF. A
+group grant carries no state, so two groups can only union. See Decision 3.
 
 ### 2. Where the empirical list and the group page disagree
 
@@ -187,7 +193,7 @@ Both directions matter, and the disagreements are the interesting part.
 | `hostKernel` / `hostDevice` / `hostInit` | **does not copy** | General tab | mass edit |
 | auto-logout | **does not copy** | `setAlo()`, replaces all rows | mass edit |
 | screen resolution | **does not copy** | `setDisp()`, replaces all rows | mass edit |
-| modules | copies (`msState` and all) | Modules tab, tri-state | mass edit (Decision 3) |
+| modules | copies (`msState` and all) | Modules tab, tri-state | **group-owned** (Decision 3, reversed) |
 | location / OU | copies `locationAssoc` | plugin group hooks | mass edit, plugin field (Decision 9) |
 | snapins | copies **and tasks them** | Snapins tab | **group-owned** |
 | printers | copies including `paIsDefault` | Printers tab | **group-owned** |
@@ -209,13 +215,14 @@ page and are all absent from the trigger. So "cover the persistentgroups list"
 is a floor, not a ceiling: mass edit must cover the **union**, or retiring
 either mechanism is a regression. That union is what Decision 8 sizes against.
 
-### 3. Modules stay in the imperative half — but the reason first given here was wrong
+### 3. Modules are the third declarative grant — reversed, 2026-09-01
 
-**The original argument does not survive contact with the code, and it is
-corrected here rather than quietly dropped, because the correction reopens a
-question this decision had treated as settled.**
+**This decision said the opposite, on a premise that turned out to be false.
+Both the original reasoning and the correction are kept, because the shape of
+the mistake is the useful part: a decision was made on a property of the data
+that nobody had read the data to check.**
 
-What this section said, and what it rested on:
+What this section originally said, and what it rested on:
 
 > ADR 0001 established that a module counts as "had" only when
 > `moduleStatusByHost.msState = 1`, because a module carries an
@@ -224,49 +231,91 @@ What this section said, and what it rested on:
 > module and a second group granting the same module *disabled* is a
 > contradiction with no correct resolution.
 
-**`msState` is vestigial. A disabled association cannot exist.** Verified
-across the whole tree on 2026-09-01:
+**`msState` was vestigial.** Verified across the whole tree on 2026-09-01:
 
-- Every write sets it to **1**. `Group::addModule()` inserts
-  `[$hostid, $moduleid, 1]` (`Items/Group.php:358`), and
-  `FOGController::addRemItem()` appends a literal `1` for any
-  `moduleassociation` insert (`Base/FOGController.php:1922`, `:1933`). There
-  is no code path anywhere that writes `0`.
-- The **schema deletes any that survive**: `DELETE FROM moduleStatusByHost
-  WHERE msState='0'` runs in two separate steps (`commons/schema.php:1497`,
-  `:3352`), so an upgraded database is purged of them as well.
-- The **client ignores it**. `Host::loadModules()` selects `msModuleID` with
-  no state filter (`Items/Host.php:681`), and `ServiceModule` treats presence
-  in that list as enabled (`Client/ServiceModule.php:91-103`). A `0` row, if
-  one somehow existed, would read as ON to the machine.
-- The only reader that filters on it is the group page's tri-state derivation
-  (`Pages/GroupManagement.php:3064`), where — every row being `1` — it is
-  equivalent to "a row exists".
+- Every write set it to **1**. `Group::addModule()` inserted
+  `[$hostid, $moduleid, 1]`, and `FOGController::addRemItem()` appended a
+  literal `1` for any `moduleassociation` insert. No code path wrote `0`.
+- The **schema deleted any that survived**: `DELETE FROM moduleStatusByHost
+  WHERE msState='0'` runs in steps **34** and **231**. Both are historical —
+  a numbered step replays once — so nothing purges such a row today, which is
+  what makes the column usable again.
+- The **client ignored it**. `Host::loadModules()` selected `msModuleID` with
+  no state filter, and `ServiceModule` treated presence in that list as
+  enabled. A `0` row would have read as ON to the machine.
 
-So a module association is a **two-state** thing: the row is there or it is
-not. The contradiction the original argument turned on has no way to arise.
+So the contradiction the original argument turned on had no way to arise. The
+decision was reported to Tom rather than built on, and he reversed it:
 
-**What that means for the decision.** With `msState` out of the picture,
-modules look exactly like snapins: a set of associations with no per-source
-attribution, where a union across sources is as well-defined as it is for a
-snapin, and removing a grant from one group leaves another group's grant
-standing. The declarative reading is therefore **available**, where this
-section previously said it was impossible.
+> *"Build the declarative options. This works similar to snapins/printers but
+> tells hosts what modules are enabled. If a host has explicitly disabled the
+> module that wins (lowest tier wins.)"*
 
-**Modules nonetheless stay imperative in this ADR, and that is now a choice
-rather than a forced move.** The reasons are cost and blast radius, not
-logic: the declarative reading needs a `groupModuleAssoc` table, a schema
-step, a constraint group, a third arm on `Assign\Resolver`, and a change to
-what `ServiceModule` reads — none of which the snapin and printer work
-already pays for. Nothing here is a reason it *could not* be done later, and
-moving modules is purely additive if it is.
+and, on whether a group may itself say *disabled*:
+
+> *"Groups can choose not to include or to include modules, but should not
+> drive enable/disable explicitly... This group says disable, this one says
+> enable, which one wins?"*
+
+**That second answer is the whole design.** A group grant is **presence-only**:
+`groupModuleAssoc` has no state column, so a group either grants a module or
+says nothing about it, and two groups can only ever union. The question with
+no defensible answer is one the schema refuses to let anyone ask.
+
+**Modules are a switch, not a thing, so the resolution has three tiers** where
+snapins and printers have two:
+
+| Tier | Meaning |
+|---|---|
+| host row, `msState = 0` | the host says OFF. Beats everything. |
+| host row, `msState = 1` | the host says ON |
+| group grant | any group the host is in says ON |
+| nothing anywhere | OFF |
+
+Only the host may say OFF — that is "lowest tier wins" as Tom put it.
+
+**"Nothing anywhere" is OFF rather than `modules`.`default`,** because that is
+already what absence means: `ServiceModule::checkPassiveModule()` computes its
+disabled list as `array_diff(globalModules, hostRows)`. Falling back to
+`default` would silently switch modules on across a fleet at upgrade.
+`default` keeps its one job, seeding a newly registered host's rows.
+
+**Nothing changes for an existing install until someone turns a module off.**
+`groupModuleAssoc` ships empty and nothing is migrated (matching Decision 18
+for printers); every existing row carries state 1; and a row meaning OFF is
+new, so no upgraded database has one.
+
+**What was built, in order:**
+
+| Unit | PR |
+|---|---|
+| `groupModuleAssoc`, constraint group 10, `msState` → `tinyint(1) DEFAULT 1` (step 409) | #1629 |
+| `Assign\Resolver::resolveModules()`, the three tiers | #1632 |
+| the client paths read the resolved list; `get('modules')` stays host-direct | #1633 |
+| `addRemItem()`'s module special case removed, the default now supplies it | #1634 |
+
+**`get('modules')` deliberately stays host-direct.** Route's host update arm
+diffs against it, so a resolved value there would write a host row for every
+grant — turning a grant back into a copy, which is the one thing this ADR
+exists to prevent. `Host::resolvedModules()` is the separate, explicit
+accessor the client protocol reads.
+
+**Still to come, and gated the same way snapins and printers are.** Nothing
+writes `groupSnapinAssoc` or `groupPrinterAssoc` yet either — `Group::
+addSnapin()` and `addPrinter()` are still the imperative copy-to-members
+versions, and converting them is Decision 10's unit E, which removes
+functionality and needs signoff. `Group::addModule()` stays imperative for
+exactly that reason: converting it alone would put modules ahead of the other
+two and leave the group page granting on one tab and copying on the next. The
+host Modules tab also has to become genuinely tri-state before a host can
+express OFF at all — today unticking deletes the row, which under this design
+means "unstated" and would let a group grant re-enable it.
 
 ADR 0001's closing sentence anticipated the opposite migration ("if snapins or
 printers ever gain a per-host enabled/disabled state, they should converge on
-the module rule"). That fork is now moot in the direction it named — the
-module rule's distinguishing state is not real — and ADR 0001's own
-description of it (`docs/adr/0001-group-association-state.md:24`) should be
-read with this section beside it.
+the module rule"). That fork is moot in the direction it named — the module
+rule's distinguishing state was not real — and the convergence went the other
+way: modules joined snapins and printers.
 
 ### 4. Snapins resolve at task creation, and the snapshot already exists
 
@@ -1123,10 +1172,12 @@ semantics gate, which is the second reason the boundary is not one.
   surprised.** This is the documentation obligation in Decision 4 and it is the
   most likely support question this change generates.
 - **ADR 0001 becomes half-true and stays in force.** Its tri-state derivation
-  is still how the group page reports member state for modules; its premise
-  that a group owns nothing is no longer true for snapins and printers. The
-  file gets an amendment note rather than a rewrite, because the module
-  asymmetry it argues for is what Decision 3 relies on.
+  is still how the group page reports member state for modules, and will be
+  until unit E reworks that page. Its premise that a group owns nothing is no
+  longer true for snapins, printers or modules. The file gets an amendment
+  note rather than a rewrite -- and the note has to say that the module
+  asymmetry it argues for is NOT real, since Decision 3 was reversed on
+  exactly that finding.
 - **`GROUP_SHARED_STATE.md` becomes the mass edit document.** Most of it
   survives the move — the no-clobber convention becomes the three-state
   convention (Decision 11), the `Hosts: (varies)` hint becomes the selection

--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -726,10 +726,16 @@ serialize through conflicts anyway.
 | C5a | The three-state action model (`FOG\Util\MassEdit`) | new `src/Util/MassEdit.php` | B | **merged** (#1622) |
 | C5b | The apply endpoint | `Pages/HostManagement.php` | C5a | **merged** (#1623) |
 | C5c | Every `hosts` column ADR 0038 sends to mass edit | `Pages/HostManagement.php` | C5b | **merged** (#1625) |
-| C5d | The row-backed settings + composite values | `Util/MassEdit.php`, `Items/HostAutoLogout.php` | C5c | open (#1626) |
-| C5e | The form, the modal, and `HOST_MASSEDIT_FIELDS` | `Pages/HostManagement.php`, `Base/FOGPage.php`, `Util/SharedHostValues.php`, `fog.host.list.js`, `docs/plugin-development.md` | C5d | open |
+| C5d | The row-backed settings + composite values | `Util/MassEdit.php`, `Items/HostAutoLogout.php` | C5c | **merged** (#1626) |
+| C5e | The form, the modal, and `HOST_MASSEDIT_FIELDS` | `Pages/HostManagement.php`, `Base/FOGPage.php`, `Util/SharedHostValues.php`, `fog.host.list.js`, `docs/plugin-development.md` | C5d | **merged** (#1628) |
+| C5f | Mass edit button moved beside "Delete selected" | `Base/FOGPage.php`, `Pages/HostManagement.php` | C5e | **merged** (#1631) |
+| M1 | `groupModuleAssoc`, constraint group 10, `msState` → tinyint (step 409) | `commons/schema.php`, `commons/schema-constraints.php`, `Base/System.php` | A | **merged** (#1629) |
+| M2 | `Resolver::resolveModules()`, the three tiers | `Assign/Resolver.php` | M1 | **merged** (#1632) |
+| M3 | Client paths read the resolved list; `checkPassiveModule` fix | `Items/Host.php`, `Client/ServiceModule.php`, `Client/FOGClient.php`, `Base/FOGPage.php` | M2 | open (#1633) |
+| M4 | `addRemItem()` module special case removed; auto-logout minimum named once | `Base/FOGController.php`, `Pages/HostManagement.php` | M3 | open (#1634) |
+| M5 | Host Modules tab becomes genuinely tri-state, so a host can say OFF | `Pages/HostManagement.php`, JS | M4 | not started |
 | D | Presentation: groups column + filter, bulk add/remove, group list "grants" | `Router/Route.php`, `Base/FOGManagerController.php`, `Pages/HostManagement.php`, JS | C5 | not started |
-| E | Group page rework + removal of the imperative tabs | `Pages/GroupManagement.php`, JS | **C5 proven** (Decision 10), D | not started |
+| E | Group page rework + removal of the imperative tabs, and `Group::addSnapin`/`addPrinter`/`addModule` become grants | `Pages/GroupManagement.php`, `Items/Group.php`, JS | **C5 proven** (Decision 10), D, M5 | not started |
 
 C5 split into five as it was built. The split is by what each piece can be
 tested against on its own -- the action model with no endpoint, the endpoint

--- a/docs/release/1.6.0-release-notes.DRAFT.md
+++ b/docs/release/1.6.0-release-notes.DRAFT.md
@@ -227,7 +227,7 @@ pre-upgrade *dump* — it is not a schema rollback.
   disagreement is logged, so nothing is lost silently.
 - **The `accesscontrol` plugin is retired**, replaced by native RBAC. Its
   registration row is removed during the upgrade.
-- **A group's snapins and printers are now grants rather than copies.** A
+- **A group's snapins, printers and modules are now grants rather than copies.** A
   group no longer copies rows onto whichever hosts happened to be members when
   you pressed the button; it holds the assignment itself, so a host added to
   the group later is covered by it and a host removed stops being covered.
@@ -250,6 +250,23 @@ pre-upgrade *dump* — it is not a schema rollback.
   group's printers therefore reaches its members on their next check-in with
   no re-tasking. A host's own default printer beats a group's; otherwise the
   default comes from the first group in order that names one.
+
+  **Modules are granted too, with one extra rule: only a HOST may turn one
+  off.** A group either grants a module or says nothing about it -- it cannot
+  say "disabled" -- so two groups can never contradict each other, and there
+  is no "this group says on, that one says off, which wins" to resolve. A host
+  that has explicitly disabled a module keeps it disabled no matter how many
+  groups grant it. Lowest tier wins.
+
+  Nothing changes on an existing server until you use it: no group grants any
+  module yet, every host keeps exactly the modules it had, and a module
+  nothing mentions is off, which is what it already was.
+
+  **Also fixed along the way:** `servicemodule-active.php` -- the endpoint a
+  client asks "is this module enabled for me" -- has been answering *no* for
+  every module on every host for the whole of 1.6. It looked the module's
+  short name up on the wrong class, which could never answer, and an empty
+  answer reads as "everything is disabled".
 
   On printer level `ar` ("FOG Handles all printers") the list the server sends
   is authoritative in both directions -- the client removes every installed

--- a/packages/web/src/Base/FOGController.php
+++ b/packages/web/src/Base/FOGController.php
@@ -1916,23 +1916,25 @@ abstract class FOGController extends FOGBase
             $assocstr
         ];
         $insert_values = [];
-        if ($assocstr == 'moduleID'
-            || strtolower($classCall) == 'moduleassociation'
-        ) {
-            $insert_fields[] = 'state';
-        }
-
+        // No special case for module associations any more. This used to
+        // append an explicit `state` of 1 to every module row, because
+        // `moduleStatusByHost`.`msState` was a varchar(1) NOT NULL DEFAULT
+        // '' -- an insert that omitted it wrote the empty string. Schema step
+        // 409 makes the column tinyint(1) NOT NULL DEFAULT 1, so the database
+        // supplies the same value and one generic insert covers every
+        // association table.
+        //
+        // The default is load-bearing, not cosmetic: under ADR 0038 a state
+        // of 0 is a host saying OFF, which beats every group grant. If the
+        // DEFAULT is ever dropped or changed, this insert starts writing the
+        // strongest statement in the system by accident. That pairing is
+        // pinned in tests/assign-resolver.test.php, which inserts a row
+        // omitting the column against the real DDL and reads it back.
         foreach ($diff as $id) {
-            $insert_val = [
+            $insert_values[] = [
                 $this->get('id'),
                 $id
             ];
-            if ($assocstr == 'moduleID'
-                || strtolower($classCall) == 'moduleassociation'
-            ) {
-                $insert_val[] = 1;
-            }
-            $insert_values[] = $insert_val;
         }
 
         // Perform batch insertion if there are values to insert.

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -2816,7 +2816,13 @@ class HostManagement extends FOGPage
         }
         if (isset($_POST['confirmalosend'])) {
             $tme = (int)filter_input(INPUT_POST, 'tme');
-            if (!(is_numeric($tme) && $tme > 4)) {
+            // HostAutoLogout::MIN_MINUTES, not the literal it was spelled as.
+            // The same rule is stated in three other places -- the host page's
+            // own validator, the group page's constant, and the data-alo-min
+            // the group form hands the browser -- and this was the one copy
+            // that would not move if the minimum ever changed. Below the
+            // minimum means OFF, which is the existing behavior.
+            if ($tme < HostAutoLogout::MIN_MINUTES) {
                 $tme = 0;
             }
             $this->obj->setAlo($tme);

--- a/tests/assign-resolver.test.php
+++ b/tests/assign-resolver.test.php
@@ -474,6 +474,34 @@ $check(
     array_key_exists(12, $mods) && ($mods[12] ?? null) === []
 );
 
+/*
+ * THE DEFAULT ON msState IS LOAD-BEARING.
+ *
+ * FOGController::addRemItem() used to append an explicit `state` of 1 to
+ * every module row, because the column was a varchar(1) NOT NULL DEFAULT ''
+ * and an insert that omitted it wrote the empty string. Schema step 409 made
+ * it tinyint(1) NOT NULL DEFAULT 1, so that special case was removed and the
+ * database now supplies the value.
+ *
+ * Which means the DEFAULT and the generic insert are one mechanism held in
+ * two files. Under ADR 0038 a state of 0 is a host saying OFF and beats every
+ * group grant, so if the default is ever dropped or flipped, every module
+ * added through the generic path silently becomes the strongest statement in
+ * the system -- and nothing would fail. This inserts a row the way
+ * addRemItem() now does, against the REAL DDL out of the manifest, and reads
+ * the answer back through the resolver rather than off the column: what
+ * matters is not that the column says 1, it is that the module comes out
+ * enabled.
+ */
+$pdo->exec(
+    "INSERT INTO `moduleStatusByHost` (`msHostID`,`msModuleID`) VALUES (12,960)"
+);
+$defaulted = \FOG\Assign\Resolver::resolveModules([12]);
+$check(
+    'a module row inserted without a state resolves as enabled',
+    ($defaulted[12] ?? []) === [960]
+);
+
 // The decision-9 gate again, on the table this resolver added. Same reason:
 // under the client's module protocol an empty answer is a legitimate "all
 // modules off", so a read that fails silently switches the fleet off rather

--- a/tests/auto-logout-minimum-has-one-spelling.test.php
+++ b/tests/auto-logout-minimum-has-one-spelling.test.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * The auto-logout minimum is stated once and read everywhere.
+ *
+ * `HostAutoLogout::MIN_MINUTES` is the rule: below it, auto-logout is OFF.
+ * It is consulted from four places -- the host page's validator, the host
+ * page's own POST handler, the group page's constant, and the `data-alo-min`
+ * the group form hands the browser -- and one of them spelled it as the
+ * literal `$tme > 4`. A magic number is not wrong until the constant moves,
+ * at which point three surfaces change and one silently does not, and the
+ * symptom is a value the form accepts and the save discards.
+ *
+ * SOURCE-ANCHORED, deliberately. The behavior is identical either way while
+ * the constant is 5 -- that is the whole reason the drift is invisible -- so
+ * a behavioral assertion here would pass against the literal it exists to
+ * forbid. What can be checked is that no second spelling exists.
+ *
+ * Usage: php tests/auto-logout-minimum-has-one-spelling.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$webroot = dirname(__DIR__) . '/packages/web';
+
+$checks = 0;
+$failures = [];
+$check = static function ($what, $ok) use (&$checks, &$failures) {
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+};
+
+$item = (string)@file_get_contents(
+    $webroot . '/src/Items/HostAutoLogout.php'
+);
+$check(
+    'HostAutoLogout declares the minimum',
+    1 === preg_match('/const MIN_MINUTES = (\d+);/', $item, $m)
+        && (int)$m[1] > 0
+);
+
+/*
+ * Every comparison of a submitted auto-logout time must name the constant.
+ * `$tme` is the field name on both pages' forms, so a comparison against a
+ * bare number is the drift this file is for.
+ */
+$pages = [
+    'src/Pages/HostManagement.php',
+    'src/Pages/GroupManagement.php',
+];
+foreach ($pages as $rel) {
+    $src = (string)@file_get_contents($webroot . '/' . $rel);
+    $check(
+        basename($rel) . ' compares $tme against a named minimum, not a literal',
+        0 === preg_match('/\$tme\s*[<>]=?\s*\d/', $src)
+    );
+    $check(
+        basename($rel) . ' still gates on the auto-logout minimum at all',
+        false !== strpos($src, 'MIN_MINUTES')
+    );
+}
+
+// The group page hands the same number to the browser. A form that lets a
+// value through which the save then discards is the visible half of this
+// drift, so the attribute has to come from the constant too.
+$group = (string)@file_get_contents(
+    $webroot . '/src/Pages/GroupManagement.php'
+);
+$check(
+    'the group form gets data-alo-min from the constant',
+    1 === preg_match(
+        '/data-alo-min="\'\s*\.\s*self::ALO_MIN_MINUTES/',
+        $group
+    )
+);
+$check(
+    'the group page aliases the constant rather than restating it',
+    1 === preg_match(
+        '/const ALO_MIN_MINUTES = HostAutoLogout::MIN_MINUTES;/',
+        $group
+    )
+);
+
+if (count($failures)) {
+    fwrite(STDERR, "FAIL: the auto-logout minimum has drifted:\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    fwrite(
+        STDERR,
+        sprintf("%d of %d checks failed\n", count($failures), $checks)
+    );
+    exit(1);
+}
+
+printf(
+    "PASS  auto-logout minimum has one spelling: %d checks\n",
+    $checks
+);
+exit(0);

--- a/tests/host-modules-are-resolved.test.php
+++ b/tests/host-modules-are-resolved.test.php
@@ -179,6 +179,32 @@ $check(
     && false === strpos($host, "'modulesResolved'")
 );
 
+/*
+ * 9. The generic association insert stays generic. addRemItem() used to
+ * append an explicit `state` of 1 for module rows, because the column was a
+ * varchar(1) NOT NULL DEFAULT '' and an omitted value wrote the empty
+ * string. Schema step 409 made it tinyint(1) NOT NULL DEFAULT 1, so the
+ * database supplies it and the special case is gone.
+ *
+ * Pinned on the source because the BEHAVIOR is indistinguishable: writing 1
+ * explicitly and letting the default write 1 produce the same row. What this
+ * catches is the special case coming back with a different value in it --
+ * and under ADR 0038, 0 is a host saying OFF and beats every group grant.
+ * That the default itself is 1 is pinned behaviorally, against the real DDL,
+ * in tests/assign-resolver.test.php.
+ */
+$controller = (string)@file_get_contents(
+    $webroot . '/src/Base/FOGController.php'
+);
+$check(
+    'addRemItem() has no module special case left',
+    false === strpos($controller, "\$assocstr == 'moduleID'")
+        && false === strpos(
+            $controller,
+            "strtolower(\$classCall) == 'moduleassociation'"
+        )
+);
+
 if (count($failures)) {
     fwrite(STDERR, "FAIL: the module read path is wrong:\n");
     foreach ($failures as $f) {


### PR DESCRIPTION
Docs only, on top of #1634. Decision 3 of ADR 0038 said modules could not be declarative because a module carries an enabled/disabled state that snapins and printers do not. **That premise was false** — `msState` was vestigial — and Tom reversed the decision on that finding. The documents that carried the old argument are the ones that have to say so.

### ADR 0038 decision 3, rewritten in place

It keeps **both** the original reasoning and the correction, because the shape of the mistake is the useful part: a decision made on a property of the data that nobody had read the data to check.

It now records Tom's two rulings verbatim — *build it*, and *a group may not say "disabled"* — the three-tier resolution, why "nothing anywhere" is OFF rather than `modules.default`, what shipped in which PR, and why `Group::addModule()` stays imperative for now.

**One factual correction inside it.** The two `DELETE ... WHERE msState='0'` statements are schema steps **34** and **231**. Both are historical — a numbered step replays once — so nothing purges such a row today, which is precisely what makes the column usable again. The earlier note cited them as though they were a standing purge, which would have made the whole design unworkable if it were true.

### Also updated

- the declarative/imperative split at the top of ADR 0038, which named `moduleStatusByHost` as imperative
- the consequences bullet about ADR 0001, which said the module asymmetry is what decision 3 *relies on*
- **ADR 0001's** own correction note, which said a disabled override cannot exist. It could not, and now it is the point; its *"toggling to All flips state 0 → 1"* line is marked superseded for modules
- `docs/GROUP_SHARED_STATE.md`, the same two places
- the unit table in `docs/development/group-split.md` gains M1–M5, and unit E gains `Group::addSnapin`/`addPrinter`/`addModule` — which is where the group *write* path actually converts
- the 1.6.0 release notes: modules join the grants bullet, with the only-a-host-may-say-off rule, the "nothing changes until you use it" reassurance, and the `servicemodule-active.php` fix

### Why `Group::addModule()` is not converted here

Nothing writes `groupSnapinAssoc` or `groupPrinterAssoc` either — `Group::addSnapin()` and `addPrinter()` are still the imperative copy-to-members versions, and converting them is unit E, which removes functionality and needs signoff. Converting modules alone would put them **ahead** of the other two and leave the group page granting on one tab and copying on the next. Modules are now exactly level with snapins and printers: grant table, resolver, reads.

### Verification

`tests/run-all.sh`: 291 passed, 0 failed (including `us-spelling`).