### PR TITLE
Host list: remove from a group as well as add, and stop losing typed group names

### DIFF
--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -956,6 +956,16 @@ Group Management" complaint. Remove is not a nicety: a label you can apply and
 cannot retract is not a label, and its absence is why the current modal reads
 as a group operation rather than a tagging one.
 
+**Built (D2).** `action=remove` is the only difference on the wire. Both
+directions run through one path — the same gates, the same id normalization,
+the same scope bounds, one loop with one branch in it — because two paths
+would be two chances to bound one direction and not the other. An
+unrecognized `action` adds, which is what every client predating this sends
+and is the direction that cannot strip a label off a fleet by accident.
+`Group::removeHost()` is the method the group page's own Hosts tab already
+uses through `assocPost('addHost', 'removeHost')`, so this is not a second
+removal path.
+
 **3. It has to *feel* lightweight, and that is a requirement with a test.**
 
 Chips, typeahead, and create-on-the-fly from the list. Nobody minds twenty
@@ -969,6 +979,20 @@ modal is already a select2 with `tags: true`, `tokenSeparators`, ajax typeahead
 against `/group/names/`, and a `createTag` handler that badges an unmatched
 term `(new)` (`fog.host.list.js:29-90`). What is missing is remove, multi-group
 clarity, and requirement 4.
+
+**Built (D2).** One modal, two buttons — Add and Remove — over the same
+multi-select, so three labels onto forty hosts is one selection and one
+action, and taking them off again is one selection and one action. The grid
+reloads in place afterward so the chips from requirement 1 are current and
+the selection survives, because the point of editing labels in bulk is to
+keep going.
+
+**A defect found while wiring the second button.** `loadGroupSelect()` runs on
+every `show.bs.modal` — select2 is destroyed on close and has to be rebuilt —
+and it bound the submit handler with a plain `.on()`. Opening the modal twice
+and clicking Add once therefore POSTed twice. Harmless while the endpoint only
+added; not harmless for a remove, and not harmless at all for a handler that
+mints groups. Both buttons are now namespaced and unbound first.
 
 **4. Create-and-associate goes through the shared path, not a second one.**
 
@@ -989,6 +1013,56 @@ already two creation paths and the newer one is the looser one.
 Reuse the shared helper. This is not tidiness: the list modal is about to
 become the *primary* surface for membership, and a second write path that
 skips the first one's validation is the wrong thing to promote.
+
+---
+
+**Amended in the building (D2): the validation moved to the endpoint, and the
+shared JS helper was NOT reused. The reasoning above was right about the
+defect and wrong about where the fix belongs.**
+
+`$.registerCreateAndAssociate()` is a helper for an association **grid tab**.
+It fetches that node's create FORM into a modal, and POSTs the created id to
+the tab's own update URL, which arrives on the button as a data attribute
+(`renderAssocCreate` puts it there). The host list has no association tab, no
+such endpoint, and no single subject — it has N hosts and M groups. Reusing it
+literally would mean opening the group create form once per new group and
+issuing one association POST per group, which is the exact opposite of
+requirement 3's stated test: *applying three labels to forty hosts is one
+selection and one action.* The two requirements conflict when requirement 4 is
+read as "use that function", and requirement 3 is the one carrying a test.
+
+What requirement 4 is actually *about* survives intact: **a second write path
+that skips the first one's validation is the wrong thing to promote.** So the
+validation was put where it holds for every caller rather than for one client:
+
+**`groupName` is UNIQUE — the manifest declares it twice over — so
+`->set('name', $taken)->save()` fails on the duplicate key, and `saveGroup()`
+discarded `save()`'s return.** Typing the name of a group that already exists
+into the modal's `(new)` slot answered `202 Successfully added` and inserted
+nothing at all. That is a worse failure than the missing collision check this
+section describes, and no amount of routing through the JS helper would have
+fixed it — a hand-rolled POST, a script, or a future client would still hit it.
+
+The endpoint now resolves every typed name against the groups that exist, in
+one query, before it does anything else; a name that resolves becomes an
+ordinary group id, and one that does not is created. `save()`'s return is
+propagated on both paths.
+
+**Two orderings in that are load-bearing and are pinned as positions, not as
+greps:**
+
+- **Resolution runs before `requirePageObjectScopeMass('group', ...)`.** A
+  resolved id is an id, so it has to be subject to the same boundary an id
+  posted directly is. Resolving afterward would make *typing a name* a way
+  past the site boundary, and nothing about the request would look wrong.
+- **Resolution runs before the `group.create` check**, for the reason given
+  under the permission table above.
+
+The endpoint also now writes an audit row (`host.groupadd` / `host.groupremove`
+with the affected count). It recorded nothing, where the mass edit beside it
+has recorded its own writes since it shipped — and once membership *is* the
+label, who applied which one to how many hosts is precisely the question the
+audit log exists to answer.
 
 **Two defects on that path must be fixed as part of this, not after it.**
 `saveGroup()` (`HostManagement.php:4083`) is a state-changing POST handler and:
@@ -1066,9 +1140,17 @@ and no role loses anything. Both checks are inside the handler rather than in
 override can only name one permission; that is the same reasoning
 `savedfilters` records for its own `null` entry (`Authorization.php:289`).
 
-The existing `SUB_OVERRIDES['host']['savegroup'] => 'group.create'` entry stays
-as the floor until the handler is split, so nothing is loosened before the
-narrower check exists to replace it.
+**Shipped.** `SUB_OVERRIDES['host']['savegroup']` is `group.edit`, and the
+`group.create` half lives in the handler where it can read the body. Both are
+pinned by `tests/savegroup-is-gated.test.php`, which executes
+`resolvePagePermission()` rather than reading the constant.
+
+One refinement the build added: the `group.create` check runs **after** typed
+names are resolved against the groups that already exist (requirement 4
+below). A name that turns out to name a group creates nothing, so demanding
+`group.create` for it would be asking for the wider right in order to do the
+narrower thing — the same inversion this split exists to undo, one level
+down.
 
 **5. The group list shows what a group grants.**
 

--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -759,17 +759,30 @@ serialize through conflicts anyway.
 | M3 | Client paths read the resolved list; `checkPassiveModule` fix | `Items/Host.php`, `Client/ServiceModule.php`, `Client/FOGClient.php`, `Base/FOGPage.php` | M2 | **merged** (#1633) |
 | M4 | `addRemItem()` module special case removed; auto-logout minimum named once | `Base/FOGController.php`, `Pages/HostManagement.php` | M3 | **merged** (#1634) |
 | M5 | Host Modules tab becomes genuinely tri-state, so a host can say OFF | `Pages/HostManagement.php`, JS | M4 | not started |
-| D1 | The `sqlfilter` relationship-filter contract, and the host list's groups column on it | `Base/FOGManagerController.php`, `Router/Route.php`, `Pages/HostManagement.php`, `fog.host.list.js` | C5 | open (#TBD) |
-| D2 | Bulk add AND remove from the list, through the shared create-and-associate path; the two `saveGroup()` defects and the permission split | `Pages/HostManagement.php`, `Auth/Authorization.php`, `fog.host.list.js` | D1 | not started |
+| D1 | The `sqlfilter` relationship-filter contract, and the host list's groups column on it | `Base/FOGManagerController.php`, `Router/Route.php`, `Pages/HostManagement.php`, `fog.host.list.js` | C5 | open (#1639) |
+| D2a | `saveGroup()` gated: CSRF, object scope both sides, and the `group.edit`/`group.create` split | `Pages/HostManagement.php`, `Auth/Authorization.php` | — | **merged** (3cb39b8df) |
+| D2b | Remove as well as add, from the list; typed names resolved against the groups that exist; the write audited | `Pages/HostManagement.php`, `Base/FOGPage.php`, `fog.host.list.js` | D1, D2a | open (#TBD) |
 | D3 | Group list "grants" column | `Router/Route.php`, `Pages/GroupManagement.php`, JS | D1 | not started |
 | E | Group page rework + removal of the imperative tabs, and `Group::addSnapin`/`addPrinter`/`addModule` become grants | `Pages/GroupManagement.php`, `Items/Group.php`, JS | **C5 proven** (Decision 10), D, M5 | not started |
 
-D split into three while building it, on the same rule C did: by what each
-piece can be tested on its own. D1 is the shared helper plus the one column
-that proves it, and it is the plan-first half -- a change to a path every grid
-in the product runs through. D2 is a write path with its own two security
-defects and a permission split, which is a different review from a read path.
-D3 needs D1's contract and nothing else.
+D split while building it, on the same rule C did: by what each piece can be
+tested on its own. D1 is the shared helper plus the one column that proves it,
+and it is the plan-first half -- a change to a path every grid in the product
+runs through. D2 is a write path, which is a different review from a read
+path; its security half (D2a) went in ahead of the rest, on its own, off the
+back of UNKNOWN-6. D3 needs D1's contract and nothing else.
+
+**Requirement 4 was amended rather than implemented as written**, and the ADR
+carries the reasoning. `$.registerCreateAndAssociate()` is a helper for an
+association GRID TAB -- it fetches that node's create form and POSTs to the
+tab's own update URL. The host list has no such tab and no single subject, so
+using it would mean one form and one POST per group, which is the opposite of
+requirement 3's stated test. What requirement 4 is about -- a second write path
+skipping the first one's validation -- was fixed at the endpoint instead, where
+it holds for a script and a future client as well as for this modal. The
+concrete defect turned out to be worse than the missing collision check the ADR
+described: `groupName` is UNIQUE, `save()`'s return was discarded, and typing an
+existing group's name answered 202 while inserting nothing.
 
 C5 split into five as it was built. The split is by what each piece can be
 tested against on its own -- the action model with no endpoint, the endpoint

--- a/docs/release/1.6.0-release-notes.DRAFT.md
+++ b/docs/release/1.6.0-release-notes.DRAFT.md
@@ -304,6 +304,30 @@ pre-upgrade *dump* — it is not a schema rollback.
   It is the one column with no sort: there is nothing on the host record to
   sort by, and a header click that quietly changed nothing would be worse than
   no arrow at all.
+
+- **You can take a host out of a group from the host list, not just put one
+  in.** The list's group button is now *Edit groups*, and the modal behind it
+  has both Add and Remove over the same selection -- so three labels onto
+  forty hosts is one selection and one action, and taking them off again is
+  one selection and one action. The list refreshes in place afterward, so the
+  chips are current and your selection survives.
+
+  **Two fixes on that endpoint you may have been hit by.**
+
+  Typing the name of a group that already exists into the "create a new
+  group" slot used to report success and do nothing at all. Group names are
+  unique, so the insert failed on the duplicate and the failure was thrown
+  away. A typed name that matches an existing group now simply means that
+  group -- the same thing picking it from the list has always meant.
+
+  And opening the modal, closing it and opening it again used to submit twice
+  when you clicked Add. Once, now, however many times you open it.
+
+  Bulk membership editing needs **Group -> Edit**, not Group -> Create. If the
+  request actually creates a group, it needs Group -> Create as well. That is
+  a widening for anyone who could already edit groups: applying a label no
+  longer requires the right to mint one. Adding or removing hosts is also
+  written to the audit log now, with who, how many, and which groups.
   <!-- verified: docs/adr/0038 decisions 4, 5, 6, 7 and 9; FOG\Assign\Resolver;
   Client/PrinterClient.php; docs/GROUP_SHARED_STATE.md -->
 - **Mass edit on the host list**, and it asks before it overwrites. Tick any

--- a/packages/web/management/js/fog/host/fog.host.list.js
+++ b/packages/web/management/js/fog/host/fog.host.list.js
@@ -94,8 +94,18 @@
             }
         });
 
