### PR TITLE
docs: name unit F's PR now it has one

### DIFF
--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -765,7 +765,7 @@ serialize through conflicts anyway.
 | D3 | Group list "grants" column | `Router/Route.php`, `Pages/GroupManagement.php`, JS | D1 | **merged** (#1643) |
 | E | Group page rework: `Group::addSnapin`/`addPrinter`/`addModule` become grants, the tri-state coverage machinery goes, the imperative controls are marked deprecated | `Items/Group*Association.php`, `Items/Group.php`, `Pages/GroupManagement.php`, JS | **C5 proven** (Decision 10), D, M5 | **merged** (#1647) |
 | E1 | UNKNOWN-4's server half simulated against the real endpoint: revoking a grant removes only the granted printers | `tests/printer-grants-reach-the-client.test.php` | E | **merged** (#1648) |
-| F | Decision 10's last step: the group page's imperative controls REMOVED, after fog-plugins #36 gave `location` and `ou` the same seam | `Pages/GroupManagement.php`, `fog.group.edit.js`, fog-plugins | E, and fog-plugins #36 | **merged** (#PENDING) |
+| F | Decision 10's last step: the group page's imperative controls REMOVED, after fog-plugins #36 gave `location` and `ou` the same seam | `Pages/GroupManagement.php`, `fog.group.edit.js`, fog-plugins | E, and fog-plugins #36 | **merged** (#1651) |
 | E2 | `groups.groupOrder` made settable -- step 404 added the column and the resolver read it, but nothing could ever write it | `Items/Group.php`, `Pages/GroupManagement.php` | E | **merged** (#1649) |
 
 **Two bugs in C5's own surface were found and fixed while D was landing**,


### PR DESCRIPTION
The units table in `docs/development/group-split.md` went in with `#PENDING` — unit F's own commit could not know its PR number. It is #1651.

One line, docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166dqQEjAs9fhqUw5zCjvxM