### PR TITLE
Host list: mass edit was never reachable -- a POST-only sub cannot be dispatched

### DIFF
--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -5618,6 +5618,10 @@ msgstr "Hier nicht erlaubt"
 msgid "Method does not exist"
 msgstr "Diese Methode ist nicht vorhanden"
 
+#, fuzzy
+msgid "Method not allowed"
+msgstr "Hier nicht erlaubt"
+
 msgid "Microsoft AD"
 msgstr "Microsoft AD"
 
@@ -9614,6 +9618,9 @@ msgid "This document"
 msgstr ""
 
 msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
+msgid "This endpoint accepts POST only."
 msgstr ""
 
 msgid "This endpoint only accepts POST."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -5630,6 +5630,10 @@ msgstr "Not allowed here"
 msgid "Method does not exist"
 msgstr "Method does not exist"
 
+#, fuzzy
+msgid "Method not allowed"
+msgstr "Not allowed here"
+
 msgid "Microsoft AD"
 msgstr ""
 
@@ -9622,6 +9626,9 @@ msgid "This document"
 msgstr ""
 
 msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
+msgid "This endpoint accepts POST only."
 msgstr ""
 
 msgid "This endpoint only accepts POST."

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5730,6 +5730,10 @@ msgstr ""
 msgid "Method does not exist"
 msgstr "Método no existe"
 
+#, fuzzy
+msgid "Method not allowed"
+msgstr "Método no existe"
+
 msgid "Microsoft AD"
 msgstr ""
 
@@ -9788,6 +9792,9 @@ msgid "This document"
 msgstr ""
 
 msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
+msgid "This endpoint accepts POST only."
 msgstr ""
 
 msgid "This endpoint only accepts POST."

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5619,6 +5619,10 @@ msgstr "Hier nicht erlaubt"
 msgid "Method does not exist"
 msgstr "Diese Methode ist nicht vorhanden"
 
+#, fuzzy
+msgid "Method not allowed"
+msgstr "Hier nicht erlaubt"
+
 msgid "Microsoft AD"
 msgstr "Microsoft AD"
 
@@ -9615,6 +9619,9 @@ msgid "This document"
 msgstr ""
 
 msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
+msgid "This endpoint accepts POST only."
 msgstr ""
 
 msgid "This endpoint only accepts POST."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -5618,6 +5618,10 @@ msgstr "Non autorisé ici"
 msgid "Method does not exist"
 msgstr "Méthode n'existe pas"
 
+#, fuzzy
+msgid "Method not allowed"
+msgstr "Non autorisé ici"
+
 msgid "Microsoft AD"
 msgstr ""
 
@@ -9607,6 +9611,9 @@ msgid "This document"
 msgstr ""
 
 msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
+msgid "This endpoint accepts POST only."
 msgstr ""
 
 msgid "This endpoint only accepts POST."

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -5450,6 +5450,10 @@ msgstr "Non ammessi qui"
 msgid "Method does not exist"
 msgstr "Metodo non esiste"
 
+#, fuzzy
+msgid "Method not allowed"
+msgstr "Non ammessi qui"
+
 msgid "Microsoft AD"
 msgstr "Microsoft AD"
 
@@ -9324,6 +9328,9 @@ msgid "This document"
 msgstr ""
 
 msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
+msgid "This endpoint accepts POST only."
 msgstr ""
 
 msgid "This endpoint only accepts POST."

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -5415,6 +5415,10 @@ msgstr "パスは許可されていません"
 msgid "Method does not exist"
 msgstr "メソッドが存在しません"
 
+#, fuzzy
+msgid "Method not allowed"
+msgstr "パスは許可されていません"
+
 msgid "Microsoft AD"
 msgstr "Microsoft AD"
 
@@ -9270,6 +9274,9 @@ msgid "This document"
 msgstr ""
 
 msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
+msgid "This endpoint accepts POST only."
 msgstr ""
 
 msgid "This endpoint only accepts POST."

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -4788,6 +4788,9 @@ msgstr ""
 msgid "Method does not exist"
 msgstr ""
 
