### PR TITLE
Host Modules tab: three states, so a host can say a module is off

### DIFF
--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -293,6 +293,7 @@ new, so no upgraded database has one.
 | `Assign\Resolver::resolveModules()`, the three tiers | #1632 |
 | the client paths read the resolved list; `get('modules')` stays host-direct | #1633 |
 | `addRemItem()`'s module special case removed, the default now supplies it | #1634 |
+| the host Modules tab becomes genuinely tri-state, so a host can say OFF | #TBD |
 
 **`get('modules')` deliberately stays host-direct.** Route's host update arm
 diffs against it, so a resolved value there would write a host row for every
@@ -310,6 +311,42 @@ two and leave the group page granting on one tab and copying on the next. The
 host Modules tab also has to become genuinely tri-state before a host can
 express OFF at all — today unticking deletes the row, which under this design
 means "unstated" and would let a group grant re-enable it.
+
+**Built (M5).** The Modules tab's per-row control is a **select** — *On / Off /
+Not set* — rather than a checkbox, and the column is headed **State** rather
+than *Associated*: a column called "Associated" over a control offering three
+answers is describing something else. Four things settled in the building:
+
+- **The tab has exactly one writer, and it is not `assocSetter`'s.**
+  `addModule()`/`removeModule()` go through the `modules` array and
+  `assocSetter`, which can only insert a row or delete one — it has no way to
+  write a row that exists and means OFF. Every write from the tab, the two
+  bulk buttons included, goes through `Host::setModuleState()`, which writes
+  `msState` directly and never marks `modules` dirty.
+- **The bulk buttons keep working and needed no client change.** They read
+  DataTables' own row selection, not the cell, so replacing the checkbox cost
+  nothing. On the wire they are unchanged — `confirmadd` means ON,
+  `confirmdel` means *unstated*, which is what deleting the row has always
+  meant.
+- **One statement covers stating a module and flipping it.** `save()` emits
+  `INSERT … ON DUPLICATE KEY UPDATE … msState=VALUES(msState)`, and
+  `UNIQUE (msHostID, msModuleID)` is what makes that fire. So ON → OFF needs
+  no read to tell it apart from a first statement.
+- **A save had to stop eating OFF rows, and that is a bug this decision
+  created rather than found.** `assocSetter` deletes `($cur - $items)`, where
+  `$cur` is every row in `moduleStatusByHost` and `$items` is
+  `get('modules')` — which `loadModules()` filters to state 1. The two sides
+  of that diff were reading different sets the moment a row could mean OFF, so
+  any save touching modules would drop it. `Host::save()` now unions the
+  existing OFF ids into the diff set, so they appear on both sides and neither
+  branch fires.
+
+  **The limit that leaves, stated because it is real.** A caller that lists
+  `modules` — the API's host update arm — cannot turn an OFF module back ON,
+  because the row already exists and `assocSetter` only inserts or deletes.
+  Clearing an OFF is the tab's job. That fails closed, which is the direction
+  "only the host may say OFF" wants: the alternative is an API write silently
+  re-enabling a module the host had switched off.
 
 ADR 0001's closing sentence anticipated the opposite migration ("if snapins or
 printers ever gain a per-host enabled/disabled state, they should converge on

--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -293,7 +293,7 @@ new, so no upgraded database has one.
 | `Assign\Resolver::resolveModules()`, the three tiers | #1632 |
 | the client paths read the resolved list; `get('modules')` stays host-direct | #1633 |
 | `addRemItem()`'s module special case removed, the default now supplies it | #1634 |
-| the host Modules tab becomes genuinely tri-state, so a host can say OFF | #TBD |
+| the host Modules tab becomes genuinely tri-state, so a host can say OFF | #1646 |
 
 **`get('modules')` deliberately stays host-direct.** Route's host update arm
 diffs against it, so a resolved value there would write a host row for every

