### PR TITLE
Host list: a groups column, and the first relationship filter

### DIFF
--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -923,6 +923,30 @@ a `prime` callback that receives every row on the page at once
 (`Route.php:7667`), so the chips cost one extra query per page rather than one
 per host.
 
+**Requirement 1 is built (D1).** The contract is `sqlfilter`, documented on
+`FOGManagerController::relationFilter()`; the column is declared in the host
+arm of `Route::_gridColumns()` and rendered by `fog.host.list.js`. Three
+things settled in the building that this section had not:
+
+- **Negation is applied outside the membership test.** `!=` handed to the
+  inner comparison asks "is in SOME group that is not lab01" — true of nearly
+  every host with two labels — where the user meant "is in NO group called
+  lab01". Both are valid SQL and answer 200, so this is pinned by a test that
+  states both forms and by rows in a scratch database that separate them.
+- **`null`/`!null` invert.** On a relationship, "empty" is "no related row at
+  all", so the membership test is the whole predicate: `null` negates and
+  `!null` does not.
+- **The membership test carries the site boundary.** A group is a site-scoped
+  node, so without it a bounded user could read group names from outside their
+  scope off a host they may see, and use the filter as an oracle for which of
+  their hosts are in one. Same `Authorization::scopedObjectWhere()` the row
+  query uses, embedded in the template and in the chips' own query.
+
+The column is deliberately **not sortable**: there is no expression to ORDER BY
+that does not cost a correlated subquery per row before the LIMIT, and a header
+click that silently changes nothing reads as a broken grid. Filtering is what
+the column is for.
+
 **2. Membership is editable from the host side, in bulk, both directions.**
 
 Add **and remove**, over the list selection, on the same gate as Queue Task /

--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -339,6 +339,8 @@ search** header row to every grid, server-parsed in
 `FOGManagerController::filter()`. All of it is on this branch. The first draft
 quoted the comment as evidence of current behavior instead of grepping for the
 mechanism — the comment should be corrected when the groups column lands.