+msgid "Method not allowed"
+msgstr ""
+
 msgid "Microsoft AD"
 msgstr ""
 
@@ -8218,6 +8221,9 @@ msgid "This document"
 msgstr ""
 
 msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
+msgid "This endpoint accepts POST only."
 msgstr ""
 
 msgid "This endpoint only accepts POST."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -5617,6 +5617,10 @@ msgstr "Não permitido aqui"
 msgid "Method does not exist"
 msgstr "O método não existe"
 
+#, fuzzy
+msgid "Method not allowed"
+msgstr "Não permitido aqui"
+
 msgid "Microsoft AD"
 msgstr ""
 
@@ -9609,6 +9613,9 @@ msgid "This document"
 msgstr ""
 
 msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
+msgid "This endpoint accepts POST only."
 msgstr ""
 
 msgid "This endpoint only accepts POST."

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -5617,6 +5617,10 @@ msgstr "这里不允许"
 msgid "Method does not exist"
 msgstr "方法不存在"
 
+#, fuzzy
+msgid "Method not allowed"
+msgstr "这里不允许"
+
 msgid "Microsoft AD"
 msgstr ""
 
@@ -9609,6 +9613,9 @@ msgid "This document"
 msgstr ""
 
 msgid "This does not change what FOG issues, and it does not change what fog-client pins. Only a self-signed CA certificate is accepted: an intermediate in the same file is dropped rather than trusted, because anchoring an intermediate would trust it as a root."
+msgstr ""
+
+msgid "This endpoint accepts POST only."
 msgstr ""
 
 msgid "This endpoint only accepts POST."