-        hostGroupUpdateBtn.on('click', function(e) {
-            e.preventDefault();
+        // One submit for both directions. The only thing that differs on the
+        // wire is `action`, so add and remove cannot drift apart about what
+        // "the selection" is or which ids are sent -- which is the same
+        // reason massEditSelection() exists server-side.
+        //
+        // A term select2 could not match an existing group by is sent as a
+        // NAME, in groups_new. The server resolves those against the groups
+        // that exist before it creates anything (groupName is UNIQUE), so
+        // typing the name of a group instead of picking it from the list
+        // does the same thing either way, and remove is told which of the
+        // names it could not find rather than silently doing nothing.
+        function submitMembership(remove) {
             var items = groupModalSelect.find('option').map(function() {return $(this).val()}).get(),
                 hosts = $.getSelectedIds(table),
                 groups = [],
@@ -118,7 +128,8 @@
                 opts = {
                     hosts: hosts,
                     groups: groups,
-                    groups_new: groups_new
+                    groups_new: groups_new,
+                    action: remove ? 'remove' : 'add'
                 };
             $.apiCall(method,action,opts,function(err) {
                 if (err) {
@@ -126,8 +137,35 @@
                 }
                 groupModalSelect.val(null);
                 groupModal.modal('hide');
+                // The Groups column is on this grid now, so the chips are
+                // stale the moment this returns. Redrawn holding the current
+                // page and selection, because the point of editing labels in
+                // bulk is to keep going.
+                table.ajax.reload(null, false);
             });
-        });
+        }
+
+        // NAMESPACED, AND UNBOUND FIRST. loadGroupSelect() runs on every
+        // show.bs.modal -- select2 is destroyed on close and has to be built
+        // again -- so a plain .on() here stacked a second handler on the
+        // second open and a third on the third. That was already true of the
+        // Add button before Remove existed: open the modal twice, click Add
+        // once, and the POST went twice. Harmless for an idempotent add;
+        // not harmless for a remove, and not harmless at all now that the
+        // handler creates groups.
+        hostGroupUpdateBtn
+            .off('click.fogGroupMembership')
+            .on('click.fogGroupMembership', function(e) {
+                e.preventDefault();
+                submitMembership(false);
+            });
+
+        $('#confirmGroupRemove')
+            .off('click.fogGroupMembership')
+            .on('click.fogGroupMembership', function(e) {
+                e.preventDefault();
+                submitMembership(true);
+            });
     }
 
     // Build the column list from the header row instead of hardcoding it.
@@ -545,7 +583,7 @@
         });
     });
 
