### PR TITLE
Diagnose before resetting, detach instead of moving a branch ref, and four more

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -322,6 +322,28 @@ if [[ -d ${gitpath}/.git ]]; then
     echo " | To move an existing install to another channel, use:"
     echo " |   cd ${gitpath}/bin && ./updatefog.sh --channel ${channel}"
     echo
+    # FETCH FIRST, and this is not optional on this path.
+    #
+    # The checkout below is the same line for a fresh clone and for a
+    # pre-existing one, and a pre-existing one may not have heard of the branch
+    # being asked for. Two ways that went wrong, both silent about the real
+    # cause:
+    #
+    #   --channel rc resolves against the REMOTE, so it can name rc-1.6.4 while
+    #   this clone has never fetched it -- the checkout then failed with
+    #   "the branch may have been renamed", which is not what happened.
+    #
+    #   A stale local `stable` checks out perfectly well and bootstrap installs
+    #   a months-old tree while reporting success, which is worse.
+    echo -n " * Fetching ${gitpath}... "
+    if git -C "$gitpath" fetch --all --prune >/dev/null 2>&1; then
+        echo "Done"
+    else
+        echo "Failed"
+        echo " | Could not fetch. Continuing with what is already in the"
+        echo " | checkout -- if the install turns out to be an old version,"
+        echo " | this is why."
+    fi
 else
     if [[ -e $gitpath && -n $(ls -A "$gitpath" 2>/dev/null) ]]; then
         fail "${gitpath} exists and is not empty, but is not a git checkout." \

--- a/bin/updatefog.sh
+++ b/bin/updatefog.sh
@@ -281,13 +281,39 @@ fi
 # installfog.sh asks anything the working copy has already moved. --yes skips
 # both.
 if [[ -z $autoYes ]]; then
+    # Refuse before asking, when there is nobody to ask.
+    #
+    # `read` gets EOF from cron or the GUI, confirmGo comes back empty, the
+    # catch-all arm below fired and this exited 0 -- so the caller recorded a
+    # successful update that never happened. A scheduled job reporting success
+    # forever is worse than one reporting a failure, because nobody looks at
+    # the first kind.
+    #
+    # The tty is tested by OPENING it, not by [[ -t 0 ]]: stdin can be
+    # redirected for perfectly ordinary reasons while a terminal is still
+    # there to prompt on, and /dev/tty exists in contexts where opening it
+    # fails with ENXIO.
+    if ! (exec < /dev/tty) 2>/dev/null; then
+        echo " * No terminal is available to confirm this update on, and --yes"
+        echo " | was not given, so nothing has been changed."
+        echo " |"
+        echo " | Pass -y/--yes to run unattended, which is what cron and the"
+        echo " | web UI should do."
+        exit 7
+    fi
     echo -n " * Continue with this update? (Y/N) "
     read confirmGo
     case $confirmGo in
         [Yy] | [Yy][Ee][Ss]) ;;
-        *)
+        # A deliberate "no" is not a failure, so it stays exit 0. The EOF case
+        # above never reaches here.
+        [Nn] | [Nn][Oo])
             echo " * Update canceled."
             exit 0