--- a/packages/web/src/Base/FOGPagePost.php
+++ b/packages/web/src/Base/FOGPagePost.php
@@ -55,6 +55,49 @@ trait FOGPagePost
     }
 
     /**
+     * Answers a GET that reached a POST-only endpoint.
+     *
+     * WHY THIS EXISTS, and it is a dispatcher constraint rather than a
+     * nicety. FOGPageManager::render() resolves the sub to a method BEFORE
+     * it considers an Ajax or Post suffix:
+     *
+     *     if (... || !method_exists($class, $method) || empty($method)) {
+     *         $method = 'index';
+     *     }
+     *     if (self::$ajax && method_exists($class, $method.'Ajax')) { ... }
+     *     if (self::$post && method_exists($class, $method.'Post')) { ... }
+     *
+     * So a sub implemented ONLY as <sub>Post is never reached. The name is
+     * not found, $method is rewritten to 'index', and the request is
+     * answered by the node's own list -- HTTP 200, valid JSON, and nothing
+     * anywhere saying the endpoint does not exist. That is how the host
+     * list's mass edit shipped unreachable: the browser POSTed to
+     * sub=masseditform, got the 86-row host list back, read data.msg as
+     * undefined and rendered an empty modal.
+     *
+     * A page therefore declares the bare method too, and points it here.
+     * The Post handler still runs for the POST -- the dispatcher appends
+     * the suffix once the bare name resolves -- so the central
+     * checkAuthAndCSRF() on that path is unchanged, and this only ever
+     * answers the verb the endpoint does not implement.
+     *
+     * @return never
+     */
+    protected static function methodNotAllowed()
+    {
+        header('Content-type: application/json');
+        header('Allow: POST');
+        self::jsonSend(
+            HTTPResponseCodes::HTTP_METHOD_NOT_ALLOWED,
+            json_encode(
+                [
+                    'error' => _('This endpoint accepts POST only.'),
+                    'title' => _('Method not allowed')
+                ]
+            )
+        );
+    }
+    /**
      * Fires a result hook then emits the JSON response.
      *
      * Preserves the existing per-method hook contract exactly: the

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -4710,6 +4710,24 @@ class HostManagement extends FOGPage
     }
 
     /**
+     * Refuses a GET to the mass edit form endpoint.
+     *
+     * @return void
+     */
+    public function massEditForm()
+    {
+        // Dispatch anchor. FOGPageManager::render() will not look for
+        // massEditFormPost() until a method literally named for the sub
+        // resolves, so without this the POST below is unreachable and the
+        // request is answered by the host list instead -- 200, valid JSON,
+        // no msg, an empty modal. See FOGPagePost::methodNotAllowed().
+        //
+        // There is no GET form here on purpose: the form's "(varies)" hints
+        // are computed over the actual selection, and several hundred host
+        // ids do not go in a query string.
+        self::methodNotAllowed();
+    }
+    /**
      * Builds the mass edit form for a selection of hosts.
      *
      * A POST rather than a GET, and that is not incidental. The hints beside
@@ -4826,6 +4844,19 @@ class HostManagement extends FOGPage
         $this->jsonSend($code, $msg);
     }
 
+    /**
+     * Refuses a GET to the mass edit apply endpoint.
+     *
+     * @return void
+     */
+    public function massEdit()
+    {
+        // Dispatch anchor for massEditPost(); see massEditForm() above.
+        // This one is a WRITE, so being silently answered by the host list
+        // meant the Update button reported nothing wrong and changed
+        // nothing at all.
+        self::methodNotAllowed();
+    }
     /**
      * Applies a three-state edit to a selection of hosts.
      *

--- a/tests/ajax-subs-are-dispatchable.test.php
+++ b/tests/ajax-subs-are-dispatchable.test.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Every sub the web UI fetches must resolve to a method on its page class.
+ *
+ * THE BUG THIS EXISTS FOR. FOGPageManager::render() picks the method BEFORE
+ * it considers an Ajax or Post suffix:
+ *
+ *     if (... || !method_exists($class, $method) || empty($method)) {
+ *         $method = 'index';
+ *         ... addJavascript("js/fog/{$node}/fog.{$node}.list.js");
+ *     }
+ *     if (self::$ajax && method_exists($class, $method.'Ajax')) { ... }
+ *     if (self::$post && method_exists($class, $method.'Post')) { ... }
+ *
+ * `$method` there is the raw sub. So an endpoint implemented ONLY as
+ * <sub>Post is never reached: the name does not resolve, $method becomes
+ * 'index', and the request is answered by the node's own list. HTTP 200,
+ * valid JSON, nothing anywhere saying the endpoint does not exist.
+ *
+ * That is how the host list's mass edit shipped completely unreachable.
+ * `massEditFormPost()` and `massEditPost()` had no bare counterparts, so a
+ * POST to sub=masseditform came back as the 86-row host list envelope --
+ * confirmed on a live 1.6 server, byte-identical across two runs. The
+ * browser read data.msg as undefined, rendered an empty modal, and showed
+ * no error because the response was a perfectly good 200. The apply half
+ * was worse: Update reported nothing wrong and wrote nothing at all.
+ *
+ * WHAT IS CHECKED. Every `sub=` the management JS fetches, paired with the
+ * node in the same URL (or the file's own directory where the URL uses
+ * Common.node), against the page class owning that node. The predicate is
+ * method_exists() -- the same call the dispatcher makes, on the same class,
+ * not a grep for the name.
+ *
+ * The one legitimate fallback is allowed by name below and no other.
+ *
+ * It also checks the other end: a bare method that exists ONLY to be found
+ * by the dispatcher must have a suffixed sibling to hand off to, or the
+ * endpoint answers 405 to everything.
+ *
+ * Usage: php tests/ajax-subs-are-dispatchable.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('ajax-subs-dispatchable');
+
+$t = new FogChecks();
+$root = dirname(__DIR__) . '/packages/web';
+
+/**
+ * Subs that are MEANT to fall through to index(), with the reason.
+ *
+ * `list` is every grid's data URL and there is no list() anywhere -- it is
+ * a PHP reserved word until 7.0 and the pages never grew one. The fallback
+ * is what serves those grids, and the caller wants exactly the index
+ * payload, which is the difference between this and the mass edit case.
+ *
+ * Adding a name here is a claim that the node's INDEX is the right answer
+ * for that sub. It is not a way to silence a missing endpoint.
+ */
+$allowedFallback = [
+    'list' => 'every grid\'s data URL; index() is the intended handler'
+];
+
+/**
+ * Nodes whose page class is not fixed, so a name lookup cannot answer.
+ *
+ * `report`: loadPageClasses() picks the class from the `f` query parameter
+ * for this node, so ReportManagement is one of many and a sub may live on
+ * any individual report.
+ *
+ * `home`: two things answer it. DashboardPage declares the node; ProcessLogin
+ * never sets one, and the login POST does not reach dispatch at all --
+ * FOGPageManager::render() returns immediately for a caller who is not
+ * logged in, which is every caller of ?node=home&sub=login.
+ */
+$unfixedNode = [
+    'report' => 'class chosen by the f parameter',
+    'home' => 'login is answered before dispatch'
+];
+
+// node => page class, read from the class's own $node property.
+$byNode = [];
+foreach (glob($root . '/src/Pages/*.php') as $f) {
+    $src = (string)file_get_contents($f);
+    if (preg_match('/public \$node = \'([a-z0-9_]+)\'/', $src, $m)) {
+        $byNode[$m[1]] = 'FOG\\Pages\\' . basename($f, '.php');
+    }
+}
+$t->check('the node to page-class map was built', count($byNode) > 5);
+
+// Every (node, sub) the product actually asks for. BOTH halves: the
+// browser's own fetches, and the action URLs PHP renders onto forms --
+// sub=massedit is the second kind, so a JS-only scan would have watched
+// the form endpoint break and missed the apply endpoint beside it.
+$pairs = [];
+foreach ([['/management/js', 'js'], ['/src', 'php']] as $spec) {
+    list($dir, $ext) = $spec;
+    $it = new \RecursiveIteratorIterator(
+        new \RecursiveDirectoryIterator($root . $dir)
+    );
+    foreach ($it as $file) {
+        if ($file->getExtension() !== $ext) {
+            continue;
+        }
+        $path = $file->getPathname();
+        $found = preg_match_all(
+            // node=<name> or Common.node, then sub=<name> in the same URL.
+            '/(?:node=([A-Za-z0-9_]+)|Common\.node)[^\'"]*?(?:&amp;|&)sub=([A-Za-z0-9_]+)/',
+            (string)file_get_contents($path),
+            $ms,
+            PREG_SET_ORDER
+        );
+        if (!$found) {
+            continue;
+        }
+        foreach ($ms as $m) {
+            $node = '' !== $m[1] ? $m[1] : basename(dirname($path));
+            $pairs[$node . '|' . $m[2]] = [$node, $m[2], basename($path)];
+        }
+    }
+}
+$t->check('the endpoint table was collected', count($pairs) > 30);
+$t->check(
+    'the host mass edit endpoints are in it, or this test proves nothing',
+    isset($pairs['host|masseditform']) && isset($pairs['host|massedit'])
+);
+
+foreach ($pairs as $pair) {
+    list($node, $sub, $where) = $pair;
+    if (isset($allowedFallback[strtolower($sub)])) {
+        continue;
+    }
+    if (isset($unfixedNode[$node])) {
+        continue;
+    }
+    if (!isset($byNode[$node])) {
+        // Not every node is a page class. 'client' and 'schema' are
+        // special-cased in FOGPageManager::render() before dispatch, and a
+        // docblock's illustrative ?node=X is not an endpoint at all. A real
+        // page's subs are covered by the pairs that DO resolve to a class.
+        continue;
+    }
+    // method_exists is the dispatcher's own predicate, run on the real
+    // class -- not a search for the name in a file.
+    $t->check(
+        "node=$node sub=$sub resolves to a method ($where)",
+        method_exists($byNode[$node], $sub)
+    );
+}
+
+/**
+ * The body of a method, read from the file it is declared in.
+ *
+ * @param string $class  class name
+ * @param string $method method name
+ *
+ * @return string
+ */
+function methodBody($class, $method)
+{
+    $r = new \ReflectionMethod($class, $method);
+    $lines = (array)file($r->getFileName());
+
+    return implode(
+        '',
+        array_slice(
+            $lines,
+            $r->getStartLine() - 1,
+            $r->getEndLine() - $r->getStartLine() + 1
+        )
+    );
+}
+
+// The other end: an anchor with nothing behind it answers 405 to every
+// verb, which is a worse endpoint than the one it replaced.
+$anchors = 0;
+foreach ($byNode as $node => $class) {
+    foreach (get_class_methods($class) as $method) {
+        if (false === strpos(methodBody($class, $method), 'methodNotAllowed(')) {
+            continue;
+        }
+        $anchors++;
+        $t->check(
+            "$class::$method() anchors a suffixed handler",
+            method_exists($class, $method . 'Post')
+            || method_exists($class, $method . 'Ajax')
+        );
+    }
+}
+$t->check('at least one dispatch anchor was examined', $anchors > 0);
+
+// And the anchor answers the right code, since 200 with the wrong body is
+// the failure this whole file is about.
+$t->check(
+    'methodNotAllowed sends 405',
+    false !== strpos(
+        methodBody('FOG\\Base\\FOGPage', 'methodNotAllowed'),
+        'HTTP_METHOD_NOT_ALLOWED'
+    )
+);
+
+$t->finish();