-    // Add host(s) to group.
+    // Edit the selected hosts' group membership, both directions.
     groupModal.registerModal(
         // On show
         null,

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -415,6 +415,9 @@ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
+msgid "A name that is not already a group is created when you add. Remove only works on groups that exist."
+msgstr ""
+
 #, fuzzy
 msgid "A page of results."
 msgstr "Alle Regeln auflisten"
@@ -755,10 +758,6 @@ msgid "Add Storage Node"
 msgstr "Speicherknoten hinzufügen"
 
 #, fuzzy
-msgid "Add To Group(s)"
-msgstr "Speichergruppe hinzufügen"
-
-#, fuzzy
 msgid "Add broadcast failed!"
 msgstr "Hinzufügen eines Broadcasts fehlgeschlagen!"
 
@@ -827,10 +826,6 @@ msgid "Add selected"
 msgstr "ausgewählte Images hinzufügen"
 
 #, fuzzy
-msgid "Add selected to group"
-msgstr "Ausgewählte Speichergruppen hinzufügen"
-
-#, fuzzy
 msgid "Add site failed!"
 msgstr "Hinzufügen eines Hosts fehlgeschlagen!"
 
@@ -872,6 +867,10 @@ msgstr "Hinzufügen eines Hosts fehlgeschlagen!"
 #, fuzzy
 msgid "Add/Remove Managed Printers"
 msgstr "FOG-verwaltete Drucker"
+
+#, php-format
+msgid "Added %1$d host(s) to %2$d group(s)."
+msgstr ""
 
 #, php-format
 msgid "Adding FOGPage: %s, Node: %s"
@@ -1864,6 +1863,10 @@ msgstr "Aktualisieren des Hosts fehlgeschlagen"
 msgid "Could not create the catch-all site"
 msgstr "Erstellen eines Snapin-Jobs fehlgeschlagen"
 
+#, fuzzy, php-format
+msgid "Could not create the group \"%s\""
+msgstr "Tmp-Datei konnte nicht gelesen werden."
+
 #, fuzzy
 msgid "Could not create the staging directory."
 msgstr "Erstellen eines Snapin-Jobs fehlgeschlagen"
@@ -1979,6 +1982,10 @@ msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 msgid "Could not update host"
+msgstr "Aktualisieren des Hosts fehlgeschlagen"
+
+#, fuzzy, php-format
+msgid "Could not update the group \"%s\""
 msgstr "Aktualisieren des Hosts fehlgeschlagen"
 
 #, php-format
@@ -2574,6 +2581,10 @@ msgstr "Snapins exportieren"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "Snapins exportieren"
+
+#, fuzzy
+msgid "Edit groups"
+msgstr "Admingruppe"
 
 #, fuzzy
 msgid "Edit selected hosts"
@@ -3506,6 +3517,10 @@ msgstr ""
 
 msgid "Group Member Attribute"
 msgstr "Gruppemmitglieder Attribut"
+
+#, fuzzy
+msgid "Group Membership"
+msgstr "Mitgliedschaft"
 
 #, fuzzy
 msgid "Group Module Associations"
@@ -5961,6 +5976,10 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+#, php-format
+msgid "No group named \"%s\" exists to remove hosts from"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -5984,10 +6003,6 @@ msgstr "Keine Hosts für Aufgaben (Task) verfügbar"
 
 #, fuzzy
 msgid "No hosts available to task"
-msgstr "Keine Hosts für Aufgaben (Task) verfügbar"
-
-#, fuzzy
-msgid "No hosts selected to be added"
 msgstr "Keine Hosts für Aufgaben (Task) verfügbar"
 
 #, fuzzy
@@ -7301,6 +7316,14 @@ msgid "Remove Fail"
 msgstr "Entfernen fehlgeschlagen"
 
 #, fuzzy
+msgid "Remove Hosts from Groups Fail"
+msgstr "Hinzufügen zur Gruppe fehlgeschlagen"
+
+#, fuzzy
+msgid "Remove Hosts from Groups Success"
+msgstr "Host erfolgreich zur Gruppe hinzugefügt"
+
+#, fuzzy
 msgid "Remove LDAP Group Associations"
 msgstr "Regel Zuordnung"
 
@@ -7333,6 +7356,10 @@ msgstr "Entfernt"
 
 #, php-format
 msgid "Removed %1$d association and satellite row(s) whose parent record no longer existed, so that foreign key constraints could be declared. Per table: %2$s"
+msgstr ""
+
+#, php-format
+msgid "Removed %1$d host(s) from %2$d group(s)."
 msgstr ""
 
 #, php-format
@@ -8795,10 +8822,6 @@ msgstr "Import erfolgreich"
 #, fuzzy
 msgid "Success."
 msgstr "Zugang"
-
-#, fuzzy
-msgid "Successfully added hosts to the provided groups!"
-msgstr "ausgewählte Hosts erfolgreich zur Gruppe hinzugefügt "
 
 #, fuzzy
 msgid "Successfully deleted"
@@ -11840,6 +11863,10 @@ msgstr ""
 #~ msgstr "ausgewählte Images hinzufügen"
 
 #, fuzzy
+#~ msgid "Add To Group(s)"
+#~ msgstr "Speichergruppe hinzufügen"
+
+#, fuzzy
 #~ msgid "Add accesscontrol failed!"
 #~ msgstr "Standort hinzufügen fehlgeschlagen"
 
@@ -11848,8 +11875,8 @@ msgstr ""
 #~ msgstr "Benutzer hinzufügen fehlgeschlagen!"
 
 #, fuzzy
-#~ msgid "Admin Group"
-#~ msgstr "Admingruppe"
+#~ msgid "Add selected to group"
+#~ msgstr "Ausgewählte Speichergruppen hinzufügen"
 
 #, fuzzy
 #~ msgid "Administrator Group"
@@ -12208,6 +12235,10 @@ msgstr ""
 #~ msgstr "Keine brauchbaren Speichergruppen gefunden"
 
 #, fuzzy
+#~ msgid "No hosts selected to be added"
+#~ msgstr "Keine Hosts für Aufgaben (Task) verfügbar"
+
+#, fuzzy
 #~ msgid "No mappings defined."
 #~ msgstr "Nicht synchronisieren"
 
@@ -12350,6 +12381,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Storage Node FTP User"
 #~ msgstr "Speicherknoten Benutzername"
+
+#, fuzzy
+#~ msgid "Successfully added hosts to the provided groups!"
+#~ msgstr "ausgewählte Hosts erfolgreich zur Gruppe hinzugefügt "
 
 #, fuzzy
 #~ msgid "Task is not an imaging task"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -420,6 +420,9 @@ msgstr "An image already exists with this name!"
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
+msgid "A name that is not already a group is created when you add. Remove only works on groups that exist."
+msgstr ""
+
 #, fuzzy
 msgid "A page of results."
 msgstr "List All %s"
@@ -759,10 +762,6 @@ msgid "Add Storage Node"
 msgstr "Add Storage Node"
 
 #, fuzzy
-msgid "Add To Group(s)"
-msgstr "Add Storage Group"
-
-#, fuzzy
 msgid "Add broadcast failed!"
 msgstr "Add snapin failed!"
 
@@ -831,10 +830,6 @@ msgid "Add selected"
 msgstr "Remove selected printers"
 
 #, fuzzy
-msgid "Add selected to group"
-msgstr "Remove selected snapins"
-
-#, fuzzy
 msgid "Add site failed!"
 msgstr "Add snapin failed!"
 
@@ -876,6 +871,10 @@ msgstr "Add snapin failed!"
 #, fuzzy
 msgid "Add/Remove Managed Printers"
 msgstr "FOG Managed Printers"
+
+#, php-format
+msgid "Added %1$d host(s) to %2$d group(s)."
+msgstr ""
 
 #, php-format
 msgid "Adding FOGPage: %s, Node: %s"
@@ -1866,6 +1865,10 @@ msgstr "Failed to update"
 msgid "Could not create the catch-all site"
 msgstr "Failed to create Snapin Job"
 
+#, fuzzy, php-format
+msgid "Could not create the group \"%s\""
+msgstr "Could not read tmp file."
+
 #, fuzzy
 msgid "Could not create the staging directory."
 msgstr "Failed to create Snapin Job"
@@ -1981,6 +1984,10 @@ msgstr "Could not read tmp file."
 
 #, fuzzy
 msgid "Could not update host"
+msgstr "Failed to update"
+
+#, fuzzy, php-format
+msgid "Could not update the group \"%s\""
 msgstr "Failed to update"
 
 #, php-format
@@ -2577,6 +2584,10 @@ msgstr "Export Snapins"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "Export Snapins"
+
+#, fuzzy
+msgid "Edit groups"
+msgstr "Modify Group"
 
 #, fuzzy
 msgid "Edit selected hosts"
@@ -3509,6 +3520,10 @@ msgstr ""
 #, fuzzy
 msgid "Group Member Attribute"
 msgstr "User Name"
+
+#, fuzzy
+msgid "Group Membership"
+msgstr "Membership"
 
 #, fuzzy
 msgid "Group Module Associations"
@@ -5973,6 +5988,10 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+#, php-format
+msgid "No group named \"%s\" exists to remove hosts from"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -5996,10 +6015,6 @@ msgstr "Hosts in Task"
 
 #, fuzzy
 msgid "No hosts available to task"
-msgstr "Hosts in Task"
-
-#, fuzzy
-msgid "No hosts selected to be added"
 msgstr "Hosts in Task"
 
 #, fuzzy
@@ -7312,6 +7327,14 @@ msgid "Remove Fail"
 msgstr "Removed"
 
 #, fuzzy
+msgid "Remove Hosts from Groups Fail"
+msgstr "Add to group"
+
+#, fuzzy
+msgid "Remove Hosts from Groups Success"
+msgstr "Install / Update Successful!"
+
+#, fuzzy
 msgid "Remove LDAP Group Associations"
 msgstr "Image Association"
 
@@ -7344,6 +7367,10 @@ msgstr "Removed"
 
 #, php-format
 msgid "Removed %1$d association and satellite row(s) whose parent record no longer existed, so that foreign key constraints could be declared. Per table: %2$s"
+msgstr ""
+
+#, php-format
+msgid "Removed %1$d host(s) from %2$d group(s)."
 msgstr ""
 
 #, php-format
@@ -8804,10 +8831,6 @@ msgstr "Successful"
 #, fuzzy
 msgid "Success."
 msgstr "Access"
-
-#, fuzzy
-msgid "Successfully added hosts to the provided groups!"
-msgstr "Successfully associated Hosts with the Group "
 
 #, fuzzy
 msgid "Successfully deleted"
@@ -11841,6 +11864,10 @@ msgstr ""
 #~ msgstr "Remove selected printers"
 
 #, fuzzy
+#~ msgid "Add To Group(s)"
+#~ msgstr "Add Storage Group"
+
+#, fuzzy
 #~ msgid "Add accesscontrol failed!"
 #~ msgstr "Add snapin failed!"
 
@@ -11849,8 +11876,8 @@ msgstr ""
 #~ msgstr "Add snapin failed!"
 
 #, fuzzy
-#~ msgid "Admin Group"
-#~ msgstr "Modify Group"
+#~ msgid "Add selected to group"
+#~ msgstr "Remove selected snapins"
 
 #, fuzzy
 #~ msgid "Administrator Group"
@@ -12188,6 +12215,10 @@ msgstr ""
 #~ msgid "No directory groups defined."
 #~ msgstr "Installed Plugins"
 
+#, fuzzy
+#~ msgid "No hosts selected to be added"
+#~ msgstr "Hosts in Task"
+
 #~ msgid "No query sent"
 #~ msgstr "No query sent"
 
@@ -12314,6 +12345,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Storage Node FTP User"
 #~ msgstr "Storage Node Username"
+
+#, fuzzy
+#~ msgid "Successfully added hosts to the provided groups!"
+#~ msgstr "Successfully associated Hosts with the Group "
 
 #, fuzzy
 #~ msgid "Task run time"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -418,6 +418,9 @@ msgstr "Una imagen ya existe con este nombre!"
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
+msgid "A name that is not already a group is created when you add. Remove only works on groups that exist."
+msgstr ""
+
 #, fuzzy
 msgid "A page of results."
 msgstr "No disponible"
@@ -769,10 +772,6 @@ msgid "Add Storage Node"
 msgstr "nodo de almacenamiento"
 
 #, fuzzy
-msgid "Add To Group(s)"
-msgstr "Grupo de almacenamiento"
-
-#, fuzzy
 msgid "Add broadcast failed!"
 msgstr "Añadir fallidos SNAPin!"
 
@@ -841,10 +840,6 @@ msgid "Add selected"
 msgstr "Impresora"
 
 #, fuzzy
-msgid "Add selected to group"
-msgstr "Impresora"
-
-#, fuzzy
 msgid "Add site failed!"
 msgstr "Añadir fallidos SNAPin!"
 
@@ -887,6 +882,10 @@ msgstr "Añadir fallidos SNAPin!"
 #, fuzzy
 msgid "Add/Remove Managed Printers"
 msgstr "Impresoras FOG Managed"
+
+#, php-format
+msgid "Added %1$d host(s) to %2$d group(s)."
+msgstr ""
 
 #, php-format
 msgid "Adding FOGPage: %s, Node: %s"
@@ -1887,6 +1886,10 @@ msgstr "No se ha podido destruir"
 msgid "Could not create the catch-all site"
 msgstr "No se pudo crear Complemento de empleo"
 
+#, fuzzy, php-format
+msgid "Could not create the group \"%s\""
+msgstr "No se pudo leer el archivo tmp."
+
 #, fuzzy
 msgid "Could not create the staging directory."
 msgstr "No se pudo crear Complemento de empleo"
@@ -2001,6 +2004,10 @@ msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
 msgid "Could not update host"
+msgstr "No se ha podido destruir"
+
+#, fuzzy, php-format
+msgid "Could not update the group \"%s\""
 msgstr "No se ha podido destruir"
 
 #, php-format
@@ -2609,6 +2616,10 @@ msgstr "snapins"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "snapins"
+
+#, fuzzy
+msgid "Edit groups"
+msgstr "modificar Grupo"
 
 #, fuzzy
 msgid "Edit selected hosts"
@@ -3559,6 +3570,10 @@ msgstr ""
 #, fuzzy
 msgid "Group Member Attribute"
 msgstr "Nombre de usuario"
+
+#, fuzzy
+msgid "Group Membership"
+msgstr "miembros"
 
 #, fuzzy
 msgid "Group Module Associations"
@@ -6081,6 +6096,10 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+#, php-format
+msgid "No group named \"%s\" exists to remove hosts from"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -6104,10 +6123,6 @@ msgstr "Anfitriones en tareas"
 
 #, fuzzy
 msgid "No hosts available to task"
-msgstr "Anfitriones en tareas"
-
-#, fuzzy
-msgid "No hosts selected to be added"
 msgstr "Anfitriones en tareas"
 
 #, fuzzy
@@ -7438,6 +7453,14 @@ msgid "Remove Fail"
 msgstr "Remoto"
 
 #, fuzzy
+msgid "Remove Hosts from Groups Fail"
+msgstr "Añadir al grupo"
+
+#, fuzzy
+msgid "Remove Hosts from Groups Success"
+msgstr "actualización Valoración falló"
+
+#, fuzzy
 msgid "Remove LDAP Group Associations"
 msgstr "Asociación para la imagen"
 
@@ -7471,6 +7494,10 @@ msgstr "retirar"
 
 #, php-format
 msgid "Removed %1$d association and satellite row(s) whose parent record no longer existed, so that foreign key constraints could be declared. Per table: %2$s"
+msgstr ""
+
+#, php-format
+msgid "Removed %1$d host(s) from %2$d group(s)."
 msgstr ""
 
 #, php-format
@@ -8963,10 +8990,6 @@ msgstr "Exitoso"
 #, fuzzy
 msgid "Success."
 msgstr "Exitoso"
-
-#, fuzzy
-msgid "Successfully added hosts to the provided groups!"
-msgstr "actualizado exitosamente"
 
 #, fuzzy
 msgid "Successfully deleted"
@@ -11999,6 +12022,10 @@ msgstr ""
 #~ msgstr "Impresora"
 
 #, fuzzy
+#~ msgid "Add To Group(s)"
+#~ msgstr "Grupo de almacenamiento"
+
+#, fuzzy
 #~ msgid "Add accesscontrol failed!"
 #~ msgstr "Añadir fallidos SNAPin!"
 
@@ -12007,8 +12034,8 @@ msgstr ""
 #~ msgstr "Añadir fallidos SNAPin!"
 
 #, fuzzy
-#~ msgid "Admin Group"
-#~ msgstr "modificar Grupo"
+#~ msgid "Add selected to group"
+#~ msgstr "Impresora"
 
 #, fuzzy
 #~ msgid "Administrator Group"
@@ -12358,6 +12385,10 @@ msgstr ""
 #~ msgstr "Instalador inteligente (recomendado)"
 
 #, fuzzy
+#~ msgid "No hosts selected to be added"
+#~ msgstr "Anfitriones en tareas"
+
+#, fuzzy
 #~ msgid "No query sent"
 #~ msgstr "Se desconoce el valor de clase enviado"
 
@@ -12474,6 +12505,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Storage Node FTP User"
 #~ msgstr "Uso del disco nodo de almacenamiento"
+
+#, fuzzy
+#~ msgid "Successfully added hosts to the provided groups!"
+#~ msgstr "actualizado exitosamente"
 
 #, fuzzy
 #~ msgid "Task run time"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -415,6 +415,9 @@ msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
+msgid "A name that is not already a group is created when you add. Remove only works on groups that exist."
+msgstr ""
+
 #, fuzzy
 msgid "A page of results."
 msgstr "Alle Regeln auflisten"
@@ -755,10 +758,6 @@ msgid "Add Storage Node"
 msgstr "Speicherknoten hinzufügen"
 
 #, fuzzy
-msgid "Add To Group(s)"
-msgstr "Speichergruppe hinzufügen"
-
-#, fuzzy
 msgid "Add broadcast failed!"
 msgstr "Hinzufügen eines Broadcasts fehlgeschlagen!"
 
@@ -827,10 +826,6 @@ msgid "Add selected"
 msgstr "ausgewählte Images hinzufügen"
 
 #, fuzzy
-msgid "Add selected to group"
-msgstr "Ausgewählte Speichergruppen hinzufügen"
-
-#, fuzzy
 msgid "Add site failed!"
 msgstr "Hinzufügen eines Hosts fehlgeschlagen!"
 
@@ -872,6 +867,10 @@ msgstr "Hinzufügen eines Hosts fehlgeschlagen!"
 #, fuzzy
 msgid "Add/Remove Managed Printers"
 msgstr "FOG-verwaltete Drucker"
+
+#, php-format
+msgid "Added %1$d host(s) to %2$d group(s)."
+msgstr ""
 
 #, php-format
 msgid "Adding FOGPage: %s, Node: %s"
@@ -1864,6 +1863,10 @@ msgstr "Aktualisieren des Hosts fehlgeschlagen"
 msgid "Could not create the catch-all site"
 msgstr "Erstellen eines Snapin-Jobs fehlgeschlagen"
 
+#, fuzzy, php-format
+msgid "Could not create the group \"%s\""
+msgstr "Tmp-Datei konnte nicht gelesen werden."
+
 #, fuzzy
 msgid "Could not create the staging directory."
 msgstr "Erstellen eines Snapin-Jobs fehlgeschlagen"
@@ -1979,6 +1982,10 @@ msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 msgid "Could not update host"
+msgstr "Aktualisieren des Hosts fehlgeschlagen"
+
+#, fuzzy, php-format
+msgid "Could not update the group \"%s\""
 msgstr "Aktualisieren des Hosts fehlgeschlagen"
 
 #, php-format
@@ -2574,6 +2581,10 @@ msgstr "Snapins exportieren"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "Snapins exportieren"
+
+#, fuzzy
+msgid "Edit groups"
+msgstr "Admingruppe"
 
 #, fuzzy
 msgid "Edit selected hosts"
@@ -3506,6 +3517,10 @@ msgstr ""
 
 msgid "Group Member Attribute"
 msgstr "Gruppemmitglieder Attribut"
+
+#, fuzzy
+msgid "Group Membership"
+msgstr "Mitgliedschaft"
 
 #, fuzzy
 msgid "Group Module Associations"
@@ -5962,6 +5977,10 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+#, php-format
+msgid "No group named \"%s\" exists to remove hosts from"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -5985,10 +6004,6 @@ msgstr "Keine Hosts für Aufgaben (Task) verfügbar"
 
 #, fuzzy
 msgid "No hosts available to task"
-msgstr "Keine Hosts für Aufgaben (Task) verfügbar"
-
-#, fuzzy
-msgid "No hosts selected to be added"
 msgstr "Keine Hosts für Aufgaben (Task) verfügbar"
 
 #, fuzzy
@@ -7302,6 +7317,14 @@ msgid "Remove Fail"
 msgstr "Entfernen fehlgeschlagen"
 
 #, fuzzy
+msgid "Remove Hosts from Groups Fail"
+msgstr "Hinzufügen zur Gruppe fehlgeschlagen"
+
+#, fuzzy
+msgid "Remove Hosts from Groups Success"
+msgstr "Host erfolgreich zur Gruppe hinzugefügt"
+
+#, fuzzy
 msgid "Remove LDAP Group Associations"
 msgstr "Regel Zuordnung"
 
@@ -7334,6 +7357,10 @@ msgstr "Entfernt"
 
 #, php-format
 msgid "Removed %1$d association and satellite row(s) whose parent record no longer existed, so that foreign key constraints could be declared. Per table: %2$s"
+msgstr ""
+
+#, php-format
+msgid "Removed %1$d host(s) from %2$d group(s)."
 msgstr ""
 
 #, php-format
@@ -8796,10 +8823,6 @@ msgstr "Import erfolgreich"
 #, fuzzy
 msgid "Success."
 msgstr "Zugang"
-
-#, fuzzy
-msgid "Successfully added hosts to the provided groups!"
-msgstr "ausgewählte Hosts erfolgreich zur Gruppe hinzugefügt "
 
 #, fuzzy
 msgid "Successfully deleted"
@@ -11841,6 +11864,10 @@ msgstr ""
 #~ msgstr "ausgewählte Images hinzufügen"
 
 #, fuzzy
+#~ msgid "Add To Group(s)"
+#~ msgstr "Speichergruppe hinzufügen"
+
+#, fuzzy
 #~ msgid "Add accesscontrol failed!"
 #~ msgstr "Standort hinzufügen fehlgeschlagen"
 
@@ -11849,8 +11876,8 @@ msgstr ""
 #~ msgstr "Benutzer hinzufügen fehlgeschlagen!"
 
 #, fuzzy
-#~ msgid "Admin Group"
-#~ msgstr "Admingruppe"
+#~ msgid "Add selected to group"
+#~ msgstr "Ausgewählte Speichergruppen hinzufügen"
 
 #, fuzzy
 #~ msgid "Administrator Group"
@@ -12209,6 +12236,10 @@ msgstr ""
 #~ msgstr "Keine brauchbaren Speichergruppen gefunden"
 
 #, fuzzy
+#~ msgid "No hosts selected to be added"
+#~ msgstr "Keine Hosts für Aufgaben (Task) verfügbar"
+
+#, fuzzy
 #~ msgid "No mappings defined."
 #~ msgstr "Nicht synchronisieren"
 
@@ -12351,6 +12382,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Storage Node FTP User"
 #~ msgstr "Speicherknoten Benutzername"
+
+#, fuzzy
+#~ msgid "Successfully added hosts to the provided groups!"
+#~ msgstr "ausgewählte Hosts erfolgreich zur Gruppe hinzugefügt "
 
 #, fuzzy
 #~ msgid "Task is not an imaging task"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -421,6 +421,9 @@ msgstr "Une image existe déjà avec ce nom!"
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
+msgid "A name that is not already a group is created when you add. Remove only works on groups that exist."
+msgstr ""
+
 #, fuzzy
 msgid "A page of results."
 msgstr "Lister tous les %s"
@@ -760,10 +763,6 @@ msgid "Add Storage Node"
 msgstr "Ajouter le nœud de stockage"
 
 #, fuzzy
-msgid "Add To Group(s)"
-msgstr "Ajouter un groupe de stockage"
-
-#, fuzzy
 msgid "Add broadcast failed!"
 msgstr "Ajouter SnapIn a échoué!"
 
@@ -832,10 +831,6 @@ msgid "Add selected"
 msgstr "Imprimante"
 
 #, fuzzy
-msgid "Add selected to group"
-msgstr "Imprimante"
-
-#, fuzzy
 msgid "Add site failed!"
 msgstr "Ajouter SnapIn a échoué!"
 
@@ -877,6 +872,10 @@ msgstr "Ajouter SnapIn a échoué!"
 #, fuzzy
 msgid "Add/Remove Managed Printers"
 msgstr "Imprimantes BROUILLARD Géré"
+
+#, php-format
+msgid "Added %1$d host(s) to %2$d group(s)."
+msgstr ""
 
 #, php-format
 msgid "Adding FOGPage: %s, Node: %s"
@@ -1868,6 +1867,10 @@ msgstr "Impossible de mettre à jour"
 msgid "Could not create the catch-all site"
 msgstr "Échec de la création d'emploi Snapin"
 
+#, fuzzy, php-format
+msgid "Could not create the group \"%s\""
+msgstr "Impossible de lire le fichier tmp."
+
 #, fuzzy
 msgid "Could not create the staging directory."
 msgstr "Échec de la création d'emploi Snapin"
@@ -1983,6 +1986,10 @@ msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
 msgid "Could not update host"
+msgstr "Impossible de mettre à jour"
+
+#, fuzzy, php-format
+msgid "Could not update the group \"%s\""
 msgstr "Impossible de mettre à jour"
 
 #, php-format
@@ -2578,6 +2585,10 @@ msgstr "Export SnapIns"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "Export SnapIns"
+
+#, fuzzy
+msgid "Edit groups"
+msgstr "Modifier Groupe"
 
 #, fuzzy
 msgid "Edit selected hosts"
@@ -3510,6 +3521,10 @@ msgstr ""
 #, fuzzy
 msgid "Group Member Attribute"
 msgstr "Nom d'utilisateur"
+
+#, fuzzy
+msgid "Group Membership"
+msgstr "Adhésion"
 
 #, fuzzy
 msgid "Group Module Associations"
@@ -5960,6 +5975,10 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+#, php-format
+msgid "No group named \"%s\" exists to remove hosts from"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -5983,10 +6002,6 @@ msgstr "Hôtes sur Task"
 
 #, fuzzy
 msgid "No hosts available to task"
-msgstr "Hôtes sur Task"
-
-#, fuzzy
-msgid "No hosts selected to be added"
 msgstr "Hôtes sur Task"
 
 #, fuzzy
@@ -7299,6 +7314,14 @@ msgid "Remove Fail"
 msgstr "supprimé"
 
 #, fuzzy
+msgid "Remove Hosts from Groups Fail"
+msgstr "Ajouter au groupe"
+
+#, fuzzy
+msgid "Remove Hosts from Groups Success"
+msgstr "Installation / Mise à jour réussie!"
+
+#, fuzzy
 msgid "Remove LDAP Group Associations"
 msgstr "Association Image"
 
@@ -7331,6 +7354,10 @@ msgstr "supprimé"
 
 #, php-format
 msgid "Removed %1$d association and satellite row(s) whose parent record no longer existed, so that foreign key constraints could be declared. Per table: %2$s"
+msgstr ""
+
+#, php-format
+msgid "Removed %1$d host(s) from %2$d group(s)."
 msgstr ""
 
 #, php-format
@@ -8789,10 +8816,6 @@ msgstr "Réussi"
 #, fuzzy
 msgid "Success."
 msgstr "Accès"
-
-#, fuzzy
-msgid "Successfully added hosts to the provided groups!"
-msgstr "Hôtes avec succès associé au groupe "
 
 #, fuzzy
 msgid "Successfully deleted"
@@ -11826,6 +11849,10 @@ msgstr ""
 #~ msgstr "Imprimante"
 
 #, fuzzy
+#~ msgid "Add To Group(s)"
+#~ msgstr "Ajouter un groupe de stockage"
+
+#, fuzzy
 #~ msgid "Add accesscontrol failed!"
 #~ msgstr "Ajouter SnapIn a échoué!"
 
@@ -11834,8 +11861,8 @@ msgstr ""
 #~ msgstr "Ajouter SnapIn a échoué!"
 
 #, fuzzy
-#~ msgid "Admin Group"
-#~ msgstr "Modifier Groupe"
+#~ msgid "Add selected to group"
+#~ msgstr "Imprimante"
 
 #, fuzzy
 #~ msgid "Administrator Group"
@@ -12181,6 +12208,10 @@ msgstr ""
 #~ msgid "No directory groups defined."
 #~ msgstr "Plugins installés"
 
+#, fuzzy
+#~ msgid "No hosts selected to be added"
+#~ msgstr "Hôtes sur Task"
+
 #~ msgid "No query sent"
 #~ msgstr "Aucune requête envoyée"
 
@@ -12307,6 +12338,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Storage Node FTP User"
 #~ msgstr "Nœud de stockage Nom d'utilisateur"
+
+#, fuzzy
+#~ msgid "Successfully added hosts to the provided groups!"
+#~ msgstr "Hôtes avec succès associé au groupe "
 
 #, fuzzy
 #~ msgid "Task run time"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -412,6 +412,9 @@ msgstr "Esiste già un ruolo con questo nome!"
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
+msgid "A name that is not already a group is created when you add. Remove only works on groups that exist."
+msgstr ""
+
 #, fuzzy
 msgid "A page of results."
 msgstr "Elencare tutte le regole"
@@ -743,10 +746,6 @@ msgstr "Aggiungere gruppo di archiviazione"
 msgid "Add Storage Node"
 msgstr "Aggiungere Storage Node"
 
-#, fuzzy
-msgid "Add To Group(s)"
-msgstr "Aggiungere gruppo di archiviazione"
-
 msgid "Add broadcast failed!"
 msgstr "Aggiunta broadcast non riuscita!"
 
@@ -809,10 +808,6 @@ msgid "Add selected"
 msgstr "Aggiungi stampanti selezionate"
 
 #, fuzzy
-msgid "Add selected to group"
-msgstr "Aggiungi gruppo di archiviazione selezionato"
-
-#, fuzzy
 msgid "Add site failed!"
 msgstr "Aggiunta host non riuscita!"
 
@@ -850,6 +845,10 @@ msgstr "Aggiunta host non riuscita!"
 #, fuzzy
 msgid "Add/Remove Managed Printers"
 msgstr "Gestione Stampanti FOG"
+
+#, php-format
+msgid "Added %1$d host(s) to %2$d group(s)."
+msgstr ""
 
 #, php-format
 msgid "Adding FOGPage: %s, Node: %s"
@@ -1814,6 +1813,10 @@ msgstr "Impossibile aggiornare l'host"
 msgid "Could not create the catch-all site"
 msgstr "Impossibile creare Snapin lavoro"
 
+#, fuzzy, php-format
+msgid "Could not create the group \"%s\""
+msgstr "Impossibile leggere il file tmp."
+
 #, fuzzy
 msgid "Could not create the staging directory."
 msgstr "Impossibile creare Snapin lavoro"
@@ -1923,6 +1926,10 @@ msgstr "Impossibile leggere il file tmp."
 
 #, fuzzy
 msgid "Could not update host"
+msgstr "Impossibile aggiornare l'host"
+
+#, fuzzy, php-format
+msgid "Could not update the group \"%s\""
 msgstr "Impossibile aggiornare l'host"
 
 #, php-format
@@ -2510,6 +2517,10 @@ msgstr "Export Snapins"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "Export Snapins"
+
+#, fuzzy
+msgid "Edit groups"
+msgstr "Gruppo amministrativo"
 
 #, fuzzy
 msgid "Edit selected hosts"
@@ -3420,6 +3431,10 @@ msgstr ""
 
 msgid "Group Member Attribute"
 msgstr "Attributo membro del gruppo"
+
+#, fuzzy
+msgid "Group Membership"
+msgstr "membri"
 
 #, fuzzy
 msgid "Group Module Associations"
@@ -5787,6 +5802,10 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+#, php-format
+msgid "No group named \"%s\" exists to remove hosts from"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -5809,10 +5828,6 @@ msgid "No hosts available to be tasked"
 msgstr "Nessun host disponibile per task"
 
 msgid "No hosts available to task"
-msgstr "Nessun host disponibile per task"
-
-#, fuzzy
-msgid "No hosts selected to be added"
 msgstr "Nessun host disponibile per task"
 
 msgid "No hosts to task"
@@ -7091,6 +7106,14 @@ msgid "Remove Fail"
 msgstr "Rimozione fallita"
 
 #, fuzzy
+msgid "Remove Hosts from Groups Fail"
+msgstr "Aggiunta host al gruppo fallita"
+
+#, fuzzy
+msgid "Remove Hosts from Groups Success"
+msgstr "Aggiunta host al gruppo completata"
+
+#, fuzzy
 msgid "Remove LDAP Group Associations"
 msgstr "Regole di associazione"
 
@@ -7122,6 +7145,10 @@ msgstr "Rimosso"
 
 #, php-format
 msgid "Removed %1$d association and satellite row(s) whose parent record no longer existed, so that foreign key constraints could be declared. Per table: %2$s"
+msgstr ""
+
+#, php-format
+msgid "Removed %1$d host(s) from %2$d group(s)."
 msgstr ""
 
 #, php-format
@@ -8527,10 +8554,6 @@ msgstr "Importazione riuscita"
 #, fuzzy
 msgid "Success."
 msgstr "Accesso"
-
-#, fuzzy
-msgid "Successfully added hosts to the provided groups!"
-msgstr "Aggiunti host selezionati al gruppo!"
 
 #, fuzzy
 msgid "Successfully deleted"
@@ -11464,6 +11487,10 @@ msgstr ""
 #~ msgstr "Aggiungi stampanti selezionate"
 
 #, fuzzy
+#~ msgid "Add To Group(s)"
+#~ msgstr "Aggiungere gruppo di archiviazione"
+
+#, fuzzy
 #~ msgid "Add accesscontrol failed!"
 #~ msgstr "Aggiunta posizione non riuscita!"
 
@@ -11471,8 +11498,9 @@ msgstr ""
 #~ msgid "Add rule failed!"
 #~ msgstr "Aggiunta utente fallita!"
 
-#~ msgid "Admin Group"
-#~ msgstr "Gruppo amministrativo"
+#, fuzzy
+#~ msgid "Add selected to group"
+#~ msgstr "Aggiungi gruppo di archiviazione selezionato"
 
 #, fuzzy
 #~ msgid "Administrator Group"
@@ -11823,6 +11851,10 @@ msgstr ""
 #~ msgstr "Nessun gruppo di storage disponibile trovato"
 
 #, fuzzy
+#~ msgid "No hosts selected to be added"
+#~ msgstr "Nessun host disponibile per task"
+
+#, fuzzy
 #~ msgid "No mappings defined."
 #~ msgstr "Non sincronizzo"
 
@@ -11957,6 +11989,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Storage Node FTP User"
 #~ msgstr "Storage Node Nome utente"
+
+#, fuzzy
+#~ msgid "Successfully added hosts to the provided groups!"
+#~ msgstr "Aggiunti host selezionati al gruppo!"
 
 #, fuzzy
 #~ msgid "Task is not an imaging task"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -402,6 +402,9 @@ msgstr "この名前のロールは既に存在します！"
 msgid "A name must be defined if using the \"name\" property"
 msgstr "\"name\" プロパティを使用する場合は、名前を定義する必要があります"
 
+msgid "A name that is not already a group is created when you add. Remove only works on groups that exist."
+msgstr ""
+
 #, fuzzy
 msgid "A page of results."
 msgstr "すべてのルールを一覧表示"
@@ -729,10 +732,6 @@ msgstr "ストレージグループを追加"
 msgid "Add Storage Node"
 msgstr "ストレージノードを追加"
 
-#, fuzzy
-msgid "Add To Group(s)"
-msgstr "グループに追加"
-
 msgid "Add broadcast failed!"
 msgstr "ブロードキャストの追加に失敗しました！"
 
@@ -793,10 +792,6 @@ msgstr "ロールの追加に失敗しました！"
 msgid "Add selected"
 msgstr "選択したホストを追加"
 
-#, fuzzy
-msgid "Add selected to group"
-msgstr "選択したストレージグループを追加"
-
 msgid "Add site failed!"
 msgstr "サイトの追加に失敗しました！"
 
@@ -834,6 +829,10 @@ msgstr "Windows キーの追加に失敗しました！"
 #, fuzzy
 msgid "Add/Remove Managed Printers"
 msgstr "FOG 管理プリンター"
+
+#, php-format
+msgid "Added %1$d host(s) to %2$d group(s)."
+msgstr ""
 
 #, php-format
 msgid "Adding FOGPage: %s, Node: %s"
@@ -1799,6 +1798,10 @@ msgstr "見つかりませんでした"
 msgid "Could not create the catch-all site"
 msgstr "スナップインジョブの作成に失敗しました"
 
+#, fuzzy, php-format
+msgid "Could not create the group \"%s\""
+msgstr "一時ファイルを読み取れませんでした。"
+
 #, fuzzy
 msgid "Could not create the staging directory."
 msgstr "スナップインジョブの作成に失敗しました"
@@ -1908,6 +1911,10 @@ msgstr "一時ファイルを読み取れませんでした。"
 
 #, fuzzy
 msgid "Could not update host"
+msgstr "ホストの更新に失敗しました"
+
+#, fuzzy, php-format
+msgid "Could not update the group \"%s\""
 msgstr "ホストの更新に失敗しました"
 
 #, php-format
@@ -2496,6 +2503,10 @@ msgstr "ノードを編集"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "ノードを編集"
+
+#, fuzzy
+msgid "Edit groups"
+msgstr "ホストを編集"
 
 #, fuzzy
 msgid "Edit selected hosts"
@@ -3395,6 +3406,10 @@ msgstr ""
 
 msgid "Group Member Attribute"
 msgstr "グループメンバー属性"
+
+#, fuzzy
+msgid "Group Membership"
+msgstr "ホストメンバーシップ"
 
 #, fuzzy
 msgid "Group Module Associations"
@@ -5751,6 +5766,10 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr "\"snapinfiles[]\" マルチパートフィールドを使用して、1 つ以上のファイルをアップロードする必要があります"
 
+#, php-format
+msgid "No group named \"%s\" exists to remove hosts from"
+msgstr ""
+
 #, fuzzy
 msgid "No groups are being created or selected"
 msgstr "削除するグループが選択されていません"
@@ -5775,10 +5794,6 @@ msgstr "タスクを実行できるホストがありません"
 
 msgid "No hosts available to task"
 msgstr "タスクを実行できるホストがありません"
-
-#, fuzzy
-msgid "No hosts selected to be added"
-msgstr "削除するグループが選択されていません"
 
 msgid "No hosts to task"
 msgstr "タスク対象のホストがありません"
@@ -7060,6 +7075,14 @@ msgid "Remove Fail"
 msgstr "削除に失敗しました"
 
 #, fuzzy
+msgid "Remove Hosts from Groups Fail"
+msgstr "ホストのグループ追加に失敗しました"
+
+#, fuzzy
+msgid "Remove Hosts from Groups Success"
+msgstr "ホストをグループに追加しました"
+
+#, fuzzy
 msgid "Remove LDAP Group Associations"
 msgstr "グループの関連付け"
 
@@ -7091,6 +7114,10 @@ msgstr "削除済み"
 
 #, php-format
 msgid "Removed %1$d association and satellite row(s) whose parent record no longer existed, so that foreign key constraints could be declared. Per table: %2$s"
+msgstr ""
+
+#, php-format
+msgid "Removed %1$d host(s) from %2$d group(s)."
 msgstr ""
 
 #, php-format
@@ -8475,10 +8502,6 @@ msgstr "インポートに成功しました"
 #, fuzzy
 msgid "Success."
 msgstr "アクセス"
-
-#, fuzzy
-msgid "Successfully added hosts to the provided groups!"
-msgstr "選択したホストをグループに追加しました！"
 
 msgid "Successfully deleted"
 msgstr "削除しました"
@@ -11427,6 +11450,10 @@ msgstr ""
 #~ msgid "Add Storage Groups"
 #~ msgstr "ストレージグループを追加"
 
+#, fuzzy
+#~ msgid "Add To Group(s)"
+#~ msgstr "グループに追加"
+
 #~ msgid "Add User"
 #~ msgstr "ユーザーを追加"
 
@@ -11446,6 +11473,10 @@ msgstr ""
 
 #~ msgid "Add selected rules"
 #~ msgstr "選択したルールを追加"
+
+#, fuzzy
+#~ msgid "Add selected to group"
+#~ msgstr "選択したストレージグループを追加"
 
 #~ msgid "Additional MACs"
 #~ msgstr "追加の MAC アドレス"
@@ -11724,9 +11755,6 @@ msgstr ""
 
 #~ msgid "ESC is defaulted"
 #~ msgstr "ESC が既定です"
-
-#~ msgid "Edit Host"
-#~ msgstr "ホストを編集"
 
 #~ msgid "Edit Image"
 #~ msgstr "イメージを編集"
@@ -12089,9 +12117,6 @@ msgstr ""
 
 #~ msgid "Host MAC"
 #~ msgstr "ホスト MAC アドレス"
-
-#~ msgid "Host Membership"
-#~ msgstr "ホストメンバーシップ"
 
 #~ msgid "Host Memory"
 #~ msgstr "ホストメモリ"
@@ -12589,6 +12614,10 @@ msgstr ""
 
 #~ msgid "No groups defined, search will return all hosts."
 #~ msgstr "グループが定義されていないため、検索ではすべてのホストが対象となります。"
+
+#, fuzzy
+#~ msgid "No hosts selected to be added"
+#~ msgstr "削除するグループが選択されていません"
 
 #, fuzzy
 #~ msgid "No mappings defined."
@@ -13108,6 +13137,10 @@ msgstr ""
 
 #~ msgid "SubnetGroup General"
 #~ msgstr "サブネットグループ全般"
+
+#, fuzzy
+#~ msgid "Successfully added hosts to the provided groups!"
+#~ msgstr "選択したホストをグループに追加しました！"
 
 #~ msgid "Successfully created"
 #~ msgstr "作成しました"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -374,6 +374,9 @@ msgstr ""
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
+msgid "A name that is not already a group is created when you add. Remove only works on groups that exist."
+msgstr ""
+
 msgid "A page of results."
 msgstr ""
 
@@ -659,9 +662,6 @@ msgstr ""
 msgid "Add Storage Node"
 msgstr ""
 
-msgid "Add To Group(s)"
-msgstr ""
-
 msgid "Add broadcast failed!"
 msgstr ""
 
@@ -713,9 +713,6 @@ msgstr ""
 msgid "Add selected"
 msgstr ""
 
-msgid "Add selected to group"
-msgstr ""
-
 msgid "Add site failed!"
 msgstr ""
 
@@ -747,6 +744,10 @@ msgid "Add windows key failed!"
 msgstr ""
 
 msgid "Add/Remove Managed Printers"
+msgstr ""
+
+#, php-format
+msgid "Added %1$d host(s) to %2$d group(s)."
 msgstr ""
 
 #, php-format
@@ -1609,6 +1610,10 @@ msgstr ""
 msgid "Could not create the catch-all site"
 msgstr ""
 
+#, php-format
+msgid "Could not create the group \"%s\""
+msgstr ""
+
 msgid "Could not create the staging directory."
 msgstr ""
 
@@ -1698,6 +1703,10 @@ msgid "Could not stage the uploaded certificate"
 msgstr ""
 
 msgid "Could not update host"
+msgstr ""
+
+#, php-format
+msgid "Could not update the group \"%s\""
 msgstr ""
 
 #, php-format
@@ -2208,6 +2217,9 @@ msgid "Edit Capone"
 msgstr ""
 
 msgid "Edit Capone ID"
+msgstr ""
+
+msgid "Edit groups"
 msgstr ""
 
 msgid "Edit selected hosts"
@@ -3014,6 +3026,9 @@ msgid "Group Matching is off for this server, so directory groups cannot be read
 msgstr ""
 
 msgid "Group Member Attribute"
+msgstr ""
+
+msgid "Group Membership"
 msgstr ""
 
 msgid "Group Module Associations"
@@ -5082,6 +5097,10 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+#, php-format
+msgid "No group named \"%s\" exists to remove hosts from"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -5101,9 +5120,6 @@ msgid "No hosts available to be tasked"
 msgstr ""
 
 msgid "No hosts available to task"
-msgstr ""
-
-msgid "No hosts selected to be added"
 msgstr ""
 
 msgid "No hosts to task"
@@ -6231,6 +6247,12 @@ msgstr ""
 msgid "Remove Fail"
 msgstr ""
 
+msgid "Remove Hosts from Groups Fail"
+msgstr ""
+
+msgid "Remove Hosts from Groups Success"
+msgstr ""
+
 msgid "Remove LDAP Group Associations"
 msgstr ""
 
@@ -6257,6 +6279,10 @@ msgstr ""
 
 #, php-format
 msgid "Removed %1$d association and satellite row(s) whose parent record no longer existed, so that foreign key constraints could be declared. Per table: %2$s"
+msgstr ""
+
+#, php-format
+msgid "Removed %1$d host(s) from %2$d group(s)."
 msgstr ""
 
 #, php-format
@@ -7490,9 +7516,6 @@ msgid "Succeeded"
 msgstr ""
 
 msgid "Success."
-msgstr ""
-
-msgid "Successfully added hosts to the provided groups!"
 msgstr ""
 
 msgid "Successfully deleted"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -420,6 +420,9 @@ msgstr "Uma imagem já existe com este nome!"
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
+msgid "A name that is not already a group is created when you add. Remove only works on groups that exist."
+msgstr ""
+
 #, fuzzy
 msgid "A page of results."
 msgstr "Listar todos os %s"
@@ -759,10 +762,6 @@ msgid "Add Storage Node"
 msgstr "Adicionar Nó de Armazenamento"
 
 #, fuzzy
-msgid "Add To Group(s)"
-msgstr "Adicionar grupo de armazenamento"
-
-#, fuzzy
 msgid "Add broadcast failed!"
 msgstr "Adicionar snap-in falhou!"
 
@@ -831,10 +830,6 @@ msgid "Add selected"
 msgstr "Impressora"
 
 #, fuzzy
-msgid "Add selected to group"
-msgstr "Impressora"
-
-#, fuzzy
 msgid "Add site failed!"
 msgstr "Adicionar snap-in falhou!"
 
@@ -876,6 +871,10 @@ msgstr "Adicionar snap-in falhou!"
 #, fuzzy
 msgid "Add/Remove Managed Printers"
 msgstr "FOG Managed Impressoras"
+
+#, php-format
+msgid "Added %1$d host(s) to %2$d group(s)."
+msgstr ""
 
 #, php-format
 msgid "Adding FOGPage: %s, Node: %s"
@@ -1867,6 +1866,10 @@ msgstr "Falha ao atualizar"
 msgid "Could not create the catch-all site"
 msgstr "Falha ao criar Snapin Job"
 
+#, fuzzy, php-format
+msgid "Could not create the group \"%s\""
+msgstr "Não foi possível ler o arquivo tmp."
+
 #, fuzzy
 msgid "Could not create the staging directory."
 msgstr "Falha ao criar Snapin Job"
@@ -1982,6 +1985,10 @@ msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
 msgid "Could not update host"
+msgstr "Falha ao atualizar"
+
+#, fuzzy, php-format
+msgid "Could not update the group \"%s\""
 msgstr "Falha ao atualizar"
 
 #, php-format
@@ -2577,6 +2584,10 @@ msgstr "exportação Snapins"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "exportação Snapins"
+
+#, fuzzy
+msgid "Edit groups"
+msgstr "modificar Grupo"
 
 #, fuzzy
 msgid "Edit selected hosts"
@@ -3509,6 +3520,10 @@ msgstr ""
 #, fuzzy
 msgid "Group Member Attribute"
 msgstr "Nome de usuário"
+
+#, fuzzy
+msgid "Group Membership"
+msgstr "Membership"
 
 #, fuzzy
 msgid "Group Module Associations"
@@ -5960,6 +5975,10 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+#, php-format
+msgid "No group named \"%s\" exists to remove hosts from"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -5983,10 +6002,6 @@ msgstr "Hotéis em Task"
 
 #, fuzzy
 msgid "No hosts available to task"
-msgstr "Hotéis em Task"
-
-#, fuzzy
-msgid "No hosts selected to be added"
 msgstr "Hotéis em Task"
 
 #, fuzzy
@@ -7299,6 +7314,14 @@ msgid "Remove Fail"
 msgstr "Removido"
 
 #, fuzzy
+msgid "Remove Hosts from Groups Fail"
+msgstr "Adicionar ao grupo"
+
+#, fuzzy
+msgid "Remove Hosts from Groups Success"
+msgstr "Instalar / Atualizar sucesso!"
+
+#, fuzzy
 msgid "Remove LDAP Group Associations"
 msgstr "Associação imagem"
 
@@ -7331,6 +7354,10 @@ msgstr "Removido"
 
 #, php-format
 msgid "Removed %1$d association and satellite row(s) whose parent record no longer existed, so that foreign key constraints could be declared. Per table: %2$s"
+msgstr ""
+
+#, php-format
+msgid "Removed %1$d host(s) from %2$d group(s)."
 msgstr ""
 
 #, php-format
@@ -8791,10 +8818,6 @@ msgstr "Bem sucedido"
 #, fuzzy
 msgid "Success."
 msgstr "Acesso"
-
-#, fuzzy
-msgid "Successfully added hosts to the provided groups!"
-msgstr "Hosts com sucesso associado ao grupo "
 
 #, fuzzy
 msgid "Successfully deleted"
@@ -11828,6 +11851,10 @@ msgstr ""
 #~ msgstr "Impressora"
 
 #, fuzzy
+#~ msgid "Add To Group(s)"
+#~ msgstr "Adicionar grupo de armazenamento"
+
+#, fuzzy
 #~ msgid "Add accesscontrol failed!"
 #~ msgstr "Adicionar snap-in falhou!"
 
@@ -11836,8 +11863,8 @@ msgstr ""
 #~ msgstr "Adicionar snap-in falhou!"
 
 #, fuzzy
-#~ msgid "Admin Group"
-#~ msgstr "modificar Grupo"
+#~ msgid "Add selected to group"
+#~ msgstr "Impressora"
 
 #, fuzzy
 #~ msgid "Administrator Group"
@@ -12183,6 +12210,10 @@ msgstr ""
 #~ msgid "No directory groups defined."
 #~ msgstr "Plugins instalados"
 
+#, fuzzy
+#~ msgid "No hosts selected to be added"
+#~ msgstr "Hotéis em Task"
+
 #~ msgid "No query sent"
 #~ msgstr "Sem consulta enviada"
 
@@ -12309,6 +12340,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Storage Node FTP User"
 #~ msgstr "Nó de armazenamento do usuário"
+
+#, fuzzy
+#~ msgid "Successfully added hosts to the provided groups!"
+#~ msgstr "Hosts com sucesso associado ao grupo "
 
 #, fuzzy
 #~ msgid "Task run time"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -420,6 +420,9 @@ msgstr "图像已经存在具有此名称！"
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
+msgid "A name that is not already a group is created when you add. Remove only works on groups that exist."
+msgstr ""
+
 #, fuzzy
 msgid "A page of results."
 msgstr "列表中的所有%s"
@@ -759,10 +762,6 @@ msgid "Add Storage Node"
 msgstr "添加存储节点"
 
 #, fuzzy
-msgid "Add To Group(s)"
-msgstr "添加存储组"
-
-#, fuzzy
 msgid "Add broadcast failed!"
 msgstr "添加管理单元失败！"
 
@@ -831,10 +830,6 @@ msgid "Add selected"
 msgstr "打印机"
 
 #, fuzzy
-msgid "Add selected to group"
-msgstr "打印机"
-
-#, fuzzy
 msgid "Add site failed!"
 msgstr "添加管理单元失败！"
 
@@ -876,6 +871,10 @@ msgstr "添加管理单元失败！"
 #, fuzzy
 msgid "Add/Remove Managed Printers"
 msgstr "FOG管理的打印机"
+
+#, php-format
+msgid "Added %1$d host(s) to %2$d group(s)."
+msgstr ""
 
 #, php-format
 msgid "Adding FOGPage: %s, Node: %s"
@@ -1867,6 +1866,10 @@ msgstr "无法更新"
 msgid "Could not create the catch-all site"
 msgstr "无法创建管理单元工作"
 
+#, fuzzy, php-format
+msgid "Could not create the group \"%s\""
+msgstr "无法读取tmp文件。"
+
 #, fuzzy
 msgid "Could not create the staging directory."
 msgstr "无法创建管理单元工作"
@@ -1982,6 +1985,10 @@ msgstr "无法读取tmp文件。"
 
 #, fuzzy
 msgid "Could not update host"
+msgstr "无法更新"
+
+#, fuzzy, php-format
+msgid "Could not update the group \"%s\""
 msgstr "无法更新"
 
 #, php-format
@@ -2577,6 +2584,10 @@ msgstr "出口Snapins"
 #, fuzzy
 msgid "Edit Capone ID"
 msgstr "出口Snapins"
+
+#, fuzzy
+msgid "Edit groups"
+msgstr "修改组"
 
 #, fuzzy
 msgid "Edit selected hosts"
@@ -3509,6 +3520,10 @@ msgstr ""
 #, fuzzy
 msgid "Group Member Attribute"
 msgstr "用户名"
+
+#, fuzzy
+msgid "Group Membership"
+msgstr "籍"
 
 #, fuzzy
 msgid "Group Module Associations"
@@ -5960,6 +5975,10 @@ msgstr ""
 msgid "No files provided in the \"snapinfiles[]\" multipart field"
 msgstr ""
 
+#, php-format
+msgid "No group named \"%s\" exists to remove hosts from"
+msgstr ""
+
 msgid "No groups are being created or selected"
 msgstr ""
 
@@ -5983,10 +6002,6 @@ msgstr "在任务主机"
 
 #, fuzzy
 msgid "No hosts available to task"
-msgstr "在任务主机"
-
-#, fuzzy
-msgid "No hosts selected to be added"
 msgstr "在任务主机"
 
 #, fuzzy
@@ -7299,6 +7314,14 @@ msgid "Remove Fail"
 msgstr "去除"
 
 #, fuzzy
+msgid "Remove Hosts from Groups Fail"
+msgstr "添加到组"
+
+#, fuzzy
+msgid "Remove Hosts from Groups Success"
+msgstr "安装/升级成功！"
+
+#, fuzzy
 msgid "Remove LDAP Group Associations"
 msgstr "图像协会"
 
@@ -7331,6 +7354,10 @@ msgstr "去除"
 
 #, php-format
 msgid "Removed %1$d association and satellite row(s) whose parent record no longer existed, so that foreign key constraints could be declared. Per table: %2$s"
+msgstr ""
+
+#, php-format
+msgid "Removed %1$d host(s) from %2$d group(s)."
 msgstr ""
 
 #, php-format
@@ -8791,10 +8818,6 @@ msgstr "成功"
 #, fuzzy
 msgid "Success."
 msgstr "访问"
-
-#, fuzzy
-msgid "Successfully added hosts to the provided groups!"
-msgstr "成功关联主机与本集团"
 
 #, fuzzy
 msgid "Successfully deleted"
@@ -11828,6 +11851,10 @@ msgstr ""
 #~ msgstr "打印机"
 
 #, fuzzy
+#~ msgid "Add To Group(s)"
+#~ msgstr "添加存储组"
+
+#, fuzzy
 #~ msgid "Add accesscontrol failed!"
 #~ msgstr "添加管理单元失败！"
 
@@ -11836,8 +11863,8 @@ msgstr ""
 #~ msgstr "添加管理单元失败！"
 
 #, fuzzy
-#~ msgid "Admin Group"
-#~ msgstr "修改组"
+#~ msgid "Add selected to group"
+#~ msgstr "打印机"
 
 #, fuzzy
 #~ msgid "Administrator Group"
@@ -12183,6 +12210,10 @@ msgstr ""
 #~ msgid "No directory groups defined."
 #~ msgstr "已安装的插件"
 
+#, fuzzy
+#~ msgid "No hosts selected to be added"
+#~ msgstr "在任务主机"
+
 #~ msgid "No query sent"
 #~ msgstr "没有查询发送"
 
@@ -12309,6 +12340,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Storage Node FTP User"
 #~ msgstr "存储节点的用户名"
+
+#, fuzzy
+#~ msgid "Successfully added hosts to the provided groups!"
+#~ msgstr "成功关联主机与本集团"
 
 #, fuzzy
 #~ msgid "Task run time"

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -1873,7 +1873,12 @@ abstract class FOGPage extends FOGBase
                         if ($node == 'host') {
                             $actionbox .= self::makeButton(
                                 'addSelectedToGroup',
-                                _('Add selected to group'),
+                                // Not "Add selected to group" any more: the
+                                // modal behind it removes as well now (ADR
+                                // 0038 Decision 16a requirement 2). The id is
+                                // unchanged, because it is what
+                                // fog.host.list.js addresses the button by.
+                                _('Edit groups'),
                                 'btn btn-secondary'
                             );
                         }
@@ -1908,20 +1913,40 @@ abstract class FOGPage extends FOGBase
                     if ($node == 'host') {
                         $modals .= self::makeModal(
                             'addToGroupModal',
-                            _('Add To Group(s)'),
+                            _('Group Membership'),
                             '<select id="groupSelect" class="" '
                             . 'name="" multiple="multiple">'
-                            . '</select>',
+                            . '</select>'
+                            . '<p class="form-text mt-2 mb-0">'
+                            . _(
+                                'A name that is not already a group is'
+                                . ' created when you add. Remove only works'
+                                . ' on groups that exist.'
+                            )
+                            . '</p>',
                             self::makeButton(
                                 'closeGroupModal',
                                 _('Cancel'),
                                 'btn btn-outline-secondary float-start',
                                 'data-bs-dismiss="modal"'
                             )
+                            // Add is emitted FIRST of the two float-end
+                            // buttons and so renders rightmost: floated
+                            // elements stack against the edge in emission
+                            // order, which is the same thing that decided
+                            // where the mass edit button sits. Reads
+                            // "Remove | Add" left to right, with the
+                            // non-destructive one under the cursor's usual
+                            // resting place.
                             . self::makeButton(
                                 'confirmGroupAdd',
                                 _('Add'),
-                                'btn btn-outline-secondary float-end'
+                                'btn btn-primary float-end ms-2'
+                            )
+                            . self::makeButton(
+                                'confirmGroupRemove',
+                                _('Remove'),
+                                'btn btn-outline-danger float-end'
                             ),
                             '',
                             'info'

--- a/packages/web/src/Items/Group.php
+++ b/packages/web/src/Items/Group.php
@@ -101,7 +101,7 @@ class Group extends FOGController
     /**
      * Saves the group elements.
      *
-     * @return object
+     * @return bool|object false when the row itself could not be written
      */
     public function save()
     {

--- a/packages/web/src/Items/Printer.php
+++ b/packages/web/src/Items/Printer.php
@@ -72,7 +72,7 @@ class Printer extends FOGController
     /**
      * Stores/updates the printer
      *
-     * @return object
+     * @return bool|object false when the row itself could not be written
      */
     public function save()
     {

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -4991,7 +4991,18 @@ class HostManagement extends FOGPage
         $this->jsonSend($code, $msg);
     }
     /**
-     * Saves host to a selected or new group depending on action.
+     * Adds the selected hosts to groups, or removes them from groups.
+     *
+     * The list's membership editor, and since ADR 0038 Decision 16a the
+     * PRIMARY way membership is edited -- a group is a label now, and the
+     * group page's own Hosts tab is one host list per group, which is three
+     * trips to apply one label to a fleet.
+     *
+     * BOTH DIRECTIONS, because a label you can apply and cannot retract is
+     * not a label (requirement 2). `action=remove` is the only difference on
+     * the wire; everything else -- the gates, the id normalization, the
+     * scope bounds -- is one path, so add and remove cannot drift apart on
+     * who may do them or to what.
      *
      * @return void
      */
@@ -5036,6 +5047,55 @@ class HostManagement extends FOGPage
                 }
             )
         );
+        // Add unless the request says otherwise. Anything unrecognized is an
+        // add: that is what every client predating the remove half sends,
+        // and it is the direction that cannot take a label off a fleet if a
+        // value is somehow wrong.
+        $remove = 'remove' === strtolower(
+            (string)filter_input(INPUT_POST, 'action')
+        );
+        // A TYPED NAME THAT ALREADY NAMES A GROUP IS THAT GROUP.
+        //
+        // `groupName` is UNIQUE (the manifest declares it twice over), so
+        // ->set('name', $taken)->save() fails on the duplicate key -- and the
+        // old code discarded save()'s return, so typing a group's own name
+        // into the modal's (new) slot silently did nothing at all. The group
+        // page's rename path has checked for this the whole time
+        // (GroupManagement.php:705, via getManager()->exists()); this endpoint
+        // is now the primary membership surface and cannot be the looser of
+        // the two.
+        //
+        // Resolved HERE, ahead of the scope bound below, and that placement
+        // is the security half: a resolved id is an id, so it has to be
+        // subject to the same boundary an id posted directly is. Typing a
+        // name must not be a way round a check.
+        //
+        // One query for every typed name. groupName's collation is
+        // case-insensitive, so this matches on exactly what the UNIQUE index
+        // would have collided on.
+        if (count($groups_new)) {
+            $existing = [];
+            foreach ((array)Route::getNames('group', ['name' => $groups_new]) as $row) {
+                $id = (int)($row->id ?? 0);
+                $name = strtolower(trim((string)($row->name ?? '')));
+                if ($id > 0 && '' !== $name) {
+                    $existing[$name] = $id;
+                }
+            }
+            if (count($existing)) {
+                $stillNew = [];
+                foreach ($groups_new as $name) {
+                    $key = strtolower($name);
+                    if (isset($existing[$key])) {
+                        $groups[] = $existing[$key];
+                        continue;
+                    }
+                    $stillNew[] = $name;
+                }
+                $groups = array_values(array_unique($groups));
+                $groups_new = $stillNew;
+            }
+        }
         // Airtight, both directions: one host outside the caller's site scope
         // denies the whole request rather than quietly adding the rest, and
         // the same for the target groups. A site-scoped operator could
@@ -5048,6 +5108,12 @@ class HostManagement extends FOGPage
         // group.create as well, and only when the request actually asks for
         // one. Checked here rather than at the route because the route cannot
         // see the body.
+        //
+        // AFTER the resolution above, deliberately. A name that turned out to
+        // name an existing group creates nothing, so it is an edit and asking
+        // for group.create would be asking for the wider right to do the
+        // narrower thing -- which is the mistake this split was written to
+        // undo.
         if (count($groups_new) && !Authorization::can('group.create')) {
             $this->jsonSend(
                 HTTPResponseCodes::HTTP_FORBIDDEN,
@@ -5063,35 +5129,93 @@ class HostManagement extends FOGPage
         }
         try {
             if (!count($hosts)) {
-                throw new \Exception(_('No hosts selected to be added'));
+                throw new \Exception(_('No hosts are selected'));
             }
             if (!count($groups) && !count($groups_new)) {
                 throw new \Exception(_('No groups are being created or selected'));
             }
-            if (count($groups)) {
-                foreach ($groups as &$group) {
-                    $Group = new Group($group);
-                    if (!$Group->isValid()) {
-                        continue;
-                    }
-                    $Group->addHost($hosts)->save();
-                    unset($group);
-                }
+            // Every name left in groups_new after the resolution above is one
+            // that does NOT exist. Removing hosts from a group that does not
+            // exist removes nothing, and creating an empty group in order to
+            // remove nobody from it is not what anyone meant -- so say so
+            // rather than reporting success over a no-op.
+            if ($remove && count($groups_new)) {
+                throw new \Exception(
+                    sprintf(
+                        _('No group named "%s" exists to remove hosts from'),
+                        implode('", "', $groups_new)
+                    )
+                );
             }
-            if (count($groups_new)) {
-                foreach ($groups_new as &$group) {
-                    self::getClass('Group')
-                        ->set('name', $group)
-                        ->addHost($hosts)
-                        ->save();
-                    unset($group);
+            $touched = [];
+            foreach ($groups as $group) {
+                $Group = new Group($group);
+                if (!$Group->isValid()) {
+                    continue;
                 }
+                if ($remove) {
+                    $Group->removeHost($hosts);
+                } else {
+                    $Group->addHost($hosts);
+                }
+                if (!$Group->save()) {
+                    throw new \Exception(
+                        sprintf(
+                            _('Could not update the group "%s"'),
+                            $Group->get('name')
+                        )
+                    );
+                }
+                $touched[] = $Group->get('name');
             }
+            foreach ($groups_new as $group) {
+                // save()'s return is propagated rather than discarded. It was
+                // discarded here, which is how a duplicate name reported
+                // success while inserting nothing -- see the resolution above
+                // for the case that made it, and tests/save-propagates-
+                // failure.test.php for why this tree treats it as a rule.
+                $New = self::getClass('Group')
+                    ->set('name', $group)
+                    ->addHost($hosts);
+                if (!$New->save()) {
+                    throw new \Exception(
+                        sprintf(_('Could not create the group "%s"'), $group)
+                    );
+                }
+                $touched[] = $group;
+            }
+            // Membership is the label, and ADR 0038 makes this the surface it
+            // is edited from -- so who applied which label to how many hosts
+            // is exactly the question the audit log exists to answer. The
+            // mass edit beside it has recorded its own writes since it
+            // shipped; this one recorded nothing.
+            Audit::record(
+                [
+                    'type' => $remove ? 'host.groupremove' : 'host.groupadd',
+                    'subjectType' => 'host',
+                    'subjectLabel' => implode(', ', $touched),
+                    'permission' => 'group.edit',
+                    'affectedCount' => count($hosts),
+                    'renderable' => 1
+                ]
+            );
             $code = HTTPResponseCodes::HTTP_ACCEPTED;
             $msg = json_encode(
                 [
-                    'msg' => _('Successfully added hosts to the provided groups!'),
-                    'title' => _('Add Hosts to Groups Success')
+                    'msg' => $remove
+                        ? sprintf(
+                            _('Removed %1$d host(s) from %2$d group(s).'),
+                            count($hosts),
+                            count($touched)
+                        )
+                        : sprintf(
+                            _('Added %1$d host(s) to %2$d group(s).'),
+                            count($hosts),
+                            count($touched)
+                        ),
+                    'title' => $remove
+                        ? _('Remove Hosts from Groups Success')
+                        : _('Add Hosts to Groups Success')
                 ]
             );
         } catch (\Exception $e) {
@@ -5099,7 +5223,9 @@ class HostManagement extends FOGPage
             $msg = json_encode(
                 [
                     'error' => $e->getMessage(),
-                    'title' => _('Add Hosts to Group Fail')
+                    'title' => $remove
+                        ? _('Remove Hosts from Groups Fail')
+                        : _('Add Hosts to Group Fail')
                 ]
             );
         }

--- a/tests/savegroup-is-gated.test.php
+++ b/tests/savegroup-is-gated.test.php
@@ -30,6 +30,29 @@
  * every existing role without it and break labeling on upgrade for
  * everybody.
  *
+ * FOUR MORE THINGS ARE PINNED SINCE THE ENDPOINT LEARNED TO REMOVE (ADR 0038
+ * Decision 16a requirement 2, unit D2). Membership is now editable in both
+ * directions from the list, and each of these fails silently rather than
+ * loudly if it is lost:
+ *
+ *   4. THE NAME RESOLUTION RUNS BEFORE THE SCOPE BOUND. A typed name that
+ *      already names a group is resolved to that group's id, and a resolved
+ *      id must be bounded exactly as an id posted directly is. Resolving
+ *      after requirePageObjectScopeMass('group', ...) would make typing a
+ *      name a way past the boundary, and nothing about the request would
+ *      look wrong.
+ *   5. AND BEFORE THE group.create GATE. A name that turned out to exist
+ *      creates nothing, so demanding group.create for it asks for the wider
+ *      right in order to do the narrower thing -- the exact inversion the
+ *      permission split was written to undo.
+ *   6. REMOVE AND ADD SHARE ONE PATH. Both directions run through the same
+ *      gates, the same id normalization and the same scope bounds; the only
+ *      difference is which method the loop calls. Two paths would be two
+ *      chances to bound one of them and not the other.
+ *   7. THE DEFAULT IS ADD. Anything unrecognized in `action` must add, not
+ *      remove: that is what every client predating this sends, and it is the
+ *      direction that cannot strip a label off a fleet by accident.
+ *
  * The three call sites cannot be executed without a session and a database,
  * so they are pinned POSITIONALLY: each must appear inside saveGroup() and
  * BEFORE its try block. A grep for the bare symbol would pass on
@@ -230,6 +253,118 @@ check(
         '/HTTPResponseCodes::HTTP_FORBIDDEN/',
         substr($body, 0, false === $tryAt ? strlen($body) : $tryAt)
     ),
+    $failures,
+    $checks
+);
+
+/*
+ * 5. Ordering. Positions inside saveGroup(), not merely presence: each of
+ *    these is correct only relative to the others, and a reordering compiles
+ *    and answers 202 exactly as before.
+ */
+$resolveAt = strpos($body, "Route::getNames('group', ['name' => \$groups_new])");
+check(
+    'saveGroup() resolves typed names against the groups that exist',
+    false !== $resolveAt,
+    $failures,
+    $checks
+);
+
+$groupScopeAt = strpos(
+    $body,
+    "Authorization::requirePageObjectScopeMass('group', \$groups);"
+);
+check(
+    'saveGroup() resolves names BEFORE bounding the group ids'
+    . ' (a typed name must not be a way past the scope check)',
+    false !== $resolveAt
+        && false !== $groupScopeAt
+        && $resolveAt < $groupScopeAt,
+    $failures,
+    $checks
+);
+
+$createGateAt = strpos($body, "Authorization::can('group.create')");
+check(
+    'saveGroup() resolves names BEFORE demanding group.create'
+    . ' (a name that already exists creates nothing)',
+    false !== $resolveAt
+        && false !== $createGateAt
+        && $resolveAt < $createGateAt,
+    $failures,
+    $checks
+);
+
+/*
+ * 6. Both directions, one path. The remove half must be a branch inside the
+ *    same loop, not a second loop with its own gates to get wrong.
+ */
+check(
+    'saveGroup() removes as well as adds',
+    false !== strpos($body, '$Group->removeHost($hosts);'),
+    $failures,
+    $checks
+);
+check(
+    'and both directions run through the same scope bounds'
+    . ' (one requirePageObjectScopeMass per node, not one per direction)',
+    1 === substr_count(
+        $body,
+        "Authorization::requirePageObjectScopeMass('host', \$hosts);"
+    )
+    && 1 === substr_count(
+        $body,
+        "Authorization::requirePageObjectScopeMass('group', \$groups);"
+    ),
+    $failures,
+    $checks
+);
+check(
+    'and the remove branch is inside the loop the add branch is in,'
+    . ' not a second loop of its own',
+    1 === substr_count($body, 'foreach ($groups as $group) {'),
+    $failures,
+    $checks
+);
+
+/*
+ * 7. The default direction is ADD. Read as an equality against the literal
+ *    'remove' -- anything else, including a missing field and a client that
+ *    predates this, is an add.
+ */
+check(
+    "saveGroup() removes only on action === 'remove', and adds otherwise",
+    1 === preg_match(
+        '/\$remove\s*=\s*\'remove\'\s*===\s*strtolower\(/',
+        $body
+    ),
+    $failures,
+    $checks
+);
+
+/*
+ * 8. Every write reports its own failure. save() returning false was
+ *    discarded here, which is how a duplicate group name answered 202 while
+ *    inserting nothing -- the defect the resolution above exists for.
+ */
+check(
+    'saveGroup() propagates a failed save() rather than reporting success',
+    0 === preg_match('/->addHost\(\$hosts\)\s*->save\(\)\s*;/', $body)
+        && 1 === preg_match('/if\s*\(\s*!\s*\$Group->save\(\)\s*\)/', $body)
+        && 1 === preg_match('/if\s*\(\s*!\s*\$New->save\(\)\s*\)/', $body),
+    $failures,
+    $checks
+);
+
+/*
+ * 9. The write is audited. Membership IS the label now, so who applied which
+ *    one to how many hosts is the question the audit log exists to answer,
+ *    and this handler recorded nothing at all.
+ */
+check(
+    'saveGroup() records an audit row naming the direction',
+    false !== strpos($body, 'Audit::record(')
+        && false !== strpos($body, "'host.groupremove' : 'host.groupadd'"),
     $failures,
     $checks
 );


### PR DESCRIPTION
ADR 0038 Decision 16a requirements 2, 3 and 4. Unit D2b of `docs/development/group-split.md`, on top of #1639.

A label you can apply and cannot retract is not a label.

## Remove

`action=remove` is the only difference on the wire. Both directions run through **one path** — the same gates, the same id normalization, the same scope bounds, one loop with one branch in it — because two paths would be two chances to bound one direction and not the other. An unrecognized `action` **adds**: that is what every client predating this sends, and it is the direction that cannot strip a label off a fleet by accident.

`Group::removeHost()` is the method the group page's own Hosts tab already drives through `assocPost('addHost', 'removeHost')`, so this is not a second removal path.

The modal is one multi-select with **Add** and **Remove** over it, so three labels onto forty hosts is one selection and one action, and taking them off again is one selection and one action. The grid reloads in place afterward, so #1639's chips are current and the selection survives.

## The defect this found

**Typing the name of a group that already exists reported success and did nothing at all.**

`groupName` is UNIQUE — the manifest declares it twice over — so `->set('name', $taken)->save()` fails on the duplicate key, and `saveGroup()` discarded `save()`'s return. The response was `202 Successfully added hosts to the provided groups!` over an insert that never happened.

Every typed name is now resolved against the groups that exist, in one query, before anything else. A name that resolves is that group — the same thing picking it from the dropdown has always meant. `save()`'s return is propagated on both paths.

**Two orderings in that are load-bearing**, and both are pinned as *positions* rather than greps, because a reordering compiles and still answers 202:

| ordering | what losing it costs |
|---|---|
| resolution before `requirePageObjectScopeMass('group', …)` | a resolved id is an id; resolving afterward makes **typing a name** a way past the site boundary, with nothing about the request looking wrong |
| resolution before the `group.create` check | a name that turns out to name a group creates nothing, so demanding `group.create` asks for the wider right to do the narrower thing — the inversion the split exists to undo |

## Requirement 4 is amended, not implemented as written

`$.registerCreateAndAssociate()` is a helper for an association **grid tab**: it fetches that node's create form into a modal and POSTs the created id to the tab's own update URL, which arrives on the button as a data attribute. The host list has no such tab, no such endpoint, and no single subject — it has N hosts and M groups. Using it literally means one form and one POST per group, which is the opposite of requirement 3's stated test: *applying three labels to forty hosts is one selection and one action.* The two requirements conflict when 4 is read as "call that function", and 3 is the one carrying a test.

What requirement 4 is *about* — a second write path skipping the first one's validation — is fixed at the endpoint, where it holds for a hand-rolled POST, a script and a future client as well as for this modal. The ADR carries the full reasoning.

## Also

- **A double-submit.** `loadGroupSelect()` runs on every `show.bs.modal` (select2 is destroyed on close and rebuilt), and bound the submit with a plain `.on()`. Open the modal twice, click Add once, and the POST went twice. Harmless while the endpoint only added; not harmless for a remove, and not harmless at all for a handler that mints groups. Both buttons are namespaced and unbound first.
- **Audited.** `host.groupadd` / `host.groupremove` with the affected count. This handler recorded nothing, where the mass edit beside it has recorded its own writes since it shipped.
- **`Group::save()` and `Printer::save()` both declared `@return object` and both have an explicit `return false`.** phpstan called the new `!$Group->save()` always-false on the strength of it — the annotation being wrong, not the check. Corrected to `bool|object`, which is what `Host`, `Snapin` and `Image` already say.

## Gates

Nine new checks in `tests/savegroup-is-gated.test.php`, each made to fail:

| mutation | red |
|---|---|
| default direction flipped to remove | ✔ |
| remove branch deleted | ✔ |
| `save()`'s return discarded again | ✔ |
| audit dropped | ✔ |
| group scope bound moved ahead of the resolution | ✔ |
| `group.create` gate moved ahead of the resolution | ✔ |

Full suite 293/293, both phpstan configs clean.

**Not verified here:** the rendered modal and the two buttons need a deploy and a browser. The server halves are structural or read off proven call sites — `Group::removeHost()` + `save()` is the sequence `GroupManagement::hostsPost()` runs today (`GroupManagement.php:2604-2616`).

## What is left in unit D

**D3** — the group list's "grants" column (requirement 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)