### PR TITLE
Host list: a failed mass edit or queue task fetch left the modal stuck on "Loading"

### DIFF
--- a/packages/web/management/js/fog/host/fog.host.list.js
+++ b/packages/web/management/js/fog/host/fog.host.list.js
@@ -734,7 +734,26 @@
                         return;
                     }
                     $('#queueTaskModal .modal-dialog').setLoading(false);
-                    queueTaskModal.modal('hide');
+                    // Same treatment as the mass edit fetch below, for the
+                    // same reason -- Bootstrap 5 drops a hide() that lands
+                    // inside the show transition, so a refusal that comes
+                    // back faster than the fade left this modal sitting on
+                    // "Loading, please wait..." with nothing in it to say
+                    // why. This one is opened from the button beside Mass
+                    // edit, over the same selection, and would have been the
+                    // next report.
+                    queueHolder.removeClass('d-none').html(
+                        '<div class="alert alert-danger mb-0">'
+                        + $.escapeHtml(
+                            String(
+                                (jqXHR.responseJSON
+                                    && jqXHR.responseJSON.error)
+                                || jqXHR.statusText
+                                || 'Request failed'
+                            )
+                        )
+                        + '</div>'
+                    );
                     $.notifyFromAPI(jqXHR.responseJSON, jqXHR);
                 }
             });
@@ -821,7 +840,30 @@
                         return;
                     }
                     $('#massEditModal .modal-dialog').setLoading(false);
-                    massEditModal.modal('hide');
+                    // The reason goes IN the modal, and the modal stays put.
+                    //
+                    // This called modal('hide'), and Bootstrap 5 DROPS a
+                    // hide() that lands inside the show transition:
+                    //
+                    //   hide() { this._isShown && !this._isTransitioning
+                    //            && (...) }
+                    //
+                    // A refusal comes back faster than the fade takes -- the
+                    // page guard that used to reject this endpoint outright
+                    // answered before any handler ran -- so the hide was
+                    // discarded and the box sat on "Loading, please wait..."
+                    // indefinitely, with only a toast beside it to say why.
+                    // Writing the reason where the person is already looking
+                    // needs no race won, and is what they wanted anyway.
+                    var reason = (jqXHR.responseJSON
+                        && jqXHR.responseJSON.error)
+                        || jqXHR.statusText
+                        || 'Request failed';
+                    massEditHolder.html(
+                        '<div class="alert alert-danger mb-0">'
+                        + $.escapeHtml(String(reason))
+                        + '</div>'
+                    );
                     $.notifyFromAPI(jqXHR.responseJSON, jqXHR);
                 }
             });

--- a/tests/mass-edit-form.test.php
+++ b/tests/mass-edit-form.test.php
@@ -425,6 +425,83 @@ $check(
     false === $needsID->invoke(null, 'bulkedit')
 );
 
+// -------------------------------------------------------------------------
+// A failed form fetch must leave the modal SAYING SO, not sitting on
+// "Loading, please wait...".
+//
+// The error handler used to call massEditModal.modal('hide'), and Bootstrap 5
+// drops a hide() that lands inside the show transition:
+//
+//     hide() { this._isShown && !this._isTransitioning && (...) }
+//
+// A refusal comes back faster than the fade takes -- the page guard above
+// answered before any handler ran -- so the hide was discarded and the box
+// stayed open with only a toast beside it to say why. That is what the bug
+// report showed. Fixing the guard removes today's cause; it does not stop
+// the next refusal (a permission denial, a 500) from hanging the same modal,
+// so the handler now writes the reason where the person is already looking.
+//
+// Both fetches on this page are checked, not just the one that was reported.
+// Queue Task is the button beside Mass edit, over the same selection, and had
+// the identical handler -- it would have been the next report.
+//
+// Sliced by position rather than grepped over the whole file: `modal('hide')`
+// appears legitimately in each success path a few lines away, so a file-wide
+// search for it would pass whatever the error handlers do. The slice is
+// anchored on the FETCH URL, because there are two error handlers in this
+// file and the first textual match is the other one.
+$listJs = (string)@file_get_contents(
+    $root . '/packages/web/management/js/fog/host/fog.host.list.js'
+);
+
+/**
+ * The error callback belonging to one $.ajax() block.
+ *
+ * @param string $js     the file
+ * @param string $anchor a string inside the block, before its error handler
+ *
+ * @return string
+ */
+$errorHandler = function ($js, $anchor) {
+    $from = strpos($js, $anchor);
+    if (false === $from) {
+        return '';
+    }
+    $at = strpos($js, 'error: function(jqXHR, textStatus) {', $from);
+    if (false === $at) {
+        return '';
+    }
+    $end = strpos($js, "\n                }", $at);
+
+    return substr($js, $at, (false === $end ? strlen($js) : $end) - $at);
+};
+
+$fetches = [
+    'mass edit' => ['sub=masseditform', 'massEditHolder.html(', "massEditModal.modal('hide')"],
+    'queue task' => ['sub=deployMulti', 'queueHolder', "queueTaskModal.modal('hide')"],
+];
+foreach ($fetches as $what => $spec) {
+    list($anchor, $writes, $hides) = $spec;
+    $errBody = $errorHandler($listJs, $anchor);
+    $check(
+        "the $what fetch still has an error handler",
+        '' !== $errBody
+    );
+    $check(
+        "the $what fetch writes the reason into the modal body",
+        false !== strpos($errBody, $writes)
+    );
+    $check(
+        "the $what fetch escapes it, the reason being server text in markup",
+        false !== strpos($errBody, '$.escapeHtml(')
+    );
+    $check(
+        "the $what fetch does not try to hide the modal,"
+        . ' which Bootstrap drops mid-transition',
+        false === strpos($errBody, $hides)
+    );
+}
+
 if (count($failures)) {
     fwrite(STDERR, "FAIL: the mass edit form is not three-state:\n");
     foreach ($failures as $f) {


### PR DESCRIPTION
Second half of the mass edit report in #1641. That PR fixed the 404; this one fixes why the modal sat on **"Loading, please wait…"** instead of closing when the fetch failed.

The error handler called `massEditModal.modal('hide')`. Bootstrap 5:

```js
hide() { this._isShown && !this._isTransitioning && (...) }
```

The click opens the modal and starts the fetch in the same breath, so a fast failure lands its `hide()` inside the 300ms show transition, `_isTransitioning` is true, and the call is silently dropped. No error, no retry. The modal is now shown and nothing will close it but the user -- which is exactly what the screenshot showed, with only the toast to say why.

Hiding was the wrong response anyway. The reason belongs in the box the user is already looking at, so both handlers now render it into the modal body as an alert, escaped through `$.escapeHtml` -- it is server text going into markup.

**Queue Task is fixed the same way.** It is the button beside Mass edit, over the same selection, and carried the identical handler; it would have been the next report.

## Gate

`tests/mass-edit-form.test.php`, 49 checks. Per fetch (`sub=masseditform`, `sub=deployMulti`) the error callback is sliced out of `fog.host.list.js` anchored on its own URL, then asserted on three properties: the reason is written into the modal body, it is escaped, and `modal('hide')` is not called.

Anchoring on the URL rather than on the first `error: function(...)` match matters -- the first textual match in that file is Queue Task, not mass edit. Finding that is what turned up the second copy of the bug.

Both mutations were run and both go red: restore `modal('hide')` in either handler and the gate fails with three checks on that fetch.