### PR DESCRIPTION
Third bug in the mass edit report, and the one behind the empty modal with no error.

## What happens

`FOGPageManager::render()` picks the method **before** it considers a suffix:

```php
if (... || !method_exists($class, $method) || empty($method)) {
    $method = 'index';
}
if (self::$ajax && method_exists($class, $method.'Ajax')) { ... }
if (self::$post && method_exists($class, $method.'Post')) { ... }
```

`$method` there is the raw sub. `massEditFormPost()` and `massEditPost()` had no bare counterparts, so `masseditform` resolved to nothing, `$method` became `index`, and the POST was answered by the host list.

Reproduced on a live 1.6 server: **HTTP 200, 83,770 bytes, the standard DataTables envelope with all 86 hosts and no `msg` key at all** — twice, byte-identical, across a deploy. The browser read `data.msg` as undefined, rendered an empty modal body, and showed no error because nothing had failed. The apply half was worse: Update reported nothing wrong and wrote nothing.

## The fix

Both endpoints declare the bare method the dispatcher has to find. The `Post` handler still runs for the POST — the dispatcher appends the suffix once the bare name resolves — so the central `checkAuthAndCSRF()` on that path is unchanged, and the anchor only ever answers the verb the endpoint does not implement.

There is deliberately no GET form: the `(varies)` hints are computed over the selection, and several hundred host ids do not go in a query string.

