### PR TITLE
Detach rather than move a branch ref, and do not read EOF as a decision

### DIFF
--- a/bin/updatefog.sh
+++ b/bin/updatefog.sh
@@ -291,7 +291,14 @@ if [[ -z $autoYes ]]; then
     read confirmGo
     case $confirmGo in
         [Yy] | [Yy][Ee][Ss]) ;;
-        *) echo " * Canceled."; exit 0 ;;
+        # A deliberate no is not a failure. EOF and a typo are not a no:
+        # with nobody at the keyboard `read` returns empty, and exiting 0
+        # there told the caller an update had succeeded when none had been
+        # attempted. The terminal check above catches the usual headless
+        # case; this covers a terminal that exists but answers nothing.
+        [Nn] | [Nn][Oo]) echo " * Canceled."; exit 0 ;;
+        "") echo " * No answer given -- canceled. Pass --yes to run unattended."; exit 7 ;;
+        *) echo " * Answer not recognized -- canceled."; exit 3 ;;
     esac
 fi
 
@@ -307,7 +314,7 @@ git -C "$gitpath" reset --hard "origin/${branch}" || fail "Could not reset to or
 if [[ ! -x "${gitpath}/bin/installfog.sh" && ! -f "${gitpath}/bin/installfog.sh" ]]; then
     fail "${branch} has no bin/installfog.sh." \
          "Nothing has been installed. To go back:" \
-         "  git -C ${gitpath} reset --hard ${currentCommit}" 6
+         "  git -C ${gitpath} checkout --detach ${currentCommit}" 6
 fi
 
 # ---------------------------------------------------------------------------
@@ -343,7 +350,15 @@ echo
 echo " * installfog.sh failed (exit ${installStatus})."
 echo " | Nothing has been reverted. To put the checkout back where it was:"
 echo " |"
-echo " |     git -C ${gitpath} reset --hard ${currentCommit}"
+# --detach, not reset --hard. This is the crossing case by definition: the
+# checkout is on working-1.6 or an rc-* branch while $currentCommit belongs
+# to stable, so resetting would point the NEW branch ref at an old commit and
+# leave it diverged. Detaching moves only HEAD, which is all that is wanted.
+#
+# The opposite of what a reset --hard onto origin/<branch> is for, which is
+# discarding local mess so an update can proceed. Going back through history
+# is a different job.
+echo " |     git -C ${gitpath} checkout --detach ${currentCommit}"
 echo " |     cd ${gitpath}/bin && ./installfog.sh"
 echo " |"
 if [[ $crossing -eq 1 ]]; then

--- a/tests/updatefog-1-5-crossing.test.sh
+++ b/tests/updatefog-1-5-crossing.test.sh
@@ -291,8 +291,13 @@ check "a failed install propagates the installer's exit status" \
     "$([[ $? -eq 9 ]]; echo $?)"
 check "it does not reset the checkout itself" \
     "$(! grep -q 'reset --hard aaaa' "$calls"; echo $?)"
-check "it names the commit to reset to instead" \
-    "$(grep -q 'reset --hard aaaaaaaa' <<< "$out"; echo $?)"
+# --detach, not reset --hard: this is the crossing case by definition, so the
+# checkout is on a 1.6 branch while the good commit belongs to stable, and a
+# reset would leave that branch ref diverged.
+check "it names the commit to go back to, as a detach" \
+    "$(grep -q 'checkout --detach aaaaaaaa' <<< "$out"; echo $?)"
+check "and does not suggest moving the current branch ref" \
+    "$(! grep -q 'reset --hard aaaa' <<< "$out"; echo $?)"
 check "and mentions revertfog.sh, because the database may already have moved" \
     "$(grep -q 'revertfog.sh' <<< "$out"; echo $?)"
 
@@ -349,6 +354,17 @@ check "it sources nothing" \
     "$(! grep -qE '^[[:space:]]*(\.|source)[[:space:]]+\.\./lib' <<< "$body"; echo $?)"
 
 echo
+# An unanswerable confirmation must not read as a deliberate "no". `read`
+# returns empty with nobody at the keyboard, and exiting 0 there told a cron
+# caller an update had succeeded when none was attempted.
+body=$(sed "s/#.*//" "$SRC")
+check "an empty answer exits non-zero" \
+    "$(grep -qE '""\) echo .* exit 7' <<< "$body"; echo $?)"
+check "an unrecognized answer exits non-zero" \
+    "$(grep -qE 'Answer not recognized' <<< "$body"; echo $?)"
+check "a deliberate no still exits 0" \
+    "$(grep -qE '\[Nn\] \| \[Nn\]\[Oo\]\).*exit 0' <<< "$body"; echo $?)"
+
 if [[ $FAIL -eq 0 ]]; then
     echo "PASS ($PASS assertions)"
     exit 0


### PR DESCRIPTION
The same two shapes fixed on `working-1.6` in #1636, here. **Draft.**

## `checkout --detach`, not `reset --hard`

Both revert suggestions change. This script's whole purpose is the crossing, so the case is *guaranteed*: the checkout is on `working-1.6` or an `rc-*` branch while `$currentCommit` belongs to `stable`. `reset --hard` points the **new** branch's ref at an old commit and leaves it diverged long after the install is sorted out. Detaching moves only HEAD, and the next run checks out a branch anyway.

That is the opposite of what `reset --hard origin/<branch>` is for — discarding local mess so an update can proceed at all, which stays exactly as it is. Going back through history is a different job.

## EOF is not a decision

`read` returns empty with nobody at the keyboard. The catch-all printed `"Canceled."` and exited **0**, so a cron caller recorded a successful update that never happened.

The terminal check added in #1605 catches the usual headless case; this covers a terminal that exists but answers nothing. A real "no" still exits 0; an empty answer exits 7 and an unrecognized one exits 3.

`tests/updatefog-1-5-crossing.test.sh`: 43 assertions, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtZHpyWZWDPSxePdTViGZy
