### PR TITLE
A group grants its snapins, printers and modules -- it does not copy them

### DIFF
--- a/docs/GROUP_SHARED_STATE.md
+++ b/docs/GROUP_SHARED_STATE.md
@@ -1,37 +1,32 @@
 # Group Shared State
 
-A **group** owns no settings of its own — it is a lens over its **member hosts**.
-The group edit page therefore *derives* what it shows from the union of its
-members, so an admin can see what hosts already have in common before changing
-anything.
+A **group** owns its snapins, printers and modules. For everything else it is
+still a lens over its **member hosts**: the group edit page *derives* what it
+shows from the union of its members, so an admin can see what hosts already
+have in common before changing anything.
 
-> **Two kinds of shared state:**
-> 1. **Associations** (snapins, printers, modules) — a host either *has* the
->    item or not, shown as a tri‑state checkbox: **All / Some / None** member
->    hosts have it.
+> **Two kinds of shared state, and only one of them is still a lens:**
+> 1. **Grants** (snapins, printers, modules) — the group **owns** these. A
+>    ticked box is a row about the group, and every member gets the item,
+>    including hosts added later. Nothing is copied onto a host.
 > 2. **Configuration values** (Active Directory, auto‑logout, kernel/general
->    fields, default printer) — a host holds a *value*, shown as a muted
->    **`Hosts: …`** hint: the shared value when every member agrees, or
->    `(varies)` when they differ.
->
-> Acting on a group still pushes to **all** member hosts — but config fields are
-> **no‑clobber**: a blank field leaves each host's value alone, so you only
-> change what you intend to.
+>    fields) — a host holds a *value*, shown as a muted **`Hosts: …`** hint:
+>    the shared value when every member agrees, or `(varies)` when they
+>    differ. These still **push to all members**, once, and are
+>    **no‑clobber**: a blank field leaves each host's value alone.
 
-> **⚠️ This is changing. Snapins, printers and modules have already changed.**
-> A group is becoming something that **grants**, rather than something that
-> copies rows onto whoever happened to be a member when a button was pressed.
-> The first half has landed for **snapins, printers and modules**: see
-> [Snapins are granted, not copied](#snapins-are-granted-not-copied) below.
-> Everything else on this page still describes the push‑to‑all model and is
-> still accurate for the page as it stands today. The reasoning, and what is
-> left to move, are in [ADR 0038](adr/0038-a-group-grants-it-does-not-copy.md).
+> **⚠️ The push‑to‑all controls are deprecated.** Everything in
+> [Configuration values](#configuration-values-shared-hints) below applies a
+> value once, to the hosts that are members at the moment the button is
+> pressed — a host added later does not get it, and a host removed keeps it.
+> Nothing records that the write happened, so nothing can replay it. Use
+> **Edit selected hosts** on the Hosts list instead; these controls carry a
+> deprecation notice on the page and will be removed in a later release. The
+> reasoning is in [ADR 0038](adr/0038-a-group-grants-it-does-not-copy.md),
+> decision 10.
 >
-> **Modules carry one extra rule.** They are a *switch*, not a thing, so a
-> host is allowed to hold one OFF against every group that grants it — lowest
-> tier wins. A group grant is presence‑only: a group either grants a module or
-> says nothing about it, and can never say "disabled", so two groups can only
-> ever union. See ADR 0038 decision 3.
+> The grant half is finished: snapins, printers and modules are group‑owned
+> and are **not** deprecated.
 
 ---
 
@@ -39,16 +34,15 @@ anything.
 
 - [Snapins are granted, not copied](#snapins-are-granted-not-copied)
   - [Printers work the same way, but are worked out live](#printers-work-the-same-way-but-are-worked-out-live)
-- [Associations (tri‑state)](#associations-tri-state)
-  - [What "has it" means](#what-has-it-means)
-  - [The badge and Has/Missing drill‑down](#the-badge-and-hasmissing-drill-down)
-  - [Toggling](#toggling)
+- [Associations (the group's own grants)](#associations-the-groups-own-grants)
+  - [What a host ends up with](#what-a-host-ends-up-with)
+  - [Ticking and unticking](#ticking-and-unticking)
+  - [Order and defaults](#order-and-defaults)
 - [Configuration values (shared hints)](#configuration-values-shared-hints)
   - [The no‑clobber convention](#the-no-clobber-convention)
   - [Active Directory](#active-directory)
   - [Auto‑logout](#auto-logout)
   - [General fields](#general-fields)
-  - [Default printer](#default-printer)
 - [Out of scope](#out-of-scope)
 
 ---
@@ -119,59 +113,63 @@ no re-tasking.
 
 ---
 
-## Associations (tri‑state)
+## Associations (the group's own grants)
 
-The **Snapins**, **Printers**, and **Modules** tabs each render every item with a
-coverage checkbox:
+The **Snapins**, **Printers** and **Modules** tabs are plain on/off lists of
+what **this group grants**. A ticked box is a row about the group; it says
+nothing about any particular host.
 
 | State | Checkbox | Meaning |
 |-------|----------|---------|
-| **All** | checked | every member host has the item |
-| **Some** | indeterminate | at least one, but not all, hosts have it |
-| **None** | unchecked | no host has it |
+| granted | checked | this group grants the item to its members |
+| not granted | unchecked | this group says nothing about the item |
 
-A **`n / total`** badge sits next to each checkbox (e.g. `5 / 15`).
+There is no third state, and no coverage badge. Until ADR 0038's unit E these
+tabs showed a derived **All / Some / None** tri‑state with an `n / total`
+badge and a Has/Missing host drill‑down — a whole vocabulary whose only job
+was to reconstruct, after the fact, what the group would have looked like if
+it had ever owned anything. It owns something now, so the derivation is gone
+along with the machinery behind it (`_groupAssocList()`,
+`getAssocHostsList()`, and the tri‑state renderer in `fog.group.edit.js`).
 
-### What "has it" means
+### What a host ends up with
 
-- **Snapins, printers** — a host "has it" when the association row exists. The
-  printer **default** flag (`paIsDefault`) is ignored here; it's a separate
-  shared *value* (see [Default printer](#default-printer)).
-- **Modules** — a host counts only when the module is **enabled**
-  (`moduleStatusByHost.msState = 1`). A disabled override pulls the item out of
-  *All* into *Some*. This asymmetry is deliberate (see `docs/adr/0001`): showing
-  a module as "All hosts have it" while some have it disabled would mislead.
+A host's effective list is its **own** rows unioned with the grants of every
+group it belongs to, worked out at read time by `FOG\Assign\Resolver`. So:
 
-### The badge and Has/Missing drill‑down
+- adding a host to the group is enough for it to gain the group's snapins,
+  printers and modules; removing it is enough to lose them again;
+- a host's own associations are untouched by anything on these tabs — a
+  snapin given directly to one host stays with that host if the group revokes
+  its grant;
+- **modules carry one extra rule.** A module is a *switch*, so a host may hold
+  one OFF (a `moduleStatusByHost` row at `msState = 0`) against every group
+  that grants it, and the host wins. A grant is presence‑only — a group can
+  turn a module on and can never turn one off — so two groups can only ever
+  union. Set it on the host's own Modules tab, which is a three‑way
+  *On / Off / Not set* select rather than a checkbox.
 
-Clicking the badge expands an on‑demand row listing, for that one item:
+### Ticking and unticking
 
-- **Hosts with this (n)** — the member hosts that have it, and
-- **Hosts without it (n)** — the member hosts that don't.
+Ticking writes one grant row; unticking deletes it. Neither touches a member
+host, so neither is destructive to per‑host state, and both take effect for
+every current and future member at once.
 
-The *without* set is exactly what a push‑to‑all will change. The lists are
-fetched per item, so large groups stay responsive.
+**Granting a snapin does not run it.** The grant decides what a snapin
+*deployment* will include; deploy it from the group's Tasks tab when you want
+it to run. (The retired `persistentgroups` plugin ran snapins on a host as it
+joined a group; nothing does that now, deliberately.)
 
-### Toggling
+### Order and defaults
 
-Clicking the checkbox acts on **all** member hosts:
+The two per‑item decisions an admin can make are columns on the grant row, so
+they belong to the group rather than being recomputed from its members:
 
-```
-None  --click-->  All        (add to every host)
-Some  --click-->  All        (add to the hosts that lack it; modules flip
-                              a disabled override back to enabled)
-All   --click-->  None       (remove from every host)
-```
-
-So an indeterminate item resolves to *All* first; the destructive
-remove‑from‑all only happens on a second click through the checked state.
-
-> **The module line above is on notice.** "Flip a disabled override back to
-> enabled" was harmless while a disabled override could not exist — nothing
-> ever wrote one. Under ADR 0038 decision 3 a disabled module row is a
-> deliberate host‑level statement that beats every group grant, so a group‑wide
-> toggle overriding it is wrong. The tab keeps this behavior until the group
-> page rework (unit E) replaces it with a grant.
+- **Snapin run order** — the *Snapin Run Order* card orders the group's own
+  grants (`gsaSequence`). A host runs its own snapins first, then the granted
+  ones in this order.
+- **Default printer** — one of the granted printers can be marked the group's
+  default (`gpaIsDefault`). A host that has chosen its own default keeps it.
 
 ---
 
@@ -223,12 +221,6 @@ Kernel, kernel arguments, init, primary disk, BIOS/EFI exit, and product key
 each carry a `Hosts: …` hint. The kernel/args/init/disk inputs prefill from the
 **group's own template** (the group stores these); the hint reports the
 *members'* state independently. Push still honors the no‑clobber convention.
-
-### Default printer
-
-The printer **Default** selector shows a `Hosts default: <printer> (all)`,
-`(varies)`, or `(none on all)` hint. Setting a default is an explicit action
-that only touches member hosts which have that printer associated.
 
 ### Enforce hostname / AD‑join reboots
 

--- a/docs/adr/0001-group-association-state.md
+++ b/docs/adr/0001-group-association-state.md
@@ -2,7 +2,22 @@
 
 ## Status
 
-accepted
+superseded by [ADR 0038](0038-a-group-grants-it-does-not-copy.md) (unit E,
+2026-09-01)
+
+The derivation this ADR describes no longer exists. A group owns its snapins,
+printers and modules, so the group page's association tabs are plain on/off
+lists of the group's own grants -- there is no All/Some/None state to derive,
+no `n / total` badge, and no Has/Missing drill-down. `_groupAssocList()`,
+`getAssocHostsList()` and the tri-state renderer in `fog.group.edit.js` are
+gone with them.
+
+Kept rather than deleted for two reasons. The *question* it answers -- what
+does "this group has this module" mean when a host can disable one -- is still
+live, and ADR 0038 answers it differently (the host's OFF beats every grant,
+and a grant cannot say OFF at all). And the correction below is the finding
+that reversed ADR 0038 decision 3, so the reasoning has to survive even though
+the behavior it justified does not.
 
 ## Context
 
@@ -55,8 +70,9 @@ this also flips `state = 0 → 1`); toggling to **None** deletes the rows.
 **Superseded for modules by ADR 0038 decision 3.** Once `state = 0` is a host
 saying OFF, flipping it to 1 on a group-wide toggle overrides a deliberate
 per-host statement, and deleting the row means "unstated" rather than "off".
-The group module tab keeps this behavior until unit E replaces it with a
-grant; the correction note above has the detail.
+Unit E replaced it with a grant on 2026-09-01: the tab writes
+`groupModuleAssoc` and touches no host, so nothing on the group page can
+override a host's OFF any more.
 
 Per-host configuration *shared values* (Active Directory, auto-logout,
 force-reboot, the printer **default** flag) are explicitly **out of scope** for

--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -88,10 +88,11 @@ with the rejected alternative stated in full. Decision 16a's five presentation
 requirements are **binding parts of that decision**, not follow-up work: the
 decision is only correct if a group is cheap to apply in bulk.
 
-Amends [ADR 0001](0001-group-association-state.md) rather than superseding it:
-0001's tri-state derivation is still how the group page reports *member* state
-after this change, but its opening sentence — "a group owns no associations of
-its own" — stops being true for snapins and printers, which is the whole point.
+**Supersedes [ADR 0001](0001-group-association-state.md)** as of unit E. This
+was recorded as an amendment while the group page still derived member
+coverage; unit E removed that derivation, so 0001 now describes machinery that
+is gone. Its opening sentence — "a group owns no associations of its own" — is
+false for snapins, printers and modules, which is the whole point.
 
 ## Context
 
@@ -301,16 +302,14 @@ grant — turning a grant back into a copy, which is the one thing this ADR
 exists to prevent. `Host::resolvedModules()` is the separate, explicit
 accessor the client protocol reads.
 
-**Still to come, and gated the same way snapins and printers are.** Nothing
-writes `groupSnapinAssoc` or `groupPrinterAssoc` yet either — `Group::
-addSnapin()` and `addPrinter()` are still the imperative copy-to-members
-versions, and converting them is Decision 10's unit E, which removes
-functionality and needs signoff. `Group::addModule()` stays imperative for
-exactly that reason: converting it alone would put modules ahead of the other
-two and leave the group page granting on one tab and copying on the next. The
-host Modules tab also has to become genuinely tri-state before a host can
-express OFF at all — today unticking deletes the row, which under this design
-means "unstated" and would let a group grant re-enable it.
+**Built (unit E), 2026-09-01.** `Group::addSnapin()`, `addPrinter()` and
+`addModule()` now write the grant tables and touch no host. They were
+converted together, not one at a time: converting one alone would have left
+the group page granting on one tab and copying on the next. The host Modules
+tab had to become genuinely tri-state first (M5, #1646), because until it did
+a host could not express OFF at all — unticking deleted the row, which under
+this design means "unstated", and a group grant would have switched it back
+on.
 
 **Built (M5).** The Modules tab's per-row control is a **select** — *On / Off /
 Not set* — rather than a checkbox, and the column is headed **State** rather
@@ -1330,6 +1329,56 @@ server-restart path, so an id below the watermark is *evidence* of a legacy row
 and not proof — which is fine for a label and would not be fine for a
 semantics gate, which is the second reason the boundary is not one.
 
+### Built (unit E), and what it deleted
+
+The declarative half is finished. Three things were settled in the building,
+and the third is a deliberate departure from the units table.
+
+- **The grant tables needed classes.** `Assign\Resolver` reads them with raw
+  SQL, which is right for a hot read path but is not a write path, so
+  `GroupSnapinAssociation`, `GroupPrinterAssociation` and
+  `GroupModuleAssociation` (plus their managers) were added -- the same shape
+  every other association table in the tree already has. They are deliberately
+  **not** in `Route::$validClasses`: exposing a new write surface over REST is
+  an access-control decision this ADR never asked for, and adding them later
+  is purely additive.
+
+- **The columns that carry an admin's decision stay out of the upsert.**
+  `insertBatch()` upserts on the unique key and sets every column it is given,
+  so naming `gsaSequence` in `addSnapin()`'s field list would reset the run
+  order every time a snapin was re-sent, and naming `gpaIsDefault` in
+  `addPrinter()`'s would reset the default. New rows land at the column
+  default and `Group::appendSnapinSequence()` numbers them afterward -- the
+  same mechanism, for the same reason, as its host-side twin.
+
+- **The imperative controls are marked deprecated, not removed.** Decision 10
+  says the order is: mass edit ships, the imperative tabs are marked
+  deprecated in the UI and the docs, they are removed in a later release. The
+  units table entry for unit E said "removal of the imperative tabs", which
+  reads past the middle step. Six cards -- the General form, Group Image
+  Association, Group Printer Configuration, Group Display Manager Settings,
+  Auto Logout Settings and Enforce Hostname -- now carry a notice saying the
+  value is applied once to today's members and pointing at "Edit selected
+  hosts". Power Management deliberately does not: it creates tasks, it does
+  not copy a value. The notice is per CARD rather than per tab, because the
+  printers and modules tabs each carry a grant tab and a push control, and a
+  tab-level banner would condemn the grants too.
+
+**What went with it.** The group page's tri-state coverage vocabulary is
+gone: `_groupAssocList()`, `getAssocHostsList()`, `_uniformDefaultPrinter()`,
+and `groupAssocRender()`/`wireGroupAssocTab()` in `fog.group.edit.js` -- the
+All/Some/None checkbox, the `n / total` badge and the Has/Missing host
+drill-down. All of it existed to reconstruct, after the fact, what the group
+would have looked like if it had ever owned anything. It owns something now.
+`getSnapinOrderList()` shrank from an intersection over every member host's
+`snapinAssoc` rows to a read of `gsaSequence`.
+
+**`AddLocationGroup.php` and `AddOUGroup.php` are untouched, and that is
+correct.** They are push controls, so they belong to the deprecation half, and
+Decision 13 says the group page's imperative tabs and the plugins' group tabs
+must be removed in the same release. Removing them now would leave the page
+with an image tab and no OU tab, which is the failure that argument names.
+
 ## Consequences
 
 - **`persistentgroups` becomes unnecessary**, and its retirement is a schema
@@ -1346,13 +1395,12 @@ semantics gate, which is the second reason the boundary is not one.
 - **A group edited mid-run does not change a task in flight, and people will be
   surprised.** This is the documentation obligation in Decision 4 and it is the
   most likely support question this change generates.
-- **ADR 0001 becomes half-true and stays in force.** Its tri-state derivation
-  is still how the group page reports member state for modules, and will be
-  until unit E reworks that page. Its premise that a group owns nothing is no
-  longer true for snapins, printers or modules. The file gets an amendment
-  note rather than a rewrite -- and the note has to say that the module
-  asymmetry it argues for is NOT real, since Decision 3 was reversed on
-  exactly that finding.
+- **ADR 0001 is superseded, and kept.** Unit E removed the tri-state
+  derivation it describes, so it no longer documents anything that runs. It
+  stays on file because the question it asks is still live -- what "this group
+  has this module" means when a host can disable one -- and because the
+  correction note on it is the finding that reversed Decision 3. Its status
+  line says superseded and points here.
 - **`GROUP_SHARED_STATE.md` becomes the mass edit document.** Most of it
   survives the move — the no-clobber convention becomes the three-state
   convention (Decision 11), the `Hosts: (varies)` hint becomes the selection

--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -758,12 +758,12 @@ serialize through conflicts anyway.
 | M2 | `Resolver::resolveModules()`, the three tiers | `Assign/Resolver.php` | M1 | **merged** (#1632) |
 | M3 | Client paths read the resolved list; `checkPassiveModule` fix | `Items/Host.php`, `Client/ServiceModule.php`, `Client/FOGClient.php`, `Base/FOGPage.php` | M2 | **merged** (#1633) |
 | M4 | `addRemItem()` module special case removed; auto-logout minimum named once | `Base/FOGController.php`, `Pages/HostManagement.php` | M3 | **merged** (#1634) |
-| M5 | Host Modules tab becomes genuinely tri-state, so a host can say OFF | `Items/Host.php`, `Pages/HostManagement.php`, `Base/FOGPageRender.php`, `fog.host.edit.js` | M4 | open (#1646) |
+| M5 | Host Modules tab becomes genuinely tri-state, so a host can say OFF | `Items/Host.php`, `Pages/HostManagement.php`, `Base/FOGPageRender.php`, `fog.host.edit.js` | M4 | **merged** (#1646) |
 | D1 | The `sqlfilter` relationship-filter contract, and the host list's groups column on it | `Base/FOGManagerController.php`, `Router/Route.php`, `Pages/HostManagement.php`, `fog.host.list.js` | C5 | **merged** (#1639) |
 | D2a | `saveGroup()` gated: CSRF, object scope both sides, and the `group.edit`/`group.create` split | `Pages/HostManagement.php`, `Auth/Authorization.php` | — | **merged** (3cb39b8df) |
 | D2b | Remove as well as add, from the list; typed names resolved against the groups that exist; the write audited | `Pages/HostManagement.php`, `Base/FOGPage.php`, `fog.host.list.js` | D1, D2a | **merged** (#1640) |
-| D3 | Group list "grants" column | `Router/Route.php`, `Pages/GroupManagement.php`, JS | D1 | open (#TBD) |
-| E | Group page rework + removal of the imperative tabs, and `Group::addSnapin`/`addPrinter`/`addModule` become grants | `Pages/GroupManagement.php`, `Items/Group.php`, JS | **C5 proven** (Decision 10), D, M5 | not started |
+| D3 | Group list "grants" column | `Router/Route.php`, `Pages/GroupManagement.php`, JS | D1 | **merged** (#1643) |
+| E | Group page rework: `Group::addSnapin`/`addPrinter`/`addModule` become grants, the tri-state coverage machinery goes, the imperative controls are marked deprecated | `Items/Group*Association.php`, `Items/Group.php`, `Pages/GroupManagement.php`, JS | **C5 proven** (Decision 10), D, M5 | open (#TBD) |
 
 **Two bugs in C5's own surface were found and fixed while D was landing**,
 both on the mass edit modal and neither shipped: the object-id guard in

--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -763,7 +763,7 @@ serialize through conflicts anyway.
 | D2a | `saveGroup()` gated: CSRF, object scope both sides, and the `group.edit`/`group.create` split | `Pages/HostManagement.php`, `Auth/Authorization.php` | — | **merged** (3cb39b8df) |
 | D2b | Remove as well as add, from the list; typed names resolved against the groups that exist; the write audited | `Pages/HostManagement.php`, `Base/FOGPage.php`, `fog.host.list.js` | D1, D2a | **merged** (#1640) |
 | D3 | Group list "grants" column | `Router/Route.php`, `Pages/GroupManagement.php`, JS | D1 | **merged** (#1643) |
-| E | Group page rework: `Group::addSnapin`/`addPrinter`/`addModule` become grants, the tri-state coverage machinery goes, the imperative controls are marked deprecated | `Items/Group*Association.php`, `Items/Group.php`, `Pages/GroupManagement.php`, JS | **C5 proven** (Decision 10), D, M5 | open (#TBD) |
+| E | Group page rework: `Group::addSnapin`/`addPrinter`/`addModule` become grants, the tri-state coverage machinery goes, the imperative controls are marked deprecated | `Items/Group*Association.php`, `Items/Group.php`, `Pages/GroupManagement.php`, JS | **C5 proven** (Decision 10), D, M5 | open (#1647) |
 
 **Two bugs in C5's own surface were found and fixed while D was landing**,
 both on the mass edit modal and neither shipped: the object-id guard in

--- a/docs/release/1.6.0-release-notes.DRAFT.md
+++ b/docs/release/1.6.0-release-notes.DRAFT.md
@@ -295,6 +295,34 @@ pre-upgrade *dump* — it is not a schema rollback.
   If you maintain something that consumes `/service/Printers.php`, prefer
   `noPrinters` over `error == "np"` from now on.
 
+- **The group page's Snapins, Printers and Modules tabs are plain lists of
+  what the group grants.** They used to show a three-way checkbox --
+  All / Some / None member hosts have this -- with an `n / total` badge you
+  could click for a Has/Missing host breakdown. All of that existed to work
+  out, after the fact, what a group would have looked like if it had ever
+  owned anything. It owns something now, so a tick means "this group grants
+  it" and nothing else. Ticking writes one row, unticking deletes one row, and
+  neither touches a member host.
+
+  The two per-item choices moved with them. **Snapin run order** now orders
+  the group's own snapins rather than trying to find the ones every member
+  happens to share; a host runs its own snapins first, then the granted ones
+  in that order. **Default printer** is one of the granted printers, and a
+  host that has chosen its own default keeps it.
+
+- **The group page's push-to-all controls are deprecated and now say so.**
+  Setting an image, kernel, product key, AD details, printer level, screen
+  resolution, auto-logout or hostname enforcement from a group applies the
+  value **once**, to whichever hosts are members at that moment. A host added
+  afterward does not get it; a host removed keeps it. That has always been
+  true and was never visible. Each of those cards now carries a notice saying
+  so and pointing at **Edit selected hosts** on the Hosts list, which does the
+  same job over any selection and can be repeated. They still work exactly as
+  before in this release, and are removed in a later one.
+
+  Power Management is not affected -- it creates tasks rather than copying a
+  value.
+
 - **The host list shows which groups a host is in, and you can search on
   them.** A new Groups column carries one chip per group, each a link to that
   group, in the same order group grants are applied -- so the column also

--- a/packages/web/management/js/fog/group/fog.group.edit.js
+++ b/packages/web/management/js/fog/group/fog.group.edit.js
@@ -236,119 +236,16 @@
     });
 
     // ---------------------------------------------------------------
-    // GROUP ASSOCIATION TRI-STATE (shared by the printer, snapin and
-    // module tabs). Each item shows All (checked) / Some (indeterminate) /
-    // None (unchecked) coverage across member hosts, an "n / total" badge,
-    // and an on-demand Has/Missing host drill-down (a DataTables child row).
-    //
-    // These plug into the generic $.registerAssociationTab via its
-    // checkboxRender/onDraw hooks; the tri-state badge markup and the
-    // drill-down AJAX stay group-local because they are not part of the
-    // generic (plain on/off) association-tab skeleton.
-    // ---------------------------------------------------------------
-
-    // Returns the checkboxRender function for a tri-state tab: the full
-    // association-cell markup (checkbox carrying data-state + the badge that
-    // opens the drill-down). The input keeps class="associated"/value=row.id
-    // so the generic add/remove/toggle plumbing keeps working.
-    function groupAssocRender(entityType, idPrefix) {
-        return function(row) {
-            var state = row.association,
-                cnt = (row.assocCount === undefined ? 0 : row.assocCount),
-                total = (row.assocTotal === undefined ? 0 : row.assocTotal),
-                checked = (state === 'all') ? ' checked' : '',
-                label = (state === 'all')
-                    ? 'bg-success'
-                    : (state === 'some' ? 'bg-warning' : 'bg-secondary');
-            return '<div class="form-check" '
-                + 'style="display:inline-block;vertical-align:middle;margin:0 6px 0 0;">'
-                + '<input type="checkbox" class="associated" data-state="' + state + '" '
-                + 'name="associate[]" id="' + idPrefix + row.id + '" value="' + row.id + '"'
-                + checked + '/></div>'
-                + '<a href="#" class="assoc-drill badge ' + label + '" '
-                + 'data-id="' + row.id + '" data-type="' + entityType + '" '
-                + 'title="Show which hosts have this">' + cnt + ' / ' + total + '</a>';
-        };
-    }
-
-    // Wire a tri-state association tab: the standard $.registerAssociationTab
-    // skeleton plus the tri-state checkbox render, the post-draw indeterminate
-    // styling for "some" rows, and the Has/Missing host drill-down. cfg extends
-    // the generic opts with entityType/idPrefix (for the render + drill-down)
-    // and an optional onDraw (run after the indeterminate styling). Returns the
-    // DataTables instance.
-    function wireGroupAssocTab(cfg) {
-        var tableSel = '#' + cfg.slug + '-table';
-        var table = $.registerAssociationTab({
-            slug: cfg.slug,
-            item: cfg.item,
-            sub: cfg.sub,
-            columns: cfg.columns,
-            order: cfg.order,
-            checkboxRender: groupAssocRender(cfg.entityType, cfg.idPrefix),
-            afterCommit: cfg.afterCommit,
-            onDraw: function(t) {
-                $(tableSel + ' input.associated').each(function() {
-                    if ($(this).data('state') === 'some') {
-                        $(this).prop('indeterminate', true);
-                    }
-                });
-                if (typeof cfg.onDraw === 'function') {
-                    cfg.onDraw(t);
-                }
-            }
-        });
-        // On-demand Has/Missing host drill-down (a DataTables child row).
-        $(tableSel).on('click', '.assoc-drill', function(e) {
-            e.preventDefault();
-            var tr = $(this).closest('tr'),
-                row = table.row(tr),
-                id = $(this).data('id'),
-                type = $(this).data('type');
-            if (row.child.isShown()) {
-                row.child.hide();
-                return;
-            }
-            row.child('<div class="assoc-drill-detail" style="padding:6px 12px;">'
-                + 'Loading…</div>').show();
-            $.ajax({
-                url: '../management/index.php?node=' + Common.node
-                    + '&sub=getAssocHostsList&id=' + Common.id
-                    + '&assoctype=' + type + '&itemid=' + id,
-                dataType: 'json',
-                success: function(d) {
-                    var has = (d && d.has) ? d.has : [],
-                        miss = (d && d.missing) ? d.missing : [];
-                    function names(arr) {
-                        if (!arr.length) {
-                            return '<em>none</em>';
-                        }
-                        return arr.map(function(h) {
-                            return $('<span>').text(h.name).html();
-                        }).join(', ');
-                    }
-                    row.child(
-                        $('<div class="assoc-drill-detail" style="padding:6px 12px;">')
-                            .append($('<div>').html('<strong>Hosts with this ('
-                                + has.length + '):</strong> ' + names(has)))
-                            .append($('<div>').html('<strong>Hosts without it ('
-                                + miss.length + '):</strong> ' + names(miss)))
-                    ).show();
-                }
-            });
-        });
-        return table;
-    }
-
-    // ---------------------------------------------------------------
     // PRINTER TAB
     // Association area
-    var groupPrintersTable = wireGroupAssocTab({
+    // ADR 0038: the group owns its printers, so this is the plain on/off
+    // association tab. It replaced a tri-state one that showed All/Some/None
+    // coverage across member hosts with an n-of-total drill-down -- a whole
+    // vocabulary that existed only because the group owned nothing itself.
+    var groupPrintersTable = $.registerAssociationTab({
         slug: 'group-printer',
         item: 'printer',
         sub: 'getPrintersList',
-        entityType: 'printer',
-        idPrefix: 'groupPrinterAssoc_',
         onDraw: function() {
             groupPrinterDefaultSelectorUpdate();
         }
@@ -357,8 +254,8 @@
     // JS lives on the printer pages, which do not load here. node:'printer'
     // because Common.node is 'group' here and would aim getPrinterInfo wrong.
     // validate matches what the printer pages pass, so hidden sections are not
-    // validated. Association goes through Group::addPrinter(), which inserts a
-    // row per member host, so the new printer reaches the whole group.
+    // validated. Association goes through Group::addPrinter(), which writes
+    // one grant row on the group.
     $.registerCreateAndAssociate('group-printer', groupPrintersTable, {
         onForm: function(form) {
             form.initPrinterFormUI({node: 'printer'});
@@ -428,17 +325,15 @@
     // ---------------------------------------------------------------
     // SNAPINS TAB
     // Association area
-    var groupSnapinsTable = wireGroupAssocTab({
+    var groupSnapinsTable = $.registerAssociationTab({
         slug: 'group-snapin',
         item: 'snapin',
         sub: 'getSnapinsList',
-        entityType: 'snapin',
-        idPrefix: 'groupSnapinAssoc_',
         afterCommit: loadGroupSnapinOrder
     });
     // wirePackTypes matches the snapin ADD page, since this modal renders the
-    // same _addFields() form. Association goes through Group::addSnapin(), which
-    // inserts a row per member host, so the new snapin lands on the whole group.
+    // same _addFields() form. Association goes through Group::addSnapin(),
+    // which writes one grant row on the group.
     $.registerCreateAndAssociate('group-snapin', groupSnapinsTable, {
         onForm: function(form) {
             form.initSnapinCommandUI({wirePackTypes: true});
@@ -446,7 +341,7 @@
     });
 
     // ---------------------------------------------------------------
-    // GROUP SNAPIN RUN ORDER (snapins shared by all hosts)
+    // GROUP SNAPIN RUN ORDER (the snapins this group grants)
     var groupSnapinOrderList = $('#group-snapin-order-list'),
         groupSnapinOrderSaveBtn = $('#group-snapin-order-save');
 
@@ -550,12 +445,10 @@
     // ---------------------------------------------------------------
     // CLIENT SETTINGS TAB
     // Association area
-    var groupModulesTable = wireGroupAssocTab({
+    var groupModulesTable = $.registerAssociationTab({
         slug: 'group-module',
         item: 'module',
         sub: 'getModulesList',
-        entityType: 'module',
-        idPrefix: 'groupModuleAssoc_',
         columns: [
             // Aisle 097: this tab overrides the default association column set,
             // so it reads the raw 'name' field rather than the server-escaped

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -260,7 +260,7 @@ msgstr ""
 msgid "(empty on all)"
 msgstr ""
 
-msgid "(none on all)"
+msgid "(none)"
 msgstr ""
 
 msgid "(set on all)"
@@ -430,6 +430,9 @@ msgstr ""
 msgid "A module already exists with this name!"
 msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 
+msgid "A module granted here is on for every host in this group, including hosts added later -- unless the host itself says otherwise. A host set to Off on its own Modules tab stays off, and no grant can override that."
+msgstr ""
+
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
@@ -454,6 +457,9 @@ msgstr "muss angegeben werden"
 #, fuzzy
 msgid "A printer already exists with this name!"
 msgstr "Ein Drucker mit diesem Namen ist bereits vorhanden!"
+
+msgid "A printer granted here reaches every host in this group, including hosts added later. Removing a host from the group takes the printer away again. A printer the host was given directly is unaffected either way."
+msgstr ""
 
 #, fuzzy
 msgid "A provider already exists with this name!"
@@ -488,6 +494,9 @@ msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
 #, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "Ein Snapin mit diesem Namen ist bereits vorhanden!"
+
+msgid "A snapin granted here reaches every host in this group, including hosts added later. Granting a snapin does not run it; deploy it from the Tasks tab when you want it to run."
+msgstr ""
 
 #, fuzzy
 msgid "A storage group already exists with this name!"
@@ -671,9 +680,6 @@ msgstr ""
 
 msgid "Action"
 msgstr "Aktion"
-
-msgid "Action will be perform on all hosts within this group"
-msgstr ""
 
 msgid "Actions"
 msgstr "Aktionen"
@@ -2412,6 +2418,10 @@ msgstr "Download fehlgeschlagen"
 msgid "Deploy Method"
 msgstr "Verteilungsmethode"
 
+#, fuzzy
+msgid "Deprecated."
+msgstr "Erstellen"
+
 msgid "Depth"
 msgstr ""
 
@@ -3614,6 +3624,10 @@ msgid "Group added!"
 msgstr "Gruppe hinzugefügt!"
 
 #, fuzzy
+msgid "Group default:"
+msgstr "Standarddrucker aktualisieren"
+
+#, fuzzy
 msgid "Group is not valid"
 msgstr "Gruppe ist nicht gültig"
 
@@ -4001,10 +4015,6 @@ msgstr "Host-Image"
 #, fuzzy
 msgid "Hosts assigned"
 msgstr "zugeordneter Host"
-
-#, fuzzy
-msgid "Hosts default:"
-msgstr "Standarddrucker aktualisieren"
 
 #, fuzzy
 msgid "Hosts in tasking"
@@ -6460,9 +6470,6 @@ msgid "Only for a peer running its own FOG database. On that peer run bin/fog-no
 msgstr ""
 
 msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
-msgstr ""
-
-msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "Open Source Computer Cloning Solution"
@@ -9309,6 +9316,9 @@ msgstr "Fehler beim Erstellen eines Tasks"
 msgid "The current user is invalid."
 msgstr "Task-Typ ist nicht gültig"
 
+msgid "The default printer for hosts in this group. A host that has its own default keeps it."
+msgstr ""
+
 msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
 msgstr ""
 
@@ -9417,6 +9427,9 @@ msgid "The object."
 msgstr "Objekt"
 
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
+msgstr ""
+
+msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "The path requested is already in use by another image!"
@@ -9611,6 +9624,9 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This applies the value once, to the hosts that are members right now. A host added to the group later does not get it, and a host removed keeps it."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -9790,22 +9806,11 @@ msgstr ""
 msgid "This tells the client to force reboots for host name changing and AD Joining."
 msgstr ""
 
-msgid "This will add and set (as needed) the default printer for all hosts in this group"
-msgstr ""
-
 msgid "This will allow you to configure how services"
 msgstr "Hiermit können Sie konfigurieren, "
 
 msgid "This will delete all powermanagement items from all hosts in this group"
 msgstr ""
-
-#, fuzzy
-msgid "This will perform the action on all hosts in this group"
-msgstr "Dies ist nicht die primäre Gruppe"
-
-#, fuzzy
-msgid "This will perform the action on all hosts in this group. A snapin is checked when every host in the group has it."
-msgstr "Dies ist nicht die primäre Gruppe"
 
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
@@ -10227,6 +10232,9 @@ msgstr ""
 
 msgid "Uptime"
 msgstr "Betriebszeit"
+
+msgid "Use \"Edit selected hosts\" on the Hosts list instead; these controls will be removed in a later release."
+msgstr ""
 
 msgid "Use Authorize to enter your API tokens before trying a call. The server-wide token is under FOG Configuration > FOG Settings > API System; your personal token is on the API tab of your user account."
 msgstr ""
@@ -12449,6 +12457,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "This server is not a master node"
 #~ msgstr " | Dies ist nicht der Master-Knoten"
+
+#, fuzzy
+#~ msgid "This will perform the action on all hosts in this group"
+#~ msgstr "Dies ist nicht die primäre Gruppe"
+
+#, fuzzy
+#~ msgid "This will perform the action on all hosts in this group. A snapin is checked when every host in the group has it."
+#~ msgstr "Dies ist nicht die primäre Gruppe"
 
 #~ msgid "Total Rows"
 #~ msgstr "Zeilen gesamt"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -265,7 +265,7 @@ msgstr ""
 msgid "(empty on all)"
 msgstr ""
 
-msgid "(none on all)"
+msgid "(none)"
 msgstr ""
 
 msgid "(set on all)"
@@ -435,6 +435,9 @@ msgstr ""
 msgid "A module already exists with this name!"
 msgstr "An image already exists with this name!"
 
+msgid "A module granted here is on for every host in this group, including hosts added later -- unless the host itself says otherwise. A host set to Off on its own Modules tab stays off, and no grant can override that."
+msgstr ""
+
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
@@ -459,6 +462,9 @@ msgstr "No image specified"
 #, fuzzy
 msgid "A printer already exists with this name!"
 msgstr "An image already exists with this name!"
+
+msgid "A printer granted here reaches every host in this group, including hosts added later. Removing a host from the group takes the printer away again. A printer the host was given directly is unaffected either way."
+msgstr ""
 
 #, fuzzy
 msgid "A provider already exists with this name!"
@@ -493,6 +499,9 @@ msgstr "An image already exists with this name!"
 #, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "An image already exists with this name!"
+
+msgid "A snapin granted here reaches every host in this group, including hosts added later. Granting a snapin does not run it; deploy it from the Tasks tab when you want it to run."
+msgstr ""
 
 #, fuzzy
 msgid "A storage group already exists with this name!"
@@ -675,9 +684,6 @@ msgstr ""
 
 msgid "Action"
 msgstr "Action"
-
-msgid "Action will be perform on all hosts within this group"
-msgstr ""
 
 msgid "Actions"
 msgstr "Actions"
@@ -2415,6 +2421,10 @@ msgstr "Download Failed"
 msgid "Deploy Method"
 msgstr "Deploy Method"
 
+#, fuzzy
+msgid "Deprecated."
+msgstr "Create"
+
 msgid "Depth"
 msgstr ""
 
@@ -3617,6 +3627,10 @@ msgid "Group added!"
 msgstr "Group added"
 
 #, fuzzy
+msgid "Group default:"
+msgstr "Update Printer"
+
+#, fuzzy
 msgid "Group is not valid"
 msgstr "Group is Invalid"
 
@@ -4003,10 +4017,6 @@ msgstr "Host Image"
 #, fuzzy
 msgid "Hosts assigned"
 msgstr "No node associated"
-
-#, fuzzy
-msgid "Hosts default:"
-msgstr "Update Printer"
 
 #, fuzzy
 msgid "Hosts in tasking"
@@ -6471,9 +6481,6 @@ msgid "Only for a peer running its own FOG database. On that peer run bin/fog-no
 msgstr ""
 
 msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
-msgstr ""
-
-msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "Open Source Computer Cloning Solution"
@@ -9318,6 +9325,9 @@ msgstr "Failed to create task"
 msgid "The current user is invalid."
 msgstr "Task type is not valid"
 
+msgid "The default printer for hosts in this group. A host that has its own default keeps it."
+msgstr ""
+
 msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
 msgstr ""
 
@@ -9426,6 +9436,9 @@ msgid "The object."
 msgstr "Object"
 
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
+msgstr ""
+
+msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "The path requested is already in use by another image!"
@@ -9619,6 +9632,9 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This applies the value once, to the hosts that are members right now. A host added to the group later does not get it, and a host removed keeps it."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -9798,22 +9814,11 @@ msgstr ""
 msgid "This tells the client to force reboots for host name changing and AD Joining."
 msgstr ""
 
-msgid "This will add and set (as needed) the default printer for all hosts in this group"
-msgstr ""
-
 msgid "This will allow you to configure how services"
 msgstr ""
 
 msgid "This will delete all powermanagement items from all hosts in this group"
 msgstr ""
-
-#, fuzzy
-msgid "This will perform the action on all hosts in this group"
-msgstr " | This is not the primary group"
-
-#, fuzzy
-msgid "This will perform the action on all hosts in this group. A snapin is checked when every host in the group has it."
-msgstr " | This is not the primary group"
 
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
@@ -10235,6 +10240,9 @@ msgstr ""
 
 msgid "Uptime"
 msgstr "Uptime"
+
+msgid "Use \"Edit selected hosts\" on the Hosts list instead; these controls will be removed in a later release."
+msgstr ""
 
 msgid "Use Authorize to enter your API tokens before trying a call. The server-wide token is under FOG Configuration > FOG Settings > API System; your personal token is on the API tab of your user account."
 msgstr ""
@@ -12412,6 +12420,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "This server is not a master node"
 #~ msgstr " | This is not the master node"
+
+#, fuzzy
+#~ msgid "This will perform the action on all hosts in this group"
+#~ msgstr " | This is not the primary group"
+
+#, fuzzy
+#~ msgid "This will perform the action on all hosts in this group. A snapin is checked when every host in the group has it."
+#~ msgstr " | This is not the primary group"
 
 #~ msgid "Total Rows"
 #~ msgstr "Total Rows"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -263,7 +263,7 @@ msgstr ""
 msgid "(empty on all)"
 msgstr ""
 
-msgid "(none on all)"
+msgid "(none)"
 msgstr ""
 
 msgid "(set on all)"
@@ -433,6 +433,9 @@ msgstr ""
 msgid "A module already exists with this name!"
 msgstr "Una imagen ya existe con este nombre!"
 
+msgid "A module granted here is on for every host in this group, including hosts added later -- unless the host itself says otherwise. A host set to Off on its own Modules tab stays off, and no grant can override that."
+msgstr ""
+
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
@@ -457,6 +460,9 @@ msgstr "No hay imagen especificada"
 #, fuzzy
 msgid "A printer already exists with this name!"
 msgstr "Una imagen ya existe con este nombre!"
+
+msgid "A printer granted here reaches every host in this group, including hosts added later. Removing a host from the group takes the printer away again. A printer the host was given directly is unaffected either way."
+msgstr ""
 
 #, fuzzy
 msgid "A provider already exists with this name!"
@@ -490,6 +496,9 @@ msgstr "Una imagen ya existe con este nombre!"
 #, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "Una imagen ya existe con este nombre!"
+
+msgid "A snapin granted here reaches every host in this group, including hosts added later. Granting a snapin does not run it; deploy it from the Tasks tab when you want it to run."
+msgstr ""
 
 #, fuzzy
 msgid "A storage group already exists with this name!"
@@ -679,9 +688,6 @@ msgstr ""
 
 msgid "Action"
 msgstr "Acción"
-
-msgid "Action will be perform on all hosts within this group"
-msgstr ""
 
 #, fuzzy
 msgid "Actions"
@@ -2443,6 +2449,10 @@ msgstr "Descarga fracasó"
 msgid "Deploy Method"
 msgstr "última Desplegado"
 
+#, fuzzy
+msgid "Deprecated."
+msgstr "Crear"
+
 msgid "Depth"
 msgstr ""
 
@@ -3667,6 +3677,10 @@ msgid "Group added!"
 msgstr "grupo añadió"
 
 #, fuzzy
+msgid "Group default:"
+msgstr "Actualizar impresora"
+
+#, fuzzy
 msgid "Group is not valid"
 msgstr "tipo de tarea no es válida"
 
@@ -4069,10 +4083,6 @@ msgstr "nombre de host"
 #, fuzzy
 msgid "Hosts assigned"
 msgstr "No nodo asociado"
-
-#, fuzzy
-msgid "Hosts default:"
-msgstr "Actualizar impresora"
 
 #, fuzzy
 msgid "Hosts in tasking"
@@ -6582,9 +6592,6 @@ msgid "Only for a peer running its own FOG database. On that peer run bin/fog-no
 msgstr ""
 
 msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
-msgstr ""
-
-msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "Open Source Computer Cloning Solution"
@@ -9481,6 +9488,9 @@ msgstr "No se pudo crear la tarea"
 msgid "The current user is invalid."
 msgstr "tipo de tarea no es válida"
 
+msgid "The default printer for hosts in this group. A host that has its own default keeps it."
+msgstr ""
+
 msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
 msgstr ""
 
@@ -9590,6 +9600,9 @@ msgid "The object."
 msgstr "Objeto"
 
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
+msgstr ""
+
+msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "The path requested is already in use by another image!"
@@ -9785,6 +9798,9 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This applies the value once, to the hosts that are members right now. A host added to the group later does not get it, and a host removed keeps it."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -9959,19 +9975,10 @@ msgstr ""
 msgid "This tells the client to force reboots for host name changing and AD Joining."
 msgstr ""
 
-msgid "This will add and set (as needed) the default printer for all hosts in this group"
-msgstr ""
-
 msgid "This will allow you to configure how services"
 msgstr ""
 
 msgid "This will delete all powermanagement items from all hosts in this group"
-msgstr ""
-
-msgid "This will perform the action on all hosts in this group"
-msgstr ""
-
-msgid "This will perform the action on all hosts in this group. A snapin is checked when every host in the group has it."
 msgstr ""
 
 msgid "This will set the configuration level to all hosts in this group"
@@ -10395,6 +10402,9 @@ msgstr ""
 
 msgid "Uptime"
 msgstr "el tiempo de actividad"
+
+msgid "Use \"Edit selected hosts\" on the Hosts list instead; these controls will be removed in a later release."
+msgstr ""
 
 msgid "Use Authorize to enter your API tokens before trying a call. The server-wide token is under FOG Configuration > FOG Settings > API System; your personal token is on the API tab of your user account."
 msgstr ""

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -260,7 +260,7 @@ msgstr ""
 msgid "(empty on all)"
 msgstr ""
 
-msgid "(none on all)"
+msgid "(none)"
 msgstr ""
 
 msgid "(set on all)"
@@ -430,6 +430,9 @@ msgstr ""
 msgid "A module already exists with this name!"
 msgstr "Eine Rolle mit diesem Namen ist bereits vorhanden!"
 
+msgid "A module granted here is on for every host in this group, including hosts added later -- unless the host itself says otherwise. A host set to Off on its own Modules tab stays off, and no grant can override that."
+msgstr ""
+
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
@@ -454,6 +457,9 @@ msgstr "muss angegeben werden"
 #, fuzzy
 msgid "A printer already exists with this name!"
 msgstr "Ein Drucker mit diesem Namen ist bereits vorhanden!"
+
+msgid "A printer granted here reaches every host in this group, including hosts added later. Removing a host from the group takes the printer away again. A printer the host was given directly is unaffected either way."
+msgstr ""
 
 #, fuzzy
 msgid "A provider already exists with this name!"
@@ -488,6 +494,9 @@ msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
 #, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "Ein Snapin mit diesem Namen ist bereits vorhanden!"
+
+msgid "A snapin granted here reaches every host in this group, including hosts added later. Granting a snapin does not run it; deploy it from the Tasks tab when you want it to run."
+msgstr ""
 
 #, fuzzy
 msgid "A storage group already exists with this name!"
@@ -671,9 +680,6 @@ msgstr ""
 
 msgid "Action"
 msgstr "Aktion"
-
-msgid "Action will be perform on all hosts within this group"
-msgstr ""
 
 msgid "Actions"
 msgstr "Aktionen"
@@ -2412,6 +2418,10 @@ msgstr "Download fehlgeschlagen"
 msgid "Deploy Method"
 msgstr "Verteilungsmethode"
 
+#, fuzzy
+msgid "Deprecated."
+msgstr "Erstellen"
+
 msgid "Depth"
 msgstr ""
 
@@ -3614,6 +3624,10 @@ msgid "Group added!"
 msgstr "Gruppe hinzugefügt!"
 
 #, fuzzy
+msgid "Group default:"
+msgstr "Standarddrucker aktualisieren"
+
+#, fuzzy
 msgid "Group is not valid"
 msgstr "Gruppe ist nicht gültig"
 
@@ -4001,10 +4015,6 @@ msgstr "Host-Image"
 #, fuzzy
 msgid "Hosts assigned"
 msgstr "zugeordneter Host"
-
-#, fuzzy
-msgid "Hosts default:"
-msgstr "Standarddrucker aktualisieren"
 
 #, fuzzy
 msgid "Hosts in tasking"
@@ -6461,9 +6471,6 @@ msgid "Only for a peer running its own FOG database. On that peer run bin/fog-no
 msgstr ""
 
 msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
-msgstr ""
-
-msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "Open Source Computer Cloning Solution"
@@ -9310,6 +9317,9 @@ msgstr "Fehler beim Erstellen eines Tasks"
 msgid "The current user is invalid."
 msgstr "Task-Typ ist nicht gültig"
 
+msgid "The default printer for hosts in this group. A host that has its own default keeps it."
+msgstr ""
+
 msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
 msgstr ""
 
@@ -9418,6 +9428,9 @@ msgid "The object."
 msgstr "Objekt"
 
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
+msgstr ""
+
+msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "The path requested is already in use by another image!"
@@ -9612,6 +9625,9 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This applies the value once, to the hosts that are members right now. A host added to the group later does not get it, and a host removed keeps it."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -9791,22 +9807,11 @@ msgstr ""
 msgid "This tells the client to force reboots for host name changing and AD Joining."
 msgstr ""
 
-msgid "This will add and set (as needed) the default printer for all hosts in this group"
-msgstr ""
-
 msgid "This will allow you to configure how services"
 msgstr "Hiermit können Sie konfigurieren, "
 
 msgid "This will delete all powermanagement items from all hosts in this group"
 msgstr ""
-
-#, fuzzy
-msgid "This will perform the action on all hosts in this group"
-msgstr "Dies ist nicht die primäre Gruppe"
-
-#, fuzzy
-msgid "This will perform the action on all hosts in this group. A snapin is checked when every host in the group has it."
-msgstr "Dies ist nicht die primäre Gruppe"
 
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
@@ -10228,6 +10233,9 @@ msgstr ""
 
 msgid "Uptime"
 msgstr "Betriebszeit"
+
+msgid "Use \"Edit selected hosts\" on the Hosts list instead; these controls will be removed in a later release."
+msgstr ""
 
 msgid "Use Authorize to enter your API tokens before trying a call. The server-wide token is under FOG Configuration > FOG Settings > API System; your personal token is on the API tab of your user account."
 msgstr ""
@@ -12450,6 +12458,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "This server is not a master node"
 #~ msgstr " | Dies ist nicht der Master-Knoten"
+
+#, fuzzy
+#~ msgid "This will perform the action on all hosts in this group"
+#~ msgstr "Dies ist nicht die primäre Gruppe"
+
+#, fuzzy
+#~ msgid "This will perform the action on all hosts in this group. A snapin is checked when every host in the group has it."
+#~ msgstr "Dies ist nicht die primäre Gruppe"
 
 #~ msgid "Total Rows"
 #~ msgstr "Zeilen gesamt"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -266,7 +266,7 @@ msgstr ""
 msgid "(empty on all)"
 msgstr ""
 
-msgid "(none on all)"
+msgid "(none)"
 msgstr ""
 
 msgid "(set on all)"
@@ -436,6 +436,9 @@ msgstr ""
 msgid "A module already exists with this name!"
 msgstr "Une image existe déjà avec ce nom!"
 
+msgid "A module granted here is on for every host in this group, including hosts added later -- unless the host itself says otherwise. A host set to Off on its own Modules tab stays off, and no grant can override that."
+msgstr ""
+
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
@@ -460,6 +463,9 @@ msgstr "Aucune image spécifiée"
 #, fuzzy
 msgid "A printer already exists with this name!"
 msgstr "Une image existe déjà avec ce nom!"
+
+msgid "A printer granted here reaches every host in this group, including hosts added later. Removing a host from the group takes the printer away again. A printer the host was given directly is unaffected either way."
+msgstr ""
 
 #, fuzzy
 msgid "A provider already exists with this name!"
@@ -494,6 +500,9 @@ msgstr "Une image existe déjà avec ce nom!"
 #, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "Une image existe déjà avec ce nom!"
+
+msgid "A snapin granted here reaches every host in this group, including hosts added later. Granting a snapin does not run it; deploy it from the Tasks tab when you want it to run."
+msgstr ""
 
 #, fuzzy
 msgid "A storage group already exists with this name!"
@@ -676,9 +685,6 @@ msgstr ""
 
 msgid "Action"
 msgstr "action"
-
-msgid "Action will be perform on all hosts within this group"
-msgstr ""
 
 msgid "Actions"
 msgstr "actes"
@@ -2416,6 +2422,10 @@ msgstr "Échec du téléchargement"
 msgid "Deploy Method"
 msgstr "Déployer Méthode"
 
+#, fuzzy
+msgid "Deprecated."
+msgstr "Créer"
+
 msgid "Depth"
 msgstr ""
 
@@ -3618,6 +3628,10 @@ msgid "Group added!"
 msgstr "Groupe ajouté"
 
 #, fuzzy
+msgid "Group default:"
+msgstr "Mise à jour de l'imprimante"
+
+#, fuzzy
 msgid "Group is not valid"
 msgstr "Groupe est non valide"
 
@@ -4004,10 +4018,6 @@ msgstr "image hôte"
 #, fuzzy
 msgid "Hosts assigned"
 msgstr "Aucun noeud associé"
-
-#, fuzzy
-msgid "Hosts default:"
-msgstr "Mise à jour de l'imprimante"
 
 #, fuzzy
 msgid "Hosts in tasking"
@@ -6458,9 +6468,6 @@ msgid "Only for a peer running its own FOG database. On that peer run bin/fog-no
 msgstr ""
 
 msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
-msgstr ""
-
-msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "Open Source Computer Cloning Solution"
@@ -9303,6 +9310,9 @@ msgstr "Impossible de créer la tâche"
 msgid "The current user is invalid."
 msgstr "Type de tâche n'est pas valide"
 
+msgid "The default printer for hosts in this group. A host that has its own default keeps it."
+msgstr ""
+
 msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
 msgstr ""
 
@@ -9411,6 +9421,9 @@ msgid "The object."
 msgstr "Objet"
 
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
+msgstr ""
+
+msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "The path requested is already in use by another image!"
@@ -9604,6 +9617,9 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This applies the value once, to the hosts that are members right now. A host added to the group later does not get it, and a host removed keeps it."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -9783,22 +9799,11 @@ msgstr ""
 msgid "This tells the client to force reboots for host name changing and AD Joining."
 msgstr ""
 
-msgid "This will add and set (as needed) the default printer for all hosts in this group"
-msgstr ""
-
 msgid "This will allow you to configure how services"
 msgstr ""
 
 msgid "This will delete all powermanagement items from all hosts in this group"
 msgstr ""
-
-#, fuzzy
-msgid "This will perform the action on all hosts in this group"
-msgstr " | Cela ne veut pas le groupe principal"
-
-#, fuzzy
-msgid "This will perform the action on all hosts in this group. A snapin is checked when every host in the group has it."
-msgstr " | Cela ne veut pas le groupe principal"
 
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
@@ -10221,6 +10226,9 @@ msgstr ""
 
 msgid "Uptime"
 msgstr "uptime"
+
+msgid "Use \"Edit selected hosts\" on the Hosts list instead; these controls will be removed in a later release."
+msgstr ""
 
 msgid "Use Authorize to enter your API tokens before trying a call. The server-wide token is under FOG Configuration > FOG Settings > API System; your personal token is on the API tab of your user account."
 msgstr ""
@@ -12402,6 +12410,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "This server is not a master node"
 #~ msgstr " | Cela ne veut pas le nœud maître"
+
+#, fuzzy
+#~ msgid "This will perform the action on all hosts in this group"
+#~ msgstr " | Cela ne veut pas le groupe principal"
+
+#, fuzzy
+#~ msgid "This will perform the action on all hosts in this group. A snapin is checked when every host in the group has it."
+#~ msgstr " | Cela ne veut pas le groupe principal"
 
 #~ msgid "Total Rows"
 #~ msgstr "Nombre de lignes"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -265,7 +265,7 @@ msgstr ""
 msgid "(empty on all)"
 msgstr ""
 
-msgid "(none on all)"
+msgid "(none)"
 msgstr ""
 
 msgid "(set on all)"
@@ -427,6 +427,9 @@ msgstr ""
 msgid "A module already exists with this name!"
 msgstr "Esiste già un ruolo con questo nome!"
 
+msgid "A module granted here is on for every host in this group, including hosts added later -- unless the host itself says otherwise. A host set to Off on its own Modules tab stays off, and no grant can override that."
+msgstr ""
+
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
@@ -450,6 +453,9 @@ msgstr "deve essere specificato"
 
 msgid "A printer already exists with this name!"
 msgstr "Nome stampante già esistente on questo nome!"
+
+msgid "A printer granted here reaches every host in this group, including hosts added later. Removing a host from the group takes the printer away again. A printer the host was given directly is unaffected either way."
+msgstr ""
 
 #, fuzzy
 msgid "A provider already exists with this name!"
@@ -483,6 +489,9 @@ msgstr "Un host già esiste con questo nome!"
 
 msgid "A snapin already exists with this name!"
 msgstr "Esiste già un snapin con questo nome!"
+
+msgid "A snapin granted here reaches every host in this group, including hosts added later. Granting a snapin does not run it; deploy it from the Tasks tab when you want it to run."
+msgstr ""
 
 #, fuzzy
 msgid "A storage group already exists with this name!"
@@ -661,9 +670,6 @@ msgstr ""
 
 msgid "Action"
 msgstr "Azione"
-
-msgid "Action will be perform on all hosts within this group"
-msgstr ""
 
 msgid "Actions"
 msgstr "azioni"
@@ -2350,6 +2356,10 @@ msgstr "Scaricamento fallito"
 msgid "Deploy Method"
 msgstr "Metodo Deploy"
 
+#, fuzzy
+msgid "Deprecated."
+msgstr "Creare"
+
 msgid "Depth"
 msgstr ""
 
@@ -3523,6 +3533,10 @@ msgstr "Aggiornamento del gruppo completato"
 msgid "Group added!"
 msgstr "Gruppo aggiunto!"
 
+#, fuzzy
+msgid "Group default:"
+msgstr "Aggiorna la stampante predefinita"
+
 msgid "Group is not valid"
 msgstr "Gruppo non valido"
 
@@ -3899,10 +3913,6 @@ msgstr "immagine host"
 #, fuzzy
 msgid "Hosts assigned"
 msgstr "Host associato"
-
-#, fuzzy
-msgid "Hosts default:"
-msgstr "Aggiorna la stampante predefinita"
 
 #, fuzzy
 msgid "Hosts in tasking"
@@ -6270,9 +6280,6 @@ msgid "Only for a peer running its own FOG database. On that peer run bin/fog-no
 msgstr ""
 
 msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
-msgstr ""
-
-msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "Open Source Computer Cloning Solution"
@@ -9024,6 +9031,9 @@ msgstr "Impossibile creare un'attività"
 msgid "The current user is invalid."
 msgstr "Tipo di attività non è valido"
 
+msgid "The default printer for hosts in this group. A host that has its own default keeps it."
+msgstr ""
+
 msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
 msgstr ""
 
@@ -9131,6 +9141,9 @@ msgid "The object."
 msgstr "oggetto"
 
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
+msgstr ""
+
+msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "The path requested is already in use by another image!"
@@ -9321,6 +9334,9 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This applies the value once, to the hosts that are members right now. A host added to the group later does not get it, and a host removed keeps it."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -9495,22 +9511,11 @@ msgstr ""
 msgid "This tells the client to force reboots for host name changing and AD Joining."
 msgstr ""
 
-msgid "This will add and set (as needed) the default printer for all hosts in this group"
-msgstr ""
-
 msgid "This will allow you to configure how services"
 msgstr "Ciò consentirà di configurare come servizi"
 
 msgid "This will delete all powermanagement items from all hosts in this group"
 msgstr ""
-
-#, fuzzy
-msgid "This will perform the action on all hosts in this group"
-msgstr "Questo non è il gruppo primario"
-
-#, fuzzy
-msgid "This will perform the action on all hosts in this group. A snapin is checked when every host in the group has it."
-msgstr "Questo non è il gruppo primario"
 
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
@@ -9924,6 +9929,9 @@ msgstr ""
 
 msgid "Uptime"
 msgstr "uptime"
+
+msgid "Use \"Edit selected hosts\" on the Hosts list instead; these controls will be removed in a later release."
+msgstr ""
 
 msgid "Use Authorize to enter your API tokens before trying a call. The server-wide token is under FOG Configuration > FOG Settings > API System; your personal token is on the API tab of your user account."
 msgstr ""
@@ -12056,6 +12064,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "This server is not a master node"
 #~ msgstr " | Questo non è il nodo master"
+
+#, fuzzy
+#~ msgid "This will perform the action on all hosts in this group"
+#~ msgstr "Questo non è il gruppo primario"
+
+#, fuzzy
+#~ msgid "This will perform the action on all hosts in this group. A snapin is checked when every host in the group has it."
+#~ msgstr "Questo non è il gruppo primario"
 
 #~ msgid "Total Rows"
 #~ msgstr "Righe totali"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -257,7 +257,7 @@ msgstr "選択したユーザーを追加"
 msgid "(empty on all)"
 msgstr ""
 
-msgid "(none on all)"
+msgid "(none)"
 msgstr ""
 
 msgid "(set on all)"
@@ -417,6 +417,9 @@ msgstr ""
 msgid "A module already exists with this name!"
 msgstr "この名前のロールは既に存在します！"
 
+msgid "A module granted here is on for every host in this group, including hosts added later -- unless the host itself says otherwise. A host set to Off on its own Modules tab stays off, and no grant can override that."
+msgstr ""
+
 msgid "A name must be defined if using the \"name\" property"
 msgstr "\"name\" プロパティを使用する場合は、名前を定義する必要があります"
 
@@ -440,6 +443,9 @@ msgstr "指定する必要があります"
 
 msgid "A printer already exists with this name!"
 msgstr "この名前のプリンターは既に存在します！"
+
+msgid "A printer granted here reaches every host in this group, including hosts added later. Removing a host from the group takes the printer away again. A printer the host was given directly is unaffected either way."
+msgstr ""
 
 #, fuzzy
 msgid "A provider already exists with this name!"
@@ -471,6 +477,9 @@ msgstr "この名前のサイトは既に存在します！"
 
 msgid "A snapin already exists with this name!"
 msgstr "この名前のスナップインは既に存在します！"
+
+msgid "A snapin granted here reaches every host in this group, including hosts added later. Granting a snapin does not run it; deploy it from the Tasks tab when you want it to run."
+msgstr ""
 
 #, fuzzy
 msgid "A storage group already exists with this name!"
@@ -646,10 +655,6 @@ msgstr ""
 
 msgid "Action"
 msgstr "操作"
-
-#, fuzzy
-msgid "Action will be perform on all hosts within this group"
-msgstr "このグループ内のすべてのホストでこの項目をクリアします。"
 
 msgid "Actions"
 msgstr "操作"
@@ -2337,6 +2342,10 @@ msgstr "ダウンロードに失敗しました"
 msgid "Deploy Method"
 msgstr "展開方法"
 
+#, fuzzy
+msgid "Deprecated."
+msgstr "作成"
+
 msgid "Depth"
 msgstr ""
 
@@ -3498,6 +3507,10 @@ msgstr "グループの更新に成功しました"
 msgid "Group added!"
 msgstr "グループを追加しました！"
 
+#, fuzzy
+msgid "Group default:"
+msgstr "ホストを作成しました"
+
 msgid "Group is not valid"
 msgstr "グループが無効です"
 
@@ -3871,10 +3884,6 @@ msgstr "ホストとユーザー"
 #, fuzzy
 msgid "Hosts assigned"
 msgstr "関連付けられたホスト"
-
-#, fuzzy
-msgid "Hosts default:"
-msgstr "ホストを作成しました"
 
 #, fuzzy
 msgid "Hosts in tasking"
@@ -6235,9 +6244,6 @@ msgid "Only for a peer running its own FOG database. On that peer run bin/fog-no
 msgstr ""
 
 msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
-msgstr ""
-
-msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "Open Source Computer Cloning Solution"
@@ -8967,6 +8973,9 @@ msgstr "タスクの作成に失敗しました"
 msgid "The current user is invalid."
 msgstr ""
 
+msgid "The default printer for hosts in this group. A host that has its own default keeps it."
+msgstr ""
+
 msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
 msgstr ""
 
@@ -9075,6 +9084,9 @@ msgid "The object."
 msgstr "オブジェクト"
 
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
+msgstr ""
+
+msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 #, fuzzy
@@ -9267,6 +9279,9 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This applies the value once, to the hosts that are members right now. A host added to the group later does not get it, and a host removed keeps it."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -9441,20 +9456,10 @@ msgstr "移行、または新しい項目の一括インポート"
 msgid "This tells the client to force reboots for host name changing and AD Joining."
 msgstr ""
 
-msgid "This will add and set (as needed) the default printer for all hosts in this group"
-msgstr ""
-
 msgid "This will allow you to configure how services"
 msgstr "ここではサービスの動作を設定できます"
 
 msgid "This will delete all powermanagement items from all hosts in this group"
-msgstr ""
-
-#, fuzzy
-msgid "This will perform the action on all hosts in this group"
-msgstr "このグループ内のすべてのホストでこの項目をクリアします。"
-
-msgid "This will perform the action on all hosts in this group. A snapin is checked when every host in the group has it."
 msgstr ""
 
 #, fuzzy
@@ -9868,6 +9873,9 @@ msgstr "ファイルをアップロード"
 
 msgid "Uptime"
 msgstr "稼働時間"
+
+msgid "Use \"Edit selected hosts\" on the Hosts list instead; these controls will be removed in a later release."
+msgstr ""
 
 msgid "Use Authorize to enter your API tokens before trying a call. The server-wide token is under FOG Configuration > FOG Settings > API System; your personal token is on the API tab of your user account."
 msgstr ""
@@ -11455,6 +11463,10 @@ msgstr ""
 
 #~ msgid "Account removed from FOG GUI at"
 #~ msgstr "FOG GUI から削除されたアカウント:"
+
+#, fuzzy
+#~ msgid "Action will be perform on all hosts within this group"
+#~ msgstr "このグループ内のすべてのホストでこの項目をクリアします。"
 
 #, fuzzy
 #~ msgid "Add Directory Group"
@@ -13334,6 +13346,10 @@ msgstr ""
 
 #~ msgid "This setting turns off all FOG Printer Management"
 #~ msgstr "この設定は FOG のプリンター管理機能をすべて無効にします"
+
+#, fuzzy
+#~ msgid "This will perform the action on all hosts in this group"
+#~ msgstr "このグループ内のすべてのホストでこの項目をクリアします。"
 
 #~ msgid "Timeout"
 #~ msgstr "タイムアウト"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -241,7 +241,7 @@ msgstr ""
 msgid "(empty on all)"
 msgstr ""
 
-msgid "(none on all)"
+msgid "(none)"
 msgstr ""
 
 msgid "(set on all)"
@@ -389,6 +389,9 @@ msgstr ""
 msgid "A module already exists with this name!"
 msgstr ""
 
+msgid "A module granted here is on for every host in this group, including hosts added later -- unless the host itself says otherwise. A host set to Off on its own Modules tab stays off, and no grant can override that."
+msgstr ""
+
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
@@ -408,6 +411,9 @@ msgid "A port must be specified"
 msgstr ""
 
 msgid "A printer already exists with this name!"
+msgstr ""
+
+msgid "A printer granted here reaches every host in this group, including hosts added later. Removing a host from the group takes the printer away again. A printer the host was given directly is unaffected either way."
 msgstr ""
 
 msgid "A provider already exists with this name!"
@@ -435,6 +441,9 @@ msgid "A site already exists with this name!"
 msgstr ""
 
 msgid "A snapin already exists with this name!"
+msgstr ""
+
+msgid "A snapin granted here reaches every host in this group, including hosts added later. Granting a snapin does not run it; deploy it from the Tasks tab when you want it to run."
 msgstr ""
 
 msgid "A storage group already exists with this name!"
@@ -590,9 +599,6 @@ msgid "Account viewed by an administrator"
 msgstr ""
 
 msgid "Action"
-msgstr ""
-
-msgid "Action will be perform on all hosts within this group"
 msgstr ""
 
 msgid "Actions"
@@ -2078,6 +2084,9 @@ msgstr ""
 msgid "Deploy Method"
 msgstr ""
 
+msgid "Deprecated."
+msgstr ""
+
 msgid "Depth"
 msgstr ""
 
@@ -3106,6 +3115,9 @@ msgstr ""
 msgid "Group added!"
 msgstr ""
 
+msgid "Group default:"
+msgstr ""
+
 msgid "Group is not valid"
 msgstr ""
 
@@ -3426,9 +3438,6 @@ msgid "Hosts and images"
 msgstr ""
 
 msgid "Hosts assigned"
-msgstr ""
-
-msgid "Hosts default:"
 msgstr ""
 
 msgid "Hosts in tasking"
@@ -5516,9 +5525,6 @@ msgid "Only for a peer running its own FOG database. On that peer run bin/fog-no
 msgstr ""
 
 msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
-msgstr ""
-
-msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "Open Source Computer Cloning Solution"
@@ -7935,6 +7941,9 @@ msgstr ""
 msgid "The current user is invalid."
 msgstr ""
 
+msgid "The default printer for hosts in this group. A host that has its own default keeps it."
+msgstr ""
+
 msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
 msgstr ""
 
@@ -8036,6 +8045,9 @@ msgid "The object."
 msgstr ""
 
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
+msgstr ""
+
+msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "The path requested is already in use by another image!"
@@ -8214,6 +8226,9 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This applies the value once, to the hosts that are members right now. A host added to the group later does not get it, and a host removed keeps it."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -8384,19 +8399,10 @@ msgstr ""
 msgid "This tells the client to force reboots for host name changing and AD Joining."
 msgstr ""
 
-msgid "This will add and set (as needed) the default printer for all hosts in this group"
-msgstr ""
-
 msgid "This will allow you to configure how services"
 msgstr ""
 
 msgid "This will delete all powermanagement items from all hosts in this group"
-msgstr ""
-
-msgid "This will perform the action on all hosts in this group"
-msgstr ""
-
-msgid "This will perform the action on all hosts in this group. A snapin is checked when every host in the group has it."
 msgstr ""
 
 msgid "This will set the configuration level to all hosts in this group"
@@ -8759,6 +8765,9 @@ msgid "Uploaded file too large."
 msgstr ""
 
 msgid "Uptime"
+msgstr ""
+
+msgid "Use \"Edit selected hosts\" on the Hosts list instead; these controls will be removed in a later release."
 msgstr ""
 
 msgid "Use Authorize to enter your API tokens before trying a call. The server-wide token is under FOG Configuration > FOG Settings > API System; your personal token is on the API tab of your user account."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -265,7 +265,7 @@ msgstr ""
 msgid "(empty on all)"
 msgstr ""
 
-msgid "(none on all)"
+msgid "(none)"
 msgstr ""
 
 msgid "(set on all)"
@@ -435,6 +435,9 @@ msgstr ""
 msgid "A module already exists with this name!"
 msgstr "Uma imagem já existe com este nome!"
 
+msgid "A module granted here is on for every host in this group, including hosts added later -- unless the host itself says otherwise. A host set to Off on its own Modules tab stays off, and no grant can override that."
+msgstr ""
+
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
@@ -459,6 +462,9 @@ msgstr "Nenhuma imagem especificada"
 #, fuzzy
 msgid "A printer already exists with this name!"
 msgstr "Uma imagem já existe com este nome!"
+
+msgid "A printer granted here reaches every host in this group, including hosts added later. Removing a host from the group takes the printer away again. A printer the host was given directly is unaffected either way."
+msgstr ""
 
 #, fuzzy
 msgid "A provider already exists with this name!"
@@ -493,6 +499,9 @@ msgstr "Uma imagem já existe com este nome!"
 #, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "Uma imagem já existe com este nome!"
+
+msgid "A snapin granted here reaches every host in this group, including hosts added later. Granting a snapin does not run it; deploy it from the Tasks tab when you want it to run."
+msgstr ""
 
 #, fuzzy
 msgid "A storage group already exists with this name!"
@@ -675,9 +684,6 @@ msgstr ""
 
 msgid "Action"
 msgstr "Açao"
-
-msgid "Action will be perform on all hosts within this group"
-msgstr ""
 
 msgid "Actions"
 msgstr "Ações"
@@ -2415,6 +2421,10 @@ msgstr "Falha no download"
 msgid "Deploy Method"
 msgstr "Método Deploy"
 
+#, fuzzy
+msgid "Deprecated."
+msgstr "Crio"
+
 msgid "Depth"
 msgstr ""
 
@@ -3617,6 +3627,10 @@ msgid "Group added!"
 msgstr "grupo adicionado"
 
 #, fuzzy
+msgid "Group default:"
+msgstr "Atualizar impressora"
+
+#, fuzzy
 msgid "Group is not valid"
 msgstr "Grupo é inválido"
 
@@ -4003,10 +4017,6 @@ msgstr "Image Host"
 #, fuzzy
 msgid "Hosts assigned"
 msgstr "No nó associado"
-
-#, fuzzy
-msgid "Hosts default:"
-msgstr "Atualizar impressora"
 
 #, fuzzy
 msgid "Hosts in tasking"
@@ -6458,9 +6468,6 @@ msgid "Only for a peer running its own FOG database. On that peer run bin/fog-no
 msgstr ""
 
 msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
-msgstr ""
-
-msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "Open Source Computer Cloning Solution"
@@ -9305,6 +9312,9 @@ msgstr "Falha ao criar tarefa"
 msgid "The current user is invalid."
 msgstr "tipo de tarefa não é válido"
 
+msgid "The default printer for hosts in this group. A host that has its own default keeps it."
+msgstr ""
+
 msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
 msgstr ""
 
@@ -9413,6 +9423,9 @@ msgid "The object."
 msgstr "Objeto"
 
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
+msgstr ""
+
+msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "The path requested is already in use by another image!"
@@ -9606,6 +9619,9 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This applies the value once, to the hosts that are members right now. A host added to the group later does not get it, and a host removed keeps it."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -9785,22 +9801,11 @@ msgstr ""
 msgid "This tells the client to force reboots for host name changing and AD Joining."
 msgstr ""
 
-msgid "This will add and set (as needed) the default printer for all hosts in this group"
-msgstr ""
-
 msgid "This will allow you to configure how services"
 msgstr ""
 
 msgid "This will delete all powermanagement items from all hosts in this group"
 msgstr ""
-
-#, fuzzy
-msgid "This will perform the action on all hosts in this group"
-msgstr " | Este não é o grupo primário"
-
-#, fuzzy
-msgid "This will perform the action on all hosts in this group. A snapin is checked when every host in the group has it."
-msgstr " | Este não é o grupo primário"
 
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
@@ -10223,6 +10228,9 @@ msgstr ""
 
 msgid "Uptime"
 msgstr "uptime"
+
+msgid "Use \"Edit selected hosts\" on the Hosts list instead; these controls will be removed in a later release."
+msgstr ""
 
 msgid "Use Authorize to enter your API tokens before trying a call. The server-wide token is under FOG Configuration > FOG Settings > API System; your personal token is on the API tab of your user account."
 msgstr ""
@@ -12404,6 +12412,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "This server is not a master node"
 #~ msgstr " | Este não é o nó mestre"
+
+#, fuzzy
+#~ msgid "This will perform the action on all hosts in this group"
+#~ msgstr " | Este não é o grupo primário"
+
+#, fuzzy
+#~ msgid "This will perform the action on all hosts in this group. A snapin is checked when every host in the group has it."
+#~ msgstr " | Este não é o grupo primário"
 
 #~ msgid "Total Rows"
 #~ msgstr "total de linhas"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -265,7 +265,7 @@ msgstr ""
 msgid "(empty on all)"
 msgstr ""
 
-msgid "(none on all)"
+msgid "(none)"
 msgstr ""
 
 msgid "(set on all)"
@@ -435,6 +435,9 @@ msgstr ""
 msgid "A module already exists with this name!"
 msgstr "图像已经存在具有此名称！"
 
+msgid "A module granted here is on for every host in this group, including hosts added later -- unless the host itself says otherwise. A host set to Off on its own Modules tab stays off, and no grant can override that."
+msgstr ""
+
 msgid "A name must be defined if using the \"name\" property"
 msgstr ""
 
@@ -459,6 +462,9 @@ msgstr "没有指定的图像"
 #, fuzzy
 msgid "A printer already exists with this name!"
 msgstr "图像已经存在具有此名称！"
+
+msgid "A printer granted here reaches every host in this group, including hosts added later. Removing a host from the group takes the printer away again. A printer the host was given directly is unaffected either way."
+msgstr ""
 
 #, fuzzy
 msgid "A provider already exists with this name!"
@@ -493,6 +499,9 @@ msgstr "图像已经存在具有此名称！"
 #, fuzzy
 msgid "A snapin already exists with this name!"
 msgstr "图像已经存在具有此名称！"
+
+msgid "A snapin granted here reaches every host in this group, including hosts added later. Granting a snapin does not run it; deploy it from the Tasks tab when you want it to run."
+msgstr ""
 
 #, fuzzy
 msgid "A storage group already exists with this name!"
@@ -675,9 +684,6 @@ msgstr ""
 
 msgid "Action"
 msgstr "行动"
-
-msgid "Action will be perform on all hosts within this group"
-msgstr ""
 
 msgid "Actions"
 msgstr "操作"
@@ -2415,6 +2421,10 @@ msgstr "下载失败"
 msgid "Deploy Method"
 msgstr "部署方法"
 
+#, fuzzy
+msgid "Deprecated."
+msgstr "创建"
+
 msgid "Depth"
 msgstr ""
 
@@ -3617,6 +3627,10 @@ msgid "Group added!"
 msgstr "集团补充"
 
 #, fuzzy
+msgid "Group default:"
+msgstr "更新打印机"
+
+#, fuzzy
 msgid "Group is not valid"
 msgstr "集团是无效的"
 
@@ -4003,10 +4017,6 @@ msgstr "主机图片"
 #, fuzzy
 msgid "Hosts assigned"
 msgstr "无关联的节点"
-
-#, fuzzy
-msgid "Hosts default:"
-msgstr "更新打印机"
 
 #, fuzzy
 msgid "Hosts in tasking"
@@ -6458,9 +6468,6 @@ msgid "Only for a peer running its own FOG database. On that peer run bin/fog-no
 msgstr ""
 
 msgid "Only needed for HTTPS netboot behind a PRIVATE CA, and it costs a 10-25 minute build on every install. It also makes Secure Boot harder, not easier: a binary carrying a private CA is not upstream's signed one, so the chain has to hand off to a MOK-signed FOG build and the MOK must be enrolled first."
-msgstr ""
-
-msgid "Only snapins shared by every host in the group can be ordered here. Saving sets this order on each host (shared snapins run first, in this order; any host-specific snapins run after). Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "Open Source Computer Cloning Solution"
@@ -9305,6 +9312,9 @@ msgstr "无法创建任务"
 msgid "The current user is invalid."
 msgstr "任务类型无效"
 
+msgid "The default printer for hosts in this group. A host that has its own default keeps it."
+msgstr ""
+
 msgid "The fields a queued task accepts. Wake-on-lan is this body with wol set, not a route of its own."
 msgstr ""
 
@@ -9413,6 +9423,9 @@ msgid "The object."
 msgstr "目的"
 
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
+msgstr ""
+
+msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
 msgid "The path requested is already in use by another image!"
@@ -9606,6 +9619,9 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This applies the value once, to the hosts that are members right now. A host added to the group later does not get it, and a host removed keeps it."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -9785,22 +9801,11 @@ msgstr ""
 msgid "This tells the client to force reboots for host name changing and AD Joining."
 msgstr ""
 
-msgid "This will add and set (as needed) the default printer for all hosts in this group"
-msgstr ""
-
 msgid "This will allow you to configure how services"
 msgstr ""
 
 msgid "This will delete all powermanagement items from all hosts in this group"
 msgstr ""
-
-#, fuzzy
-msgid "This will perform the action on all hosts in this group"
-msgstr "|这不是主要组"
-
-#, fuzzy
-msgid "This will perform the action on all hosts in this group. A snapin is checked when every host in the group has it."
-msgstr "|这不是主要组"
 
 msgid "This will set the configuration level to all hosts in this group"
 msgstr ""
@@ -10223,6 +10228,9 @@ msgstr ""
 
 msgid "Uptime"
 msgstr "正常运行时间"
+
+msgid "Use \"Edit selected hosts\" on the Hosts list instead; these controls will be removed in a later release."
+msgstr ""
 
 msgid "Use Authorize to enter your API tokens before trying a call. The server-wide token is under FOG Configuration > FOG Settings > API System; your personal token is on the API tab of your user account."
 msgstr ""
@@ -12404,6 +12412,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "This server is not a master node"
 #~ msgstr "|这不是主节点"
+
+#, fuzzy
+#~ msgid "This will perform the action on all hosts in this group"
+#~ msgstr "|这不是主要组"
+
+#, fuzzy
+#~ msgid "This will perform the action on all hosts in this group. A snapin is checked when every host in the group has it."
+#~ msgstr "|这不是主要组"
 
 #~ msgid "Total Rows"
 #~ msgstr "共行"

--- a/packages/web/src/Items/Group.php
+++ b/packages/web/src/Items/Group.php
@@ -128,47 +128,47 @@ class Group extends FOGController
         );
     }
     /**
-     * Adds printers to hosts in this group
+     * Grants printers to this group.
      *
-     * @param array $addArray the printers to add
+     * ADR 0038: the row lands on the GROUP (groupPrinterAssoc), not on each
+     * member host. A host added to the group afterward gains the printer,
+     * and a host removed loses it, because Assign\Resolver unions the grant
+     * with the host's own printerAssoc rows at read time. Before this the
+     * method wrote one printerAssoc row per host that existed at the moment
+     * the button was pressed, and nothing recorded that it had happened.
+     *
+     * @param array $addArray the printers to grant
      *
      * @return object
      */
     public function addPrinter($addArray)
     {
         // Drop any stale/blank ids (e.g. a 0 from an empty submission) so a
-        // group push can't seed phantom paPrinterID=0 rows on member hosts.
-        // The host-side path is already covered -- FOGController::addRemItem()
-        // array_filter()s before adding -- but this builds its insert batch
-        // directly, so nothing was filtering it. addSnapin() has carried the
-        // same guard for the same reason; addModule() now does too.
+        // grant can't seed a phantom gpaPrinterID=0 row. insertBatch builds
+        // its statement directly and nothing else is filtering it.
         $addArray = self::positiveIntIds($addArray);
-        if (count($addArray ?: []) > 0) {
-            $insert_fields = ['hostID', 'printerID'];
-            $insert_values = [];
-            $hosts = $this->get('hosts');
-            if (count($hosts ?: []) > 0) {
-                foreach ((array)$hosts as $ind => &$hostID) {
-                    foreach ((array)$addArray as &$printerID) {
-                        $insert_values[] = [$hostID, $printerID];
-                        unset($printerID);
-                    }
-                    unset($hostID);
-                }
-            }
-            if (count($insert_values ?: []) > 0) {
-                self::getClass('PrinterAssociationManager')
-                    ->insertBatch(
-                        $insert_fields,
-                        $insert_values
-                    );
-            }
+        $groupID = (int)$this->get('id');
+        if ($groupID < 1 || count($addArray) < 1) {
+            return $this;
         }
+        $insert_values = [];
+        foreach ($addArray as $printerID) {
+            $insert_values[] = [$groupID, $printerID];
+        }
+        // isDefault is deliberately NOT in the field list. insertBatch
+        // upserts on the (gpaGroupID, gpaPrinterID) unique key and sets every
+        // column it is given, so naming it would reset a default the admin
+        // had already chosen every time the printer was re-sent.
+        self::getClass('GroupPrinterAssociationManager')
+            ->insertBatch(
+                ['groupID', 'printerID'],
+                $insert_values
+            );
 
         return $this;
     }
     /**
-     * Removes printers from all hosts in this group.
+     * Revokes printers from this group.
      *
      * @param array $removeArray The array of items to remove.
      *
@@ -177,49 +177,47 @@ class Group extends FOGController
     public function removePrinter($removeArray)
     {
         Route::deletemass(
-            'printerassociation',
+            'groupprinterassociation',
             [
                 'printerID' => $removeArray,
-                'hostID' => $this->get('hosts')
+                'groupID' => $this->get('id')
             ]
         );
         return $this;
     }
     /**
-     * Updates the default printer
+     * Sets which of the group's granted printers is the default.
      *
-     * @param int   $printerid the printer id to update
+     * One row at a time rather than a member sweep: the group owns exactly
+     * one row per printer now, so "the default" is a column on the grant.
+     * A host that has set its own default still wins -- the group's answer
+     * is only consulted when the host has none (Assign\Resolver).
+     *
+     * @param int $printerid the printer id to make default, or 0 for none
      *
      * @return object
      */
     public function updateDefault($printerid)
     {
-        $printers = Route::getIds(
-            'printerassociation',
-            ['hostID' => $this->get('hosts')],
-            'printerID'
-        );
-        $printers = array_diff(
-            $printers,
-            [$printerid]
-        );
-        self::getClass('PrinterAssociationManager')
+        $groupID = (int)$this->get('id');
+        if ($groupID < 1) {
+            return $this;
+        }
+        $printerid = (int)$printerid;
+        // Clear first, unconditionally: passing 0 is how the page says "no
+        // default", and that has to be expressible.
+        self::getClass('GroupPrinterAssociationManager')
             ->update(
-                [
-                    'printerID' => $printers,
-                    'hostID' => $this->get('hosts'),
-                    'isDefault' => '1'
-                ],
+                ['groupID' => $groupID],
                 '',
                 ['isDefault' => 0]
             );
-        if ($printerid) {
-            self::getClass('PrinterAssociationManager')
+        if ($printerid > 0) {
+            self::getClass('GroupPrinterAssociationManager')
                 ->update(
                     [
-                        'printerID' => $printerid,
-                        'hostID' => $this->get('hosts'),
-                        'isDefault' => ['0', '']
+                        'groupID' => $groupID,
+                        'printerID' => $printerid
                     ],
                     '',
                     ['isDefault' => 1]
@@ -228,64 +226,44 @@ class Group extends FOGController
         return $this;
     }
     /**
-     * Add Snapins to all hosts in the group.
+     * Grants snapins to this group.
      *
-     * @param array $addArray the items to add
+     * ADR 0038: one row on the group, not one row per member host. See
+     * addPrinter() for the shape of the change.
+     *
+     * @param array $addArray the items to grant
      *
      * @return object
      */
     public function addSnapin($addArray)
     {
         // Drop any stale/blank ids (e.g. a 0 from an empty submission) so a
-        // group push can't seed phantom saSnapinID=0 rows on member hosts.
+        // grant can't seed a phantom gsaSnapinID=0 row.
         $addArray = self::positiveIntIds($addArray);
-        $insert_fields = ['hostID', 'snapinID'];
+        $groupID = (int)$this->get('id');
+        if ($groupID < 1 || count($addArray) < 1) {
+            return $this;
+        }
         $insert_values = [];
-        $hosts = $this->get('hosts');
-        if (count($hosts ?: []) > 0) {
-            array_walk(
-                $hosts,
-                function (
-                    &$hostID,
-                    $index
-                ) use (
-                    &$insert_values,
-                    $addArray
-                ) {
-                    foreach ($addArray as $snapinID) {
-                        $insert_values[] = [$hostID, $snapinID];
-                    }
-                }
+        foreach ($addArray as $snapinID) {
+            $insert_values[] = [$groupID, $snapinID];
+        }
+        // sequence is deliberately NOT in the field list, for the same
+        // reason isDefault is not in addPrinter's: insertBatch upserts on the
+        // unique key and would overwrite the run order the admin set on the
+        // Snapin Run Order card. New rows therefore land at the column
+        // default of 0, and the sweep below numbers them.
+        self::getClass('GroupSnapinAssociationManager')
+            ->insertBatch(
+                ['groupID', 'snapinID'],
+                $insert_values
             );
-        }
-        if (count($insert_values ?: []) > 0) {
-            self::getClass('SnapinAssociationManager')
-                ->insertBatch(
-                    $insert_fields,
-                    $insert_values
-                );
-            // insertBatch cannot carry the sequence: it upserts on the
-            // (saHostID, saSnapinID) unique key, so a snapin the host already
-            // had would have its deliberate run-order overwritten. The rows
-            // therefore land at sequence 0, which sorts them ahead of every
-            // deliberately ordered snapin (Host::loadSnapins orders by
-            // sequence ASC, and createSnapinTasking numbers the tasks in that
-            // order). Number them per host afterward instead.
-            //
-            // Host::save() used to sweep these up incidentally -- its
-            // appendSnapinSequence() gate was always true, because
-            // assocSetter() had already consumed the isLoaded() flag it
-            // tested. Fixing that gate (#906/#910) correctly stopped the
-            // sweep, so the sequence is assigned here at the source.
-            foreach ($hosts as $hostID) {
-                Host::appendSnapinSequence($hostID);
-            }
-        }
+        $this->appendSnapinSequence();
 
         return $this;
     }
     /**
-     * Remove snapin from all hosts in group.
+     * Revokes snapins from this group.
      *
      * @param array $removeArray the items to remove
      *
@@ -294,85 +272,135 @@ class Group extends FOGController
     public function removeSnapin($removeArray)
     {
         Route::deletemass(
-            'snapinassociation',
+            'groupsnapinassociation',
             [
                 'snapinID' => $removeArray,
-                'hostID' => $this->get('hosts')
+                'groupID' => $this->get('id')
             ]
         );
         return $this;
     }
     /**
-     * Sets the run order of the snapins shared by every host in the group.
+     * Numbers any of this group's snapin grants that have no sequence yet.
      *
-     * The submitted ids are the snapins common to all member hosts. On each
-     * host those shared snapins are sequenced first (1..N in the submitted
-     * order); any host-specific snapins are then renumbered to follow,
-     * preserving their existing relative order ("shared first, extras after").
+     * The host-side twin is Host::appendSnapinSequence() and this is the same
+     * mechanism for the same reason: a row inserted without a sequence sits
+     * at the column default of 0, which sorts it ahead of every deliberately
+     * ordered snapin. Numbering after the insert rather than during it is
+     * what lets addSnapin() leave an existing row's order alone.
      *
-     * @param array $snapinIDs the ordered shared snapin ids
+     * @return object
+     */
+    public function appendSnapinSequence()
+    {
+        $groupID = (int)$this->get('id');
+        if ($groupID < 1) {
+            return $this;
+        }
+        $associations = Route::getList(
+            'groupsnapinassociation',
+            ['groupID' => $groupID],
+            'AND',
+            'sequence'
+        );
+        $maxSequence = 0;
+        $unsequenced = [];
+        foreach ($associations as $association) {
+            $sequence = (int)$association->sequence;
+            if ($sequence > 0) {
+                $maxSequence = max($maxSequence, $sequence);
+            } else {
+                $unsequenced[] = $association->snapinID;
+            }
+        }
+        foreach ($unsequenced as $snapinID) {
+            self::getClass('GroupSnapinAssociationManager')
+                ->update(
+                    [
+                        'groupID' => $groupID,
+                        'snapinID' => $snapinID
+                    ],
+                    '',
+                    ['sequence' => ++$maxSequence]
+                );
+        }
+        return $this;
+    }
+    /**
+     * Sets the run order of the snapins this group grants.
+     *
+     * The submitted ids are the group's own grants, so this writes
+     * gsaSequence and touches no host. Before ADR 0038 it had to reconstruct
+     * an order per member host -- "shared snapins first, host-specific ones
+     * after" -- because the group owned nothing to order.
+     *
+     * @param array $snapinIDs the ordered snapin ids (first runs first)
      *
      * @return object
      */
     public function setSnapinOrder($snapinIDs)
     {
-        $shared = self::positiveIntIds($snapinIDs);
-        if (count($shared) < 1) {
+        $groupID = (int)$this->get('id');
+        if ($groupID < 1) {
             return $this;
         }
-        $hosts = (array)$this->get('hosts');
-        foreach ($hosts as $hostID) {
-            $Host = new Host($hostID);
-            if (!$Host->isValid()) {
+        $sequence = 0;
+        foreach ((array)$snapinIDs as $snapinID) {
+            $snapinID = (int)$snapinID;
+            if ($snapinID < 1) {
                 continue;
             }
-            // get('snapins') is already ordered by sequence.
-            $hostSnapins = array_map('intval', (array)$Host->get('snapins'));
-            // Shared snapins this host actually has, in the submitted order,
-            // followed by the host's remaining snapins in their current order.
-            $sharedOnHost = array_values(array_intersect($shared, $hostSnapins));
-            $extras = array_values(array_diff($hostSnapins, $shared));
-            $Host->setSnapinOrder(array_merge($sharedOnHost, $extras));
-            unset($Host);
+            ++$sequence;
+            self::getClass('GroupSnapinAssociationManager')
+                ->update(
+                    [
+                        'groupID' => $groupID,
+                        'snapinID' => $snapinID
+                    ],
+                    '',
+                    ['sequence' => $sequence]
+                );
         }
         return $this;
     }
     /**
-     * Add modules to all hosts in group.
+     * Grants modules to this group.
      *
-     * @param array $addArray the items to add
+     * ADR 0038: presence is the whole statement. There is no state column on
+     * groupModuleAssoc because a group cannot turn a module OFF -- only a
+     * host can, with a moduleStatusByHost row at msState=0, and that beats
+     * every grant. The old version wrote msState=1 onto every member host,
+     * which is exactly the copy that made a host's own OFF unrepresentable.
+     *
+     * @param array $addArray the items to grant
      *
      * @return object
      */
     public function addModule($addArray)
     {
-        // Same guard as addPrinter/addSnapin: this builds its insert batch
-        // directly rather than going through addRemItem()'s array_filter(),
-        // so a blank submission would seed phantom moduleID=0 rows.
         $addArray = self::positiveIntIds($addArray);
-        $insert_fields = ['hostID', 'moduleID', 'state'];
+        $groupID = (int)$this->get('id');
+        if ($groupID < 1 || count($addArray) < 1) {
+            return $this;
+        }
         $insert_values = [];
-        $hostids = $this->get('hosts');
-        foreach ((array) $hostids as &$hostid) {
-            foreach ((array) $addArray as &$moduleid) {
-                $insert_values[] = [$hostid, $moduleid, 1];
-                unset($moduleid);
-            }
-            unset($hostid);
+        foreach ($addArray as $moduleID) {
+            $insert_values[] = [$groupID, $moduleID];
         }
-        if (count($insert_values ?: []) > 0) {
-            self::getClass('ModuleAssociationManager')
-                ->insertBatch(
-                    $insert_fields,
-                    $insert_values
-                );
-            unset($insert_value);
-        }
+        self::getClass('GroupModuleAssociationManager')
+            ->insertBatch(
+                ['groupID', 'moduleID'],
+                $insert_values
+            );
 
         return $this;
     }
     /**
-     * Remove modules from hosts in group.
+     * Revokes modules from this group.
+     *
+     * A host that had the module only through this grant loses it. A host
+     * that stated the module on for itself keeps it, because its own row is
+     * a separate fact.
      *
      * @param array $removeArray The items to remove
      *
@@ -381,10 +409,10 @@ class Group extends FOGController
     public function removeModule($removeArray)
     {
         Route::deletemass(
-            'moduleassociation',
+            'groupmoduleassociation',
             [
                 'moduleID' => $removeArray,
-                'hostID' => $this->get('hosts')
+                'groupID' => $this->get('id')
             ]
         );
 

--- a/packages/web/src/Items/GroupModuleAssociation.php
+++ b/packages/web/src/Items/GroupModuleAssociation.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * The group module grant class.
+ *
+ * PHP version 7.4+
+ *
+ * @category GroupModuleAssociation
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Items;
+
+use FOG\Base\FOGController;
+
+/**
+ * The group module grant class.
+ *
+ * A row here says "this group turns this module on", and it is
+ * presence-only: there is no state column, because a group cannot turn a
+ * module off. Only a host can do that, with a moduleStatusByHost row at
+ * msState=0, which beats every grant (ADR 0038, and the tiers are resolved
+ * in Assign\Resolver::resolveModules).
+ *
+ * @category GroupModuleAssociation
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class GroupModuleAssociation extends FOGController
+{
+    /**
+     * The group module grant table.
+     *
+     * @var string
+     */
+    protected $databaseTable = 'groupModuleAssoc';
+    /**
+     * The group module grant fields and common names.
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'gmaID',
+        'groupID' => 'gmaGroupID',
+        'moduleID' => 'gmaModuleID'
+    ];
+    /**
+     * The required fields.
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'groupID',
+        'moduleID'
+    ];
+    /**
+     * Get's the group object.
+     *
+     * @return object
+     */
+    public function getGroup()
+    {
+        return new Group($this->get('groupID'));
+    }
+    /**
+     * Get's the module object.
+     *
+     * @return object
+     */
+    public function getModule()
+    {
+        return new Module($this->get('moduleID'));
+    }
+}

--- a/packages/web/src/Items/GroupPrinterAssociation.php
+++ b/packages/web/src/Items/GroupPrinterAssociation.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * The group printer grant class.
+ *
+ * PHP version 7.4+
+ *
+ * @category GroupPrinterAssociation
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Items;
+
+use FOG\Base\FOGController;
+
+/**
+ * The group printer grant class.
+ *
+ * A row here says "this group grants this printer", which is a different
+ * statement from printerAssoc's "this host has this printer" -- ADR 0038.
+ * The grant is resolved onto a host at read time by Assign\Resolver; nothing
+ * is copied onto the member hosts.
+ *
+ * `isDefault` is the group's answer to "which of these is the default
+ * printer", and it loses to a default the host set for itself. It is
+ * tinyint(1) here rather than printerAssoc's legacy varchar(2).
+ *
+ * @category GroupPrinterAssociation
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class GroupPrinterAssociation extends FOGController
+{
+    /**
+     * The group printer grant table.
+     *
+     * @var string
+     */
+    protected $databaseTable = 'groupPrinterAssoc';
+    /**
+     * The group printer grant fields and common names.
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'gpaID',
+        'groupID' => 'gpaGroupID',
+        'printerID' => 'gpaPrinterID',
+        'isDefault' => 'gpaIsDefault'
+    ];
+    /**
+     * The required fields.
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'groupID',
+        'printerID'
+    ];
+    /**
+     * Get's the group object.
+     *
+     * @return object
+     */
+    public function getGroup()
+    {
+        return new Group($this->get('groupID'));
+    }
+    /**
+     * Get's the printer object.
+     *
+     * @return object
+     */
+    public function getPrinter()
+    {
+        return new Printer($this->get('printerID'));
+    }
+}

--- a/packages/web/src/Items/GroupSnapinAssociation.php
+++ b/packages/web/src/Items/GroupSnapinAssociation.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * The group snapin grant class.
+ *
+ * PHP version 7.4+
+ *
+ * @category GroupSnapinAssociation
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Items;
+
+use FOG\Base\FOGController;
+
+/**
+ * The group snapin grant class.
+ *
+ * A row here says "this group grants this snapin", which is a different
+ * statement from snapinAssoc's "this host has this snapin" -- ADR 0038. The
+ * grant is resolved onto a host at read time by Assign\Resolver, so adding a
+ * host to the group is enough for it to gain the snapin and removing it is
+ * enough to lose it. Nothing is copied onto the member hosts.
+ *
+ * @category GroupSnapinAssociation
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class GroupSnapinAssociation extends FOGController
+{
+    /**
+     * The group snapin grant table.
+     *
+     * @var string
+     */
+    protected $databaseTable = 'groupSnapinAssoc';
+    /**
+     * The group snapin grant fields and common names.
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'gsaID',
+        'groupID' => 'gsaGroupID',
+        'snapinID' => 'gsaSnapinID',
+        'sequence' => 'gsaSequence'
+    ];
+    /**
+     * The required fields.
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'groupID',
+        'snapinID'
+    ];
+    /**
+     * Get's the group object.
+     *
+     * @return object
+     */
+    public function getGroup()
+    {
+        return new Group($this->get('groupID'));
+    }
+    /**
+     * Get's the snapin object.
+     *
+     * @return object
+     */
+    public function getSnapin()
+    {
+        return new Snapin($this->get('snapinID'));
+    }
+}

--- a/packages/web/src/Managers/GroupModuleAssociationManager.php
+++ b/packages/web/src/Managers/GroupModuleAssociationManager.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * The group module grant manager class.
+ *
+ * PHP version 7.4+
+ *
+ * @category GroupModuleAssociationManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Managers;
+
+use FOG\Base\FOGManagerController;
+
+/**
+ * The group module grant manager class.
+ *
+ * @category GroupModuleAssociationManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class GroupModuleAssociationManager extends FOGManagerController
+{
+}

--- a/packages/web/src/Managers/GroupPrinterAssociationManager.php
+++ b/packages/web/src/Managers/GroupPrinterAssociationManager.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * The group printer grant manager class.
+ *
+ * PHP version 7.4+
+ *
+ * @category GroupPrinterAssociationManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Managers;
+
+use FOG\Base\FOGManagerController;
+
+/**
+ * The group printer grant manager class.
+ *
+ * @category GroupPrinterAssociationManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class GroupPrinterAssociationManager extends FOGManagerController
+{
+}

--- a/packages/web/src/Managers/GroupSnapinAssociationManager.php
+++ b/packages/web/src/Managers/GroupSnapinAssociationManager.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * The group snapin grant manager class.
+ *
+ * PHP version 7.4+
+ *
+ * @category GroupSnapinAssociationManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Managers;
+
+use FOG\Base\FOGManagerController;
+
+/**
+ * The group snapin grant manager class.
+ *
+ * @category GroupSnapinAssociationManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class GroupSnapinAssociationManager extends FOGManagerController
+{
+}

--- a/packages/web/src/Pages/GroupManagement.php
+++ b/packages/web/src/Pages/GroupManagement.php
@@ -407,33 +407,57 @@ class GroupManagement extends FOGPage
             . '</p>';
     }
     /**
-     * Whether every member host shares the same default printer, and which.
-     * The default is the printerAssoc row with paIsDefault=1; a host with no
-     * default reads as '' (none), so mixed defaults register as "varies".
+     * The notice a control that COPIES onto member hosts carries.
      *
-     * @return array ['uniform' => bool, 'value' => string]
+     * ADR 0038 decision 10: mass edit on the host list ships first, then the
+     * group page's imperative controls are marked deprecated, then they are
+     * removed in a later release. This is the middle step, and it is a
+     * separate thing from the grant tabs beside it -- a snapin, printer or
+     * module granted by this group is not deprecated and is not going
+     * anywhere. Only the controls that write a value onto whichever hosts
+     * happen to be members at the moment the button is pressed are, because
+     * nothing records that the write happened and so nothing can replay it
+     * for a host added afterward.
+     *
+     * @return string the markup, or '' when there is nothing to say
      */
-    private function _uniformDefaultPrinter()
+    private static function _pushDeprecationNotice()
     {
-        $info = ['uniform' => false, 'value' => ''];
-        $hostIDs = array_map('intval', (array)$this->obj->get('hosts'));
-        if (count($hostIDs) < 1) {
-            return $info;
-        }
-        $sql = sprintf(
-            'SELECT COUNT(*) AS `n`, '
-            . "COUNT(DISTINCT COALESCE(pa.`paPrinterID`, '')) AS `d`, "
-            . "MIN(COALESCE(pa.`paPrinterID`, '')) AS `v` "
-            . 'FROM `hosts` h '
-            . 'LEFT JOIN `printerAssoc` pa '
-            . 'ON pa.`paHostID` = h.`hostID` AND pa.`paIsDefault` = 1 '
-            . 'WHERE h.`hostID` IN (%s)',
-            implode(',', $hostIDs)
+        return '<div class="alert alert-warning" role="alert">'
+            . '<strong>' . _('Deprecated.') . '</strong> '
+            . _(
+                'This applies the value once, to the hosts that are members '
+                . 'right now. A host added to the group later does not get '
+                . 'it, and a host removed keeps it.'
+            )
+            . ' '
+            . _(
+                'Use "Edit selected hosts" on the Hosts list instead; these '
+                . 'controls will be removed in a later release.'
+            )
+            . '</div>';
+    }
+    /**
+     * The printer this group grants as the default, or 0 for none.
+     *
+     * ADR 0038: one row on the group answers this. It replaces a per-member
+     * COUNT(DISTINCT)/MIN sweep over printerAssoc that could only report
+     * "they all agree on X" or "(varies)", because the group had no default
+     * of its own to report.
+     *
+     * @return int the printer id, or 0
+     */
+    private function _groupDefaultPrinter()
+    {
+        $ids = Route::getIds(
+            'groupprinterassociation',
+            [
+                'groupID' => $this->obj->get('id'),
+                'isDefault' => 1
+            ],
+            'printerID'
         );
-        $row = self::$DB->query($sql)->fetch();
-        $info['uniform'] = ((int)$row->get('n') > 0 && (int)$row->get('d') <= 1);
-        $info['value'] = (string)$row->get('v');
-        return $info;
+        return count((array)$ids) > 0 ? (int)reset($ids) : 0;
     }
     /**
      * Displays the group general tab.
@@ -648,7 +672,8 @@ class GroupManagement extends FOGPage
             '',
             'warning'
         );
-        $alert = '<div class="alert alert-info" role="alert">'
+        $alert = self::_pushDeprecationNotice()
+            . '<div class="alert alert-info" role="alert">'
             . _('Leave a field blank to keep each host\'s current value.')
             . ' '
             . _('Type')
@@ -804,6 +829,7 @@ class GroupManagement extends FOGPage
         echo '<h4 class="card-title">';
         echo _('Group Image Association');
         echo '</h4>';
+        echo self::_pushDeprecationNotice();
         echo '</div>';
         echo '<div class="card-body">';
         echo $rendered;
@@ -889,17 +915,20 @@ class GroupManagement extends FOGPage
     {
         // Printer Associations. Trailing 'printer' opts this tab into the
         // "Create New Printer" button and modal (see renderAssocCreate). The
-        // created printer is associated through this tab's own update URL, i.e.
-        // Group::addPrinter(), which inserts a row per member host -- so the new
-        // printer reaches every host in the group, exactly as "Add selected"
-        // does. The header text already tells the user that.
+        // created printer is granted through this tab's own update URL, i.e.
+        // Group::addPrinter(), which writes one row on the GROUP.
         $this->renderAssocTab(
             'group-printer',
             _('Group Printer Assignment'),
             _('Printer Name'),
             'printer',
             'btn btn-primary float-end',
-            _('This will perform the action on all hosts in this group'),
+            _(
+                'A printer granted here reaches every host in this group, '
+                . 'including hosts added later. Removing a host from the '
+                . 'group takes the printer away again. A printer the host '
+                . 'was given directly is unaffected either way.'
+            ),
             'printer'
         );
 
@@ -923,8 +952,8 @@ class GroupManagement extends FOGPage
         echo _('Group Default Printer');
         echo '</h4>';
         echo '<p class="form-text">';
-        echo _('This will add and set '
-            . '(as needed) the default printer for all hosts in this group');
+        echo _('The default printer for hosts in this group. A host that '
+            . 'has its own default keeps it.');
         echo '</p>';
         echo '</div>';
         echo '<div class="card-body">';
@@ -943,6 +972,7 @@ class GroupManagement extends FOGPage
         echo '<h4 class="card-title">';
         echo _('Group Printer Configuration');
         echo '</h4>';
+        echo self::_pushDeprecationNotice();
         echo '<p class="form-text">';
         echo _('This will set the configuration level to all hosts in this group');
         echo '</p>';
@@ -1080,8 +1110,7 @@ class GroupManagement extends FOGPage
     {
         // Trailing 'snapin' opts this tab into the "Create New Snapin" button
         // and modal (see renderAssocCreate). Association runs through
-        // Group::addSnapin(), which inserts a row per member host, so the new
-        // snapin lands on every host in the group like "Add selected" does.
+        // Group::addSnapin(), which writes one row on the GROUP.
         $this->renderAssocTab(
             'group-snapin',
             _('Group Snapin Assignment'),
@@ -1089,8 +1118,10 @@ class GroupManagement extends FOGPage
             'snapin',
             'btn btn-primary float-end',
             _(
-                'This will perform the action on all hosts in this group. '
-                . 'A snapin is checked when every host in the group has it.'
+                'A snapin granted here reaches every host in this group, '
+                . 'including hosts added later. Granting a snapin does not '
+                . 'run it; deploy it from the Tasks tab when you want it to '
+                . 'run.'
             ),
             'snapin'
         );
@@ -1115,9 +1146,8 @@ class GroupManagement extends FOGPage
         echo '</h4>';
         echo '<p class="form-text">';
         echo _(
-            'Only snapins shared by every host in the group can be ordered '
-            . 'here. Saving sets this order on each host (shared snapins run '
-            . 'first, in this order; any host-specific snapins run after). '
+            'The order this group\'s snapins run in. A host runs its own '
+            . 'snapins first, then the ones granted here, in this order. '
             . 'Order only changes execution when "Abort snapin sequence on '
             . 'failure" is enabled for the task.'
         );
@@ -1156,7 +1186,12 @@ class GroupManagement extends FOGPage
             'btn btn-primary float-end',
             _('Disabled items are not displayed. Legacy items are removed.')
             . '<br/>'
-            . _('Action will be perform on all hosts within this group')
+            . _(
+                'A module granted here is on for every host in this group, '
+                . 'including hosts added later -- unless the host itself '
+                . 'says otherwise. A host set to Off on its own Modules tab '
+                . 'stays off, and no grant can override that.'
+            )
         );
 
         $props = ' method="post" action="'
@@ -1270,6 +1305,7 @@ class GroupManagement extends FOGPage
             echo '<h4 class="card-title">';
             echo _('Group Display Manager Settings');
             echo '</h4>';
+            echo self::_pushDeprecationNotice();
             echo '</div>';
             echo '<div class="card-body">';
             echo self::makeFormTag(
@@ -1342,6 +1378,7 @@ class GroupManagement extends FOGPage
             echo '<h4 class="card-title">';
             echo _('Auto Logout Settings');
             echo '</h4>';
+            echo self::_pushDeprecationNotice();
             echo '<p class="form-text">';
             echo _('Minimum time limit for Auto Logout to become active is 5 minutes.');
             echo '</p>';
@@ -1428,6 +1465,7 @@ class GroupManagement extends FOGPage
         echo '<h4 class="card-title">';
         echo _('Enforce Hostname | AD Join Reboots');
         echo '</h4>';
+        echo self::_pushDeprecationNotice();
         echo '<p class="form-text">';
         echo _(
             'This tells the client to force reboots for host name '
@@ -2799,14 +2837,26 @@ class GroupManagement extends FOGPage
      */
     public function getPrintersList()
     {
-        return $this->_groupAssocList(
+        // ADR 0038: the group owns its printers now, so this is the same
+        // plain association tab the host page uses. It replaces a custom
+        // query that reduced every printer to how its MEMBER hosts covered
+        // it (all/some/none plus an n-of-total badge) -- machinery whose
+        // only job was to reconstruct, after the fact, what the group would
+        // have looked like if it had ever owned anything.
+        $this->assocItemsList(
             'printer',
-            'printerassociation',
-            'printers',
-            'pID',
-            'printerAssoc',
-            'paPrinterID',
-            'paHostID'
+            'groupprinterassociation',
+            'groupPrinterAssoc',
+            '`printers`.`pID`',
+            '`groupPrinterAssoc`.`gpaPrinterID`',
+            '`groupPrinterAssoc`.`gpaGroupID`',
+            [
+                [
+                    'db' => 'groupAssoc',
+                    'dt' => 'association',
+                    'removeFromQuery' => true
+                ]
+            ]
         );
     }
     /**
@@ -2848,22 +2898,19 @@ class GroupManagement extends FOGPage
             '',
             true
         );
-        // Shared-default hint: which printer (if any) every member host
-        // currently has as its default.
-        $def = $this->_uniformDefaultPrinter();
-        if (!$def['uniform']) {
-            $defText = _('(varies)');
-        } elseif ($def['value'] === '' || $def['value'] === '0') {
-            $defText = _('(none on all)');
+        // Which printer this group currently grants as the default. A host
+        // that has chosen its own default still keeps it -- the group's
+        // answer is only used when the host has none.
+        $def = $this->_groupDefaultPrinter();
+        if ($def < 1) {
+            $defText = _('(none)');
         } else {
-            $defText = (
-                isset($printers[$def['value']])
-                ? \Initiator::e($printers[$def['value']])
-                : ('#' . $def['value'])
-            ) . ' ' . _('(all)');
+            $defText = isset($printers[$def])
+                ? \Initiator::e($printers[$def])
+                : ('#' . $def);
         }
         $hint = '<p class="form-text help-block-spaced">'
-            . _('Hosts default:') . ' ' . $defText
+            . _('Group default:') . ' ' . $defText
             . '</p>';
         $this->jsonSend(HTTPResponseCodes::HTTP_SUCCESS, json_encode(
             [
@@ -2879,156 +2926,63 @@ class GroupManagement extends FOGPage
      */
     public function getSnapinsList()
     {
-        return $this->_groupAssocList(
+        // See getPrintersList() for why this is now a plain association tab.
+        $this->assocItemsList(
             'snapin',
-            'snapinassociation',
-            'snapins',
-            'sID',
-            'snapinAssoc',
-            'saSnapinID',
-            'saHostID'
+            'groupsnapinassociation',
+            'groupSnapinAssoc',
+            '`snapins`.`sID`',
+            '`groupSnapinAssoc`.`gsaSnapinID`',
+            '`groupSnapinAssoc`.`gsaGroupID`',
+            [
+                [
+                    'db' => 'groupAssoc',
+                    'dt' => 'association',
+                    'removeFromQuery' => true
+                ]
+            ]
         );
     }
     /**
-     * Builds a group association list with tri-state member coverage.
+     * Returns the snapins this group grants, in run order.
      *
-     * A group owns no associations of its own, so each item is reduced to how
-     * its member hosts cover it: 'all', 'some' or 'none'. getItemsList can only
-     * express a direct association, so we hand it a custom query that computes
-     * the coverage (and the covered-host count + group host total) per item
-     * while complex() still handles paging/search/ordering server-side. The
-     * extra columns surface as `association`, `assocCount` and `assocTotal`.
-     *
-     * @param string $primary      primary node (snapin|module|printer)
-     * @param string $secondary    association node (drives getItemsList naming)
-     * @param string $primaryTable  primary table name
-     * @param string $pkColumn      primary table primary-key column
-     * @param string $assocTable    association table name
-     * @param string $itemColumn    association table item-id column
-     * @param string $hostColumn    association table host-id column
-     * @param string $extraWhere    extra association filter (e.g. enabled only)
-     * @param string $where         primary-row filter passed to getItemsList
-     *
-     * @return void
-     */
-    private function _groupAssocList(
-        $primary,
-        $secondary,
-        $primaryTable,
-        $pkColumn,
-        $assocTable,
-        $itemColumn,
-        $hostColumn,
-        $extraWhere = '',
-        $where = ''
-    ) {
-        $hostIDs = array_map('intval', (array)$this->obj->get('hosts'));
-        $hostCount = count($hostIDs);
-        if ($hostCount > 0) {
-            $sub = sprintf(
-                '(SELECT COUNT(*) FROM `%s` WHERE `%s` = `%s`.`%s` '
-                . 'AND `%s` IN (%s)%s)',
-                $assocTable,
-                $itemColumn,
-                $primaryTable,
-                $pkColumn,
-                $hostColumn,
-                implode(',', $hostIDs),
-                $extraWhere ? ' ' . $extraWhere : ''
-            );
-            $assocExpr = "CASE WHEN $sub = 0 THEN 'none' "
-                . "WHEN $sub = $hostCount THEN 'all' ELSE 'some' END";
-            $countExpr = $sub;
-        } else {
-            $assocExpr = "'none'";
-            $countExpr = '0';
-        }
-        $qStr = 'SELECT `%s`,'
-            . $assocExpr . ' AS `groupAssoc`,'
-            . $countExpr . ' AS `groupAssocCount`,'
-            . $hostCount . ' AS `groupAssocTotal` '
-            . 'FROM `%s` %s %s %s';
-        $addColumns = [
-            ['do' => 'groupAssocCount', 'dt' => 'assocCount'],
-            ['do' => 'groupAssocTotal', 'dt' => 'assocTotal'],
-        ];
-        return $this->obj->getItemsList(
-            $primary,
-            $secondary,
-            [],
-            $where,
-            $addColumns,
-            $qStr,
-            '',
-            '',
-            // Sorting the labels themselves gives all/none/some, because that
-            // is their alphabetical order. Rank them so the column sorts the
-            // way the tri-state reads: fully covered, then partial, then not
-            // covered. Done as an ORDER BY expression over the alias rather
-            // than a second CASE in the SELECT -- the coverage subquery is
-            // correlated and already evaluated three times per row, and MySQL
-            // does not fold identical copies of it together.
-            "FIELD(`groupAssoc`,'all','some','none')"
-        );
-    }
-    /**
-     * Returns the snapins shared by every host in the group, in run order.
+     * ADR 0038: the group owns the rows, so the order is read straight off
+     * gsaSequence. Before the split there was nothing on the group to order,
+     * so this had to intersect every member host's snapinAssoc rows to find
+     * the ones they all shared and guess a starting order from the lowest
+     * sequence any host happened to carry.
      *
      * @return void
      */
     public function getSnapinOrderList()
     {
-        $hostIDs = (array)$this->obj->get('hosts');
-        $hostCount = count($hostIDs);
         $data = [];
-        if ($hostCount > 0) {
-            $assocs = Route::getList(
-                'snapinassociation',
-                ['hostID' => $hostIDs],
-                'AND',
-                'sequence'
-            );
-            $counts = [];
-            $minSeq = [];
-            foreach ($assocs as $assoc) {
-                $sid = (int)$assoc->snapinID;
-                $seq = (int)$assoc->sequence;
-                $counts[$sid] = ($counts[$sid] ?? 0) + 1;
-                if (!isset($minSeq[$sid]) || $seq < $minSeq[$sid]) {
-                    $minSeq[$sid] = $seq;
-                }
+        $grants = Route::getList(
+            'groupsnapinassociation',
+            ['groupID' => $this->obj->get('id')],
+            'AND',
+            'sequence'
+        );
+        $snapinIDs = [];
+        foreach ($grants as $grant) {
+            $snapinIDs[] = (int)$grant->snapinID;
+        }
+        if (count($snapinIDs) > 0) {
+            $names = [];
+            $Snapins = Route::getList('snapin', ['id' => $snapinIDs]);
+            foreach ($Snapins as $Snapin) {
+                $names[(int)$Snapin->id] = $Snapin->name;
             }
-            // Intersection: snapins present on every host.
-            $shared = [];
-            foreach ($counts as $sid => $count) {
-                if ($count === $hostCount) {
-                    $shared[] = $sid;
+            foreach ($snapinIDs as $sid) {
+                // Same contract as the host tab: only list ids that resolve
+                // to a real snapin (skip stale/0 associations).
+                if (!isset($names[$sid])) {
+                    continue;
                 }
-            }
-            // Present them in a sensible starting order (lowest sequence).
-            usort(
-                $shared,
-                function ($a, $b) use ($minSeq) {
-                    return [$minSeq[$a], $a] <=> [$minSeq[$b], $b];
-                }
-            );
-            if (count($shared) > 0) {
-                $Snapins = Route::getList('snapin', ['id' => $shared]);
-                $names = [];
-                foreach ($Snapins as $Snapin) {
-                    $names[(int)$Snapin->id] = $Snapin->name;
-                }
-                foreach ($shared as $sid) {
-                    // Same contract as the host tab: only list ids that
-                    // resolve to a real snapin (skip stale/0 associations).
-                    if (!isset($names[$sid])) {
-                        continue;
-                    }
-                    $data[] = [
-                        'id' => $sid,
-                        'name' => $names[$sid]
-                    ];
-                }
+                $data[] = [
+                    'id' => $sid,
+                    'name' => $names[$sid]
+                ];
             }
         }
         $this->jsonSend(HTTPResponseCodes::HTTP_SUCCESS, json_encode(['data' => $data]));
@@ -3057,89 +3011,28 @@ class GroupManagement extends FOGPage
         $where = "`modules`.`short_name` IN ('"
             . implode("','", $keys)
             . "')";
-        // A module counts as "had" by a host only when enabled (msState=1);
-        // a disabled override (msState=0) keeps the item out of "all".
-        return $this->_groupAssocList(
-            'module',
-            'moduleassociation',
-            'modules',
-            'id',
-            'moduleStatusByHost',
-            'msModuleID',
-            'msHostID',
-            'AND `msState` = 1',
-            $where
-        );
-    }
-    /**
-     * On-demand drill-down for an item in the "some" state: which member
-     * hosts have it (Has set) and which do not (Missing set).
-     *
-     * GET params: assoctype (snapin|module|printer), itemid.
-     *
-     * @return void
-     */
-    public function getAssocHostsList()
-    {
-        header('Content-type: application/json');
-        $map = [
-            'snapin' => [
-                'class' => 'snapinassociation',
-                'itemKey' => 'snapinID',
-                'where' => []
-            ],
-            'printer' => [
-                'class' => 'printerassociation',
-                'itemKey' => 'printerID',
-                'where' => []
-            ],
-            'module' => [
-                'class' => 'moduleassociation',
-                'itemKey' => 'moduleID',
-                'where' => ['state' => 1]
-            ],
+        $join = [
+            'LEFT OUTER JOIN `groupModuleAssoc` '
+            . 'ON `modules`.`id` = `groupModuleAssoc`.`gmaModuleID` '
+            . "AND `groupModuleAssoc`.`gmaGroupID` = '"
+            . $this->obj->get('id')
+            . "'"
         ];
-        $type = (string)filter_input(INPUT_GET, 'assoctype');
-        $itemID = (int)filter_input(INPUT_GET, 'itemid');
-        if (!isset($map[$type]) || $itemID < 1) {
-            $this->jsonSend(HTTPResponseCodes::HTTP_SUCCESS, json_encode(['has' => [], 'missing' => []]));
-        }
-        $hostIDs = array_map('intval', (array)$this->obj->get('hosts'));
-        $names = [];
-        $order = [];
-        if (count($hostIDs) > 0) {
-            $hosts = Route::getList('host', ['id' => $hostIDs]);
-            foreach ($hosts as $host) {
-                $names[(int)$host->id] = $host->name;
-                $order[] = (int)$host->id;
-            }
-        }
-        $has = [];
-        $missing = [];
-        if (count($order) > 0) {
-            $find = array_merge(
-                $map[$type]['where'],
-                [
-                    $map[$type]['itemKey'] => $itemID,
-                    'hostID' => $hostIDs
-                ]
-            );
-            $hasSet = array_flip(
-                array_map('intval', (array)Route::getIds($map[$type]['class'], $find, 'hostID'))
-            );
-            foreach ($order as $hostID) {
-                $entry = [
-                    'id' => $hostID,
-                    'name' => $names[$hostID] ?? ('#' . $hostID)
-                ];
-                if (isset($hasSet[$hostID])) {
-                    $has[] = $entry;
-                } else {
-                    $missing[] = $entry;
-                }
-            }
-        }
-        $this->jsonSend(HTTPResponseCodes::HTTP_SUCCESS, json_encode(['has' => $has, 'missing' => $missing]));
+        // Two states here, not the host tab's three. A grant is
+        // presence-only: a group can turn a module on and cannot turn one
+        // off, so there is no state column to surface (ADR 0038).
+        $columns[] = [
+            'db' => 'groupAssoc',
+            'dt' => 'association',
+            'removeFromQuery' => true
+        ];
+        $this->obj->getItemsList(
+            'module',
+            'groupmoduleassociation',
+            $join,
+            $where,
+            $columns
+        );
     }
     /**
      * Tasking for this group.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -355,12 +355,6 @@ parameters:
 			path: packages/web/src/Pages/GroupManagement.php
 
 		-
-			message: '#^Method FOG\\Pages\\GroupManagement\:\:_groupAssocList\(\) with return type void returns mixed but should not return anything\.$#'
-			identifier: return.void
-			count: 1
-			path: packages/web/src/Pages/GroupManagement.php
-
-		-
 			message: '#^Method FOG\\Pages\\GroupManagement\:\:getHostsList\(\) with return type void returns null but should not return anything\.$#'
 			identifier: return.void
 			count: 1
@@ -412,12 +406,6 @@ parameters:
 			message: '#^Result of method FOG\\Base\\FOGPage\:\:newPMDisplay\(\) \(void\) is used\.$#'
 			identifier: method.void
 			count: 2
-			path: packages/web/src/Pages/GroupManagement.php
-
-		-
-			message: '#^Result of method FOG\\Pages\\GroupManagement\:\:_groupAssocList\(\) \(void\) is used\.$#'
-			identifier: method.void
-			count: 3
 			path: packages/web/src/Pages/GroupManagement.php
 
 		-

--- a/tests/group-grants-are-owned.test.php
+++ b/tests/group-grants-are-owned.test.php
@@ -1,0 +1,462 @@
+<?php
+/**
+ * A group grants; it does not copy.
+ *
+ * ADR 0038's whole point. Before this, Group::addSnapin() wrote one
+ * `snapinAssoc` row per member host -- a bulk write onto the hosts that
+ * existed at the moment the button was pressed. Nothing recorded that the
+ * write had happened, so nothing could replay it: a host added to the group
+ * afterward got nothing, and a host removed kept everything.
+ *
+ * Now the row lands on the GROUP -- `groupSnapinAssoc`, `groupPrinterAssoc`,
+ * `groupModuleAssoc` -- and Assign\Resolver unions it with the host's own
+ * rows at read time.
+ *
+ * WHAT THIS DRIVES:
+ *
+ *   1. The six add/remove methods write the GRANT table and never the host
+ *      association table. Writing both would be the copy arriving by another
+ *      door, and it would look identical from the group page.
+ *   2. None of them reads the member host list. `$this->get('hosts')` inside
+ *      one of these methods IS the copy, whatever it goes on to do with it.
+ *   3. Every write is scoped by groupID. An unscoped DELETE on a grant table
+ *      revokes it for every group on the server.
+ *   4. addSnapin() does not name `sequence`, and addPrinter() does not name
+ *      `isDefault`, in the insert field list. insertBatch upserts on the
+ *      unique key and sets every column it is given, so naming them would
+ *      silently reset an order or a default the admin had chosen -- the same
+ *      trap Host::appendSnapinSequence() documents on the host side.
+ *   5. An unsaved group and an empty id set write nothing at all, and only
+ *      positive integer ids reach the database.
+ *   6. The group page reads the grant tables, and the tri-state member
+ *      coverage machinery it replaces is gone. That vocabulary
+ *      (all/some/none, the n-of-total badge, the Has/Missing drill-down)
+ *      existed only to reconstruct what the group would have looked like if
+ *      it had ever owned anything; leaving it behind would report member
+ *      coverage on a tab that is no longer describing member coverage.
+ *
+ * Usage: php tests/group-grants-are-owned.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+use FOG\Base\FOGCore;
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('group-grants-are-owned');
+
+$t = new FogChecks();
+$db = FogTestHarness::fakeDb();
+$root = dirname(__DIR__) . '/packages/web';
+
+$admin = FOGCore::getClass('User')->set('id', 1)->set('name', 'fog');
+foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
+    FogTestHarness::setStatic($cls, 'FOGUser', $admin);
+}
+FogTestHarness::setStatic('Authorization', '_permCache', [1 => ['*']]);
+
+/**
+ * Runs one Group method and returns the statements it issued.
+ *
+ * @param FogFakeDb $db      the fake
+ * @param string    $method  the method to call
+ * @param mixed     $arg     its single argument
+ * @param int       $groupID the group
+ * @param callable  $respond optional SELECT responder
+ *
+ * @return array the statements issued
+ */
+function runGroup($db, $method, $arg, $groupID = 3, $respond = null)
+{
+    $db->log = [];
+    $db->responder = $respond;
+    FOGCore::getClass('Group')
+        ->set('id', $groupID)
+        ->{$method}($arg);
+    $db->responder = null;
+
+    return $db->log;
+}
+
+/**
+ * The statements that touched one table.
+ *
+ * Scoped on purpose: a run also reads settings and may write a history row,
+ * and counting those would make this assert something other than it says.
+ *
+ * @param array  $log   statements
+ * @param string $table the table name
+ *
+ * @return array
+ */
+function onTable(array $log, $table)
+{
+    $out = [];
+    foreach ($log as $sql) {
+        if (false !== strpos((string)$sql, $table)) {
+            $out[] = (string)$sql;
+        }
+    }
+
+    return $out;
+}
+
+/**
+ * Source with its comments stripped.
+ *
+ * These assertions are about what the code DOES; a comment naming the old
+ * behavior would otherwise fail a check for the old behavior.
+ *
+ * @param string $body source
+ *
+ * @return string
+ */
+function codeOnly($body)
+{
+    $body = preg_replace('#/\*.*?\*/#s', '', (string)$body);
+
+    return (string)preg_replace('#//[^\n]*#', '', (string)$body);
+}
+
+/**
+ * One method's source, comments stripped.
+ *
+ * @param string $src    the file
+ * @param string $method the method name
+ *
+ * @return string
+ */
+function methodBody($src, $method)
+{
+    $start = strpos($src, "\n    public function $method(");
+    if (false === $start) {
+        return '';
+    }
+    $end = strpos($src, "\n    /**", $start + 1);
+
+    return codeOnly(
+        false === $end
+            ? substr($src, $start)
+            : substr($src, $start, $end - $start)
+    );
+}
+
+$groupSrc = (string)file_get_contents($root . '/src/Items/Group.php');
+$pageSrc = (string)file_get_contents($root . '/src/Pages/GroupManagement.php');
+$jsSrc = (string)file_get_contents(
+    $root . '/management/js/fog/group/fog.group.edit.js'
+);
+
+$grants = [
+    'snapin' => ['groupSnapinAssoc', 'snapinAssoc', 'GroupSnapinAssociationManager'],
+    'printer' => ['groupPrinterAssoc', 'printerAssoc', 'GroupPrinterAssociationManager'],
+    'module' => ['groupModuleAssoc', 'moduleStatusByHost', 'GroupModuleAssociationManager'],
+];
+
+// ---------------------------------------------------------------
+// Invariant 1 and 2, read off the source: the grant table, and only it.
+foreach ($grants as $kind => $info) {
+    list($grantTable, $hostTable, $manager) = $info;
+    $add = methodBody($groupSrc, 'add' . ucfirst($kind));
+    $rem = methodBody($groupSrc, 'remove' . ucfirst($kind));
+
+    $t->check(
+        "add$kind() writes through $manager",
+        '' !== $add && false !== strpos($add, $manager)
+    );
+    $t->check(
+        "add$kind() does not read the member host list",
+        '' !== $add && false === strpos($add, "get('hosts')")
+    );
+    $t->check(
+        "remove$kind() does not read the member host list",
+        '' !== $rem && false === strpos($rem, "get('hosts')")
+    );
+    $t->check(
+        "remove$kind() deletes from the grant table, scoped by groupID",
+        false !== strpos($rem, "'group" . $kind . "association'")
+        && false !== strpos($rem, "'groupID'")
+    );
+}
+
+// The host-side managers must not appear in the six methods at all. Named
+// individually rather than swept, so a failure says which one came back.
+foreach (['Snapin', 'Printer', 'Module'] as $kind) {
+    $both = methodBody($groupSrc, 'add' . $kind)
+        . methodBody($groupSrc, 'remove' . $kind);
+    $t->check(
+        "neither add$kind() nor remove$kind() touches {$kind}AssociationManager",
+        false === strpos($both, "getClass('{$kind}AssociationManager')")
+    );
+    $t->check(
+        "nor {$kind}Association through deletemass",
+        false === strpos($both, "'" . strtolower($kind) . "association'")
+    );
+}
+
+// ---------------------------------------------------------------
+// Invariant 4: the columns that carry an admin's decision are left out of
+// the upsert.
+$add = methodBody($groupSrc, 'addSnapin');
+$t->check(
+    'addSnapin() inserts groupID and snapinID only',
+    false !== strpos($add, "['groupID', 'snapinID']")
+    && false === strpos($add, "'sequence'")
+);
+$t->check(
+    'and numbers the new rows afterward instead',
+    false !== strpos($add, 'appendSnapinSequence()')
+);
+$t->check(
+    'addPrinter() inserts groupID and printerID only',
+    false !== strpos(methodBody($groupSrc, 'addPrinter'), "['groupID', 'printerID']")
+    && false === strpos(methodBody($groupSrc, 'addPrinter'), "'isDefault'")
+);
+
+// ---------------------------------------------------------------
+// Behavior. One insert per kind, on the grant table, carrying the group id
+// and no host id.
+$log = runGroup($db, 'addModule', [4, 6]);
+$stmts = onTable($log, 'groupModuleAssoc');
+$t->check(
+    'addModule() writes groupModuleAssoc',
+    1 === count($stmts)
+);
+$sql = implode(' ', $stmts);
+$t->check(
+    'and names no host column',
+    false === stripos($sql, 'hostID') && false === stripos($sql, 'msHostID')
+);
+$t->check(
+    'and it is an upsert, so re-granting is not a unique-key error',
+    false !== stripos($sql, 'ON DUPLICATE KEY UPDATE')
+);
+$t->check(
+    'addModule() writes nothing to moduleStatusByHost',
+    0 === count(onTable($log, 'moduleStatusByHost'))
+);
+
+$log = runGroup($db, 'addPrinter', [8]);
+$t->check(
+    'addPrinter() writes groupPrinterAssoc and not printerAssoc',
+    1 === count(onTable($log, 'groupPrinterAssoc'))
+    && 0 === count(onTable($log, '`printerAssoc`'))
+);
+
+// addSnapin also runs the sequence sweep, which reads its own table first.
+$log = runGroup(
+    $db,
+    'addSnapin',
+    [2],
+    3,
+    function ($sql) {
+        if (false !== strpos($sql, 'groupSnapinAssoc')
+            && 0 === stripos(ltrim($sql), 'SELECT')
+        ) {
+            return [['gsaSnapinID' => 2, 'gsaSequence' => 0, 'gsaID' => 1]];
+        }
+        return null;
+    }
+);
+$t->check(
+    'addSnapin() writes groupSnapinAssoc and not snapinAssoc',
+    count(onTable($log, 'groupSnapinAssoc')) > 0
+    && 0 === count(onTable($log, '`snapinAssoc`'))
+);
+$t->check(
+    'addSnapin() numbers a row that landed at sequence 0',
+    false !== stripos(implode(' ', onTable($log, 'groupSnapinAssoc')), 'UPDATE')
+);
+
+// ---------------------------------------------------------------
+// Invariant 3: the DELETE is bound to this group.
+$log = runGroup($db, 'removeSnapin', [2]);
+$del = implode(' ', onTable($log, 'groupSnapinAssoc'));
+$t->check(
+    'removeSnapin() binds the group id into the DELETE',
+    false !== stripos($del, 'DELETE') && false !== strpos($del, 'gsaGroupID')
+);
+
+// ---------------------------------------------------------------
+// Invariant 5.
+$t->check(
+    'an unsaved group writes nothing',
+    0 === count(onTable(runGroup($db, 'addModule', [4], 0), 'groupModuleAssoc'))
+);
+$t->check(
+    'an empty id set writes nothing',
+    0 === count(onTable(runGroup($db, 'addModule', []), 'groupModuleAssoc'))
+);
+$t->check(
+    'no usable id writes nothing',
+    0 === count(
+        onTable(runGroup($db, 'addModule', ['nope', 0, -2]), 'groupModuleAssoc')
+    )
+);
+$log = runGroup($db, 'addModule', ['4; DROP TABLE `hosts`']);
+$t->check(
+    'a non-numeric id cannot carry SQL through',
+    false === stripos(implode(' ', $log), 'DROP TABLE')
+);
+
+// ---------------------------------------------------------------
+// updateDefault and setSnapinOrder are group-level now.
+$body = methodBody($groupSrc, 'updateDefault');
+$t->check(
+    'updateDefault() writes the grant row, not every member host',
+    false !== strpos($body, 'GroupPrinterAssociationManager')
+    && false === strpos($body, "get('hosts')")
+);
+$log = runGroup($db, 'updateDefault', 8);
+$sql = implode(' ', onTable($log, 'groupPrinterAssoc'));
+$t->check(
+    'updateDefault() clears the old default before setting the new one',
+    2 === count(onTable($log, 'groupPrinterAssoc'))
+    && false !== strpos($sql, 'gpaIsDefault')
+);
+$t->check(
+    'updateDefault(0) clears without setting anything',
+    1 === count(onTable(runGroup($db, 'updateDefault', 0), 'groupPrinterAssoc'))
+);
+$body = methodBody($groupSrc, 'setSnapinOrder');
+$t->check(
+    'setSnapinOrder() writes gsaSequence on the group, not on each host',
+    false !== strpos($body, 'GroupSnapinAssociationManager')
+    && false === strpos($body, "get('hosts')")
+    && false === strpos($body, 'new Host(')
+);
+$log = runGroup($db, 'setSnapinOrder', [5, 6]);
+$t->check(
+    'and one statement per snapin, in the submitted order',
+    2 === count(onTable($log, 'groupSnapinAssoc'))
+);
+
+// ---------------------------------------------------------------
+// Invariant 6: the page reads the grant tables.
+// Both halves, because naming the grant table somewhere in the method is not
+// the same as reading it: the modules tab keeps `groupModuleAssoc` in its ON
+// clause even if the JOIN itself is pointed back at the host state table.
+foreach (
+    [
+        'getSnapinsList' => ['groupSnapinAssoc', 'snapinAssoc'],
+        'getPrintersList' => ['groupPrinterAssoc', 'printerAssoc'],
+        'getModulesList' => ['groupModuleAssoc', 'moduleStatusByHost'],
+    ] as $method => $tables
+) {
+    list($grantTable, $hostTable) = $tables;
+    $body = methodBody($pageSrc, $method);
+    $t->check(
+        "$method() reads $grantTable",
+        false !== strpos($body, $grantTable)
+    );
+    $t->check(
+        "$method() does not read $hostTable",
+        '' !== $body
+        && false === strpos(str_replace($grantTable, '', $body), $hostTable)
+    );
+}
+$t->check(
+    'getSnapinOrderList() reads the group grants, not a member intersection',
+    false !== strpos(
+        methodBody($pageSrc, 'getSnapinOrderList'),
+        "'groupsnapinassociation'"
+    )
+);
+
+// The coverage vocabulary is gone from both halves.
+foreach (['_groupAssocList', 'getAssocHostsList', '_uniformDefaultPrinter'] as $gone) {
+    $t->check(
+        "$gone() is gone from the group page",
+        false === strpos($pageSrc, $gone)
+    );
+}
+foreach (['wireGroupAssocTab', 'groupAssocRender', 'assocCount', 'assoc-drill'] as $gone) {
+    $t->check(
+        "$gone is gone from the group edit script",
+        false === strpos($jsSrc, $gone)
+    );
+}
+
+// ---------------------------------------------------------------
+// The three grant classes exist and are keyed the way the resolver reads
+// them. A field map that disagrees with the schema fails silently: the
+// query compiles against a column that is not there.
+$expect = [
+    'GroupSnapinAssociation' => [
+        'groupSnapinAssoc',
+        ['groupID' => 'gsaGroupID', 'snapinID' => 'gsaSnapinID', 'sequence' => 'gsaSequence'],
+    ],
+    'GroupPrinterAssociation' => [
+        'groupPrinterAssoc',
+        ['groupID' => 'gpaGroupID', 'printerID' => 'gpaPrinterID', 'isDefault' => 'gpaIsDefault'],
+    ],
+    'GroupModuleAssociation' => [
+        'groupModuleAssoc',
+        ['groupID' => 'gmaGroupID', 'moduleID' => 'gmaModuleID'],
+    ],
+];
+$schema = (string)file_get_contents($root . '/commons/schema.php');
+foreach ($expect as $class => $info) {
+    list($table, $fields) = $info;
+    $obj = FOGCore::getClass($class);
+    $ref = new \ReflectionObject($obj);
+    $tProp = $ref->getProperty('databaseTable');
+    $tProp->setAccessible(true);
+    $fProp = $ref->getProperty('databaseFields');
+    $fProp->setAccessible(true);
+    $t->check(
+        "$class is bound to $table",
+        $table === $tProp->getValue($obj)
+    );
+    $map = (array)$fProp->getValue($obj);
+    foreach ($fields as $common => $column) {
+        $t->check(
+            "$class maps $common to $column",
+            isset($map[$common]) && $column === $map[$common]
+        );
+        $t->check(
+            "and schema.php declares `$column`",
+            false !== strpos($schema, '`' . $column . '`')
+        );
+    }
+}
+
+// ---------------------------------------------------------------
+// Decision 10's middle step: the controls that COPY onto member hosts say
+// so, and the grant tabs beside them do not. Getting that backwards would
+// tell an admin the group's snapins are going away, which is the opposite
+// of what this ADR does.
+$notice = '_pushDeprecationNotice';
+$t->check(
+    'the push-deprecation notice exists',
+    false !== strpos($pageSrc, "private static function $notice(")
+);
+foreach (
+    [
+        'groupGeneral',
+        'groupImage',
+        'groupPrinters',
+        'groupModules',
+        'groupPowermanagement',
+    ] as $method
+) {
+    $body = methodBody($pageSrc, $method);
+    // groupPowermanagement is the control: it creates tasks rather than
+    // copying a value, so it must NOT be marked.
+    $want = 'groupPowermanagement' !== $method;
+    $t->check(
+        $want
+            ? "$method() marks its imperative controls deprecated"
+            : "$method() is not marked, because it copies nothing",
+        $want === (false !== strpos($body, $notice))
+    );
+}
+// One per imperative card, not one per tab: the printers and modules tabs
+// each carry a grant tab AND a push control, so a single tab-level banner
+// would condemn the grants too.
+$t->check(
+    'every imperative card carries its own notice',
+    6 === substr_count($pageSrc, "self::$notice()")
+);
+
+$t->finish();


### PR DESCRIPTION
ADR 0038 **unit E**, the declarative half. Closes the last open unit of the group split.

## What was wrong

`Group::addSnapin()`, `addPrinter()` and `addModule()` each wrote **one row per member host** -- a bulk write onto whoever happened to be a member at the moment the button was pressed. Nothing recorded that the write had happened, so nothing could replay it: a host added to the group afterward got nothing, and a host removed kept everything.

## What changed

The row lands on the **group** now -- `groupSnapinAssoc`, `groupPrinterAssoc`, `groupModuleAssoc`, the tables schema steps 403-409 already created -- and `Assign\Resolver` unions it with the host's own rows at read time. All three converted together on purpose: converting one alone would leave the group page granting on one tab and copying on the next.

**What that deletes.** The group page's tri-state coverage vocabulary is gone: `_groupAssocList()`, `getAssocHostsList()`, `_uniformDefaultPrinter()`, and `groupAssocRender()` / `wireGroupAssocTab()` in `fog.group.edit.js` -- between them the All/Some/None checkbox, the `n / total` badge and the Has/Missing host drill-down. All of it existed to reconstruct, after the fact, what a group would have looked like if it had ever owned anything. `getSnapinOrderList()` shrank from an intersection over every member's `snapinAssoc` rows to a read of `gsaSequence`.

The two per-item decisions moved onto the grant row, which is what those columns were added for: **snapin run order** is `gsaSequence` on the group's own rows, and **default printer** is `gpaIsDefault`. A host that chose its own default keeps it.

## Three things worth a reviewer's eye

- **Three new grant classes, deliberately not in `Route::$validClasses`.** `Resolver` reads those tables with raw SQL, which is right for a hot read path and is not a write path. Exposing a new write surface over REST is an access-control decision this ADR never asked for; adding it later is purely additive.
- **`sequence` and `isDefault` are absent from the insert field lists.** `insertBatch()` upserts on the unique key and sets every column it is given, so naming them would reset an admin's run order or default every time an item was re-sent. New rows land at the column default and `Group::appendSnapinSequence()` numbers them afterward -- the same mechanism, for the same reason, as its host-side twin.
- **This is Decision 10's middle step, not its last one.** The units table said "removal of the imperative tabs", which reads past the sequence the decision actually sets: mass edit ships -> the imperative controls are marked deprecated -> they are removed in a **later** release. So the six push-to-all cards (General, Group Image Association, Group Printer Configuration, Group Display Manager Settings, Auto Logout Settings, Enforce Hostname) carry a deprecation notice and **still work**. Power Management does not get one: it creates tasks, it does not copy a value. The notice is per **card** rather than per tab, because the printers and modules tabs each carry a grant tab beside a push control and a tab-level banner would condemn the grants too.

`fog-plugins`' `AddLocationGroup.php` / `AddOUGroup.php` are untouched for the same reason -- they are push controls, and Decision 13 says the page's imperative tabs and the plugins' group tabs come out in the same release.

## Docs

ADR 0001 moves from *amended* to *superseded* (the derivation it documents no longer exists) and is kept, because its correction note is the finding that reversed ADR 0038 decision 3. `GROUP_SHARED_STATE.md`'s associations section is replaced rather than edited. Release notes gain the two user-visible changes.

## Verification

`tests/group-grants-are-owned.test.php` -- **78 checks**. Every one of **sixteen mutations** goes red: the host-side managers coming back, a method reading `get('hosts')` again, an unscoped DELETE, `sequence` named in the upsert, the id filter and unsaved-group guards dropped, the modules tab pointed back at `moduleStatusByHost`, the coverage drill-down restored, the order list intersecting members again, a wrong column in a field map, a card losing its notice, and Power Management wrongly gaining one.

Locally: `sh tests/run-all.sh` -> **298 passed, 0 failed**; both phpstan configs -> `[OK] No errors`. The baseline **shrank** by two entries (`_groupAssocList` is gone); nothing was added to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166dqQEjAs9fhqUw5zCjvxM