+            ;;
+        *)
+            echo " * Answer not recognized -- update canceled."
+            exit 3
             ;;
     esac
 fi

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -267,7 +267,7 @@ offerRevert() {
     # install is fixed. Detaching moves only HEAD, which is all that is wanted:
     # the next updatefog.sh run checks out a branch again anyway.
     #
-    # This is a different judgement from gitUpdateToBranch, which keeps
+    # This is a different judgment from gitUpdateToBranch, which keeps
     # reset --hard deliberately -- there it is discarding local mess to make an
     # update possible, here it is navigating history.
     echo " * This install did not finish, and the checkout has moved since the"

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -234,17 +234,46 @@ markInstallCommit() {
 # nothing to go back to -- in both cases the failure is not about the code
 # having changed, so pointing at git would be a wrong diagnosis.
 offerRevert() {
-    local status=$1 head
+    local status=$1 head recorded
     [[ $status -eq 0 ]] && return 0
-    [[ -n ${FOG_last_good_commit} ]] || return 0
     [[ -d ${FOG_git_path}/.git ]] || return 0
+
+    # Read back off disk, NOT from $FOG_last_good_commit in memory.
+    #
+    # markInstallCommit() sets the in-memory value before writeUpdateFile()
+    # persists it -- it has to, because writeUpdateFile emits the file FROM
+    # that variable. So if anything between the two fails, including
+    # writeUpdateFile itself, memory already holds the current HEAD and a
+    # comparison against it finds them equal and says nothing. That is exactly
+    # the run this function exists for.
+    #
+    # .fogsettings is the honest answer: it still names the last commit that
+    # actually got as far as being written down. On a run that succeeded it
+    # holds HEAD, and the comparison below correctly stays quiet.
+    # No back-reference: strip the key, then the quoting. Simpler to read and
+    # immune to the escaping accidents a capture group invites here.
+    recorded=$(sed -n 's/^FOG_last_good_commit=//p' \
+        "${fogprogramdir}/.fogsettings" 2>/dev/null | tr -d "\"' " | tail -n1)
+    [[ -n $recorded ]] || return 0
+
     head=$(git -C "${FOG_git_path}" rev-parse HEAD 2>/dev/null) || return 0
-    [[ -z $head || $head == ${FOG_last_good_commit} ]] && return 0
+    [[ -z $head || $head == $recorded ]] && return 0
     echo
+    # --detach, not `reset --hard`. The case this exists for is an update that
+    # switched channels and then failed, so the checkout is on (say)
+    # working-1.6 while the last good commit belongs to stable -- and
+    # `reset --hard` would point the working-1.6 REF at a stable commit,
+    # leaving a diverged branch that git status complains about long after the
+    # install is fixed. Detaching moves only HEAD, which is all that is wanted:
+    # the next updatefog.sh run checks out a branch again anyway.
+    #
+    # This is a different judgement from gitUpdateToBranch, which keeps
+    # reset --hard deliberately -- there it is discarding local mess to make an
+    # update possible, here it is navigating history.
     echo " * This install did not finish, and the checkout has moved since the"
     echo " | last one that did. To put the code back where it was and re-run:"
     echo " |"
-    echo " |     git -C ${FOG_git_path} reset --hard ${FOG_last_good_commit}"
+    echo " |     git -C ${FOG_git_path} checkout --detach ${recorded}"
     echo " |     cd ${FOG_git_path}/bin && ./installfog.sh"
     echo " |"
     echo " | Nothing has been reverted for you. Your customizations were already"
@@ -470,11 +499,22 @@ backupPreservedCustomizations() {
     # So: back up (live directory) minus (what the source tree ships). No
     # guessing, and a fully custom name is covered however it got there.
     [[ -z ${BOOT_kernel_backups_kept} || ! ${BOOT_kernel_backups_kept} =~ ^[0-9]+$ || ${BOOT_kernel_backups_kept} -lt 1 ]] && BOOT_kernel_backups_kept=3
-    local kbdir="${customizationsDir}/kernel-backups" k kf bn
+    local kbdir="${customizationsDir}/kernel-backups" k kf bn n
     local shippeddir="${webdirsrc%/}/service/ipxe"
     if [[ -d $ipxedir ]]; then
         mkdir -p "$kbdir" >>$error_log 2>&1 || warn=1
-        rm -rf "${kbdir}/gen-${BOOT_kernel_backups_kept}" >>$error_log 2>&1
+        # Every generation at or above the retention, not just gen-N. Lowering
+        # --kernel-backup-count from 5 to 3 used to leave gen-4 and gen-5 on
+        # disk forever: outside the rotation loop below, so never shifted and
+        # never pruned, frozen at whatever they last held -- while
+        # restorekernel.sh --list went on offering them as though they were
+        # current snapshots.
+        for k in "${kbdir}"/gen-*; do
+            [[ -d $k ]] || continue
+            n="${k##*/gen-}"
+            [[ $n =~ ^[0-9]+$ ]] || continue
+            [[ $n -ge ${BOOT_kernel_backups_kept} ]] && rm -rf "$k" >>$error_log 2>&1
+        done
         # GH-1579: rotate on BOOT_kernel_backups_kept, not on the retired
         # pre-GH-1120 spelling kernelBackupGenerations. That name now survives
         # only as a migration source (see migrateDeprecatedKeys) and in the

--- a/lib/common/update.sh
+++ b/lib/common/update.sh
@@ -48,11 +48,75 @@ gitUpdateToBranch() {
     st=$?
     errorStat $st
     [[ $st -ne 0 ]] && return 1
+    # WHY THERE IS A LADDER HERE AND NOT JUST A RESET
+    #
+    # `git reset --hard` stays, and stays as the last rung, because the tree
+    # genuinely can be unclean in ways an ordinary checkout cannot survive --
+    # the reference case being a `chmod -R` over a parent directory, which
+    # leaves every file looking modified to git and makes a plain pull fail.
+    # Refusing there would strand exactly the server that most needs updating.
+    #
+    # What was wrong was doing it unconditionally and silently. A clean tree
+    # needs no reset at all, and a dirty one deserves to have its contents
+    # named before they are discarded -- an admin who edited something inside
+    # the checkout should be able to read what went, not discover it later.
+    #
+    # So: clean tree, no reset. Dirty tree, say what is dirty, then reset.
+    local dirty modecount total
+    dirty=$(git -C "${FOG_git_path}" status --porcelain 2>>$error_log)
+
     dots "Checking out ${branch}"
     git -C "${FOG_git_path}" checkout "$branch" >>$error_log 2>&1
     st=$?
     errorStat $st
-    [[ $st -ne 0 ]] && return 1
+    if [[ $st -ne 0 && -z $dirty ]]; then
+        # A clean tree that will not check out is not the case reset --hard
+        # was put here for, and hiding a real git failure behind it would be
+        # the worst of both.
+        echo " * Could not check out ${branch}, and the working tree is clean --"
+        echo " | so this is not a local-modification problem. See $error_log."
+        return 1
+    fi
+
+    if [[ -z $dirty ]]; then
+        # Nothing to discard. The reset would be a no-op against a tree that
+        # already matches, so skip it and say nothing.
+        dots "Fast-forwarding to origin/${branch}"
+        git -C "${FOG_git_path}" merge --ff-only "origin/${branch}" >>$error_log 2>&1
+        st=$?
+        errorStat $st
+        [[ $st -eq 0 ]] && return 0
+        # A clean tree that will not fast-forward means the branch has been
+        # rewritten upstream (a force-push, or a rebased rc-*). Falling through
+        # to the reset is right, and now it is the only thing left to try.
+        echo " * origin/${branch} is not a fast-forward from here, so the"
+        echo " | checkout is being reset onto it."
+    else
+        total=$(printf '%s
+' "$dirty" | grep -c .)
+        # Permission-only noise is its own case and has its own fix. A
+        # `chmod -R` over a parent leaves every tracked file modified with no
+        # content change at all, and `core.fileMode false` addresses that
+        # surgically -- worth saying, because the reset below will "fix" it
+        # once and it will come back the next time someone runs chmod.
+        modecount=$(git -C "${FOG_git_path}" diff --summary 2>/dev/null | grep -c 'mode change')
+        echo " * The checkout has ${total} local change(s), which are about to be discarded:"
+        printf '%s
+' "$dirty" | sed 's/^/ |   /' | head -n 20
+        [[ $total -gt 20 ]] && echo " |   ... and $((total - 20)) more"
+        if [[ $modecount -gt 0 ]]; then
+            echo " |"
+            echo " | ${modecount} of these are permission changes with no content change,"
+            echo " | which usually means a chmod ran over a parent directory. If that"
+            echo " | keeps happening, git config --global core.fileMode false stops git"
+            echo " | reporting it, and is a better fix than resetting every update."
+        fi
+        echo " |"
+        echo " | The full list is in $error_log."
+        printf '%s
+' "$dirty" >> "$error_log"
+    fi
+
     dots "Resetting to origin/${branch}"
     git -C "${FOG_git_path}" reset --hard "origin/${branch}" >>$error_log 2>&1
     st=$?

--- a/tests/kernel-backup-rotation.test.sh
+++ b/tests/kernel-backup-rotation.test.sh
@@ -142,6 +142,29 @@ check "a retention of 5 prunes gen-6" \
     "$([[ ! -d $kbdir/gen-6 ]]; echo $?)"
 
 # ---------------------------------------------------------------------------
+# LOWERING the retention prunes what is now above it.
+#
+# The prune used to remove only gen-N, so going from 5 to 3 left gen-4 and
+# gen-5 on disk forever: above the rotation loop, so never shifted and never
+# pruned again, frozen at whatever they last held -- while restorekernel.sh
+# --list went on offering them as current snapshots.
+# ---------------------------------------------------------------------------
+BOOT_kernel_backups_kept=3
+install lowered
+
+check "lowering the retention prunes gen-4" \
+    "$([[ ! -d $kbdir/gen-4 ]]; echo $?)"
+
+check "and gen-5" \
+    "$([[ ! -d $kbdir/gen-5 ]]; echo $?)"
+
+check "while keeping what is still inside the new retention" \
+    "$([[ -d $kbdir/gen-1 && -d $kbdir/gen-2 ]]; echo $?)"
+
+check "and gen-1 still holds the newest snapshot" \
+    "$([[ $(cat "$kbdir/gen-1/marker" 2>/dev/null) == lowered ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
 # A retention of 1 must not fall into the same off-by-one from the other side:
 # the loop is skipped legitimately here, and gen-1 is simply replaced.
 # ---------------------------------------------------------------------------

--- a/tests/revert-offer.test.sh
+++ b/tests/revert-offer.test.sh
@@ -75,6 +75,25 @@ eval "$snippet"
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
+# offerRevert reads the RECORDED commit out of .fogsettings rather than the
+# in-memory variable, so the fixture has to be a file. That indirection is the
+# point: markInstallCommit necessarily sets the variable before
+# writeUpdateFile persists it -- writeUpdateFile emits the file FROM the
+# variable -- so a failure between the two leaves memory holding HEAD while
+# disk still names the last commit that actually got written down.
+fogprogramdir="$work/opt"
+mkdir -p "$fogprogramdir"
+
+# An empty argument removes the record entirely, standing in for a fresh
+# install that has never written one.
+record() {
+    if [[ -z $1 ]]; then
+        rm -f "$fogprogramdir/.fogsettings"
+        return 0
+    fi
+    printf "FOG_last_good_commit='%s'\n" "$1" > "$fogprogramdir/.fogsettings"
+}
+
 # A throwaway checkout with two commits, so there is a real "previous" one.
 FOG_git_path="$work/repo"
 mkdir -p "$FOG_git_path"
@@ -92,9 +111,20 @@ second=$(git -C "$FOG_git_path" rev-parse HEAD)
 # markInstallCommit records HEAD, and never fails a run that has no commit.
 # ---------------------------------------------------------------------------
 unset FOG_last_good_commit
+record ""
 markInstallCommit
 check "markInstallCommit records the current HEAD" \
     "$([[ $FOG_last_good_commit == "$second" ]]; echo $?)"
+
+# THE CASE THE DISK READ EXISTS FOR.
+#
+# markInstallCommit has just set the in-memory value to HEAD, and the run then
+# fails before writeUpdateFile gets the file written -- so .fogsettings still
+# names the previous good commit. Comparing against memory would find
+# HEAD == HEAD and stay silent on exactly the run that needed the offer.
+record "$first"
+check "a stale in-memory value does not silence the offer" \
+    "$(grep -q "checkout --detach ${first}" <<< "$(offerRevert 1)"; echo $?)"
 
 notarepo="$work/tarball"
 mkdir -p "$notarepo"
@@ -106,14 +136,22 @@ check "a tarball install records nothing and does not fail" "$?"
 # ---------------------------------------------------------------------------
 # The offer fires exactly once: failed run, recorded commit, HEAD moved.
 # ---------------------------------------------------------------------------
-FOG_last_good_commit="$first"
+record "$first"
 out=$(offerRevert 1)
 
 check "a failed run with a moved HEAD prints an offer" \
-    "$(grep -q 'reset --hard' <<< "$out"; echo $?)"
+    "$(grep -q 'checkout --detach' <<< "$out"; echo $?)"
 
 check "it names the RECORDED commit, not HEAD" \
-    "$(grep -q "reset --hard ${first}" <<< "$out"; echo $?)"
+    "$(grep -q "checkout --detach ${first}" <<< "$out"; echo $?)"
+
+# --detach rather than `reset --hard`, which would point the CURRENT branch
+# ref at the commit. The case this exists for is an update that switched
+# channels and then failed, so the checkout is on working-1.6 while the good
+# commit belongs to stable -- resetting there leaves a diverged branch that
+# outlives the problem it was fixing.
+check "it does not suggest moving the current branch ref" \
+    "$(! grep -q 'reset --hard' <<< "$out"; echo $?)"
 
 check "it names the checkout to run git in" \
     "$(grep -q -- "-C ${FOG_git_path}" <<< "$out"; echo $?)"
@@ -132,19 +170,19 @@ check "the file on disk is untouched" \
 # And the silence. Each of these is a case where naming git would be a wrong
 # diagnosis.
 # ---------------------------------------------------------------------------
-FOG_last_good_commit="$first"
+record "$first"
 check "a SUCCESSFUL run offers nothing" \
     "$([[ -z $(offerRevert 0) ]]; echo $?)"
 
-FOG_last_good_commit="$second"
+record "$second"
 check "a re-run at the same commit offers nothing" \
     "$([[ -z $(offerRevert 1) ]]; echo $?)"
 
-unset FOG_last_good_commit
+record ""
 check "a first install, with nothing recorded, offers nothing" \
     "$([[ -z $(offerRevert 1) ]]; echo $?)"
 
-FOG_last_good_commit="$first"
+record "$first"
 check "a checkout that is not a git tree offers nothing" \
     "$([[ -z $(FOG_git_path="$notarepo" offerRevert 1) ]]; echo $?)"
 
@@ -299,6 +337,33 @@ logAt=$(grep -n '^error_log=' <<< "$u" | head -1 | cut -d: -f1)
 firstUse=$(grep -n '[$]error_log' <<< "$u" | head -1 | cut -d: -f1)
 check "and sets it before its first use" \
     "$([[ -n $logAt && -n $firstUse && $logAt -lt $firstUse ]]; echo $?)"
+
+
+# ---------------------------------------------------------------------------
+# A run with nobody to answer must not report success.
+#
+# `read confirmGo` gets EOF from cron or the web UI, confirmGo comes back
+# empty, and the catch-all arm used to print "Update canceled." and exit 0 --
+# so the caller recorded a successful update that never happened. A scheduled
+# job reporting success forever is worse than one reporting a failure, because
+# nobody looks at the first kind.
+# ---------------------------------------------------------------------------
+check "updatefog.sh refuses when there is no terminal to confirm on" \
+    "$(grep -q 'exec < /dev/tty' <<< "$u"; echo $?)"
+
+# Before the git work, not after it: refusing once the checkout has moved
+# leaves the server on a different commit than its install.
+ttyAt=$(grep -n 'exec < /dev/tty' <<< "$u" | head -1 | cut -d: -f1)
+gitAt2=$(grep -n 'gitUpdateToBranch' <<< "$u" | head -1 | cut -d: -f1)
+check "and refuses before the checkout is moved" \
+    "$([[ -n $ttyAt && -n $gitAt2 && $ttyAt -lt $gitAt2 ]]; echo $?)"
+
+# An unrecognized answer is not the same as "no", and neither is EOF.
+check "an unrecognized answer does not exit 0" \
+    "$(grep -qE 'Answer not recognized' <<< "$u"; echo $?)"
+
+check "a deliberate no is still exit 0" \
+    "$(grep -qE '\[Nn\] \| \[Nn\]\[Oo\]\)' <<< "$u"; echo $?)"
 
 
 printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$pass" "$fail"


### PR DESCRIPTION
The remaining findings from the post-merge review, plus a correction to one of them. **Draft.**

## `reset --hard` stays — the diagnosis around it is what was missing

You were right that this is a deliberate failsafe, and my reviewer's finding conflated two different commands.

`gitUpdateToBranch`'s `git reset --hard origin/$branch` keeps its place as the **last rung**. The tree genuinely can be unclean in ways an ordinary checkout cannot survive — a `chmod -R` over a parent leaves every file looking modified and makes a plain pull fail — and refusing there would strand exactly the server that most needs updating.

What was wrong was doing it *unconditionally and silently*. Now:

1. `git status --porcelain` first.
2. **Clean tree** → plain checkout and `merge --ff-only`. No reset at all.
3. **Clean tree that won't fast-forward** → the branch was rewritten upstream (force-push, rebased `rc-*`); reset is the only thing left, and it says so.
4. **Dirty tree** → prints exactly what is about to be discarded (first 20, full list to the log), *then* resets.
5. **Permission-only changes** are called out separately, because `git config core.fileMode false` is the surgical fix and a reset only papers over it until the next `chmod`.
6. A clean tree that won't check out at all is reported as a real git failure rather than hidden behind a reset.

## `offerRevert` → `checkout --detach`

The opposite judgement, deliberately: there the reset discards local mess to make an update possible; here it is navigating history. The case this exists for is an update that **switched channels** and then failed — the checkout is on `working-1.6` while the last good commit belongs to `stable`, so `reset --hard` points the *`working-1.6` ref* at a `stable` commit and leaves a diverged branch long after the install is fixed.

## `offerRevert` reads `.fogsettings`, not memory

`markInstallCommit` **has** to set the variable before `writeUpdateFile` runs — `writeUpdateFile` emits the file *from* it. So a failure between the two left memory holding HEAD, the comparison finding HEAD == HEAD, and the offer silent on exactly the run that needed it. Disk still names the last commit that got written down.

That's a cleaner fix than the staging/promote pair I first wrote, which would have persisted a stale value.

## Three more

- **Kernel prune** removes every generation at or above the retention, not just `gen-N`. Lowering `--kernel-backup-count` 5 → 3 left `gen-4`/`gen-5` on disk forever — outside the rotation loop, never shifted, never pruned — while `restorekernel.sh --list` offered them as current.
- **`bootstrap.sh` fetches before checking out a pre-existing clone.** It printed "not cloning over it" and then ran the same checkout as a fresh clone. `--channel rc` resolves against the *remote*, so it could name a branch the clone has never fetched and fail with a misleading "branch may have been renamed" — or a stale local `stable` checks out fine and it installs a months-old tree reporting success.
- **`updatefog.sh` refuses rather than reporting success with nobody to answer.** `read` got EOF from cron or the web UI, the catch-all printed "Update canceled." and exited **0**, so the caller recorded an update that never happened. Tested by *opening* `/dev/tty`, before the git work. A deliberate "no" still exits 0; an unrecognized answer does not.

## Tests

`revert-offer` 38, `kernel-backup-rotation` 15, `reports-preserved` 14, `rc-channel-resolution` 23, `detect-os-family` 44, plus the existing suites — all green. Both new behaviours confirmed to fail against the old code before being kept.

`bootstrap-installer.test.sh` reports **6 failures before and after**, identical sets: its sandbox PATH is built with `ln -sf`, which under Git Bash produces *copies*, and a copied `bash.exe` cannot find its DLLs. Runner artifact, not a defect — it should pass on Linux CI.

`FOG_MANAGED_BEGIN` untouched, verified.

## Still outstanding on dev-branch

`bin/updatefog.sh` there has the same two shapes — a `reset --hard` suggestion where `--detach` is accurate, and a confirmation whose catch-all exits 0. Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtZHpyWZWDPSxePdTViGZy
