### PR TITLE
Badges set a background with no text color, so dark mode was unreadable

### DIFF
--- a/packages/web/management/js/fog/about/fog.about.apitokens.js
+++ b/packages/web/management/js/fog/about/fog.about.apitokens.js
@@ -57,10 +57,10 @@
             return data;
           }
           if (data > 0) {
-            return '<span class="badge bg-success">'
+            return '<span class="badge text-bg-success">'
               + '<i class="fas fa-circle-check"></i></span>';
           }
-          return '<span class="badge bg-danger">'
+          return '<span class="badge text-bg-danger">'
             + '<i class="fas fa-circle-xmark"></i></span>';
         },
         targets: 5

--- a/packages/web/management/js/fog/fog.filters.js
+++ b/packages/web/management/js/fog/fog.filters.js
@@ -83,7 +83,7 @@
 
     function showChip(dt, name) {
         var host = chipHost(dt);
-        var chip = el('span', 'badge bg-primary d-inline-flex align-items-center gap-2');
+        var chip = el('span', 'badge text-bg-primary d-inline-flex align-items-center gap-2');
         var close = el('button', 'btn-close btn-close-white');
         host.innerHTML = '';
         chip.appendChild(el('i', 'fas fa-filter'));
@@ -224,19 +224,19 @@
         var by = filter.sharedBy ? ' by ' + filter.sharedBy : '';
         switch (filter.source) {
         case 'user':
-            return el('span', 'badge bg-info ms-2', 'Shared with you' + by);
+            return el('span', 'badge text-bg-info ms-2', 'Shared with you' + by);
         case 'group':
             return el(
-                'span', 'badge bg-info ms-2',
+                'span', 'badge text-bg-info ms-2',
                 'Shared with a group you are in' + by
             );
         case 'role':
             return el(
-                'span', 'badge bg-info ms-2',
+                'span', 'badge text-bg-info ms-2',
                 'Shared with a role you hold' + by
             );
         default:
-            return el('span', 'badge bg-secondary ms-2', 'Everyone');
+            return el('span', 'badge text-bg-secondary ms-2', 'Everyone');
         }
     }
 

--- a/packages/web/management/js/fog/group/fog.group.list.js
+++ b/packages/web/management/js/fog/group/fog.group.list.js
@@ -48,8 +48,13 @@
                     // cell uses. These strings are composed server-side
                     // because they are translated, not because they are
                     // trusted.
+                    // text-bg-secondary, not bg-secondary: it pins the
+                    // text color as well as the background, both
+                    // !important, so the badge reads the same in either
+                    // theme. See the host list's group chips for the rule
+                    // in fog-default-ui that otherwise wins the color.
                     return $.map(list, function(grant) {
-                        return '<span class="badge bg-secondary me-1">' +
+                        return '<span class="badge text-bg-secondary me-1">' +
                             $.escapeHtml(String(grant)) +
                             '</span>';
                     }).join('');

--- a/packages/web/management/js/fog/host/fog.host.list.js
+++ b/packages/web/management/js/fog/host/fog.host.list.js
@@ -248,8 +248,17 @@
                 // Built here rather than server-side so the names are escaped
                 // by the same helper every other JS-rendered cell uses. A
                 // group name is user-supplied text and this cell is markup.
+                //
+                // text-bg-secondary, not bg-secondary: it pins the text
+                // color AND the background, both !important, so the chip
+                // reads the same in either theme. bg-secondary pins only
+                // the background, which left the text to fog-default-ui's
+                // own .badge rule -- and that re-themes badges per mode
+                // (--fog-badge-bg / --fog-text-strong, and a white-on-
+                // primary variant), so dark mode came out near-invisible
+                // while light mode looked fine.
                 return $.map(list, function(group) {
-                    return '<a class="badge bg-secondary ' +
+                    return '<a class="badge text-bg-secondary ' +
                         'text-decoration-none me-1" ' +
                         'href="../management/index.php?node=group&amp;' +
                         'sub=edit&amp;id=' +
@@ -331,7 +340,12 @@
                     return '<span class="text-muted">' + (data || '') +
                         '</span>';
                 }
-                return '<span class="badge bg-' + tone + '">' +
+                // text-bg-, not bg-: see the group chips above. Bootstrap
+                // picks the readable foreground per tone -- white on danger,
+                // black on warning -- where bg- alone leaves it to
+                // fog-default-ui's own .badge rule and the answer changes
+                // with the theme.
+                return '<span class="badge text-bg-' + tone + '">' +
                     (data || '') + '</span>';
             },
             targets: colIndex.sbstate
