### PR TITLE
fix: mass edit could never run — the object-id guard matched 'edit' as a substring

### DIFF
--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -331,6 +331,43 @@ abstract class FOGPage extends FOGBase
         self::redirect("../management/index.php?node={$node}");
     }
     /**
+     * Does this sub act on ONE object, named by an id in the URL?
+     *
+     * EXACT, not a substring, and that is the whole of this method. The
+     * constructor asked `false !== stripos($sub, 'edit')`, which is true of
+     * every sub whose name merely CONTAINS the word -- and the two the mass
+     * edit feature added do:
+     *
+     *     stripos('masseditform', 'edit') === 4
+     *     stripos('massedit', 'edit')     === 4
+     *
+     * Both act on a selection POSTed in the body and have no id by design, so
+     * the guard fired on every use and answered 404 `No host exists with ID`
+     * with nothing after "ID" -- the id it was complaining about did not
+     * exist because there was never meant to be one. The modal that fetches
+     * the form sat on "Loading, please wait..." for as long as it was left
+     * open, because a 404 is not the shape its success handler reads.
+     *
+     * Mass edit therefore could not work at all on a running server, in
+     * either half: the form fetch AND the apply were both refused before
+     * either handler ran. Nothing in the suite could see it, because every
+     * gate on that feature tests a handler or a builder directly and this
+     * guard is upstream of both.
+     *
+     * A method rather than an inline comparison so the rule can be executed
+     * by a test against the sub names that actually exist, rather than
+     * grepped for. `sub=edit` is the only object sub in the tree -- 27 URLs
+     * spell it, and nothing else containing "edit" is an object page.
+     *
+     * @param mixed $sub the sub from the request
+     *
+     * @return bool
+     */
+    protected static function subNeedsObjectID($sub)
+    {
+        return 'edit' === strtolower(trim((string)$sub));
+    }
+    /**
      * Initializes the page class
      *
      * @param mixed $name name of the page to initialize
@@ -372,7 +409,7 @@ abstract class FOGPage extends FOGBase
             $f = filter_input(INPUT_GET, 'f');
         }
         if ($node !== 'service'
-            && false !== stripos($sub, 'edit')
+            && self::subNeedsObjectID($sub)
             && (!isset($id)
             || !is_numeric($id)
             || $id < 1)

--- a/tests/mass-edit-form.test.php
+++ b/tests/mass-edit-form.test.php
@@ -383,6 +383,48 @@ $check(
     )
 );
 
+// -------------------------------------------------------------------------
+// The page guard must not swallow the mass edit subs.
+//
+// FOGPage::__construct() refuses a sub that acts on one object when the URL
+// carries no id. It asked `false !== stripos($sub, 'edit')`, and BOTH mass
+// edit subs contain the word:
+//
+//     stripos('masseditform', 'edit') === 4
+//     stripos('massedit', 'edit')     === 4
+//
+// so both were refused with 404 `No host exists with ID` -- no id after
+// "ID", because there was never meant to be one -- and the modal that
+// fetches the form sat on "Loading, please wait..." indefinitely, a 404
+// being nothing its success handler reads. The feature could not work at
+// all on a running server, in either half, and every other gate on it is
+// DOWNSTREAM of this guard and so could not see it.
+//
+// EXECUTED, not grepped. The rule lives in one method precisely so a test
+// can call it with the sub names that actually exist. A grep for the
+// absence of stripos() would pass on the next spelling of the same mistake.
+$needsID = new \ReflectionMethod('FOG\\Base\\FOGPage', 'subNeedsObjectID');
+$needsID->setAccessible(true);
+$check(
+    "the object guard fires for sub=edit, which is the one object sub there is",
+    true === $needsID->invoke(null, 'edit')
+);
+$check(
+    'and is case-insensitive about it',
+    true === $needsID->invoke(null, 'Edit')
+);
+foreach (['massedit', 'masseditform'] as $listSub) {
+    $check(
+        "the object guard does NOT fire for sub=$listSub,"
+        . ' which acts on a POSTed selection and has no id',
+        false === $needsID->invoke(null, $listSub)
+    );
+}
+$check(
+    'and does not fire for a sub that merely ends in the word',
+    false === $needsID->invoke(null, 'bulkedit')
+);
+
 if (count($failures)) {
     fwrite(STDERR, "FAIL: the mass edit form is not three-state:\n");
     foreach ($failures as $f) {


### PR DESCRIPTION
Mass edit was broken for every host on the list, and when it failed it failed silently. Two independent bugs in the same click, both fixed here.

## 1. The object-id guard matched `edit` as a substring

`FOGPage`'s constructor refuses a request that names a sub needing an object with no usable `id`:

```php
if (false !== stripos($sub, 'edit') && (!isset($id) || ...)) {
    self::objectNotFound($node, ...);
}
```

`stripos` matches `massedit` and `masseditform` too. Those subs act on the *selection* -- the ids arrive in the POST body as `hostIDs[]`, and there is no `id` on the query string by design -- so the guard fired on every mass edit fetch and answered **No host exists with ID** with no id to name, because there never was one.

The test is exact match now, in a named method so the reason is written down beside it:

```php
protected static function subNeedsObjectID($sub)
{
    return 'edit' === strtolower(trim((string)$sub));
}
```

`service` was already exempted from the guard for its own reasons and stays exempt.

## 2. The modal could not close, so the failure looked like a hang

The error handler called `massEditModal.modal('hide')`. Bootstrap 5:

```js
hide() { this._isShown && !this._isTransitioning && (...) }
```

The click opens the modal and starts the fetch together, so a fast failure lands its `hide()` inside the 300ms show transition, `_isTransitioning` is true, and the call is dropped -- no error, no retry. The modal is shown and nothing will close it but the user. That is the "Loading, please wait..." in the report.

Hiding was the wrong response regardless: the reason belongs in the box the user is already looking at. Both handlers now render it into the modal body as an alert, escaped through `$.escapeHtml` -- it is server text going into markup.

**Queue Task is fixed the same way.** It is the button beside Mass edit, over the same selection, and had the identical handler. It would have been the next report.

## Gates

`tests/mass-edit-form.test.php`, 49 checks.

- An executed reflection gate on `subNeedsObjectID` -- true for `edit`/`Edit`, false for `massedit`, `masseditform`, `bulkedit`. It calls the method rather than grepping for it, so gutting the body goes red.
- Per fetch (`sub=masseditform`, `sub=deployMulti`), the error callback is sliced out anchored on its own URL and asserted on three properties: the reason is written into the modal body, it is escaped, and `modal('hide')` is not called.

Every gate was mutation-tested to red before being trusted: restoring `stripos`, and restoring `modal('hide')` in each of the two handlers.