--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -758,7 +758,7 @@ serialize through conflicts anyway.
 | M2 | `Resolver::resolveModules()`, the three tiers | `Assign/Resolver.php` | M1 | **merged** (#1632) |
 | M3 | Client paths read the resolved list; `checkPassiveModule` fix | `Items/Host.php`, `Client/ServiceModule.php`, `Client/FOGClient.php`, `Base/FOGPage.php` | M2 | **merged** (#1633) |
 | M4 | `addRemItem()` module special case removed; auto-logout minimum named once | `Base/FOGController.php`, `Pages/HostManagement.php` | M3 | **merged** (#1634) |
-| M5 | Host Modules tab becomes genuinely tri-state, so a host can say OFF | `Pages/HostManagement.php`, JS | M4 | not started |
+| M5 | Host Modules tab becomes genuinely tri-state, so a host can say OFF | `Items/Host.php`, `Pages/HostManagement.php`, `Base/FOGPageRender.php`, `fog.host.edit.js` | M4 | open (#TBD) |
 | D1 | The `sqlfilter` relationship-filter contract, and the host list's groups column on it | `Base/FOGManagerController.php`, `Router/Route.php`, `Pages/HostManagement.php`, `fog.host.list.js` | C5 | **merged** (#1639) |
 | D2a | `saveGroup()` gated: CSRF, object scope both sides, and the `group.edit`/`group.create` split | `Pages/HostManagement.php`, `Auth/Authorization.php` | — | **merged** (3cb39b8df) |
 | D2b | Remove as well as add, from the list; typed names resolved against the groups that exist; the write audited | `Pages/HostManagement.php`, `Base/FOGPage.php`, `fog.host.list.js` | D1, D2a | **merged** (#1640) |

--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -758,7 +758,7 @@ serialize through conflicts anyway.
 | M2 | `Resolver::resolveModules()`, the three tiers | `Assign/Resolver.php` | M1 | **merged** (#1632) |
 | M3 | Client paths read the resolved list; `checkPassiveModule` fix | `Items/Host.php`, `Client/ServiceModule.php`, `Client/FOGClient.php`, `Base/FOGPage.php` | M2 | **merged** (#1633) |
 | M4 | `addRemItem()` module special case removed; auto-logout minimum named once | `Base/FOGController.php`, `Pages/HostManagement.php` | M3 | **merged** (#1634) |
-| M5 | Host Modules tab becomes genuinely tri-state, so a host can say OFF | `Items/Host.php`, `Pages/HostManagement.php`, `Base/FOGPageRender.php`, `fog.host.edit.js` | M4 | open (#TBD) |
+| M5 | Host Modules tab becomes genuinely tri-state, so a host can say OFF | `Items/Host.php`, `Pages/HostManagement.php`, `Base/FOGPageRender.php`, `fog.host.edit.js` | M4 | open (#1646) |
 | D1 | The `sqlfilter` relationship-filter contract, and the host list's groups column on it | `Base/FOGManagerController.php`, `Router/Route.php`, `Pages/HostManagement.php`, `fog.host.list.js` | C5 | **merged** (#1639) |
 | D2a | `saveGroup()` gated: CSRF, object scope both sides, and the `group.edit`/`group.create` split | `Pages/HostManagement.php`, `Auth/Authorization.php` | — | **merged** (3cb39b8df) |
 | D2b | Remove as well as add, from the list; typed names resolved against the groups that exist; the write audited | `Pages/HostManagement.php`, `Base/FOGPage.php`, `fog.host.list.js` | D1, D2a | **merged** (#1640) |

--- a/docs/release/1.6.0-release-notes.DRAFT.md
+++ b/docs/release/1.6.0-release-notes.DRAFT.md
@@ -262,6 +262,17 @@ pre-upgrade *dump* — it is not a schema rollback.
   module yet, every host keeps exactly the modules it had, and a module
   nothing mentions is off, which is what it already was.
 
+  **The host's Modules tab now says all three states out loud.** The column
+  is *State*, and each row is a dropdown: **On**, **Off**, or **Not set**.
+  That is a real change from a checkbox, and the reason is that a checkbox
+  only has two answers where a module now has three. Unticking used to delete
+  the row -- which under the rule above means "not set", so a group that
+  grants the module would turn it straight back on. **Off** is the host's own
+  answer and no group overrides it.
+
+  *Add selected* and *Remove selected* still work over a tick of rows and
+  mean **On** and **Not set**, so bulk is unchanged.
+
   **Also fixed along the way:** `servicemodule-active.php` -- the endpoint a
   client asks "is this module enabled for me" -- has been answering *no* for
   every module on every host for the whole of 1.6. It looked the module's

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -1561,7 +1561,13 @@ $.registerGeneralTab = function(opts) {
 //                    (group's tri-state All/Some/None badge + host drill-down).
 //                    The returned markup must still carry an
 //                    input.associated[value=row.id] so the toggle/add/remove
-//                    plumbing keeps working.
+//                    plumbing keeps working -- UNLESS the tab commits the
+//                    cell itself, as host-module does: its cell is a
+//                    three-state select (ADR 0038) and there is no checkbox
+//                    to toggle, so it binds its own change handler in
+//                    onDraw. The Add/Remove buttons are unaffected either
+//                    way; they read DataTables' row selection, not this
+//                    cell.
 // opts.onDraw      - optional function(table) run at the end of every table
 //                    redraw, after the checkbox styling/binding and button
 //                    enable/disable. For tabs that mirror a side panel off the

--- a/packages/web/management/js/fog/host/fog.host.edit.js
+++ b/packages/web/management/js/fog/host/fog.host.edit.js
@@ -828,6 +828,45 @@
     // CLIENT SETTINGS TAB
     // Association area — col 0 is the module name (not a mainLink), given
     // responsivePriority so it never collapses.
+    // A module is a SWITCH with three states, not a link that exists or
+    // does not (ADR 0038):
+    //
+    //   On       a host row saying yes
+    //   Off      a host row saying no -- and only a host may say it, so it
+    //            beats every group grant
+    //   Not set  no host row; a group that grants the module turns it on,
+    //            and nothing else does
+    //
+    // So the cell is a select, not a checkbox. Unticking a checkbox deletes
+    // the row, which under this design means "not set" -- and a group grant
+    // would then switch the module straight back on, which is the opposite
+    // of what the click meant.
+    //
+    // The row-selection plumbing is untouched: "Add selected" and "Remove
+    // selected" read DataTables' own selection, not this control, so bulk
+    // still works and now means On and Not set respectively.
+    function moduleStateSelect(row) {
+        // NULL from the LEFT JOIN is the third state, and it must not be
+        // confused with '0'. == null catches null and undefined only.
+        var state = row.state == null
+                ? 'unset'
+                : (parseInt(row.state, 10) === 1 ? 'on' : 'off'),
+            options = [
+                ['on', 'On'],
+                ['off', 'Off'],
+                ['unset', 'Not set']
+            ],
+            html = '<select class="form-select form-select-sm module-state"'
+                + ' data-module="' + $.escapeHtml(String(row.id)) + '">';
+        $.each(options, function(i, opt) {
+            html += '<option value="' + opt[0] + '"'
+                + (state === opt[0] ? ' selected' : '')
+                + '>' + opt[1] + '</option>';
+        });
+
+        return html + '</select>';
+    }
+
     var hostModulesTable = $.registerAssociationTab({
         slug: 'host-module',
         item: 'module',
@@ -841,7 +880,42 @@
                 responsivePriority: -1,
                 targets: 0
             }
-        ]
+        ],
+        checkboxRender: moduleStateSelect,
+        // Bound here rather than once at load: the cell is re-rendered on
+        // every draw, so a handler bound to the old element is gone. .off()
+        // first for the same reason the shared checkbox binding does it --
+        // a responsive recalc redraws and would otherwise stack handlers
+        // and fire one commit per draw.
+        onDraw: function(table) {
+            var btn = $('#host-module-send');
+            $('#host-module-table select.module-state')
+                .off('change.moduleState')
+                .on('change.moduleState', function() {
+                    var sel = $(this);
+                    $.apiCall(
+                        btn.attr('method'),
+                        btn.attr('action'),
+                        {
+                            confirmmodulestate: 1,
+                            moduleid: sel.data('module'),
+                            state: sel.val()
+                        },
+                        function(err) {
+                            if (err) {
+                                // Redraw so the control shows what the
+                                // server actually holds. Leaving the failed
+                                // choice on screen is the worse outcome:
+                                // the row would read as OFF while the host
+                                // still says nothing.
+                                table.draw(false);
+                                return;
+                            }
+                            table.draw(false);
+                        }
+                    );
+                });
+        }
     });
 
     // Display manager area

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -6270,6 +6270,9 @@ msgstr "(empfohlen)"
 msgid "Not reported"
 msgstr "(empfohlen)"
 
+msgid "Not set means a group may enable this module. Off is the host's own answer and no group can override it."
+msgstr ""
+
 #, fuzzy
 msgid "Not signed in"
 msgstr "Nicht synchronisieren"
@@ -10096,6 +10099,10 @@ msgid "Unknown identity provider"
 msgstr ""
 
 #, fuzzy
+msgid "Unknown module state"
+msgstr "Host Moduleinstellungen"
+
+#, fuzzy
 msgid "Unknown permission"
 msgstr "Ein unbekannter Upload-Fehler ist aufgetreten"
 
@@ -12112,10 +12119,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Update Site Fail"
 #~ msgstr "Host-Update fehlgeschlagen"
-
-#, fuzzy
-#~ msgid "Host module settings"
-#~ msgstr "Host Moduleinstellungen"
 
 #, fuzzy
 #~ msgid "Hostext Create Fail"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -6281,6 +6281,9 @@ msgstr ""
 msgid "Not reported"
 msgstr "Inventory"
 
+msgid "Not set means a group may enable this module. Off is the host's own answer and no group can override it."
+msgstr ""
+
 #, fuzzy
 msgid "Not signed in"
 msgstr "Installed Plugins"
@@ -10102,6 +10105,9 @@ msgid "Unknown filter field(s) for %s: %s"
 msgstr ""
 
 msgid "Unknown identity provider"
+msgstr ""
+
+msgid "Unknown module state"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -6393,6 +6393,9 @@ msgstr ""
 msgid "Not reported"
 msgstr "ID de inventario"
 
+msgid "Not set means a group may enable this module. Off is the host's own answer and no group can override it."
+msgstr ""
+
 #, fuzzy
 msgid "Not signed in"
 msgstr "Instalador inteligente (recomendado)"
@@ -10263,6 +10266,10 @@ msgid "Unknown identity provider"
 msgstr ""
 
 #, fuzzy
+msgid "Unknown module state"
+msgstr "Descripción del Grupo"
+
+#, fuzzy
 msgid "Unknown permission"
 msgstr "Se produjo un error de carga desconocida. Código de retorno: "
 
@@ -12265,10 +12272,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Update Site Fail"
 #~ msgstr "actualización Valoración falló"
-
-#, fuzzy
-#~ msgid "Host module settings"
-#~ msgstr "Descripción del Grupo"
 
 #, fuzzy
 #~ msgid "Hostext Create Fail"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -6271,6 +6271,9 @@ msgstr "(empfohlen)"
 msgid "Not reported"
 msgstr "(empfohlen)"
 
+msgid "Not set means a group may enable this module. Off is the host's own answer and no group can override it."
+msgstr ""
+
 #, fuzzy
 msgid "Not signed in"
 msgstr "Nicht synchronisieren"
@@ -10097,6 +10100,10 @@ msgid "Unknown identity provider"
 msgstr ""
 
 #, fuzzy
+msgid "Unknown module state"
+msgstr "Host Moduleinstellungen"
+
+#, fuzzy
 msgid "Unknown permission"
 msgstr "Ein unbekannter Upload-Fehler ist aufgetreten"
 
@@ -12113,10 +12120,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Update Site Fail"
 #~ msgstr "Host-Update fehlgeschlagen"
-
-#, fuzzy
-#~ msgid "Host module settings"
-#~ msgstr "Host Moduleinstellungen"
 
 #, fuzzy
 #~ msgid "Hostext Create Fail"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -6268,6 +6268,9 @@ msgstr ""
 msgid "Not reported"
 msgstr "Inventaire"
 
+msgid "Not set means a group may enable this module. Off is the host's own answer and no group can override it."
+msgstr ""
+
 #, fuzzy
 msgid "Not signed in"
 msgstr "Plugins installés"
@@ -10090,6 +10093,10 @@ msgid "Unknown identity provider"
 msgstr ""
 
 #, fuzzy
+msgid "Unknown module state"
+msgstr "hôte description de"
+
+#, fuzzy
 msgid "Unknown permission"
 msgstr "Erreur inconnue de téléchargement a eu lieu. Code de retour: "
 
@@ -12089,10 +12096,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Update Site Fail"
 #~ msgstr "Mise à jour de l'hôte a échoué"
-
-#, fuzzy
-#~ msgid "Host module settings"
-#~ msgstr "hôte description de"
 
 #, fuzzy
 #~ msgid "Hostext Create Fail"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -6084,6 +6084,9 @@ msgstr "Consigliato"
 msgid "Not reported"
 msgstr "Consigliato"
 
+msgid "Not set means a group may enable this module. Off is the host's own answer and no group can override it."
+msgstr ""
+
 #, fuzzy
 msgid "Not signed in"
 msgstr "Non sincronizzo"
@@ -9794,6 +9797,10 @@ msgid "Unknown identity provider"
 msgstr ""
 
 #, fuzzy
+msgid "Unknown module state"
+msgstr "Impostazioni del modulo host"
+
+#, fuzzy
 msgid "Unknown permission"
 msgstr "Si è verificato errore di caricamento sconosciuto"
 
@@ -11733,9 +11740,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Update Site Fail"
 #~ msgstr "Aggiornamento Host completato"
-
-#~ msgid "Host module settings"
-#~ msgstr "Impostazioni del modulo host"
 
 #, fuzzy
 #~ msgid "Hostext Create Fail"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -6049,6 +6049,9 @@ msgstr "保護されていません"
 msgid "Not reported"
 msgstr "保護されていません"
 
+msgid "Not set means a group may enable this module. Off is the host's own answer and no group can override it."
+msgstr ""
+
 #, fuzzy
 msgid "Not signed in"
 msgstr "同期していません"
@@ -9735,6 +9738,9 @@ msgid "Unknown filter field(s) for %s: %s"
 msgstr ""
 
 msgid "Unknown identity provider"
+msgstr ""
+
+msgid "Unknown module state"
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -5350,6 +5350,9 @@ msgstr ""
 msgid "Not reported"
 msgstr ""
 
+msgid "Not set means a group may enable this module. Off is the host's own answer and no group can override it."
+msgstr ""
+
 msgid "Not signed in"
 msgstr ""
 
@@ -8645,6 +8648,9 @@ msgid "Unknown filter field(s) for %s: %s"
 msgstr ""
 
 msgid "Unknown identity provider"
+msgstr ""
+
+msgid "Unknown module state"
 msgstr ""
 
 msgid "Unknown permission"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -6268,6 +6268,9 @@ msgstr ""
 msgid "Not reported"
 msgstr "Inventário"
 
+msgid "Not set means a group may enable this module. Off is the host's own answer and no group can override it."
+msgstr ""
+
 #, fuzzy
 msgid "Not signed in"
 msgstr "Plugins instalados"
@@ -10092,6 +10095,10 @@ msgid "Unknown identity provider"
 msgstr ""
 
 #, fuzzy
+msgid "Unknown module state"
+msgstr "anfitrião Descrição"
+
+#, fuzzy
 msgid "Unknown permission"
 msgstr "Ocorreu um erro de upload desconhecido. Código de retorno: "
 
@@ -12091,10 +12098,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Update Site Fail"
 #~ msgstr "Anfitrião Update Failed"
-
-#, fuzzy
-#~ msgid "Host module settings"
-#~ msgstr "anfitrião Descrição"
 
 #, fuzzy
 #~ msgid "Hostext Create Fail"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -6268,6 +6268,9 @@ msgstr ""
 msgid "Not reported"
 msgstr "库存"
 
+msgid "Not set means a group may enable this module. Off is the host's own answer and no group can override it."
+msgstr ""
+
 #, fuzzy
 msgid "Not signed in"
 msgstr "已安装的插件"
@@ -10092,6 +10095,10 @@ msgid "Unknown identity provider"
 msgstr ""
 
 #, fuzzy
+msgid "Unknown module state"
+msgstr "主机描述"
+
+#, fuzzy
 msgid "Unknown permission"
 msgstr "发生未知上传错误。返回代码："
 
@@ -12091,10 +12098,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Update Site Fail"
 #~ msgstr "主机更新失败"
-
-#, fuzzy
-#~ msgid "Host module settings"
-#~ msgstr "主机描述"
 
 #, fuzzy
 #~ msgid "Hostext Create Fail"

--- a/packages/web/src/Base/FOGPageRender.php
+++ b/packages/web/src/Base/FOGPageRender.php
@@ -73,6 +73,14 @@ trait FOGPageRender
      *                          Suppresses the Remove button and the confirm
      *                          modal it opens, so the tab stops offering an
      *                          operation the model has no way to perform.
+     * @param string $assocHeader optional header for the association column.
+     *                          Defaults to "Associated", which is right for
+     *                          a link row that either exists or does not.
+     *                          The host Modules tab passes "State": a module
+     *                          has three (on, off, unstated -- ADR 0038), and
+     *                          a column headed "Associated" over a control
+     *                          offering three answers describes something
+     *                          else.
      *
      * @return void
      */
@@ -85,11 +93,12 @@ trait FOGPageRender
         $helpBlock = '',
         $createNode = '',
         $noun = '',
-        $allowRemove = true
+        $allowRemove = true,
+        $assocHeader = ''
     ) {
         $this->headerData = [
             $colHeader,
-            _('Associated')
+            '' !== $assocHeader ? $assocHeader : _('Associated')
         ];
         $this->attributes = [
             [],

--- a/packages/web/src/Items/Host.php
+++ b/packages/web/src/Items/Host.php
@@ -344,6 +344,41 @@ class Host extends FOGController
         // it left the other assocSetter() call sites able to persist an id-0
         // row, and the isLoaded() gate it needed in order to run at all is
         // what poisoned assocSetter into wiping the host's snapins (PR #906).
+        // An explicit OFF row must survive a save that did not ask to clear
+        // it. ADR 0038: only a HOST may say a module is off, and that is the
+        // one statement a group grant cannot overrule -- so losing it
+        // silently switches a module back on across a fleet.
+        //
+        // assocSetter deletes ($cur - $items), where $cur is every row in
+        // moduleStatusByHost and $items is get('modules'). loadModules()
+        // filters to state 1, so an OFF row is in $cur and never in $items:
+        // the two sides of the diff are not reading the same set, and every
+        // save that touches modules at all would drop it. Union the OFF ids
+        // into the diff set so they appear on both sides and neither insert
+        // nor delete fires for them.
+        //
+        // The consequence, stated because it is a real limit rather than an
+        // oversight: a caller that lists `modules` cannot turn an OFF module
+        // back ON, because the row already exists and assocSetter only ever
+        // inserts or deletes. Clearing an OFF is the host Modules tab's job
+        // (Host::setModuleState()), which writes msState directly. That
+        // fails closed, which is the direction this rule wants.
+        if ($this->isDirty('modules')) {
+            $off = self::statedModuleIDs($this->get('id'), 0);
+            if (count($off)) {
+                $this->set(
+                    'modules',
+                    array_values(
+                        array_unique(
+                            array_merge(
+                                (array)$this->get('modules'),
+                                $off
+                            )
+                        )
+                    )
+                );
+            }
+        }
         $this
             ->assocSetter('Group', 'group')
             ->assocSetter('Module', 'module')
@@ -1905,6 +1940,93 @@ class Host extends FOGController
                     ['sequence' => $sequence]
                 );
         }
+        return $this;
+    }
+    /**
+     * The module ids this host has STATED a state for.
+     *
+     * ADR 0038 gives a module three states on a host: a row with msState 1
+     * (on), a row with msState 0 (off, and it beats every group grant), and
+     * no row at all (unstated -- a group may grant it, and nothing else
+     * turns it on). loadModules() answers the middle question only.
+     *
+     * @param int      $hostID The host.
+     * @param int|null $state  1, 0, or null for either.
+     *
+     * @return array int module ids
+     */
+    public static function statedModuleIDs($hostID, $state = null)
+    {
+        $hostID = (int)$hostID;
+        if ($hostID < 1) {
+            return [];
+        }
+        $find = ['hostID' => $hostID];
+        if (null !== $state) {
+            $find['state'] = (int)$state;
+        }
+
+        return array_map(
+            'intval',
+            (array)Route::getIds('moduleassociation', $find, 'moduleID')
+        );
+    }
+    /**
+     * Writes a module's state on this host, or clears it.
+     *
+     * The tri-state half of ADR 0038's module rule. Deliberately NOT routed
+     * through addModule()/removeModule(): those go through the `modules`
+     * array and assocSetter, which has no vocabulary for a row that exists
+     * and means OFF -- it can only insert a row or delete one. Writing
+     * msState directly is the only way to express the third state, and
+     * leaving `modules` untouched is what keeps save() from re-running that
+     * diff over a value this method already settled.
+     *
+     * @param array    $moduleIDs The modules to write.
+     * @param int|null $state     1 for on, 0 for off, null to clear the row
+     *                            and leave the module unstated.
+     *
+     * @return object
+     */
+    public function setModuleState($moduleIDs, $state)
+    {
+        $hostID = (int)$this->get('id');
+        $ids = [];
+        foreach ((array)$moduleIDs as $id) {
+            $id = (int)$id;
+            if ($id > 0) {
+                $ids[$id] = $id;
+            }
+        }
+        if ($hostID < 1 || !count($ids)) {
+            return $this;
+        }
+        if (null === $state) {
+            Route::deletemass(
+                'moduleassociation',
+                ['hostID' => $hostID, 'moduleID' => array_values($ids)]
+            );
+
+            return $this;
+        }
+        $state = (int)$state ? 1 : 0;
+        // One call covers both creating the row and flipping an existing
+        // one, because save() emits
+        //
+        //   INSERT INTO `moduleStatusByHost` (...) VALUES (...)
+        //   ON DUPLICATE KEY UPDATE ... `msState`=VALUES(`msState`)
+        //
+        // and UNIQUE (msHostID, msModuleID) is what makes that fire. So
+        // turning ON to OFF is the same statement as stating it for the
+        // first time, and no read is needed to tell the two apart.
+        foreach ($ids as $id) {
+            self::getClass('ModuleAssociation')
+                ->set('hostID', $hostID)
+                ->set('moduleID', $id)
+                ->set('state', $state)
+                ->save();
+        }
+
         return $this;
     }
     /**

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -2598,6 +2598,11 @@ class HostManagement extends FOGPage
     public function hostModules()
     {
         // Association Area
+        // ADR 0038: a module is a switch with three states, not a link that
+        // exists or does not. The per-row control is a select rather than a
+        // checkbox, so "off" can be said out loud -- unticking used to
+        // delete the row, which now means "unstated" and lets a group grant
+        // turn the module back on.
         $this->renderAssocTab(
             'host-module',
             _('Host Module Associations'),
@@ -2605,6 +2610,13 @@ class HostManagement extends FOGPage
             'module',
             'btn btn-primary float-end',
             _('Disabled items are not displayed. Legacy items are removed.')
+            . ' '
+            . _('Not set means a group may enable this module. Off is the '
+            . 'host\'s own answer and no group can override it.'),
+            '',
+            '',
+            true,
+            _('State')
         );
 
         $props = ' method="post" action="'
@@ -2815,7 +2827,47 @@ class HostManagement extends FOGPage
      */
     public function hostModulePost()
     {
-        $this->assocPost('addModule', 'removeModule');
+        self::checkAuthAndCSRF();
+        // NOT assocPost('addModule', 'removeModule'). Those go through the
+        // `modules` array and assocSetter, which can only insert a row or
+        // delete one -- it has no way to write a row that exists and means
+        // OFF, which is the state ADR 0038 adds. Every write from this tab
+        // therefore goes through Host::setModuleState(), including the two
+        // bulk buttons, so the tab has exactly one writer and `modules` is
+        // never marked dirty from here.
+        //
+        // The wire shape is the association tab's own, unchanged, so the
+        // bulk buttons keep working with no client change:
+        //   confirmadd + additems[]  -> ON
+        //   confirmdel + remitems[]  -> unstated (the row is removed)
+        // plus this tab's own third state:
+        //   confirmmodulestate + moduleid + state
+        if (isset($_POST['confirmadd'])) {
+            $items = filter_input_array(
+                INPUT_POST,
+                ['additems' => ['flags' => FILTER_REQUIRE_ARRAY]]
+            );
+            $this->obj->setModuleState((array)$items['additems'], 1);
+        }
+        if (isset($_POST['confirmdel'])) {
+            $items = filter_input_array(
+                INPUT_POST,
+                ['remitems' => ['flags' => FILTER_REQUIRE_ARRAY]]
+            );
+            $this->obj->setModuleState((array)$items['remitems'], null);
+        }
+        if (isset($_POST['confirmmodulestate'])) {
+            $moduleID = (int)filter_input(INPUT_POST, 'moduleid');
+            $state = filter_input(INPUT_POST, 'state');
+            // Three spellings, and anything else is refused rather than
+            // guessed at: a state this endpoint does not recognize must not
+            // silently become one it does.
+            $states = ['on' => 1, 'off' => 0, 'unset' => null];
+            if (!array_key_exists((string)$state, $states)) {
+                throw new \Exception(_('Unknown module state'));
+            }
+            $this->obj->setModuleState([$moduleID], $states[(string)$state]);
+        }
         if (isset($_POST['confirmdisplaysend'])) {
             $x = (int)filter_input(INPUT_POST, 'x');
             $y = (int)filter_input(INPUT_POST, 'y');
@@ -5368,6 +5420,19 @@ class HostManagement extends FOGPage
             'db' => 'hostAssoc',
             'dt' => 'association',
             'removeFromQuery' => true
+        ];
+        // The host's own state for this module, which the association
+        // column cannot carry: 'associated'/'dissociated' has two values
+        // and ADR 0038 gives a module three. NULL here is the third -- the
+        // LEFT JOIN found no row, so the host has said nothing and a group
+        // grant may still turn it on.
+        //
+        // nosearch because the free-text box would otherwise match every
+        // row on a typed 0 or 1, which is never what the box is for.
+        $columns[] = [
+            'db' => 'msState',
+            'dt' => 'state',
+            'nosearch' => true
         ];
         return $this->obj->getItemsList(
             'module',

--- a/tests/host-modules-are-tristate.test.php
+++ b/tests/host-modules-are-tristate.test.php
@@ -1,0 +1,398 @@
+<?php
+/**
+ * A host can say a module is OFF, and saying it must stick.
+ *
+ * ADR 0038 gives a module three states where snapins and printers have two:
+ *
+ *   host row, msState = 1   the host says ON
+ *   host row, msState = 0   the host says OFF, and beats every group grant
+ *   no row at all           unstated -- a group grant turns it on, nothing
+ *                           else does
+ *
+ * Before this, the Modules tab was a plain association grid: ticking wrote a
+ * row, unticking DELETED it. Under the rule above that is not "off", it is
+ * "unstated" -- so a host in a group that grants the module would have it
+ * switched straight back on, which is the opposite of what the click meant.
+ * A host could not express OFF at all.
+ *
+ * WHAT THIS DRIVES:
+ *
+ *   1. setModuleState() writes msState directly and is the tab's ONLY
+ *      writer. Routing through addModule()/removeModule() cannot work:
+ *      those go through the `modules` array and assocSetter, which can
+ *      only insert a row or delete one and has no way to write a row that
+ *      exists and means OFF.
+ *   2. It upserts. Flipping ON to OFF is an update of an existing row, not
+ *      an insert -- an insert would hit UNIQUE (msHostID, msModuleID).
+ *   3. Clearing removes the row, because "unstated" IS the absent row.
+ *   4. Only positive integer ids reach the database, and an empty set or an
+ *      unsaved host runs nothing at all.
+ *   5. An unknown state string is refused, not guessed at. A state this
+ *      endpoint does not recognize must never silently become one it does,
+ *      and the dangerous direction is any wrong answer becoming ON.
+ *   6. save() protects existing OFF rows from assocSetter. It deletes
+ *      ($cur - $items) where $cur is every row and $items is get('modules'),
+ *      which loadModules() filters to state 1 -- so without the union an OFF
+ *      row is on one side of that diff only, and every save touching modules
+ *      would drop it.
+ *   7. The grid ships the raw state, and the browser distinguishes NULL from
+ *      0. Reading a missing row as "off" would show the host asserting
+ *      something it has not said.
+ *
+ * Usage: php tests/host-modules-are-tristate.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+use FOG\Base\FOGCore;
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('host-modules-tristate');
+
+$t = new FogChecks();
+$db = FogTestHarness::fakeDb();
+$root = dirname(__DIR__) . '/packages/web';
+
+$admin = FOGCore::getClass('User')->set('id', 1)->set('name', 'fog');
+foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
+    FogTestHarness::setStatic($cls, 'FOGUser', $admin);
+}
+FogTestHarness::setStatic('Authorization', '_permCache', [1 => ['*']]);
+
+/**
+ * Runs setModuleState against a canned set of existing rows.
+ *
+ * @param FogFakeDb $db       the fake
+ * @param array     $existing module ids the host already has a row for
+ * @param array     $ids      the ids to write
+ * @param int|null  $state    1, 0 or null
+ * @param int       $hostID   the host
+ *
+ * @return array the statements issued
+ */
+function writeState($db, array $existing, $ids, $state, $hostID = 5)
+{
+    $db->log = [];
+    $db->responder = function ($sql) use ($existing) {
+        if (false !== strpos($sql, 'moduleStatusByHost')
+            && 0 === stripos(ltrim($sql), 'SELECT')
+        ) {
+            $rows = [];
+            foreach ($existing as $id) {
+                $rows[] = ['msModuleID' => $id, 'msID' => $id];
+            }
+            return $rows;
+        }
+        return null;
+    };
+    FOGCore::getClass('Host')
+        ->set('id', $hostID)
+        ->setModuleState($ids, $state);
+    $db->responder = null;
+
+    return $db->log;
+}
+
+/**
+ * Counts statements of one kind against moduleStatusByHost.
+ *
+ * Scoped to that table on purpose: a save() also writes a history row and
+ * reads FOG_LOG_INFO dozens of times, and counting those would make this
+ * assert something other than what it says.
+ *
+ * @param array  $log  statements
+ * @param string $verb SQL leading keyword
+ *
+ * @return int
+ */
+function countVerb(array $log, $verb)
+{
+    $n = 0;
+    foreach ($log as $sql) {
+        $sql = (string)$sql;
+        if (false === strpos($sql, 'moduleStatusByHost')) {
+            continue;
+        }
+        if (0 === stripos(ltrim($sql), $verb)) {
+            $n++;
+        }
+    }
+
+    return $n;
+}
+/**
+ * The statements that touched the module table.
+ *
+ * @param array $log statements
+ *
+ * @return array
+ */
+function moduleStatements(array $log)
+{
+    $out = [];
+    foreach ($log as $sql) {
+        if (false !== strpos((string)$sql, 'moduleStatusByHost')) {
+            $out[] = (string)$sql;
+        }
+    }
+
+    return $out;
+}
+/**
+ * A method's body with its comments stripped.
+ *
+ * Needed because these assertions are about what the code DOES: a comment
+ * saying "not addModule()" would otherwise fail a check for addModule().
+ *
+ * @param string $body source
+ *
+ * @return string
+ */
+function codeOnly($body)
+{
+    $body = preg_replace('#/\*.*?\*/#s', '', (string)$body);
+
+    return (string)preg_replace('#//[^\n]*#', '', (string)$body);
+}
+
+// Invariant 2: the write is an UPSERT, so flipping an existing row and
+// stating one for the first time are the same statement -- and neither
+// needs a read first to tell which case it is.
+$log = writeState($db, [7], [7], 0);
+$t->check(
+    'flipping an existing row to OFF is one write',
+    1 === countVerb($log, 'INSERT')
+);
+$sql = implode(' ', moduleStatements($log));
+$t->check(
+    'and it is the upsert, which is what stops the unique key rejecting it',
+    false !== stripos($sql, 'ON DUPLICATE KEY UPDATE')
+);
+$t->check(
+    'the write carries msState',
+    false !== stripos($sql, '`msState`=VALUES(`msState`)')
+);
+$t->check(
+    'and it reads nothing first, because it does not need to',
+    0 === countVerb($log, 'SELECT')
+);
+
+// A module with no row takes the identical path.
+$log = writeState($db, [], [9], 1);
+$t->check(
+    'a module with no row is written the same way',
+    1 === countVerb($log, 'INSERT')
+);
+
+// Two modules, one write each.
+$log = writeState($db, [7], [7, 9], 1);
+$t->check(
+    'two modules are two writes',
+    2 === countVerb($log, 'INSERT')
+);
+
+// Invariant 3.
+$log = writeState($db, [7], [7], null);
+$t->check(
+    'clearing a state deletes the row, because unstated IS no row',
+    countVerb($log, 'DELETE') === 1
+);
+$t->check(
+    'clearing writes no state',
+    0 === countVerb($log, 'UPDATE') && 0 === countVerb($log, 'INSERT')
+);
+
+// Invariant 4.
+$t->check(
+    'no usable id runs nothing',
+    0 === count(moduleStatements(writeState($db, [7], ['nope', 0, -2], 1)))
+);
+$t->check(
+    'an empty set runs nothing',
+    0 === count(moduleStatements(writeState($db, [7], [], 1)))
+);
+$t->check(
+    'an unsaved host runs nothing',
+    0 === count(moduleStatements(writeState($db, [7], [9], 1, 0)))
+);
+$log = writeState($db, [], ['9; DROP TABLE `hosts`'], 1);
+$t->check(
+    'a non-numeric id cannot carry SQL through',
+    false === strpos(implode(' ', $log), 'DROP TABLE')
+);
+// The delete path is where the id count is observable: deletemass binds one
+// placeholder per id, so the statement says how many survived the cast.
+// Counting writes cannot show this -- an invalid id fails validation and
+// silently produces no statement at all, so a missing cast looks identical
+// to a working one.
+$log = moduleStatements(writeState($db, [7], ['nope', 7, -2, '7'], null));
+$del = '';
+foreach ($log as $sql) {
+    if (0 === stripos(ltrim($sql), 'DELETE')) {
+        $del = $sql;
+    }
+}
+$t->check('the delete statement was found', '' !== $del);
+$t->check(
+    'exactly one id survives the cast and the dedupe',
+    1 === substr_count($del, ':where_1_')
+);
+
+/**
+ * The body of a method, read from the file it is declared in.
+ *
+ * @param string $class  class
+ * @param string $method method
+ *
+ * @return string
+ */
+function bodyOf($class, $method)
+{
+    $r = new \ReflectionMethod($class, $method);
+    $lines = (array)file($r->getFileName());
+
+    return implode(
+        '',
+        array_slice(
+            $lines,
+            $r->getStartLine() - 1,
+            $r->getEndLine() - $r->getStartLine() + 1
+        )
+    );
+}
+
+// Invariant 1: the tab has exactly one writer, and it is not assocSetter's.
+$post = codeOnly(bodyOf('FOG\\Pages\\HostManagement', 'hostModulePost'));
+$t->check(
+    'the tab writes through setModuleState',
+    2 < substr_count($post, 'setModuleState(')
+);
+$t->check(
+    'the tab does not route modules through addModule/removeModule',
+    false === strpos($post, "assocPost('addModule'")
+    && false === strpos($post, 'addModule(')
+    && false === strpos($post, 'removeModule(')
+);
+$t->check(
+    'and still runs the CSRF gate assocPost used to run for it',
+    false !== strpos($post, 'checkAuthAndCSRF()')
+);
+// The bulk buttons keep their existing wire shape, so no client change.
+$t->check(
+    'confirmadd still means ON',
+    (bool)preg_match('/confirmadd.*?setModuleState\(.*?, 1\);/s', $post)
+);
+$t->check(
+    'confirmdel still means unstated, not OFF',
+    (bool)preg_match('/confirmdel.*?setModuleState\(.*?, null\);/s', $post)
+);
+
+// Invariant 5.
+$t->check(
+    'an unrecognized state throws rather than defaulting',
+    false !== strpos($post, "throw new \\Exception(_('Unknown module state'))")
+);
+$states = [];
+if (preg_match('/\$states = \[(.*?)\];/s', $post, $m)) {
+    $states = $m[1];
+}
+$t->check(
+    'the three states are named, and only three',
+    false !== strpos($states, "'on' => 1")
+    && false !== strpos($states, "'off' => 0")
+    && false !== strpos($states, "'unset' => null")
+    && 3 === substr_count($states, '=>')
+);
+
+// Invariant 6, as a position: the union has to run before the diff it
+// protects against, not merely exist somewhere in save().
+$save = codeOnly(bodyOf('FOG\\Items\\Host', 'save'));
+$unionAt = strpos($save, "statedModuleIDs(\$this->get('id'), 0)");
+$assocAt = strpos($save, "assocSetter('Module', 'module')");
+$t->check('save() reads the OFF rows', false !== $unionAt);
+$t->check('save() still runs the module assocSetter', false !== $assocAt);
+$t->check(
+    'the OFF rows are protected BEFORE the diff that would drop them',
+    false !== $unionAt && false !== $assocAt && $unionAt < $assocAt
+);
+$t->check(
+    'and it is gated on modules being dirty, so it costs an untouched save nothing',
+    (bool)preg_match(
+        '/isDirty\(\'modules\'\).*?statedModuleIDs/s',
+        $save
+    )
+);
+
+// statedModuleIDs itself, executed: the state filter is the whole point.
+$db->log = [];
+$db->responder = function () {
+    return [];
+};
+FogTestHarness::callStatic('FOG\\Items\\Host', 'statedModuleIDs', [5, 0]);
+$db->responder = null;
+$t->check(
+    'statedModuleIDs filters on the state it was asked for',
+    false !== strpos(implode(' ', $db->log), 'msState')
+);
+$t->check(
+    'an unsaved host reads nothing',
+    [] === FogTestHarness::callStatic(
+        'FOG\\Items\\Host',
+        'statedModuleIDs',
+        [0, 0]
+    )
+);
+
+// Invariant 7, both halves.
+$list = codeOnly(bodyOf('FOG\\Pages\\HostManagement', 'getModulesList'));
+$t->check(
+    'the grid ships the raw msState',
+    (bool)preg_match("/'db' => 'msState',\s*'dt' => 'state'/", $list)
+);
+$t->check(
+    'and keeps it out of the free-text search',
+    (bool)preg_match("/'dt' => 'state',\s*'nosearch' => true/", $list)
+);
+
+$js = (string)file_get_contents(
+    $root . '/management/js/fog/host/fog.host.edit.js'
+);
+$render = '';
+if (preg_match('/function moduleStateSelect\(row\) \{(.*?)\n {4}\}/s', $js, $m)) {
+    $render = $m[1];
+}
+$t->check('the module state cell renderer was found', '' !== $render);
+$t->check(
+    'the cell is a select, not a checkbox',
+    false !== strpos($render, '<select')
+    && false === strpos($render, 'type="checkbox"')
+);
+$t->check(
+    'it offers exactly the three states',
+    false !== strpos($render, "['on', 'On']")
+    && false !== strpos($render, "['off', 'Off']")
+    && false !== strpos($render, "['unset', 'Not set']")
+);
+$t->check(
+    'a missing row reads as unset, and == null does not catch 0',
+    false !== strpos($render, "row.state == null")
+    && false !== strpos($render, "'unset'")
+);
+$t->check(
+    'the module id is escaped into the markup',
+    false !== strpos($render, '$.escapeHtml(String(row.id))')
+);
+$t->check(
+    'the tab commits its own cell rather than leaving a dead checkbox',
+    false !== strpos($js, 'confirmmodulestate')
+    && false !== strpos($js, "off('change.moduleState')")
+);
+$t->check(
+    'the column says State, not Associated',
+    false !== strpos(
+        bodyOf('FOG\\Pages\\HostManagement', 'hostModules'),
+        "_('State')"
+    )
+);
+
+$t->finish();


### PR DESCRIPTION
ADR 0038 M5 — the last thing standing between the module rule and being usable.

A module is a switch with three states:

| State | Means |
|---|---|
| **On** | a host row saying yes |
| **Off** | a host row saying no — and only a host may say it, so it beats every group grant |
| **Not set** | no host row; a group that grants the module turns it on, and nothing else does |

The tab was a plain association grid, so a host could not express **Off** at all. Unticking *deleted* the row — which under this rule means "not set", so a host in a group that grants the module would have it switched straight back on. The opposite of what the click meant.

The per-row control is now a select, and the column is headed **State** rather than *Associated*: a column called "Associated" over a control offering three answers is describing something else.

## Four things settled in the building

**The tab has exactly one writer, and it is not `assocSetter`'s.** `addModule()`/`removeModule()` go through the `modules` array and `assocSetter`, which can only insert a row or delete one — it has no way to write a row that exists and means OFF. Every write from this tab, the two bulk buttons included, goes through `Host::setModuleState()`, which writes `msState` directly and never marks `modules` dirty.

**The bulk buttons keep working and needed no client change.** They read DataTables' own row selection, not the cell, so replacing the checkbox cost nothing. On the wire they are unchanged: `confirmadd` means ON, `confirmdel` means *unstated*, which is what deleting the row has always meant.

**One statement covers stating a module and flipping it.** `save()` emits `INSERT … ON DUPLICATE KEY UPDATE … msState=VALUES(msState)`, and `UNIQUE (msHostID, msModuleID)` is what makes that fire — so ON → OFF needs no read to tell it apart from a first statement. The first cut had an update/insert split and a SELECT to choose between them; the upsert made all of it dead weight.

**A save had to stop eating OFF rows — a bug this change created rather than found.** `assocSetter` deletes `($cur - $items)`, where `$cur` is every row in `moduleStatusByHost` and `$items` is `get('modules')`, which `loadModules()` filters to state 1. The two sides of that diff read different sets the moment a row can mean OFF, so any save touching modules would drop it. `Host::save()` now unions the existing OFF ids into the diff set so they appear on both sides and neither branch fires.

> **The limit that leaves, stated because it is real.** A caller that lists `modules` — the API's host update arm — cannot turn an OFF module back ON, because the row already exists and `assocSetter` only inserts or deletes. Clearing an OFF is the tab's job. That fails closed, which is the direction *only the host may say OFF* wants: the alternative is an API write silently re-enabling a module the host had switched off.

## Gate

`tests/host-modules-are-tristate.test.php`, 36 checks, driving `setModuleState()` against a fake database: the upsert is one write with no read first, clearing deletes the row, only positive integers reach the statement, and an empty set or an unsaved host runs nothing. Plus the position invariant — the OFF-row union must run *before* the `assocSetter` chain it protects against — and the browser reading NULL as *not set* rather than as off.

**Eleven mutations were run and all eleven go red**, including one that first survived. "Junk ids write nothing" was passing for the wrong reason: an invalid id fails validation and silently produces no statement, so a missing cast looked identical to a working one. The delete path binds one placeholder per id, which is where the count is actually observable, and that is what the check reads now.
