### PR TITLE
Group list: a Grants column, so a label group does not read like a heavy one

### DIFF
--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -1159,6 +1159,38 @@ reads as a label at a glance and a heavy group reads as heavy. This is the
 cheapest half of making one entity serve both jobs legibly, and without it the
 Group Management list is forty rows that all look identically consequential.
 
+**Built (D3).** A **Grants** column on the Group Management list, rendered as
+badges: `3 snapins`, `1 printer`, `2 modules`, and nothing at all for a group
+that grants nothing -- which is the reading the requirement is actually
+after. Four things settled in the building that this section had not:
+
+- **Counts, not names.** The question is "is this heavy"; a group with twenty
+  snapins would answer it with twenty chips of noise, and the column would
+  become the thing it exists to cut through.
+- **Three kinds, and an image is not one of them.** Snapins, printers and
+  modules -- the three `FOG\Assign\Resolver` resolves. A group PUSHES an
+  image at its hosts imperatively (`Group::addImage`); it does not grant one,
+  so it is not a property of the group to show.
+- **Primed per page, not selected.** Folding the counts into
+  `Group::$sqlQueryStr` beside `gmMembers` would make the column sortable,
+  and it is why that was rejected: that query already `LEFT JOIN`s
+  `groupMembers` and counts it, so three more joins multiply into a cartesian
+  product per group row -- 500 hosts x 20 snapins x 10 printers is 100k
+  intermediate rows for one group -- and every count would have to become
+  `COUNT(DISTINCT)` to survive the fan-out. One indexed `GROUP BY` per page is
+  cheaper by orders of magnitude. The column is unsortable for the same
+  reason the host list's groups column is, and stated the same way.
+- **No site boundary on the counts, and that is a finding rather than an
+  omission.** Snapin, printer and module are not site-scoped nodes
+  (`SiteScope::$_nodes` holds host, user, group and usergroup). A caller who
+  can see the group row can see what it grants; there is nothing here to leak
+  across a boundary the way group NAMES can on the host list, which is why
+  requirement 1's membership test carries a scope and this does not.
+
+It carries **no `sqlfilter`**. D1's contract is there to be added to, and
+nobody has asked to filter groups by what they grant; the requirement is
+about reading the list at a glance.
+
 **What this decision costs, stated rather than hidden.** "Group" remains a bad
 name for a label. The model is right and the word is wrong, and no amount of
 chips fixes a noun. If the requests for tags continue after 1.6 with all five