@@ -355,7 +369,7 @@
                 // date alone would say the opposite.
                 if (String(row.sbenrollvia || '') === 'mok-pending') {
                     return data +
-                        ' <span class="badge bg-warning">pending</span>';
+                        ' <span class="badge text-bg-warning">pending</span>';
                 }
                 // The comparison the fingerprint column exists for, shown
                 // where somebody scanning a fleet will see it. 'stale' means
@@ -369,7 +383,7 @@
                 // is decoration -- the exception is what needs finding.
                 if (String(row.sbenrollfresh || '') === 'stale') {
                     return data +
-                        ' <span class="badge bg-danger">old cert</span>';
+                        ' <span class="badge text-bg-danger">old cert</span>';
                 }
                 return data;
             },

--- a/packages/web/management/js/fog/image/fog.image.list.js
+++ b/packages/web/management/js/fog/image/fog.image.list.js
@@ -92,8 +92,8 @@
         columnDefs.push({
             responsivePriority: 0,
             render: function(data, type, row) {
-                var lock = '<span class="badge bg-warning"><i class="fas fa-lock fa-1x"></i></span>';
-                var unlock = '<span class="badge bg-danger"><i class="fas fa-unlock fa-fx"></i></span>';
+                var lock = '<span class="badge text-bg-warning"><i class="fas fa-lock fa-1x"></i></span>';
+                var unlock = '<span class="badge text-bg-danger"><i class="fas fa-unlock fa-fx"></i></span>';
                 if (row.protected > 0) {
                     return lock;
                 }
@@ -105,8 +105,8 @@
     if ('isEnabled' in colIndex) {
         columnDefs.push({
             render: function(data, type, row) {
-                var enabled = '<span class="badge bg-success"><i class="fas fa-circle-check"></i></span>';
-                var disabled = '<span class="badge bg-danger"><i class="fas fa-circle-xmark"></i></span>';
+                var enabled = '<span class="badge text-bg-success"><i class="fas fa-circle-check"></i></span>';
+                var disabled = '<span class="badge text-bg-danger"><i class="fas fa-circle-xmark"></i></span>';
                 if (row.isEnabled > 0) {
                     return enabled;
                 }

--- a/packages/web/management/js/fog/ipxe/fog.ipxe.list.js
+++ b/packages/web/management/js/fog/ipxe/fog.ipxe.list.js
@@ -40,7 +40,7 @@
                         var label = 'danger',
                             check = 'times-circle';
                     }
-                    return '<span class="badge bg-'
+                    return '<span class="badge text-bg-'
                         + label
                         + '"><i class="fas fa-'
                         + check
@@ -57,7 +57,7 @@
                         var label = 'danger',
                             check = 'times-circle';
                     }
-                    return '<span class="badge bg-'
+                    return '<span class="badge text-bg-'
                         + label
                         + '"><i class="fas fa-'
                         + check

--- a/packages/web/management/js/fog/plugin/fog.plugin.list.js
+++ b/packages/web/management/js/fog/plugin/fog.plugin.list.js
@@ -84,10 +84,10 @@
                     // no manifest, so compatError() finds nothing wrong and
                     // the row would otherwise look completely ordinary.
                     if (row.missing > 0) {
-                        return data + ' <span class="badge bg-danger" title="The plugin directory is gone. It cannot be activated. Use Forget to remove the row."><i class="fas fa-link-slash"></i> Missing</span>';
+                        return data + ' <span class="badge text-bg-danger" title="The plugin directory is gone. It cannot be activated. Use Forget to remove the row."><i class="fas fa-link-slash"></i> Missing</span>';
                     }
                     if (row.incompatible) {
-                        return data + ' <span class="badge bg-danger" title="'+$('<div/>').text(row.incompatible).html()+'"><i class="fas fa-ban"></i> Incompatible</span>';
+                        return data + ' <span class="badge text-bg-danger" title="'+$('<div/>').text(row.incompatible).html()+'"><i class="fas fa-ban"></i> Incompatible</span>';
                     }
                     return data;
                 },
@@ -112,8 +112,8 @@
             },
             {
                 render: function(data, type, row) {
-                    var enabled = '<span class="badge bg-success"><i class="fas fa-circle-check"></i></span>';
-                    var disabled = '<span class="badge bg-danger"><i class="fas fa-circle-xmark"></i></span>';
+                    var enabled = '<span class="badge text-bg-success"><i class="fas fa-circle-check"></i></span>';
+                    var disabled = '<span class="badge text-bg-danger"><i class="fas fa-circle-xmark"></i></span>';
                     if (data > 0) {
                         return enabled;
                     } else {
@@ -126,8 +126,8 @@
                 // Installed status only; the "Update available" action now
                 // rides on the always-visible name column above.
                 render: function(data, type, row) {
-                    var enabled = '<span class="badge bg-success"><i class="fas fa-circle-check"></i></span>';
-                    var disabled = '<span class="badge bg-danger"><i class="fas fa-circle-xmark"></i></span>';
+                    var enabled = '<span class="badge text-bg-success"><i class="fas fa-circle-check"></i></span>';
+                    var disabled = '<span class="badge text-bg-danger"><i class="fas fa-circle-xmark"></i></span>';
                     if (data > 0) {
                         return enabled;
                     } else {

--- a/packages/web/management/js/fog/snapin/fog.snapin.list.js
+++ b/packages/web/management/js/fog/snapin/fog.snapin.list.js
@@ -32,8 +32,8 @@
             },
             {
                 render: function(data, type, row) {
-                    var lock = '<span class="badge bg-warning"><i class="fas fa-lock fa-1x"></i></span>';
-                    var unlock = '<span class="badge bg-danger"><i class="fas fa-unlock fa-fx"></i></span>';
+                    var lock = '<span class="badge text-bg-warning"><i class="fas fa-lock fa-1x"></i></span>';
+                    var unlock = '<span class="badge text-bg-danger"><i class="fas fa-unlock fa-fx"></i></span>';
                     if (row.protected > 0) {
                         return lock;
                     } else {
@@ -44,8 +44,8 @@
             },
             {
                 render: function(data, type, row) {
-                    var enabled = '<span class="badge bg-success"><i class="fas fa-circle-check"></i></span>';
-                    var disabled = '<span class="badge bg-danger"><i class="fas fa-circle-xmark"></i></span>';
+                    var enabled = '<span class="badge text-bg-success"><i class="fas fa-circle-check"></i></span>';
+                    var disabled = '<span class="badge text-bg-danger"><i class="fas fa-circle-xmark"></i></span>';
                     if (row.isEnabled > 0) {
                         return enabled;
                     } else {
@@ -57,8 +57,8 @@
             {
                 responsivePriority: 0,
                 render: function(data, type, row) {
-                    var enabled = '<span class="badge bg-success"><i class="fas fa-circle-check"></i></span>';
-                    var disabled = '<span class="badge bg-danger"><i class="fas fa-circle-xmark"></i></span>';
+                    var enabled = '<span class="badge text-bg-success"><i class="fas fa-circle-check"></i></span>';
+                    var disabled = '<span class="badge text-bg-danger"><i class="fas fa-circle-xmark"></i></span>';
                     if (data > 0) {
                         return enabled;
                     } else {

--- a/packages/web/management/js/fog/storagenode/fog.storagenode.list.js
+++ b/packages/web/management/js/fog/storagenode/fog.storagenode.list.js
@@ -45,16 +45,16 @@
             },
             {
                 render: function(data, type, row) {
-                    var enabled = '<span class="badge bg-success"><i class="fas fa-circle-check"></i></span>';
-                    var disabled = '<span class="badge bg-danger"><i class="fas fa-circle-xmark"></i></span>';
+                    var enabled = '<span class="badge text-bg-success"><i class="fas fa-circle-check"></i></span>';
+                    var disabled = '<span class="badge text-bg-danger"><i class="fas fa-circle-xmark"></i></span>';
                     return (data > 0 ? enabled : disabled);
                 },
                 targets: 2
             },
             {
                 render: function(data, type, row) {
-                    var enabled = '<span class="badge bg-success"><i class="fas fa-circle-check"></i></span>';
-                    var disabled = '<span class="badge bg-danger"><i class="fas fa-circle-xmark"></i></span>';
+                    var enabled = '<span class="badge text-bg-success"><i class="fas fa-circle-check"></i></span>';
+                    var disabled = '<span class="badge text-bg-danger"><i class="fas fa-circle-xmark"></i></span>';
                     return (data > 0 ? enabled : disabled);
                 },
                 targets: 3

--- a/packages/web/management/js/fog/user/fog.user.edit.js
+++ b/packages/web/management/js/fog/user/fog.user.edit.js
@@ -126,10 +126,10 @@
                             return data;
                         }
                         if (data > 0) {
-                            return '<span class="badge bg-success">'
+                            return '<span class="badge text-bg-success">'
                                 + '<i class="fas fa-circle-check"></i></span>';
                         }
-                        return '<span class="badge bg-danger">'
+                        return '<span class="badge text-bg-danger">'
                             + '<i class="fas fa-circle-xmark"></i></span>';
                     },
                     targets: 4

--- a/packages/web/management/js/fog/user/fog.user.list.js
+++ b/packages/web/management/js/fog/user/fog.user.list.js
@@ -21,8 +21,8 @@
             },
             {
                 render: function(data, type, row) {
-                    var enabled = '<span class="badge bg-success"><i class="fas fa-circle-check"></i></span>';
-                    var disabled = '<span class="badge bg-danger"><i class="fas fa-circle-xmark"></i></span>';
+                    var enabled = '<span class="badge text-bg-success"><i class="fas fa-circle-check"></i></span>';
+                    var disabled = '<span class="badge text-bg-danger"><i class="fas fa-circle-xmark"></i></span>';
                     if (data > 0) {
                         return enabled;
                     } else {
@@ -44,9 +44,9 @@
                 // fa-key rather than fa-robot because the bundled Font
                 // Awesome is 4.7.0 and has no fa-robot.
                 render: function(data, type, row) {
-                    var apiOnly = '<span class="badge bg-warning">'
+                    var apiOnly = '<span class="badge text-bg-warning">'
                         + '<i class="fas fa-key"></i></span>';
-                    var interactive = '<span class="badge bg-secondary">'
+                    var interactive = '<span class="badge text-bg-secondary">'
                         + '<i class="fas fa-user"></i></span>';
                     if (data > 0) {
                         return apiOnly;

--- a/packages/web/src/Pages/FOGConfigurationPage.php
+++ b/packages/web/src/Pages/FOGConfigurationPage.php
@@ -609,12 +609,12 @@ class FOGConfigurationPage extends FOGPage
             . \Initiator::e(gmdate('Y-m-d', $ts)) . '</small>';
         $days = (int) floor(($ts - time()) / 86400);
         if ($days < 0) {
-            $out .= '<br><span class="badge bg-danger">'
+            $out .= '<br><span class="badge text-bg-danger">'
                 . _('Expired') . '</span>';
         } elseif ($days <= 30) {
             // 30 days is the window every ACME client renews inside, so a
             // certificate still amber here is one nothing is renewing.
-            $out .= '<br><span class="badge bg-warning">' . sprintf(
+            $out .= '<br><span class="badge text-bg-warning">' . sprintf(
                 // One day left is precisely when somebody reads this badge,
                 // so it is the case worth getting right.
                 /* translators: %d is a number of days */

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -3506,7 +3506,7 @@ class Route extends FOGBase
                             // green now" question and is worth reading off
                             // the grid.
                             if ($d === null || $d === '') {
-                                return '<span class="badge bg-secondary">'
+                                return '<span class="badge text-bg-secondary">'
                                     . _('Not pinged')
                                     . '</span>';
                             }
@@ -3525,7 +3525,7 @@ class Route extends FOGBase
                                 // around them is, which also keeps an HTML
                                 // entity out of the msgid.
                                 if (Ping::METHOD_ICMP === $how) {
-                                    return '<span class="badge bg-success">'
+                                    return '<span class="badge text-bg-success">'
                                         . sprintf(
                                             '%s &middot; ICMP',
                                             _('Online')
@@ -3533,23 +3533,23 @@ class Route extends FOGBase
                                         . '</span>';
                                 }
                                 if (Ping::METHOD_TCP === $how) {
-                                    return '<span class="badge bg-success">'
+                                    return '<span class="badge text-bg-success">'
                                         . sprintf(
                                             '%s &middot; TCP',
                                             _('Online')
                                         )
                                         . '</span>';
                                 }
-                                return '<span class="badge bg-success">'
+                                return '<span class="badge text-bg-success">'
                                     . _('Online')
                                     . '</span>';
                             }
                             if (Ping::isAlive($d)) {
-                                return '<span class="badge bg-info">'
+                                return '<span class="badge text-bg-info">'
                                     . _('Up, port closed')
                                     . '</span>';
                             }
-                            return '<span class="badge bg-secondary">'
+                            return '<span class="badge text-bg-secondary">'
                                 . _(socket_strerror((int)$d))
                                 . '</span>';
                         }
@@ -10006,7 +10006,7 @@ class Route extends FOGBase
                         // "experimental experimental". Plain type text is easy
                         // to skim past on a page whose whole purpose is picking
                         // the build every client will boot from.
-                        $k_i_type = '<span class="badge bg-warning">'
+                        $k_i_type = '<span class="badge text-bg-warning">'
                             . $k_i_type
                             . '</span>';
                     }

--- a/tests/badge-chips-pin-their-text-color.test.php
+++ b/tests/badge-chips-pin-their-text-color.test.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * The grid chips must pin their text color, not just their background.
+ *
+ * `.badge` is not Bootstrap's alone here. fog-default-ui re-themes it:
+ *
+ *     .badge{background-color:var(--fog-badge-bg);color:var(--fog-text-strong)}
+ *     .badge{background-color:#fff;color:var(--fog-primary)}
+ *
+ * Those are theme tokens, and they load after Bootstrap. So `bg-secondary`
+ * -- which is `!important` on the BACKGROUND only -- leaves the text color
+ * to whichever of those rules wins, and the answer differs between light
+ * and dark mode. The host list's group chips shipped that way and came out
+ * near-unreadable in dark mode while light mode looked fine, which is the
+ * worst version of this bug: whoever builds it never sees it.
+ *
+ * `text-bg-secondary` sets both, both `!important`:
+ *
+ *     .text-bg-secondary{color:#fff!important;background-color:RGBA(...)!important}
+ *
+ * so the chip is the same in either theme and no stylesheet load order can
+ * change it. That is the invariant here -- not the particular color.
+ *
+ * Pinned rather than left to the comment beside it because "bg-secondary is
+ * shorter" is a plausible tidy-up, and the thing it breaks is invisible to
+ * anyone not using the other theme.
+ *
+ * Usage: php tests/badge-chips-pin-their-text-color.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('badge-chips-text-color');
+
+$t = new FogChecks();
+$js = dirname(__DIR__) . '/packages/web/management/js/fog';
+
+$chips = [
+    'host list group chips' => $js . '/host/fog.host.list.js',
+    'group list grants badges' => $js . '/group/fog.group.list.js'
+];
+
+foreach ($chips as $what => $path) {
+    $src = (string)file_get_contents($path);
+    $t->check("the $what file was read", '' !== $src);
+    $t->check(
+        "the $what pin the text color with text-bg-",
+        false !== strpos($src, 'badge text-bg-secondary')
+    );
+}
+
+// And nowhere in the product, because this is not a property of two
+// renderers -- every badge on every grid had it, and fixing only the two
+// that were reported leaves the same complaint waiting on the next list.
+//
+// The tones are named rather than matched as [a-z]+ so bg-body,
+// bg-transparent and the rest are not swept in: there is no text-bg- for
+// those, and pinning a class that does not exist renders as nothing.
+$tones = 'primary|secondary|success|danger|warning|info|light|dark';
+$roots = [
+    dirname(__DIR__) . '/packages/web/management/js/fog',
+    dirname(__DIR__) . '/packages/web/src'
+];
+$offenders = [];
+foreach ($roots as $root) {
+    $it = new \RecursiveIteratorIterator(
+        new \RecursiveDirectoryIterator($root)
+    );
+    foreach ($it as $file) {
+        $ext = $file->getExtension();
+        if ('js' !== $ext && 'php' !== $ext) {
+            continue;
+        }
+        if (false !== strpos($file->getFilename(), '.min.')) {
+            continue;
+        }
+        $src = (string)file_get_contents($file->getPathname());
+        // badge then a bare tone background, in either order, with other
+        // utility classes allowed between them -- plus the concatenated
+        // form, where the tone is a variable.
+        if (preg_match('/badge[\w\- ]*\sbg-(?:' . $tones . ')\b/', $src)
+            || preg_match('/\bbg-(?:' . $tones . ')\s[\w\- ]*badge\b/', $src)
+            || preg_match('/badge\s+bg-[\'"]/', $src)
+        ) {
+            $offenders[] = $file->getFilename();
+        }
+    }
+}
+sort($offenders);
+$t->check(
+    'no badge anywhere sets a background without its text color'
+    . (count($offenders) ? ': ' . implode(', ', $offenders) : ''),
+    0 === count($offenders)
+);
+
+// The utility has to exist in the bundle we ship, or this pins a class
+// name that renders as nothing at all.
+$css = dirname(__DIR__) . '/packages/web/management/css/bootstrap5.min.css';
+$bundle = (string)file_get_contents($css);
+$t->check(
+    'text-bg-secondary is defined in the shipped bootstrap bundle',
+    false !== strpos($bundle, '.text-bg-secondary{')
+);
+$t->check(
+    'and it is the definition that sets color, not only background',
+    (bool)preg_match(
+        '/\.text-bg-secondary\{color:#[0-9a-f]{3,6}!important;background-color:/',
+        $bundle
+    )
+);
+
+$t->finish();

--- a/tests/certificate-table.test.php
+++ b/tests/certificate-table.test.php
@@ -59,7 +59,7 @@ $t->check(
 $soon = $expiry->invoke(null, ['not_after' => gmdate('M j H:i:s Y', time() + 10 * 86400) . ' GMT']);
 $t->check(
     'one inside 30 days is amber',
-    false !== strpos($soon, 'badge bg-warning')
+    false !== strpos($soon, 'badge text-bg-warning')
 );
 $t->check(
     'and says how many days are left',
@@ -69,7 +69,7 @@ $t->check(
 $gone = $expiry->invoke(null, ['not_after' => gmdate('M j H:i:s Y', time() - 86400) . ' GMT']);
 $t->check(
     'an expired one is red',
-    false !== strpos($gone, 'badge bg-danger')
+    false !== strpos($gone, 'badge text-bg-danger')
 );
 $t->check(
     'and says so rather than showing a negative count',

--- a/tests/user-list-columns.test.php
+++ b/tests/user-list-columns.test.php
@@ -98,11 +98,11 @@ $t->check(
 $t->check(
     'API-only is marked with a warning badge, not a danger one',
     (bool)preg_match(
-        "/var apiOnly = '<span class=\"badge bg-warning\">/",
+        "/var apiOnly = '<span class=\"badge text-bg-warning\">/",
         $jsSrc
     )
     && (bool)preg_match(
-        "/var interactive = '<span class=\"badge bg-secondary\">/",
+        "/var interactive = '<span class=\"badge text-bg-secondary\">/",
         $jsSrc
     )
 );


### PR DESCRIPTION
Reported on the host list's group chips: fine in light mode, near-invisible in dark. It turned out not to be those chips — it is every badge in the product.

## Why

`.badge` is not Bootstrap's alone here. `fog-default-ui` re-themes it:

```css
.badge{background-color:var(--fog-badge-bg);color:var(--fog-text-strong)}
.badge{background-color:#fff;color:var(--fog-primary)}
```

Those are theme tokens, and they load after Bootstrap. `bg-secondary` and friends are `!important` on the **background only**, so the text color is left to whichever of those rules wins — and the answer differs between light and dark.

That is the worst shape this bug takes: whoever builds it never sees it, because they are in the other theme.

`text-bg-secondary` sets both, both `!important`, and Bootstrap picks the readable foreground per tone — white on danger, black on warning:

```css
.text-bg-secondary{color:#fff!important;background-color:RGBA(var(--bs-secondary-rgb),1)!important}
```

So the badge reads the same in either theme and no stylesheet load order can change it.

## Scope

Swept across the product rather than fixed where it was reported — 13 files, every grid badge plus the two PHP-rendered ones, including the four sites that build the tone by concatenation (`'badge bg-' + tone`). Fixing only the reported chips leaves the same complaint waiting on the next list.

The tones are named explicitly rather than matched as a pattern: `bg-body` and `bg-transparent` have no `text-bg-` counterpart, and pinning a class that does not exist renders as nothing at all.

## Gate

`tests/badge-chips-pin-their-text-color.test.php` walks both source roots and fails on any badge naming a tone background without its paired text color — in either class order, and in the concatenated form. It also asserts `.text-bg-secondary` is actually defined in the bundle we ship, and that its definition sets `color`, not only the background.

Four mutations were run — the two reported chips, a dynamic-tone badge, and a PHP-rendered one — and all four go red.

`certificate-table` and `user-list-columns` pinned the old class names; both now pin the new pairing.