## Deliberately NOT fixed in the dispatcher

Making the existence check suffix-aware is the tempting one-liner and it would newly expose **32 other `<node><tab>Post` methods** — `hostGroupPost`, `hostModulePost`, `siteHostPost` and the rest. Those are not subs: they are called from inside `editPost()`'s switch on the tab, and tab updates reach them through `sub=edit`. Several would run against an invalid `$this->obj`. That is a real change to take on its own terms, not inside a bug fix.

## Gate

`tests/ajax-subs-are-dispatchable.test.php`, 45 checks. Every sub the product asks for, from **both** halves of the product: the browser's fetches and the action URLs PHP renders onto forms. `sub=massedit` is the second kind, so a JS-only scan would have caught the form endpoint and missed the apply endpoint beside it.

The predicate is `method_exists()` on the real class — the same call the dispatcher makes, not a grep for the name.

Three exclusions, each with the reason recorded rather than a silent skip:

| Excluded | Why |
|---|---|
| `sub=list` | every grid's data URL; `index()` **is** its handler |
| node `report` | `loadPageClasses()` picks the class from the `f` parameter |
| node `home` | the login POST never reaches dispatch — `render()` returns early for a caller who is not logged in |

It also checks the other end: a bare method that exists only to be found must have a suffixed sibling, or the endpoint answers 405 to everything.

Four mutations were run and all four go red: removing either anchor, renaming the handler an anchor fronts, and making `methodNotAllowed()` send 200.