+**Corrected in D1**, along with the two sentences beside it that said sorting
+was the only filter available for Secure Boot state.
 
 ```
 git grep -l 'SearchBuilder\|_searchtypes\|_sbCriterion' -- packages/web
@@ -367,6 +369,29 @@ path its first relationship column**, by growing the column contract an optional
 subquery form that `_sbCriterion()` uses in place of `` `db` ``. Smaller than
 the first draft implied on the UI side, and a change to a helper every grid runs
 through on the server side.
+
+**Built in D1 as `sqlfilter`** — `FOGManagerController::relationFilter()` holds
+the contract and its reasoning. A column declares `table`, `column` and a
+`match` template with one `%s`, and deliberately declares **no `db`**: that is
+the fail-safe rather than a workaround, because pluck(), orderColumn() and the
+plain LIKE all already skip a column without one, so a path that has not been
+taught about relationships cannot reach it. Two things the build found that the
+plan above did not:
+
+- **Negation has to be applied OUTSIDE the membership test.** `!=` pushed
+  inside asks "is in SOME group that is not lab01", which is true of nearly
+  every host carrying two labels, where the user meant "is in NO group called
+  lab01". Both are valid SQL and both answer 200. Proven on rows, not asserted:
+  the wrong form returns a host that IS in lab01.
+- **`null` and `!null` invert the sense.** On a relationship "empty" means no
+  related row at all, so the membership test is the whole predicate and there
+  is nothing to compare — `null` negates and `!null` does not, the opposite way
+  round to every other pair.
+
+The free-text box goes through the same contract, not only the Filter panel.
+They were one copied line apart in `filter()`, and a global search box that
+silently cannot find a host by its group name reads as the search being broken
+rather than as the column being special.
 
 Two constraints on that expression, both already paid for here:
 
@@ -731,11 +756,20 @@ serialize through conflicts anyway.
 | C5f | Mass edit button moved beside "Delete selected" | `Base/FOGPage.php`, `Pages/HostManagement.php` | C5e | **merged** (#1631) |
 | M1 | `groupModuleAssoc`, constraint group 10, `msState` → tinyint (step 409) | `commons/schema.php`, `commons/schema-constraints.php`, `Base/System.php` | A | **merged** (#1629) |
 | M2 | `Resolver::resolveModules()`, the three tiers | `Assign/Resolver.php` | M1 | **merged** (#1632) |
-| M3 | Client paths read the resolved list; `checkPassiveModule` fix | `Items/Host.php`, `Client/ServiceModule.php`, `Client/FOGClient.php`, `Base/FOGPage.php` | M2 | open (#1633) |
-| M4 | `addRemItem()` module special case removed; auto-logout minimum named once | `Base/FOGController.php`, `Pages/HostManagement.php` | M3 | open (#1634) |
+| M3 | Client paths read the resolved list; `checkPassiveModule` fix | `Items/Host.php`, `Client/ServiceModule.php`, `Client/FOGClient.php`, `Base/FOGPage.php` | M2 | **merged** (#1633) |
+| M4 | `addRemItem()` module special case removed; auto-logout minimum named once | `Base/FOGController.php`, `Pages/HostManagement.php` | M3 | **merged** (#1634) |
 | M5 | Host Modules tab becomes genuinely tri-state, so a host can say OFF | `Pages/HostManagement.php`, JS | M4 | not started |
-| D | Presentation: groups column + filter, bulk add/remove, group list "grants" | `Router/Route.php`, `Base/FOGManagerController.php`, `Pages/HostManagement.php`, JS | C5 | not started |
+| D1 | The `sqlfilter` relationship-filter contract, and the host list's groups column on it | `Base/FOGManagerController.php`, `Router/Route.php`, `Pages/HostManagement.php`, `fog.host.list.js` | C5 | open (#TBD) |
+| D2 | Bulk add AND remove from the list, through the shared create-and-associate path; the two `saveGroup()` defects and the permission split | `Pages/HostManagement.php`, `Auth/Authorization.php`, `fog.host.list.js` | D1 | not started |
+| D3 | Group list "grants" column | `Router/Route.php`, `Pages/GroupManagement.php`, JS | D1 | not started |
 | E | Group page rework + removal of the imperative tabs, and `Group::addSnapin`/`addPrinter`/`addModule` become grants | `Pages/GroupManagement.php`, `Items/Group.php`, JS | **C5 proven** (Decision 10), D, M5 | not started |
+
+D split into three while building it, on the same rule C did: by what each
+piece can be tested on its own. D1 is the shared helper plus the one column
+that proves it, and it is the plan-first half -- a change to a path every grid
+in the product runs through. D2 is a write path with its own two security
+defects and a permission split, which is a different review from a read path.
+D3 needs D1's contract and nothing else.
 
 C5 split into five as it was built. The split is by what each piece can be
 tested against on its own -- the action model with no endpoint, the endpoint

--- a/docs/release/1.6.0-release-notes.DRAFT.md
+++ b/docs/release/1.6.0-release-notes.DRAFT.md
@@ -283,6 +283,27 @@ pre-upgrade *dump* — it is not a schema rollback.
 
   If you maintain something that consumes `/service/Printers.php`, prefer
   `noPrinters` over `error == "np"` from now on.
+
+- **The host list shows which groups a host is in, and you can search on
+  them.** A new Groups column carries one chip per group, each a link to that
+  group, in the same order group grants are applied -- so the column also
+  tells you which group wins when two of them grant the same thing.
+
+  It is searchable three ways, all of which run in the database rather than on
+  the page you happen to be looking at, so the counts and the paging are right:
+  the free-text box above the table, the Column search box in the header row,
+  and the Filter panel. "Is not in group X" means exactly that -- in NO group
+  called X -- rather than "is in some other group as well", and the panel's
+  Empty / Not empty find the hosts in no group at all and the hosts in at
+  least one.
+
+  The column shows only groups you are allowed to see. On a server using
+  sites, a user scoped to one site sees their own groups' names and nothing
+  else, and cannot use the filter to learn about the rest.
+
+  It is the one column with no sort: there is nothing on the host record to
+  sort by, and a header click that quietly changed nothing would be worse than
+  no arrow at all.
   <!-- verified: docs/adr/0038 decisions 4, 5, 6, 7 and 9; FOG\Assign\Resolver;
   Client/PrinterClient.php; docs/GROUP_SHARED_STATE.md -->
 - **Mass edit on the host list**, and it asks before it overwrites. Tick any

--- a/packages/web/management/js/fog/host/fog.host.list.js
+++ b/packages/web/management/js/fog/host/fog.host.list.js
@@ -180,6 +180,50 @@
             targets: colIndex.primac
         });
     }
+    if ('groups' in colIndex) {
+        columnDefs.push({
+            // Not sortable, because the server has nothing to ORDER BY. This
+            // column is a relationship through groupMembers rather than a
+            // column of `hosts`, so it carries no `db` and orderColumn()
+            // skips it -- a header click would re-request the page and give
+            // back the same order, which reads as the grid being broken.
+            // Filtering is what the column is for and that does reach the
+            // query; see the sqlfilter contract on
+            // FOGManagerController::relationFilter().
+            orderable: false,
+            // Kept through the responsive collapse. A label you cannot see
+            // on a narrow window is not doing its job.
+            responsivePriority: 1,
+            render: function (data, type, row) {
+                // Display only. Sort, search and the CSV export get the
+                // server's plain comma-joined names back untouched -- markup
+                // baked into the value is the GH-1446 failure, where
+                // registerExportTable() escapes each cell and the chips land
+                // in the CSV as literal '<a class="badge...'.
+                if (type !== 'display') {
+                    return data;
+                }
+                var list = row.groups_list || [];
+                if (!list.length) {
+                    return '';
+                }
+                // Built here rather than server-side so the names are escaped
+                // by the same helper every other JS-rendered cell uses. A
+                // group name is user-supplied text and this cell is markup.
+                return $.map(list, function(group) {
+                    return '<a class="badge bg-secondary ' +
+                        'text-decoration-none me-1" ' +
+                        'href="../management/index.php?node=group&amp;' +
+                        'sub=edit&amp;id=' +
+                        encodeURIComponent(group.id) + '">' +
+                        $.escapeHtml(String(group.name || '')) +
+                        '</a>';
+                }).join('');
+            },
+            targets: colIndex.groups
+        });
+    }
+
     if ('deployed' in colIndex) {
         columnDefs.push({
             render: function (data, type, row) {

--- a/packages/web/src/Base/FOGManagerController.php
+++ b/packages/web/src/Base/FOGManagerController.php
@@ -739,6 +739,12 @@ abstract class FOGManagerController extends FOGBase
      * learn a value the response refuses to contain. The searchable flag in
      * the request cannot serve for this -- the client sends it.
      *
+     * A column with no `db` at all is skipped too, and that is now decided in
+     * _likeClause() rather than in the guards: a relationship column
+     * deliberately has no `db` and is matched through its 'sqlfilter'
+     * instead. See relationFilter() for the contract and for why the absent
+     * `db` is the fail-safe rather than something to work around.
+     *
      * A SearchBuilder payload, when the request carries one, is ANDed onto
      * whatever the two boxes above produced -- the same relationship the
      * per-column boxes already have to the global one. See
@@ -770,15 +776,15 @@ abstract class FOGManagerController extends FOGBase
                 $column = self::columnFor($columns, $requestColumn['data']);
                 if (null === $column
                     || $requestColumn['searchable'] != 'true'
-                    || !isset($column['db'])
                     || (isset($column['removeFromQuery']) && $column['removeFromQuery'])
                     || (isset($column['nosearch']) && $column['nosearch'])
                 ) {
                     continue;
                 }
-                $columnSrch = $column['db'];
-                $binding = self::bind($bindings, '%'.$str.'%', \PDO::PARAM_STR);
-                $globalSearch[] = "`".$columnSrch."` LIKE ".$binding;
+                $clause = self::_likeClause($column, $str, $bindings);
+                if ($clause !== '') {
+                    $globalSearch[] = $clause;
+                }
             }
         }
         // Individual column filtering
@@ -790,7 +796,6 @@ abstract class FOGManagerController extends FOGBase
                 if (null === $column
                     || $requestColumn['searchable'] != 'true'
                     || $str == ''
-                    || !isset($column['db'])
                     || (isset($column['removeFromQuery']) && $column['removeFromQuery'])
                     || (isset($column['nosearch']) && $column['nosearch'])
                 ) {
@@ -821,13 +826,10 @@ abstract class FOGManagerController extends FOGBase
                     }
                     continue;
                 }
-                $columnSrch = $column['db'];
-                $binding = self::bind(
-                    $bindings,
-                    '%' . $str . '%',
-                    \PDO::PARAM_STR
-                );
-                $columnSearch[] = "`".$columnSrch."` LIKE ".$binding;
+                $clause = self::_likeClause($column, $str, $bindings);
+                if ($clause !== '') {
+                    $columnSearch[] = $clause;
+                }
             }
         }
         // Combine the filters into a single string
@@ -855,6 +857,40 @@ abstract class FOGManagerController extends FOGBase
             $where = 'WHERE '.$where;
         }
         return $where;
+    }
+    /**
+     * The contains-anywhere clause behind the free-text box and behind a
+     * per-column box carrying no condition.
+     *
+     * Split out because a relationship column spells it differently and the
+     * two boxes have to agree about that. They were one copied line apart,
+     * and a free-text box that cannot find a host by its group name is the
+     * same defect as a header box that cannot -- just harder to notice,
+     * because the box still works for every other column.
+     *
+     * @param array  $column   The column definition
+     * @param string $str      The text typed into the box
+     * @param array  $bindings Array of values for PDO bindings
+     *
+     * @return string The clause, or '' when the column cannot be matched
+     */
+    private static function _likeClause($column, $str, &$bindings)
+    {
+        $filter = self::relationFilter($column);
+        if (null !== $filter) {
+            $binding = self::bind($bindings, '%' . $str . '%', \PDO::PARAM_STR);
+
+            return self::_relationClause(
+                $filter,
+                self::_relationColumn($filter) . ' LIKE ' . $binding
+            );
+        }
+        if (!isset($column['db'])) {
+            return '';
+        }
+        $binding = self::bind($bindings, '%' . $str . '%', \PDO::PARAM_STR);
+
+        return '`' . $column['db'] . '` LIKE ' . $binding;
     }
     /**
      * The search type a column is treated as: 'date', 'num' or 'string'.
@@ -930,16 +966,130 @@ abstract class FOGManagerController extends FOGBase
             if (!isset($column['dt'])) {
                 continue;
             }
-            if (!isset($column['db'])
-                || (isset($column['removeFromQuery']) && $column['removeFromQuery'])
+            if ((isset($column['removeFromQuery']) && $column['removeFromQuery'])
                 || (isset($column['nosearch']) && $column['nosearch'])
             ) {
+                $types[$column['dt']] = false;
+                continue;
+            }
+            // A relationship column carries no `db` and is typed from the
+            // column it actually compares, on the table it reaches. Still the
+            // SERVER reading a real column's real type, which is the whole
+            // invariant this method exists for -- see relationFilter().
+            $filter = self::relationFilter($column);
+            if (null !== $filter) {
+                $types[$column['dt']] = self::searchBuilderType(
+                    $filter['table'],
+                    $filter['column']
+                );
+                continue;
+            }
+            if (!isset($column['db'])) {
                 $types[$column['dt']] = false;
                 continue;
             }
             $types[$column['dt']] = self::searchBuilderType($table, $column['db']);
         }
         return $types;
+    }
+    /**
+     * A column's relationship filter, validated, or null if it has none.
+     *
+     * THE 'sqlfilter' CONTRACT. A grid column normally names one scalar of
+     * the table being listed, in `db`, and every path here builds SQL out of
+     * that identifier. Some columns are not scalars of anything: the host
+     * list's Groups column is a many-to-many through `groupMembers`, so there
+     * is no `hosts` column to name and no type to read off one.
+     *
+     * Such a column declares `sqlfilter` INSTEAD of `db`:
+     *
+     *     'sqlfilter' => [
+     *         'table'  => 'groups',      // a real table
+     *         'column' => 'groupName',   // a real column of it
+     *         'match'  => 'EXISTS (SELECT 1 FROM `groupMembers` ... '
+     *                   . 'WHERE `gmHostID` = `hosts`.`hostID` AND (%s))',
+     *     ]
+     *
+     * `match` is a membership test with ONE `%s`, which receives the
+     * comparison built from `table`.`column` -- so the criterion is still
+     * built, typed and bound by the code below, and the column definition
+     * supplies only the join that reaches the row.
+     *
+     * Leaving `db` unset is deliberate and is the fail-safe, not an
+     * oversight. Every path that interpolates a raw identifier -- the SELECT
+     * list via pluck(), ORDER BY via orderColumn(), the plain LIKE in
+     * filter() -- already skips a column without one, so a relationship
+     * column can only ever be reached through the arms that know what it is.
+     * A path taught about `sqlfilter` opts in; one that is not, ignores it.
+     *
+     * `match` is raw SQL and is only ever written in PHP, in a column
+     * definition -- the same standing as a column's `order` expression, which
+     * orderRef() emits unquoted for the same reason. Nothing from a request
+     * reaches it: the request names a column by its output name and that is
+     * matched against these definitions before anything here runs.
+     *
+     * @param array $column The column definition
+     *
+     * @return array|null The filter, or null when the column has none or the
+     *                    one it has is malformed
+     */
+    protected static function relationFilter($column)
+    {
+        if (!isset($column['sqlfilter']) || !is_array($column['sqlfilter'])) {
+            return null;
+        }
+        $filter = $column['sqlfilter'];
+        foreach (['table', 'column', 'match'] as $key) {
+            if (!isset($filter[$key])
+                || !is_string($filter[$key])
+                || '' === $filter[$key]
+            ) {
+                return null;
+            }
+        }
+        // The table and column are interpolated as identifiers, so they have
+        // to look like identifiers. A plugin's typo here would otherwise be a
+        // syntax error on every draw of its grid, with the list answering 406
+        // and nothing saying which column did it.
+        if (!preg_match('/^[A-Za-z0-9_]+$/', $filter['table'])
+            || !preg_match('/^[A-Za-z0-9_]+$/', $filter['column'])
+        ) {
+            return null;
+        }
+        // Exactly one placeholder: the comparison goes in one place, and a
+        // template with none would silently filter on nothing at all.
+        if (1 !== substr_count($filter['match'], '%s')) {
+            return null;
+        }
+        return $filter;
+    }
+    /**
+     * Puts a built comparison into a relationship column's membership test.
+     *
+     * str_replace rather than sprintf deliberately: `match` and the clause
+     * handed to it are both SQL, and SQL contains '%' -- a LIKE pattern, a
+     * plugin's own scope fragment -- which sprintf would read as a
+     * conversion and either mangle or refuse.
+     *
+     * @param array  $filter The validated filter
+     * @param string $inner  The comparison to place
+     *
+     * @return string
+     */
+    private static function _relationClause($filter, $inner)
+    {
+        return str_replace('%s', $inner, $filter['match']);
+    }
+    /**
+     * The quoted column a relationship filter compares.
+     *
+     * @param array $filter The validated filter
+     *
+     * @return string
+     */
+    private static function _relationColumn($filter)
+    {
+        return '`' . $filter['table'] . '`.`' . $filter['column'] . '`';
     }
     /**
      * Turns a DataTables SearchBuilder payload into a WHERE fragment.
@@ -1059,21 +1209,42 @@ abstract class FOGManagerController extends FOGBase
         // value, so matching on it would let a caller use match/no-match to
         // read what the response refuses to contain.
         if (null === $column
-            || !isset($column['db'])
             || (isset($column['removeFromQuery']) && $column['removeFromQuery'])
             || (isset($column['nosearch']) && $column['nosearch'])
         ) {
             return '';
         }
-        $type = self::searchBuilderType($table, $column['db']);
+        $filter = self::relationFilter($column);
+        if (null === $filter && !isset($column['db'])) {
+            return '';
+        }
+        if (null !== $filter) {
+            $col = self::_relationColumn($filter);
+            $type = self::searchBuilderType(
+                $filter['table'],
+                $filter['column']
+            );
+        } else {
+            $col = '`' . $column['db'] . '`';
+            $type = self::searchBuilderType($table, $column['db']);
+        }
         $condition = isset($criterion['condition'])
             ? (string)$criterion['condition']
             : '';
         if (!in_array($condition, self::$_sbConditions[$type], true)) {
             return '';
         }
-        $col = '`' . $column['db'] . '`';
         $values = self::_sbValues($criterion);
+        if (null !== $filter) {
+            return self::_sbRelation(
+                $filter,
+                $col,
+                $type,
+                $condition,
+                $values,
+                $bindings
+            );
+        }
         switch ($type) {
             case 'date':
                 return self::_sbDate($col, $condition, $values, $bindings);
@@ -1081,6 +1252,82 @@ abstract class FOGManagerController extends FOGBase
                 return self::_sbNum($col, $condition, $values, $bindings);
         }
         return self::_sbString($col, $condition, $values, $bindings);
+    }
+    /**
+     * One criterion against a relationship column.
+     *
+     * NEGATION IS THE WHOLE REASON THIS IS NOT A WRAPPER. A scalar's "is not
+     * lab01" is one comparison; a relationship's is not. Handing '!=' to
+     * _sbString() and dropping the result into the membership test asks
+     *
+     *     is this host in SOME group that is not called lab01
+     *
+     * which is true of nearly every host with two groups, where what the user
+     * picked means
+     *
+     *     is this host in NO group called lab01.
+     *
+     * So the POSITIVE comparison is built and the negation is applied to the
+     * membership test from outside. Every '!' condition in $_sbConditions has
+     * its positive twin in the same list, so stripping the '!' can only ever
+     * name a condition this server already implements for that type.
+     *
+     * 'null' and '!null' invert that, and it is not a special case so much as
+     * the same rule read carefully: on a relationship "empty" means no
+     * related row AT ALL, so the membership test IS the whole predicate and
+     * there is nothing to compare. 'null' therefore negates and '!null' does
+     * not -- the opposite way round to every other pair here.
+     *
+     * @param array  $filter    The validated filter
+     * @param string $col       The quoted column being compared
+     * @param string $type      The resolved column type
+     * @param string $condition The whitelisted condition key
+     * @param array  $values    The criterion's values
+     * @param array  $bindings  Array of values for PDO bindings
+     *
+     * @return string
+     */
+    private static function _sbRelation(
+        $filter,
+        $col,
+        $type,
+        $condition,
+        $values,
+        &$bindings
+    ) {
+        $negate = 0 === strpos($condition, '!');
+        $positive = $negate ? substr($condition, 1) : $condition;
+        if ('null' === $positive) {
+            // Nothing to compare, so the inner predicate is a constant and
+            // the sense flips: see the docblock.
+            $inner = '1';
+            $negate = !$negate;
+        } else {
+            switch ($type) {
+                case 'date':
+                    $inner = self::_sbDate($col, $positive, $values, $bindings);
+                    break;
+                case 'num':
+                    $inner = self::_sbNum($col, $positive, $values, $bindings);
+                    break;
+                default:
+                    $inner = self::_sbString(
+                        $col,
+                        $positive,
+                        $values,
+                        $bindings
+                    );
+            }
+            // An unfilled criterion, dropped for the reason _sbString() gives.
+            // The three builders all return '' BEFORE binding anything, so
+            // dropping here leaves no binding behind for PDO to refuse.
+            if ('' === $inner) {
+                return '';
+            }
+        }
+        $sql = self::_relationClause($filter, $inner);
+
+        return $negate ? 'NOT (' . $sql . ')' : $sql;
     }
     /**
      * The values off a criterion, in the order the client sorted them.

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -117,11 +117,18 @@ class HostManagement extends FOGPage
         // entry with it and the two cannot fall out of step.
         $this->headerData = [
             _('Host'),
-            _('Primary MAC')
+            _('Primary MAC'),
+            // Beside the two columns that say WHICH machine this is, because
+            // that is what a group is now: a label on the host, not a place
+            // its settings were copied from (ADR 0038). Rendered as chips by
+            // fog.host.list.js and filterable from either search box -- see
+            // the groups column in Route::_gridColumns().
+            _('Groups')
         ];
         $this->attributes = [
             ['data-col' => 'mainlink'],
-            ['data-col' => 'primac']
+            ['data-col' => 'primac'],
+            ['data-col' => 'groups']
         ];
         if (self::$fogpingactive) {
             $this->headerData[] = _('Ping Status');
@@ -153,10 +160,11 @@ class HostManagement extends FOGPage
             // Both default to hidden in the column picker's sense of the
             // word only in that most fleets will not look at them daily;
             // they are emitted always, because the one time they matter is
-            // when someone is picking enrollment targets and needs to sort by
-            // them. Sorting is the filter here -- this grid has no
-            // per-column search UI, so the global box matches the STORED
-            // word ('disabled', 'setup') rather than the rendered label.
+            // when someone is picking enrollment targets and needs to sort or
+            // filter by them. Both are searchable on the STORED word
+            // ('disabled', 'setup') rather than the rendered label -- that is
+            // what the free-text box and the Column search header box match,
+            // and what the Filter panel offers as conditions.
             _('Secure Boot'),
             _('SB Enrolled'),
             _('Description')

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -243,6 +243,20 @@ class Route extends FOGBase
      */
     protected static $relCache = [];
     /**
+     * Group memberships for the hosts on the grid page being rendered.
+     *
+     * Keyed host id => list of ['id' => int, 'name' => string], in the order
+     * assignment resolution walks the groups. Filled by ONE pair of queries
+     * in the Groups column's primer and read by its formatter -- the same
+     * per-page batching $relCache does for the foreign-key columns, and for
+     * the same reason: a lookup per row here is GH-707 again.
+     *
+     * Emptied at the top of every listem() call, exactly as $relCache is.
+     *
+     * @var array
+     */
+    protected static $hostGroupCache = [];
+    /**
      * The class the current API route is serving, recorded so printer() can
      * strip secrets from a payload that does not name its own class.
      *
@@ -3121,6 +3135,7 @@ class Route extends FOGBase
             self::$data = [];
             // Fresh per grid -- see $relCache and rel().
             self::$relCache = [];
+            self::$hostGroupCache = [];
             $classname = strtolower($class);
             $classman = self::getClass("{$classname}manager");
             $table = $classman->getTable();
@@ -3696,6 +3711,73 @@ class Route extends FOGBase
         switch ($classname) {
             case 'host':
                 $columns[] = ['db' => 'imageName', 'dt' => 'imagename'];
+                // The host's group memberships, and a filter that can find
+                // them. ADR 0038 Decision 16a requirement 1: a group is a
+                // label, and a label you cannot see on the list or search by
+                // is not one.
+                //
+                // Deliberately NO 'db'. There is no scalar on `hosts` behind
+                // this -- it is a many-to-many through `groupMembers` -- and
+                // every path in FOGManagerController that interpolates a raw
+                // identifier already skips a column that has none: the SELECT
+                // list, ORDER BY, the plain LIKE. That is the fail-safe this
+                // column relies on rather than works around, and it is why
+                // the column is unsortable (there is no expression to sort by
+                // that does not cost a correlated subquery per row before the
+                // LIMIT). See relationFilter() for the 'sqlfilter' contract.
+                //
+                // The membership test is scoped, because a group IS a
+                // site-scoped node (SiteScope::$_nodes). Without this a
+                // site-bounded user could read the names of groups outside
+                // their scope off a host they are allowed to see, and could
+                // use the filter to ask which of their hosts are in one.
+                $groupScope = Authorization::scopedObjectWhere(
+                    'group',
+                    '`groups`.`groupID`'
+                );
+                $columns[] = [
+                    'dt' => 'groups',
+                    'prime' => function ($rows) use ($groupScope) {
+                        self::_primeHostGroups(
+                            array_column((array) $rows, 'hostID'),
+                            $groupScope
+                        );
+                    },
+                    'formatter' => function ($d, $row) {
+                        // PLAIN TEXT, no markup, for the reason the sbstate
+                        // column states: registerExportTable() escapes each
+                        // cell, so a chip baked in here lands in the CSV as
+                        // a literal <span> (GH-1446). fog.host.list.js
+                        // renders the chips from groups_list below, and only
+                        // for type === 'display'.
+                        return implode(
+                            ', ',
+                            array_column(self::_hostGroups($row), 'name')
+                        );
+                    },
+                    'sqlfilter' => [
+                        'table' => 'groups',
+                        'column' => 'groupName',
+                        'match' => 'EXISTS (SELECT 1 FROM `groupMembers`'
+                            . ' INNER JOIN `groups`'
+                            . ' ON `groups`.`groupID`'
+                            . ' = `groupMembers`.`gmGroupID`'
+                            . ' WHERE `groupMembers`.`gmHostID`'
+                            . ' = `hosts`.`hostID`'
+                            . ($groupScope ? ' AND ' . $groupScope : '')
+                            . ' AND (%s))'
+                    ]
+                ];
+                // The same memberships as ids and names, for the renderer.
+                // Rides along in the JSON with no header of its own, exactly
+                // as primac_vendor and sbstatecode do, so it never reaches
+                // the CSV export path.
+                $columns[] = [
+                    'dt' => 'groups_list',
+                    'formatter' => function ($d, $row) {
+                        return self::_hostGroups($row);
+                    }
+                ];
                 $columns[] = ['db' => 'hmMAC', 'dt' => 'primac'];
                 // Vendor name for the primary MAC; rides along in the JSON
                 // and is rendered as a tooltip icon client-side. Not a
@@ -7644,6 +7726,107 @@ class Route extends FOGBase
                 $objects[$id] :
                 self::getClass($class)->set('id', $id);
         }
+    }
+    /**
+     * Loads the group memberships for a page of host rows.
+     *
+     * Two queries for the whole page: the membership rows, then the groups
+     * themselves in the order assignment resolution walks them. Chips read
+     * left to right in that order on purpose -- it is the order that decides
+     * which group's grant lands first (ADR 0038 Decision 6), so the list
+     * shows the precedence rather than hiding it behind alphabetical.
+     *
+     * @param array  $hostIDs    The page's host ids, unsanitized.
+     * @param string $scopeWhere The caller's group boundary as SQL, or ''.
+     *
+     * @return void
+     */
+    private static function _primeHostGroups($hostIDs, $scopeWhere = '')
+    {
+        self::$hostGroupCache = [];
+        $ids = [];
+        foreach ((array) $hostIDs as $id) {
+            $id = (int) $id;
+            if ($id > 0) {
+                $ids[$id] = $id;
+            }
+        }
+        if (!count($ids)) {
+            return;
+        }
+        $rows = self::_rawRows(
+            'SELECT `gmHostID`,`gmGroupID` FROM `groupMembers`'
+            . ' WHERE `gmHostID` IN (' . implode(',', $ids) . ')'
+        );
+        $byHost = [];
+        $groupIDs = [];
+        foreach ($rows as $row) {
+            $groupID = (int) $row['gmGroupID'];
+            $byHost[(int) $row['gmHostID']][$groupID] = true;
+            $groupIDs[$groupID] = $groupID;
+        }
+        if (!count($groupIDs)) {
+            return;
+        }
+        $named = self::_rawRows(
+            'SELECT `groupID`,`groupName` FROM `groups`'
+            . ' WHERE `groupID` IN (' . implode(',', $groupIDs) . ')'
+            . ($scopeWhere ? ' AND ' . $scopeWhere : '')
+            // The order Assign\Resolver::_orderedGroupIDs() uses, stated the
+            // same way for the same reason: groupID last so the sequence is
+            // deterministic whether or not groupName's UNIQUE index is
+            // actually on the disk (schema step 401).
+            . ' ORDER BY `groupOrder`,`groupName`,`groupID`'
+        );
+        foreach ($named as $row) {
+            $groupID = (int) $row['groupID'];
+            foreach ($byHost as $hostID => $memberships) {
+                if (!isset($memberships[$groupID])) {
+                    continue;
+                }
+                self::$hostGroupCache[$hostID][] = [
+                    'id' => $groupID,
+                    'name' => (string) $row['groupName']
+                ];
+            }
+        }
+    }
+    /**
+     * The primed memberships for one grid row.
+     *
+     * @param array $row The raw database row.
+     *
+     * @return array list of ['id' => int, 'name' => string]
+     */
+    private static function _hostGroups($row)
+    {
+        $hostID = isset($row['hostID']) ? (int) $row['hostID'] : 0;
+
+        return $hostID > 0 && isset(self::$hostGroupCache[$hostID])
+            ? self::$hostGroupCache[$hostID]
+            : [];
+    }
+    /**
+     * Runs one read and returns its rows.
+     *
+     * A failure returns no rows rather than throwing: this feeds a grid CELL,
+     * and a column that cannot answer should leave itself blank rather than
+     * take the whole list down. That is the opposite of Assign\Resolver,
+     * which throws on the same shape of query -- and deliberately so, because
+     * there a missing row is a grant silently not applied.
+     *
+     * @param string $sql The query. Built here, never from a request.
+     *
+     * @return array
+     */
+    private static function _rawRows($sql)
+    {
+        $res = self::$DB->query($sql);
+        if (false !== $res->error) {
+            return [];
+        }
+
+        return (array) $res->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
     }
     /**
      * Builds a grid column whose formatter resolves a related object.

--- a/tests/fixtures/route-column-contract.txt
+++ b/tests/fixtures/route-column-contract.txt
@@ -90,8 +90,10 @@ host	36	hostExitEfi	efiexit	-	-
 host	37	hostEnforce	enforce	-	-
 host	38	hostInfoLock	tokenlock	-	-
 host	39	imageName	imagename	-	-
-host	40	hmMAC	primac	-	-
-host	41	hmMAC	primac_vendor	f	(none)
+host	40	-	groups	f	(none)
+host	41	-	groups_list	f	-
+host	42	hmMAC	primac	-	-
+host	43	hmMAC	primac_vendor	f	(none)
 hostautologout	0	haloID	id	-	-
 hostautologout	1	haloID	DT_RowId	f	-
 hostautologout	2	haloHostID	hostID	-	-

--- a/tests/searchbuilder-filter-clause.test.php
+++ b/tests/searchbuilder-filter-clause.test.php
@@ -33,6 +33,16 @@
  *    of this file rendered the bindings into the SQL text and so was blind
  *    to it, which shipped a 406 on 'before' and 'after'.
  *
+ * 5. A relationship column negates from OUTSIDE its membership test. A
+ *    column declaring 'sqlfilter' has no scalar behind it -- the host list's
+ *    Groups column is a many-to-many through `groupMembers` -- so "is not
+ *    lab01" cannot be one comparison. Pushed inside, it asks "is in SOME
+ *    group that is not lab01", which is true of nearly every host carrying
+ *    two labels; what the user picked means "is in NO group called lab01".
+ *    Both forms are valid SQL, both answer 200, and the wrong one returns
+ *    plausible rows -- which is why it is pinned here rather than left to a
+ *    lab run.
+ *
  * Standalone like its neighbors: filter() and its helpers are static and
  * touch no state, so a stub base carrying a fixed column-type map is enough
  * to exercise them with no boot and no database.
@@ -73,6 +83,12 @@ abstract class FOGBase
         'hosts.hostID' => 'INT(11) NOT NULL',
         'hosts.hostSecToken' => 'LONGTEXT NOT NULL',
         'hosts.hostMembers' => 'INT(11)',
+        // The column a relationship filter compares. On a real server this
+        // is read from the schema manifest exactly like the four above --
+        // the point being that a relationship column is still typed from a
+        // real column of a real table, never from what the request claims.
+        'groups.groupName' => 'VARCHAR(64) NOT NULL',
+        'groups.groupOrder' => 'INT(11) NOT NULL',
     ];
 
     /**
@@ -260,7 +276,42 @@ $columns = [
     ['db' => 'hostDeployed', 'dt' => 'deployed'],
     ['db' => 'hostSecToken', 'dt' => 'token', 'nosearch' => true],
     ['db' => 'hostMembers', 'dt' => 'members', 'removeFromQuery' => true],
+    // A relationship column, exactly as Route::_gridColumns() declares the
+    // host list's Groups column: no 'db', so every raw-identifier path skips
+    // it, and an 'sqlfilter' the criterion paths know how to read.
+    [
+        'dt' => 'groups',
+        'sqlfilter' => [
+            'table' => 'groups',
+            'column' => 'groupName',
+            'match' => 'EXISTS (SELECT 1 FROM `groupMembers`'
+                . ' INNER JOIN `groups`'
+                . ' ON `groups`.`groupID` = `groupMembers`.`gmGroupID`'
+                . ' WHERE `groupMembers`.`gmHostID` = `hosts`.`hostID`'
+                . ' AND (%s))'
+        ]
+    ],
 ];
+
+/**
+ * The membership test above, around one comparison.
+ *
+ * Written out once so a case below states the COMPARISON it expects rather
+ * than a wall of join text -- the comparison and its sense are what these
+ * cases are about.
+ *
+ * @param string $inner The comparison the criterion built
+ *
+ * @return string
+ */
+function groupsMatch($inner)
+{
+    return 'EXISTS (SELECT 1 FROM `groupMembers`'
+        . ' INNER JOIN `groups`'
+        . ' ON `groups`.`groupID` = `groupMembers`.`gmGroupID`'
+        . ' WHERE `groupMembers`.`gmHostID` = `hosts`.`hostID`'
+        . ' AND (' . $inner . '))';
+}
 
 /**
  * A DataTables request carrying per-column header-box searches.
@@ -627,6 +678,185 @@ $cases[] = [
         . " AND `hostName` LIKE 'lab%' ESCAPE '\\\\'",
 ];
 
+/* -- relationship columns --------------------------------------------- */
+
+$cases[] = [
+    'name' => 'a relationship column filters through its membership test',
+    'request' => sbRequest([sbCriterion('groups', 'contains', ['lab'])]),
+    'expect' => 'WHERE ('
+        . groupsMatch("`groups`.`groupName` LIKE '%lab%' ESCAPE '\\\\'")
+        . ')',
+];
+
+$cases[] = [
+    'name' => 'equals names the group exactly',
+    'request' => sbRequest([sbCriterion('groups', '=', ['lab01'])]),
+    'expect' => 'WHERE ('
+        . groupsMatch("`groups`.`groupName` = 'lab01'")
+        . ')',
+];
+
+$cases[] = [
+    // Invariant 5. The comparison inside stays POSITIVE and the whole
+    // membership test is negated, so this reads "in no group called lab01".
+    // The wrong form -- NOT pushed inside -- would read "in some group that
+    // is not lab01" and match nearly every host with two groups.
+    'name' => 'not-equals negates the membership, not the comparison',
+    'request' => sbRequest([sbCriterion('groups', '!=', ['lab01'])]),
+    'expect' => 'WHERE (NOT ('
+        . groupsMatch("`groups`.`groupName` = 'lab01'")
+        . '))',
+];
+
+$cases[] = [
+    'name' => 'not-contains negates the membership too',
+    'request' => sbRequest([sbCriterion('groups', '!contains', ['lab'])]),
+    'expect' => 'WHERE (NOT ('
+        . groupsMatch("`groups`.`groupName` LIKE '%lab%' ESCAPE '\\\\'")
+        . '))',
+];
+
+$cases[] = [
+    // 'null' on a relationship means no related row AT ALL, so the
+    // membership test is the whole predicate and the sense is the opposite
+    // way round to every other pair: 'null' negates, '!null' does not.
+    'name' => 'empty finds the hosts in no group at all',
+    'request' => sbRequest([sbCriterion('groups', 'null')]),
+    'expect' => 'WHERE (NOT (' . groupsMatch('1') . '))',
+];
+
+$cases[] = [
+    'name' => 'not-empty finds the hosts in at least one group',
+    'request' => sbRequest([sbCriterion('groups', '!null')]),
+    'expect' => 'WHERE (' . groupsMatch('1') . ')',
+];
+
+$cases[] = [
+    // The type comes from `groups`.`groupName`, which is text -- so a range
+    // condition is not on offer for this column any more than it is for
+    // hostName, even though the request says nothing about which table the
+    // comparison lands on.
+    'name' => 'a relationship column is typed from the column it compares',
+    'request' => sbRequest([sbCriterion('groups', '>', ['m'])]),
+    'expect' => '',
+];
+
+$cases[] = [
+    'name' => 'an unfilled relationship criterion is dropped',
+    'request' => sbRequest([sbCriterion('groups', 'contains', [''])]),
+    'expect' => '',
+];
+
+$cases[] = [
+    'name' => 'the header box reaches a relationship column',
+    'request' => colRequest(
+        ['groups' => colValue('starts', ['lab'])],
+        $columns
+    ),
+    'expect' => 'WHERE '
+        . groupsMatch("`groups`.`groupName` LIKE 'lab%' ESCAPE '\\\\'"),
+];
+
+$cases[] = [
+    // The free-text box has to find a group by name too. It and the header
+    // box were one copied line apart, and a global box that silently cannot
+    // match this column reads as the search being broken rather than as the
+    // column being special.
+    'name' => 'the free-text box reaches a relationship column',
+    'request' => [
+        'search' => ['value' => 'lab'],
+        'columns' => [
+            [
+                'data' => 'groups',
+                'searchable' => 'true',
+                'search' => ['value' => ''],
+            ],
+        ],
+    ],
+    'expect' => "WHERE (" . groupsMatch(
+        "`groups`.`groupName` LIKE '%lab%'"
+    ) . ")",
+];
+
+$cases[] = [
+    // The template is SQL and SQL contains '%' -- a LIKE pattern written
+    // into a plugin's own scope fragment is the case that turns up. sprintf
+    // would read '%L' as a conversion and either mangle the clause or throw
+    // a ValueError on PHP 8, so the placeholder is substituted with
+    // str_replace. Nothing about the wrong version looks wrong until the
+    // list answers 500.
+    'name' => "a literal '%' in the membership test survives substitution",
+    'assert' => function () use ($columns) {
+        $percent = $columns;
+        $percent[5]['sqlfilter']['match'] =
+            "EXISTS (SELECT 1 FROM `t` WHERE `x` LIKE 'a%L' AND (%s))";
+        $want = "WHERE (EXISTS (SELECT 1 FROM `t` WHERE `x` LIKE 'a%L'"
+            . " AND (`groups`.`groupName` = 'lab01')))";
+        $got = SearchBuilderProbe::build(
+            sbRequest([sbCriterion('groups', '=', ['lab01'])]),
+            $percent
+        );
+
+        return $got === $want
+            ? ''
+            : "expected: $want\n    got:      $got";
+    },
+];
+
+$cases[] = [
+    'name' => 'a malformed sqlfilter matches nothing rather than half of it',
+    'assert' => function () use ($columns) {
+        $broken = $columns;
+        // Every way the contract can be wrong, one at a time. Each must
+        // produce NO clause -- a template with no placeholder would filter
+        // on nothing while looking like it filtered, which is the shape that
+        // returns plausible wrong rows.
+        $mutations = [
+            'no table' => ['column' => 'groupName', 'match' => 'X (%s)'],
+            'no column' => ['table' => 'groups', 'match' => 'X (%s)'],
+            'no match' => ['table' => 'groups', 'column' => 'groupName'],
+            'no placeholder' => [
+                'table' => 'groups',
+                'column' => 'groupName',
+                'match' => 'X (1)',
+            ],
+            'two placeholders' => [
+                'table' => 'groups',
+                'column' => 'groupName',
+                'match' => 'X (%s) AND Y (%s)',
+            ],
+            'quoted identifier' => [
+                'table' => '`groups`',
+                'column' => 'groupName',
+                'match' => 'X (%s)',
+            ],
+            'injected identifier' => [
+                'table' => 'groups',
+                'column' => 'groupName` = 1 OR `1',
+                'match' => 'X (%s)',
+            ],
+        ];
+        $problems = [];
+        foreach ($mutations as $why => $filter) {
+            $broken[5]['sqlfilter'] = $filter;
+            $got = SearchBuilderProbe::build(
+                sbRequest([sbCriterion('groups', 'contains', ['lab'])]),
+                $broken
+            );
+            if ('' !== $got) {
+                $problems[] = $why . ' produced: ' . $got;
+            }
+            $types = SearchBuilderProbe::types('hosts', $broken);
+            if (false !== ($types['groups'] ?? null)) {
+                $problems[] = $why . ' was offered to the browser as '
+                    . json_encode($types['groups'] ?? null);
+            }
+        }
+
+        return implode("\n    ", $problems);
+    },
+];
+
 /* -- the viewer's timezone -------------------------------------------- */
 
 /*
@@ -716,6 +946,10 @@ $expectTypes = [
     'deployed' => 'date',
     'token' => false,
     'members' => false,
+    // Offered as a text filter even though there is no `hosts` column behind
+    // it: reported false, the UI would leave the column out of the picker
+    // entirely and the feature would be invisible.
+    'groups' => 'string',
 ];
 $gotTypes = SearchBuilderProbe::types('hosts', $columns);
 if ($gotTypes !== $expectTypes) {


### PR DESCRIPTION
ADR 0038 Decision 16a requirement 1, unit D1 of `docs/development/group-split.md`.

A group is a label now. A label you cannot see on the host list, or search by, is not one.

## What this is, in one paragraph

The grid filter framework (#1471/#1476/#1477) is **column-backed by construction**: `_sbCriterion()` builds `` `$column['db']` `` and returns empty for a column that has no `db`, and the type comes from `columnType()` reading a real column of a real table. Group membership is a many-to-many through `groupMembers` — there is no `hosts` column to name. So this is not "add a column" and not "build filtering": it is **teaching the shared filter path its first relationship column**, which is a change to a helper every grid in the product runs through.

## The contract

A column declares `sqlfilter` **instead of** `db`:

```php
'sqlfilter' => [
    'table'  => 'groups',      // a real table
    'column' => 'groupName',   // a real column of it
    'match'  => 'EXISTS (SELECT 1 FROM `groupMembers` ... '
              . 'WHERE `gmHostID` = `hosts`.`hostID` AND (%s))',
]
```

The criterion is still built, typed and bound by the same code every other column uses. The column definition supplies only the join that reaches the row. Full reasoning is on `FOGManagerController::relationFilter()`.

**The absent `db` is the fail-safe, not a workaround.** `pluck()` (the SELECT list), `orderColumn()` (ORDER BY) and the plain LIKE in `filter()` all already skip a column without one, so a relationship column can only ever be reached through the arms that were taught what it is. A path that has not been taught ignores it.

## Three things the plan did not have, found in the building

**1. Negation has to be applied OUTSIDE the membership test.** This would have shipped wrong and looked right.

| form | asks | on the fixture |
|---|---|---|
| `NOT (EXISTS(... name = 'lab01'))` | in **no** group called lab01 | `h-office-only`, `h-no-groups` |
| `EXISTS(... name <> 'lab01')` | in **some** group that is not lab01 | `h-lab-and-office`, `h-office-only` |

Both are valid SQL and both answer 200. The wrong one returns a host that **is** in lab01. Proven on rows in a scratch MariaDB, then pinned in the test.

**2. `null`/`!null` invert.** On a relationship, "empty" means no related row *at all*, so the membership test is the whole predicate and there is nothing to compare — `null` negates and `!null` does not, the opposite way round to every other pair.

**3. The free-text box has to go through the same contract**, not only the Filter panel. It and the header box were one copied line apart in `filter()`, and a global search that silently cannot find a host by its group name reads as the search being broken rather than as the column being special.

## Access control

The membership test **and** the chips' own query carry `Authorization::scopedObjectWhere('group', ...)`. A group is a site-scoped node (`SiteScope::$_nodes`), so without it a site-bounded user could read the names of groups outside their scope off a host they are allowed to see, and use the filter as an oracle for which of their hosts are in one.

## The column

- **Chips**, one per group, each linking to that group, rendered client-side and escaped with `$.escapeHtml`. The visible cell the server sends is plain text — `registerExportTable()` escapes each cell, so markup baked in server-side lands in the CSV as literal text (GH-1446). Same `type !== 'display'` split `sbstate` already uses.
- **Two queries per page**, not per host, via the column table's existing `prime` mechanism.
- **Ordered the way assignment resolution walks the groups**, so the chips read left to right in the order that decides which group's grant lands first (Decision 6).
- **Not sortable.** There is no expression to ORDER BY that does not cost a correlated subquery per row before the `LIMIT`, and a header click that quietly changes nothing reads as a broken grid.

Also corrected the comment at `HostManagement.php:150` that still said this grid has no per-column search UI. It has had one since #1471/#1476/#1477 — exactly the kind of comment that gets read as current, and the first draft of the proposal did read it that way.

## Gates

Extended `tests/searchbuilder-filter-clause.test.php` (106 checks), which already asserts on **every** case that no binding is left unnamed — the `_sbDate()` failure that answered HTTP 406 on Before/After.

Every new gate was made to fail before being trusted:

| mutation | red |
|---|---|
| negation never applied | ✔ |
| `$condition` pushed inside instead of `$positive` | ✔ |
| `null` sense not inverted | ✔ |
| `_likeClause()` loses its relationship arm | ✔ |
| placeholder count unchecked | ✔ |
| identifier pattern unchecked (shows the injection it stops) | ✔ |
| `searchTypes()` loses its relationship arm | ✔ |
| `sprintf` in place of `str_replace` | ✔ (ValueError) |

Full suite 293/293, both phpstan configs clean, `route-column-contract.txt` regenerated.

**Not verified here:** the rendered page. The chips, the responsive behavior and the Filter panel's picker need a deploy and a browser.

## What is left in unit D

- **D2** — bulk add *and remove* from the list through the shared create-and-associate path, plus `saveGroup()`'s two confirmed defects (no CSRF, no object scope) and the `group.create`/`group.edit` split.
- **D3** — the group list's "grants" column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)