--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -759,18 +759,29 @@ serialize through conflicts anyway.
 | M3 | Client paths read the resolved list; `checkPassiveModule` fix | `Items/Host.php`, `Client/ServiceModule.php`, `Client/FOGClient.php`, `Base/FOGPage.php` | M2 | **merged** (#1633) |
 | M4 | `addRemItem()` module special case removed; auto-logout minimum named once | `Base/FOGController.php`, `Pages/HostManagement.php` | M3 | **merged** (#1634) |
 | M5 | Host Modules tab becomes genuinely tri-state, so a host can say OFF | `Pages/HostManagement.php`, JS | M4 | not started |
-| D1 | The `sqlfilter` relationship-filter contract, and the host list's groups column on it | `Base/FOGManagerController.php`, `Router/Route.php`, `Pages/HostManagement.php`, `fog.host.list.js` | C5 | open (#1639) |
+| D1 | The `sqlfilter` relationship-filter contract, and the host list's groups column on it | `Base/FOGManagerController.php`, `Router/Route.php`, `Pages/HostManagement.php`, `fog.host.list.js` | C5 | **merged** (#1639) |
 | D2a | `saveGroup()` gated: CSRF, object scope both sides, and the `group.edit`/`group.create` split | `Pages/HostManagement.php`, `Auth/Authorization.php` | — | **merged** (3cb39b8df) |
-| D2b | Remove as well as add, from the list; typed names resolved against the groups that exist; the write audited | `Pages/HostManagement.php`, `Base/FOGPage.php`, `fog.host.list.js` | D1, D2a | open (#TBD) |
-| D3 | Group list "grants" column | `Router/Route.php`, `Pages/GroupManagement.php`, JS | D1 | not started |
+| D2b | Remove as well as add, from the list; typed names resolved against the groups that exist; the write audited | `Pages/HostManagement.php`, `Base/FOGPage.php`, `fog.host.list.js` | D1, D2a | **merged** (#1640) |
+| D3 | Group list "grants" column | `Router/Route.php`, `Pages/GroupManagement.php`, JS | D1 | open (#TBD) |
 | E | Group page rework + removal of the imperative tabs, and `Group::addSnapin`/`addPrinter`/`addModule` become grants | `Pages/GroupManagement.php`, `Items/Group.php`, JS | **C5 proven** (Decision 10), D, M5 | not started |
+
+**Two bugs in C5's own surface were found and fixed while D was landing**,
+both on the mass edit modal and neither shipped: the object-id guard in
+`FOGPage`'s constructor matched `edit` as a SUBSTRING, so `masseditform` was
+refused as "No host exists with ID" (#1641); and the failure handler's
+`modal('hide')` landed inside Bootstrap's show transition, where
+`Modal.hide()` drops it silently, so the box sat on "Loading, please wait..."
+with only a toast to say why (#1642). The second was ported to the Queue Task
+modal beside it, which had the identical handler.
 
 D split while building it, on the same rule C did: by what each piece can be
 tested on its own. D1 is the shared helper plus the one column that proves it,
 and it is the plan-first half -- a change to a path every grid in the product
 runs through. D2 is a write path, which is a different review from a read
 path; its security half (D2a) went in ahead of the rest, on its own, off the
-back of UNKNOWN-6. D3 needs D1's contract and nothing else.
+back of UNKNOWN-6. D3 needs D1's contract and nothing else -- and in the
+event needed none of it, because nobody has asked to FILTER groups by what
+they grant. D3 is a display column: a primer, a formatter and a renderer.
 
 **Requirement 4 was amended rather than implemented as written**, and the ADR
 carries the reasoning. `$.registerCreateAndAssociate()` is a helper for an

--- a/docs/release/1.6.0-release-notes.DRAFT.md
+++ b/docs/release/1.6.0-release-notes.DRAFT.md
@@ -330,6 +330,22 @@ pre-upgrade *dump* — it is not a schema rollback.
   written to the audit log now, with who, how many, and which groups.
   <!-- verified: docs/adr/0038 decisions 4, 5, 6, 7 and 9; FOG\Assign\Resolver;
   Client/PrinterClient.php; docs/GROUP_SHARED_STATE.md -->
+- **The group list says what each group grants.** A new **Grants** column
+  shows `3 snapins`, `1 printer`, `2 modules` -- and nothing at all for a
+  group that is only a label. Groups now do two jobs, and a list where a
+  label and a group that installs software at every host in it look
+  identically consequential hides the only thing you needed from it.
+
+  It counts rather than names, because the question the column answers is
+  "is this heavy": a group with twenty snapins would answer it with twenty
+  badges. Images are not counted -- a group pushes an image at its hosts, it
+  does not grant one.
+
+  Like the host list's Groups column, this one does not sort. The counts are
+  gathered a page at a time rather than selected, so there is nothing for the
+  server to order by.
+  <!-- verified: docs/adr/0038 decision 16a requirement 5;
+  Router/Route.php::_primeGroupGrants(); tests/group-grants-column.test.php -->
 - **Mass edit on the host list**, and it asks before it overwrites. Tick any
   set of hosts, press **Mass edit**, and every field is paired with its own
   *No change / Set on all / Clear on all* control. Nothing is written unless

--- a/packages/web/management/js/fog/group/fog.group.list.js
+++ b/packages/web/management/js/fog/group/fog.group.list.js
@@ -5,7 +5,8 @@
         ],
         columns: [
             {data: 'mainlink'},
-            {data: 'members'}
+            {data: 'members'},
+            {data: 'grants'}
         ],
         rowId: 'id',
         columnDefs: [
@@ -16,6 +17,44 @@
             {
                 responsivePriority: 0,
                 targets: 1
+            },
+            {
+                // Not sortable. The counts behind this column are primed one
+                // page at a time rather than selected, so the server has no
+                // expression to ORDER BY and a header click would re-request
+                // the page and hand back the same order -- which reads as
+                // the grid being broken. See the group arm of
+                // Route::_gridColumns() for why it is not folded into the
+                // list query instead.
+                orderable: false,
+                // Kept through the responsive collapse: "does this group
+                // push software" is the question the column exists for, and
+                // it does not stop mattering on a narrow window.
+                responsivePriority: 1,
+                render: function(data, type, row) {
+                    // Display only. Sort, search and the CSV export get the
+                    // server's plain comma-joined text back untouched --
+                    // markup baked into the value is the GH-1446 failure,
+                    // where registerExportTable() escapes each cell and the
+                    // badges land in the CSV as literal '<span class="...'.
+                    if (type !== 'display') {
+                        return data;
+                    }
+                    var list = row.grants_list || [];
+                    if (!list.length) {
+                        return '';
+                    }
+                    // Escaped with the same helper every other JS-rendered
+                    // cell uses. These strings are composed server-side
+                    // because they are translated, not because they are
+                    // trusted.
+                    return $.map(list, function(grant) {
+                        return '<span class="badge bg-secondary me-1">' +
+                            $.escapeHtml(String(grant)) +
+                            '</span>';
+                    }).join('');
+                },
+                targets: 2
             }
         ]
     });

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -125,10 +125,28 @@ msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "%d module"
+msgid_plural "%d modules"
+msgstr[0] "Modulname"
+msgstr[1] "Modulname"
+
+#, fuzzy, php-format
+msgid "%d printer"
+msgid_plural "%d printers"
+msgstr[0] "Drucker"
+msgstr[1] "Drucker"
+
+#, fuzzy, php-format
 msgid "%d selected host"
 msgid_plural "%d selected hosts"
 msgstr[0] "Ausgewählten MAcs freigeben"
 msgstr[1] "Ausgewählten MAcs freigeben"
+
+#, fuzzy, php-format
+msgid "%d snapin"
+msgid_plural "%d snapins"
+msgstr[0] "Snapin"
+msgstr[1] "Snapin"
 
 #, php-format
 msgid "%d token(s) disabled."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -130,10 +130,28 @@ msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "%d module"
+msgid_plural "%d modules"
+msgstr[0] "Module Name"
+msgstr[1] "Module Name"
+
+#, fuzzy, php-format
+msgid "%d printer"
+msgid_plural "%d printers"
+msgstr[0] "Printer"
+msgstr[1] "Printer"
+
+#, fuzzy, php-format
 msgid "%d selected host"
 msgid_plural "%d selected hosts"
 msgstr[0] "Approve selected Hosts"
 msgstr[1] "Approve selected Hosts"
+
+#, fuzzy, php-format
+msgid "%d snapin"
+msgid_plural "%d snapins"
+msgstr[0] "Snapin"
+msgstr[1] "Snapin"
 
 #, php-format
 msgid "%d token(s) disabled."

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -128,10 +128,28 @@ msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "%d module"
+msgid_plural "%d modules"
+msgstr[0] "Módulo"
+msgstr[1] "Módulo"
+
+#, fuzzy, php-format
+msgid "%d printer"
+msgid_plural "%d printers"
+msgstr[0] "Impresora"
+msgstr[1] "Impresora"
+
+#, fuzzy, php-format
 msgid "%d selected host"
 msgid_plural "%d selected hosts"
 msgstr[0] "retirar"
 msgstr[1] "retirar"
+
+#, fuzzy, php-format
+msgid "%d snapin"
+msgid_plural "%d snapins"
+msgstr[0] "snapin"
+msgstr[1] "snapin"
 
 #, php-format
 msgid "%d token(s) disabled."

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -125,10 +125,28 @@ msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "%d module"
+msgid_plural "%d modules"
+msgstr[0] "Modulname"
+msgstr[1] "Modulname"
+
+#, fuzzy, php-format
+msgid "%d printer"
+msgid_plural "%d printers"
+msgstr[0] "Drucker"
+msgstr[1] "Drucker"
+
+#, fuzzy, php-format
 msgid "%d selected host"
 msgid_plural "%d selected hosts"
 msgstr[0] "Ausgewählten MAcs freigeben"
 msgstr[1] "Ausgewählten MAcs freigeben"
+
+#, fuzzy, php-format
+msgid "%d snapin"
+msgid_plural "%d snapins"
+msgstr[0] "Snapin"
+msgstr[1] "Snapin"
 
 #, php-format
 msgid "%d token(s) disabled."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -131,10 +131,28 @@ msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "%d module"
+msgid_plural "%d modules"
+msgstr[0] "Module"
+msgstr[1] "Module"
+
+#, fuzzy, php-format
+msgid "%d printer"
+msgid_plural "%d printers"
+msgstr[0] "Imprimante"
+msgstr[1] "Imprimante"
+
+#, fuzzy, php-format
 msgid "%d selected host"
 msgid_plural "%d selected hosts"
 msgstr[0] "Approuver hôtes sélectionnés"
 msgstr[1] "Approuver hôtes sélectionnés"
+
+#, fuzzy, php-format
+msgid "%d snapin"
+msgid_plural "%d snapins"
+msgstr[0] "snapin"
+msgstr[1] "snapin"
 
 #, php-format
 msgid "%d token(s) disabled."

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -130,10 +130,28 @@ msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "%d module"
+msgid_plural "%d modules"
+msgstr[0] "Nome Modulo"
+msgstr[1] "Nome Modulo"
+
+#, fuzzy, php-format
+msgid "%d printer"
+msgid_plural "%d printers"
+msgstr[0] "Stampante"
+msgstr[1] "Stampante"
+
+#, fuzzy, php-format
 msgid "%d selected host"
 msgid_plural "%d selected hosts"
 msgstr[0] "Approvare MAC selezionati"
 msgstr[1] "Approvare MAC selezionati"
+
+#, fuzzy, php-format
+msgid "%d snapin"
+msgid_plural "%d snapins"
+msgstr[0] "snapin"
+msgstr[1] "snapin"
 
 #, php-format
 msgid "%d token(s) disabled."

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -121,10 +121,28 @@ msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "%d module"
+msgid_plural "%d modules"
+msgstr[0] "モジュール MD5"
+msgstr[1] "モジュール MD5"
+
+#, fuzzy, php-format
+msgid "%d printer"
+msgid_plural "%d printers"
+msgstr[0] "プリンター"
+msgstr[1] "プリンター"
+
+#, fuzzy, php-format
 msgid "%d selected host"
 msgid_plural "%d selected hosts"
 msgstr[0] "選択したホストを承認"
 msgstr[1] "選択したホストを承認"
+
+#, fuzzy, php-format
+msgid "%d snapin"
+msgid_plural "%d snapins"
+msgstr[0] "スナップイン"
+msgstr[1] "スナップイン"
 
 #, php-format
 msgid "%d token(s) disabled."

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -106,8 +106,26 @@ msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, php-format
+msgid "%d module"
+msgid_plural "%d modules"
+msgstr[0] ""
+msgstr[1] ""
+
+#, php-format
+msgid "%d printer"
+msgid_plural "%d printers"
+msgstr[0] ""
+msgstr[1] ""
+
+#, php-format
 msgid "%d selected host"
 msgid_plural "%d selected hosts"
+msgstr[0] ""
+msgstr[1] ""
+
+#, php-format
+msgid "%d snapin"
+msgid_plural "%d snapins"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -130,10 +130,28 @@ msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "%d module"
+msgid_plural "%d modules"
+msgstr[0] "Nome do módulo"
+msgstr[1] "Nome do módulo"
+
+#, fuzzy, php-format
+msgid "%d printer"
+msgid_plural "%d printers"
+msgstr[0] "Impressora"
+msgstr[1] "Impressora"
+
+#, fuzzy, php-format
 msgid "%d selected host"
 msgid_plural "%d selected hosts"
 msgstr[0] "Aprovar Hosts selecionados"
 msgstr[1] "Aprovar Hosts selecionados"
+
+#, fuzzy, php-format
+msgid "%d snapin"
+msgid_plural "%d snapins"
+msgstr[0] "Snapin"
+msgstr[1] "Snapin"
 
 #, php-format
 msgid "%d token(s) disabled."

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -130,10 +130,28 @@ msgid "%d host(s) are assigned an image they cannot run"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "%d module"
+msgid_plural "%d modules"
+msgstr[0] "模块名称"
+msgstr[1] "模块名称"
+
+#, fuzzy, php-format
+msgid "%d printer"
+msgid_plural "%d printers"
+msgstr[0] "打印机"
+msgstr[1] "打印机"
+
+#, fuzzy, php-format
 msgid "%d selected host"
 msgid_plural "%d selected hosts"
 msgstr[0] "批准选定主机"
 msgstr[1] "批准选定主机"
+
+#, fuzzy, php-format
+msgid "%d snapin"
+msgid_plural "%d snapins"
+msgstr[0] "管理单元"
+msgstr[1] "管理单元"
 
 #, php-format
 msgid "%d token(s) disabled."

--- a/packages/web/src/Pages/GroupManagement.php
+++ b/packages/web/src/Pages/GroupManagement.php
@@ -74,11 +74,17 @@ class GroupManagement extends FOGPage
         parent::__construct($this->name);
         $this->headerData = [
             _('Name'),
-            _('Members')
+            _('Members'),
+            // What the group grants, so a plain label group reads as one and
+            // a group that pushes snapins at every host in it reads as
+            // heavy. ADR 0038 Decision 16a requirement 5; the column is
+            // built in the group arm of Route::_gridColumns().
+            _('Grants')
         ];
         $this->attributes = [
             [],
-            ['width' => 16]
+            ['width' => 16],
+            []
         ];
     }
     /**

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -257,6 +257,19 @@ class Route extends FOGBase
      */
     protected static $hostGroupCache = [];
     /**
+     * What each group on the grid page being rendered grants.
+     *
+     * Keyed group id => list of already-translated strings, one per kind of
+     * grant the group carries and none for a kind it does not. Filled by ONE
+     * query in the Grants column's primer and read by its formatter, on the
+     * same per-page batching rule as $relCache and $hostGroupCache.
+     *
+     * Emptied at the top of every listem() call, exactly as those are.
+     *
+     * @var array
+     */
+    protected static $groupGrantCache = [];
+    /**
      * The class the current API route is serving, recorded so printer() can
      * strip secrets from a payload that does not name its own class.
      *
@@ -3136,6 +3149,7 @@ class Route extends FOGBase
             // Fresh per grid -- see $relCache and rel().
             self::$relCache = [];
             self::$hostGroupCache = [];
+            self::$groupGrantCache = [];
             $classname = strtolower($class);
             $classman = self::getClass("{$classname}manager");
             $table = $classman->getTable();
@@ -3815,6 +3829,64 @@ class Route extends FOGBase
                     'db' => 'gmMembers',
                     'dt' => 'members',
                     'removeFromQuery' => true
+                ];
+                // What the group grants. ADR 0038 Decision 16a requirement
+                // 5: once a group is also a label, a list of forty rows that
+                // all look identically consequential hides the one thing a
+                // reader needs -- whether this row is a label or something
+                // that will push software at every host in it.
+                //
+                // Counts rather than names on purpose. The question the
+                // column answers is "is this heavy", and a group with twenty
+                // snapins would answer it with twenty chips of noise.
+                //
+                // Deliberately NO 'db', for the same reason the host list's
+                // groups column has none: there is no scalar on `groups`
+                // behind it. Unlike that column it carries no 'sqlfilter'
+                // either -- nobody has asked to filter groups by what they
+                // grant, and the contract is there to be added to when they
+                // do.
+                //
+                // Not folded into Group::$sqlQueryStr beside gmMembers,
+                // although that would make it sortable. That query already
+                // LEFT JOINs groupMembers and counts it; three more joins
+                // multiply into a cartesian product per group row -- 500
+                // hosts x 20 snapins x 10 printers is 100k intermediate rows
+                // for one group -- and every count would have to become
+                // COUNT(DISTINCT) to survive the fan-out. One indexed
+                // GROUP BY per page is cheaper than that by orders of
+                // magnitude, and it is the pattern the groups column on the
+                // host list already set.
+                //
+                // No site boundary on the counts, and that is a finding
+                // rather than an omission: snapin, printer and module are
+                // not site-scoped nodes (SiteScope::$_nodes holds host,
+                // user, group and usergroup). A caller who can see the group
+                // row can see what it grants; there is nothing here to leak
+                // across a boundary the way group NAMES can on the host
+                // list.
+                $columns[] = [
+                    'dt' => 'grants',
+                    'prime' => function ($rows) {
+                        self::_primeGroupGrants(
+                            array_column((array) $rows, 'groupID')
+                        );
+                    },
+                    'formatter' => function ($d, $row) {
+                        // PLAIN TEXT, no markup: registerExportTable()
+                        // escapes each cell, so a badge baked in here lands
+                        // in the CSV as a literal <span> (GH-1446).
+                        return implode(', ', self::_groupGrants($row));
+                    }
+                ];
+                // The same strings as a list, for the renderer. Rides along
+                // in the JSON with no header of its own, as groups_list and
+                // primac_vendor do, so it never reaches the CSV export.
+                $columns[] = [
+                    'dt' => 'grants_list',
+                    'formatter' => function ($d, $row) {
+                        return self::_groupGrants($row);
+                    }
                 ];
                 break;
             case 'site':
@@ -7804,6 +7876,116 @@ class Route extends FOGBase
 
         return $hostID > 0 && isset(self::$hostGroupCache[$hostID])
             ? self::$hostGroupCache[$hostID]
+            : [];
+    }
+    /**
+     * Counts what every group on the grid page grants, in one query.
+     *
+     * ADR 0038 Decision 16a requirement 5. The three tables are the three
+     * things a group grants under this ADR and the three FOG\Assign\Resolver
+     * resolves -- snapins, printers and modules. An image is NOT among them:
+     * a group pushes an image onto its hosts imperatively (Group::addImage),
+     * it does not grant one, so it is not a property of the group to show.
+     *
+     * The strings are composed here rather than client-side because they are
+     * translated, and the browser has no catalog. The renderer's job is to
+     * escape them and wrap them in a badge.
+     *
+     * @param array $groupIDs The page's group ids, unsanitized.
+     *
+     * @return void
+     */
+    private static function _primeGroupGrants($groupIDs)
+    {
+        self::$groupGrantCache = [];
+        $ids = [];
+        foreach ((array) $groupIDs as $id) {
+            $id = (int) $id;
+            if ($id > 0) {
+                $ids[$id] = $id;
+            }
+        }
+        if (!count($ids)) {
+            return;
+        }
+        $in = implode(',', $ids);
+        // One UNION ALL rather than three round trips. Each arm is a plain
+        // GROUP BY on the assoc table's leading index column, so none of
+        // them reads a row it does not count.
+        $kinds = [
+            'snapin' => ['groupSnapinAssoc', 'gsaGroupID'],
+            'printer' => ['groupPrinterAssoc', 'gpaGroupID'],
+            'module' => ['groupModuleAssoc', 'gmaGroupID']
+        ];
+        $selects = [];
+        foreach ($kinds as $kind => $spec) {
+            list($table, $col) = $spec;
+            $selects[] = 'SELECT \'' . $kind . '\' AS `kind`,'
+                . '`' . $col . '` AS `gid`,COUNT(*) AS `n`'
+                . ' FROM `' . $table . '`'
+                . ' WHERE `' . $col . '` IN (' . $in . ')'
+                . ' GROUP BY `' . $col . '`';
+        }
+        $rows = self::_rawRows(implode(' UNION ALL ', $selects));
+        // Bucketed by kind first so the badges come out in a fixed order --
+        // snapins, printers, modules -- whatever order the UNION returns.
+        $byKind = [];
+        foreach ($rows as $row) {
+            $gid = (int) $row['gid'];
+            $n = (int) $row['n'];
+            if ($gid > 0 && $n > 0) {
+                $byKind[(string) $row['kind']][$gid] = $n;
+            }
+        }
+        foreach ($kinds as $kind => $spec) {
+            if (!isset($byKind[$kind])) {
+                continue;
+            }
+            foreach ($byKind[$kind] as $gid => $n) {
+                self::$groupGrantCache[$gid][] = sprintf(
+                    self::_grantLabel($kind, $n),
+                    $n
+                );
+            }
+        }
+    }
+    /**
+     * The translated "%d snapins" label for one kind of grant.
+     *
+     * Split out because ngettext needs its two forms as literals for the
+     * catalog extractor to find them; building the msgid from $kind would
+     * leave every one of these untranslated in every language.
+     *
+     * @param string $kind One of snapin, printer, module.
+     * @param int    $n    How many, for the plural form.
+     *
+     * @return string A format string taking one %d.
+     */
+    private static function _grantLabel($kind, $n)
+    {
+        switch ($kind) {
+            case 'snapin':
+                return ngettext('%d snapin', '%d snapins', $n);
+            case 'printer':
+                return ngettext('%d printer', '%d printers', $n);
+            default:
+                return ngettext('%d module', '%d modules', $n);
+        }
+    }
+    /**
+     * The primed grants for one grid row.
+     *
+     * @param array $row The raw database row.
+     *
+     * @return array list of translated strings, empty for a plain label
+     *               group that grants nothing.
+     */
+    private static function _groupGrants($row)
+    {
+        $groupID = isset($row['groupID']) ? (int) $row['groupID'] : 0;
+
+        return $groupID > 0 && isset(self::$groupGrantCache[$groupID])
+            ? self::$groupGrantCache[$groupID]
             : [];
     }
     /**

--- a/tests/fixtures/route-column-contract.txt
+++ b/tests/fixtures/route-column-contract.txt
@@ -29,6 +29,8 @@ group	9	groupKernelArgs	kernelArgs	-	-
 group	10	groupPrimaryDisk	kernelDevice	-	-
 group	11	groupInit	init	-	-
 group	12	gmMembers	members	-	-
+group	13	-	grants	f	(none)
+group	14	-	grants_list	f	-
 groupassociation	0	gmID	id	-	-
 groupassociation	1	gmID	DT_RowId	f	-
 groupassociation	2	gmHostID	hostID	-	-

--- a/tests/group-grants-column.test.php
+++ b/tests/group-grants-column.test.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * The group list's Grants column: what it asks the database, and what it
+ * renders.
+ *
+ * ADR 0038 Decision 16a requirement 5. Once a group is also a label, the
+ * Group Management list is forty rows that all look identically
+ * consequential -- and the one thing a reader needs from it is whether this
+ * row is a plain label or something that pushes software at every host in
+ * it.
+ *
+ * The column shape (no `db`, a formatter, a primer that touches no relCache
+ * key) is pinned by tests/fixtures/route-column-contract.txt. What that
+ * fixture cannot see is behavior, which is what this drives:
+ *
+ *   1. ONE query per page, not one per row and not one per kind of grant.
+ *      This is GH-707's rule, and the reason the column is primed at all.
+ *   2. It counts all three things a group grants under this ADR -- snapins,
+ *      printers and modules -- and nothing else. An image is not among them:
+ *      a group PUSHES an image imperatively (Group::addImage), it does not
+ *      grant one.
+ *   3. The badges come out in a fixed order (snapins, printers, modules)
+ *      whatever order the rows come back in. A UNION has no order of its
+ *      own, so without the bucketing two groups could show the same grants
+ *      in different orders on the same page.
+ *   4. Only integers reach the SQL. The ids arrive from the grid's row set
+ *      and are interpolated, not bound -- so the casting is the whole of the
+ *      defense.
+ *   5. A group that grants nothing renders empty, and a group id that was
+ *      never primed renders empty rather than reading another row's cache.
+ *   6. A failed query blanks the cell instead of throwing. This feeds a grid
+ *      CELL; taking the whole list down over it would be the wrong trade,
+ *      and it is the opposite of Assign\Resolver, where a missing row is a
+ *      grant silently not applied.
+ *   7. The header row and the JS column list agree in COUNT and in ORDER.
+ *      fog.group.list.js binds by position, so a header added on one side
+ *      only is DataTables error 18 -- "Incorrect column count" -- which
+ *      kills the whole grid and says nothing. See
+ *      tests/grid-header-column-agreement.test.php for the host list's
+ *      structural fix; the group list is small enough to still bind by
+ *      index, so the index is what gets pinned.
+ *   8. The renderer escapes, and only decorates for type 'display'. Server
+ *      text in markup, and GH-1446: registerExportTable() escapes each cell,
+ *      so a badge baked into the value lands in the CSV as a literal
+ *      '<span class="...'.
+ *
+ * Usage: php tests/group-grants-column.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('group-grants-column');
+
+$t = new FogChecks();
+$db = FogTestHarness::fakeDb();
+
+$root = dirname(__DIR__) . '/packages/web';
+
+/**
+ * Primes the cache against a canned answer and returns the SQL that was run.
+ *
+ * @param FogFakeDb $db     the fake
+ * @param array     $ids    group ids to prime
+ * @param array     $answer rows the UNION returns
+ *
+ * @return array the statements the primer issued
+ */
+function primeGrants($db, array $ids, array $answer)
+{
+    $db->log = [];
+    $db->responder = function ($sql) use ($answer) {
+        return false !== strpos($sql, 'groupSnapinAssoc') ? $answer : null;
+    };
+    FogTestHarness::callStatic('Route', '_primeGroupGrants', [$ids]);
+    $db->responder = null;
+
+    return $db->log;
+}
+
+/**
+ * @param int $id group id
+ *
+ * @return array the primed strings
+ */
+function grantsFor($id)
+{
+    return (array)FogTestHarness::callStatic(
+        'Route',
+        '_groupGrants',
+        [['groupID' => $id]]
+    );
+}
+
+// Deliberately out of display order, and interleaved across groups, so
+// invariant 3 is testing the bucketing rather than the fixture's own order.
+$answer = [
+    ['kind' => 'module', 'gid' => 1, 'n' => 1],
+    ['kind' => 'printer', 'gid' => 2, 'n' => 4],
+    ['kind' => 'snapin', 'gid' => 1, 'n' => 2],
+    ['kind' => 'printer', 'gid' => 1, 'n' => 1],
+];
+$log = primeGrants($db, [1, 2, 3], $answer);
+
+$t->check('the primer issues exactly one query', 1 === count($log));
+
+$sql = isset($log[0]) ? $log[0] : '';
+foreach (['groupSnapinAssoc', 'groupPrinterAssoc', 'groupModuleAssoc'] as $tbl) {
+    $t->check(
+        "the one query counts $tbl",
+        false !== strpos($sql, '`' . $tbl . '`')
+    );
+}
+$t->check(
+    'it counts nothing else a group is associated with',
+    false === strpos($sql, 'groupMembers')
+    && false === strpos($sql, 'groupImageAssoc')
+);
+$t->check(
+    'it asks only for the ids on the page',
+    3 === substr_count($sql, 'IN (1,2,3)')
+);
+$t->check(
+    'each arm groups by the assoc row it counts',
+    3 === substr_count($sql, 'GROUP BY')
+);
+
+// Invariant 3: fixed display order regardless of the row order above.
+$t->check(
+    'group 1 reads snapins, printers, modules in that order',
+    ['2 snapins', '1 printer', '1 module'] === grantsFor(1)
+);
+$t->check(
+    'a single grant takes the singular form',
+    ['1 module'] === array_slice(grantsFor(1), -1)
+);
+$t->check(
+    'group 2 reads only what it grants',
+    ['4 printers'] === grantsFor(2)
+);
+// Invariant 5, both halves.
+$t->check(
+    'a group with no grants reads empty',
+    [] === grantsFor(3)
+);
+$t->check(
+    'a group that was never primed reads empty',
+    [] === grantsFor(99)
+);
+$t->check(
+    'a row with no group id reads empty',
+    [] === (array)FogTestHarness::callStatic('Route', '_groupGrants', [[]])
+);
+
+// Invariant 4. The ids are interpolated, so this is the whole defense.
+$log = primeGrants($db, ['4; DROP TABLE `groups`', '0', '-3', 7], []);
+$sql = isset($log[0]) ? $log[0] : '';
+$t->check(
+    'a non-numeric id cannot carry SQL into the query',
+    false === strpos($sql, 'DROP TABLE')
+);
+$t->check(
+    'a non-numeric id is cast, not dropped',
+    3 === substr_count($sql, 'IN (4,7)')
+);
+$t->check(
+    'ids that are not positive are dropped',
+    false === strpos($sql, '-3') && false === strpos($sql, ',0')
+);
+$log = primeGrants($db, ['nope', 0], []);
+$t->check(
+    'no usable id runs no query at all',
+    0 === count($log)
+);
+$t->check(
+    'and leaves the cache empty rather than stale',
+    [] === grantsFor(1)
+);
+
+// Invariant 6. The responder still answers, so a primer that ignored the
+// error would fill the cell from those rows -- without that this passes for
+// the wrong reason, because the fake returns no rows on a plain miss anyway.
+$db->log = [];
+$db->responder = function ($sql) {
+    return false !== strpos($sql, 'groupSnapinAssoc')
+        ? [['kind' => 'snapin', 'gid' => 1, 'n' => 9]]
+        : null;
+};
+$db->error = 'the database went away';
+FogTestHarness::callStatic('Route', '_primeGroupGrants', [[1]]);
+$db->error = false;
+$db->responder = null;
+$t->check(
+    'a failed query blanks the cell instead of throwing',
+    [] === grantsFor(1)
+);
+
+// Invariant 7. Header order server-side, column order client-side.
+$page = (string)file_get_contents($root . '/src/Pages/GroupManagement.php');
+$js = (string)file_get_contents(
+    $root . '/management/js/fog/group/fog.group.list.js'
+);
+$header = [];
+if (preg_match('/\$this->headerData = \[(.*?)\];/s', $page, $m)) {
+    preg_match_all("/_\('([^']+)'\)/", $m[1], $hm);
+    $header = $hm[1];
+}
+$columns = [];
+if (preg_match('/columns: \[(.*?)\],\s*rowId/s', $js, $m)) {
+    preg_match_all("/data: '([^']+)'/", $m[1], $cm);
+    $columns = $cm[1];
+}
+$t->check('the header row was found', count($header) > 0);
+$t->check('the JS column list was found', count($columns) > 0);
+$t->check(
+    'header and column counts agree, or DataTables kills the grid',
+    count($header) === count($columns)
+);
+$t->check(
+    'Grants is the last header',
+    'Grants' === end($header)
+);
+$t->check(
+    'grants is the column at that same index',
+    'grants' === end($columns)
+);
+$grantsIndex = array_search('grants', $columns, true);
+$t->check(
+    'the grants columnDef targets that index',
+    false !== $grantsIndex
+    && preg_match(
+        '/orderable: false,.*?targets: ' . (int)$grantsIndex . '\b/s',
+        $js
+    )
+);
+$t->check(
+    'the attributes list has an entry per header',
+    preg_match('/\$this->attributes = \[(.*?)\];/s', $page, $am)
+    && count($header) === substr_count($am[1], PHP_EOL . '            [')
+);
+
+// Invariant 8, on the renderer itself rather than on the file.
+$render = '';
+if (preg_match('/render: function\(data, type, row\) \{(.*?)\n {16}\}/s', $js, $m)) {
+    $render = $m[1];
+}
+$t->check('the grants renderer was found', '' !== $render);
+$t->check(
+    'it hands back the plain value for anything but display',
+    false !== strpos($render, "type !== 'display'")
+    && false !== strpos($render, 'return data;')
+);
+$t->check(
+    'it reads the list the server sends alongside',
+    false !== strpos($render, 'row.grants_list')
+);
+$t->check(
+    'it escapes every string it puts in markup',
+    false !== strpos($render, '$.escapeHtml(String(grant))')
+);
+// The other half of invariant 8: the value the formatter joins is plain
+// text. The formatter is implode(', ', ...) over exactly these strings, so
+// a badge introduced server-side would show up here first -- and in the CSV
+// export as literal markup, which is what GH-1446 was.
+primeGrants($db, [1], [['kind' => 'snapin', 'gid' => 1, 'n' => 3]]);
+$plain = grantsFor(1);
+$t->check(
+    'the server composes plain text, never markup',
+    ['3 snapins'] === $plain
+    && false === strpos($plain[0], '<')
+    && false === strpos($plain[0], '&')
+);
+
+$t->finish();


### PR DESCRIPTION
Last of ADR 0038 Decision 16a. Requirement 5: *"a column saying whether a group carries snapins or printers, so a label-group reads as a label at a glance and a heavy group reads as heavy."*

A **Grants** column on the Group Management list, rendered as badges -- `3 snapins`, `1 printer`, `2 modules` -- and nothing at all for a group that is only a label.

## Four things the ADR left open, settled here

**Counts, not names.** The question the column answers is "is this heavy". A group with twenty snapins would answer it with twenty chips of noise, and the column would become the thing it exists to cut through.

**Three kinds, and an image is not one of them.** Snapins, printers and modules -- what `Assign\Resolver` resolves. A group *pushes* an image at its hosts imperatively (`Group::addImage`); it does not grant one, so it is not a property of the group to show.

**Primed a page at a time rather than selected, which is also why it does not sort.** Folding the counts into `Group::$sqlQueryStr` beside `gmMembers` would make the column sortable, and is exactly why it was rejected: that query already `LEFT JOIN`s `groupMembers` and counts it, so three more joins multiply into a cartesian product per group row -- 500 hosts x 20 snapins x 10 printers is 100k intermediate rows for one group -- and every count would have to become `COUNT(DISTINCT)` to survive the fan-out. One indexed `GROUP BY` per page is cheaper by orders of magnitude. The column says it is unsortable rather than accepting a header click that changes nothing, which reads as a broken grid.

**No site boundary on the counts -- a finding, not an omission.** Snapin, printer and module are not site-scoped nodes; `SiteScope::$_nodes` holds host, user, group and usergroup. A caller who can see the group row can see what it grants, so there is nothing here to leak the way group *names* can on the host list. That is why requirement 1's membership test carries a scope and this one does not.

It carries **no `sqlfilter`**. D1's contract is there to be added to when someone asks to filter groups by what they grant; nobody has, and the requirement is about reading the list at a glance.

## Shape

The labels are composed server-side because they are translated and the browser has no catalog. The renderer escapes them and wraps them in a badge; the server sends plain comma-joined text so the CSV export does not get literal markup (GH-1446).

## Gate

`tests/group-grants-column.test.php`, 31 checks, driving the primer against the harness's fake database rather than reading it:

- one query per page -- not one per row, not one per kind
- all three assoc tables and nothing else
- a fixed badge order (snapins, printers, modules) whatever order the UNION returns
- only integers reach the SQL; the ids are interpolated, so the cast is the whole defense
- an unprimed group id reads empty rather than another row's cache
- a failed query blanks the cell instead of taking the list down

Plus the header row and the JS column list pinned to the same count *and* order. `fog.group.list.js` still binds by index, and a mismatch is DataTables error 18 -- "Incorrect column count" -- which kills the whole grid and says nothing.

**Eleven mutations were run and all eleven go red**, including one that only started failing after the error-path fixture was fixed: with the responder returning no rows, "a failed query blanks the cell" passed whether or not the guard was there.
