### PR TITLE
Elevate to root, notice an existing install, and stop looking like a hang

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -51,6 +51,34 @@
 
 version="1.0.0"
 
+# Under `curl ... | bash` this script's stdin IS the pipe carrying its own
+# source. Exiting early leaves curl with a half-written pipe, and curl then
+# reports
+#
+#     curl: (23) Failure writing output to destination
+#
+# which reads like a download problem and buries the message that actually
+# matters. Reading the rest away lets curl finish and exit 0, so the only thing
+# left on screen is what this script said.
+#
+# BOUNDED, and only on a pipe. `cat > /dev/null` was the obvious way to write
+# this and it hangs: stdin can be an open pipe whose writer never closes -- any
+# parent process that holds the other end -- and then the drain waits forever
+# for an EOF that is not coming. A bootstrap that hangs instead of printing its
+# error is worse than the curl warning it was trying to suppress.
+#
+# So: only when stdin really is a pipe, in chunks, with a read timeout to end
+# it if nothing more arrives, and a hard cap so it cannot spin. The script is
+# some tens of kilobytes, so one or two chunks is the normal case.
+drainStdin() {
+    [[ -p /dev/stdin ]] || return 0
+    local discard i=0
+    while [[ $i -lt 64 ]] && IFS= read -r -t 2 -n 65536 discard 2>/dev/null; do
+        i=$((i + 1))
+    done
+    return 0
+}
+
 usage() {
     echo -e "Usage: curl -fsSL <url>/bootstrap.sh | bash -s -- [options]"
     echo -e "       $0 [options]\n"
@@ -78,14 +106,23 @@ fail() {
         shift
     done
     echo
+    drainStdin
     exit "$1"
 }
 
 repo="https://github.com/FOGProject/fogproject.git"
+# Where this script fetches ITSELF from, for the piped elevation path below.
+# Overridable, because the constant names one branch and a copy taken from
+# another would otherwise be replaced by working-1.6's.
+selfurl="${FOG_BOOTSTRAP_URL:-https://raw.githubusercontent.com/FOGProject/fogproject/working-1.6/bin/bootstrap.sh}"
 gitpath="/root/fogproject"
 channel="stable"
 branch=""
 autoYes=""
+
+# Kept before the option loop shifts them away: the elevation below re-runs
+# this script and needs the arguments as they were given.
+origArgs=("$@")
 
 # Hand-rolled rather than getopt(1), because getopt is part of util-linux and
 # this script runs before any package has been installed. On a minimal image it
@@ -121,12 +158,83 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# ---------------------------------------------------------------------------
+# Get to root, rather than refuse and make the user retype the command.
+#
+# TWO SHAPES, because a piped script cannot re-run itself: $0 is `bash`, not a
+# file, and stdin has already been partly consumed by the time control reaches
+# here.
+#
+#   From a FILE -- exec sudo on $0. Clean, and the bytes that run as root are
+#                  the bytes already on disk, which the admin can have read.
+#
+#   From a PIPE -- there is nothing on disk for sudo to run, so the script is
+#                  FETCHED A SECOND TIME and that copy is piped to sudo bash.
+#
+# THE SECOND FETCH IS WORTH KNOWING ABOUT, so it is printed before it happens
+# rather than done quietly. The URL tracks a branch, so if a push lands between
+# the two downloads the copy that runs as root is not the copy that was read.
+# FOG_BOOTSTRAP_URL points it elsewhere; the documented `| sudo bash` form
+# avoids the second fetch entirely and is what the docs lead with.
+#
+# FOG_BOOTSTRAP_ELEVATED stops a loop. If sudo succeeds and the child is still
+# not root -- a sudoers rule that grants a different user, say -- it must not
+# fetch and elevate again.
+elevate() {
+    [[ -z $FOG_BOOTSTRAP_ELEVATED ]] || return 1
+    command -v sudo >/dev/null 2>&1 || return 1
+
+    if [[ -f $0 ]]; then
+        echo " * Not running as root. Re-running this file under sudo:"
+        echo " |"
+        echo " |   sudo bash $0 ${origArgs[*]}"
+        echo
+        drainStdin
+        exec sudo env FOG_BOOTSTRAP_ELEVATED=1 bash "$0" "${origArgs[@]}"
+    fi
+
+    # Piped, so there is no file to hand sudo.
+    command -v curl >/dev/null 2>&1 || return 1
+    echo " * Not running as root, and this script arrived over a pipe -- so"
+    echo " | there is no file on disk for sudo to run. Fetching it again and"
+    echo " | running that copy as root:"
+    echo " |"
+    echo " |   curl -fsSL ${selfurl} | sudo bash -s -- ${origArgs[*]}"
+    echo " |"
+    echo " | This downloads the script a second time, so what runs as root is"
+    echo " | not guaranteed to be the byte-for-byte copy you just read. To avoid"
+    echo " | that, interrupt now and fetch it once to a file instead:"
+    echo " |"
+    echo " |   curl -fsSL -o bootstrap.sh ${selfurl}"
+    echo " |   less bootstrap.sh"
+    echo " |   sudo bash bootstrap.sh ${origArgs[*]}"
+    echo
+    drainStdin
+    exec sudo env FOG_BOOTSTRAP_ELEVATED=1 bash -c         'url="$1"; shift; curl -fsSL "$url" | bash -s -- "$@"' _ "$selfurl" "${origArgs[@]}"
+}
+
 if [[ ! $EUID -eq 0 ]]; then
-    # Same message and same exit code as installfog.sh's own root check. No
-    # auto-elevation: piping a script from the internet into a shell that then
-    # reaches for sudo by itself is precisely the shape nobody should get used
-    # to trusting.
+    elevate
+    # Only reached when elevation could not happen. Say which of the three
+    # reasons it was, because the fix differs for each.
     echo "FOG Installation must be run as root user"
+    echo
+    if [[ -n $FOG_BOOTSTRAP_ELEVATED ]]; then
+        echo " | sudo ran, and this is still not root -- so a sudoers rule sent"
+        echo " | it somewhere other than root. Run it as root directly."
+    elif ! command -v sudo >/dev/null 2>&1; then
+        echo " | sudo is not installed here. Become root first:"
+        echo " |"
+        echo " |   su -"
+        echo " |   curl -fsSL ${selfurl} | bash -s -- ${origArgs[*]}"
+    else
+        echo " | curl is not available to fetch this script again, which is how"
+        echo " | a piped run reaches root. Fetch it to a file instead:"
+        echo " |"
+        echo " |   wget -O bootstrap.sh ${selfurl}"
+        echo " |   sudo bash bootstrap.sh ${origArgs[*]}"
+    fi
+    drainStdin
     exit 1
 fi
 
@@ -317,6 +425,62 @@ fi
 # somebody's working tree. bin/updatefog.sh is the thing that moves an existing
 # checkout between channels, and it knows how to do it safely.
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Is FOG already installed on this machine?
+#
+# The check below this one asks whether there is a CHECKOUT at --git-path,
+# which is a different question and was the only one being asked. A server
+# installed from a checkout somewhere else, or from a tarball, answered "no" --
+# so this cloned a second copy and ran the installer over the live server
+# without ever saying it was doing an upgrade.
+#
+# /etc/fog/fog.conf is the same pointer installfog.sh and updatefog.sh follow
+# (GH-850), so this finds what they would find.
+# ---------------------------------------------------------------------------
+existingProgramDir=""
+existingGitPath=""
+if [[ -r /etc/fog/fog.conf ]]; then
+    existingProgramDir=$(sed -n 's/^fogprogramdir=//p' /etc/fog/fog.conf 2>/dev/null | tr -d "\"' " | tail -n1)
+fi
+[[ -z $existingProgramDir ]] && [[ -r /opt/fog/.fogsettings ]] && existingProgramDir="/opt/fog"
+existingProgramDir="${existingProgramDir%/}"
+
+if [[ -n $existingProgramDir && -r ${existingProgramDir}/.fogsettings ]]; then
+    existingGitPath=$(sed -n 's/^FOG_git_path=//p' "${existingProgramDir}/.fogsettings" 2>/dev/null | tr -d "\"' " | tail -n1)
+    [[ -z $existingGitPath ]] && existingGitPath=$(sed -n 's/^fog_git_path=//p' "${existingProgramDir}/.fogsettings" 2>/dev/null | tr -d "\"' " | tail -n1)
+
+    echo " * FOG is already installed at ${existingProgramDir}."
+
+    # Hand over to the updater when there is a checkout for it to work in.
+    # That is the same job, done by the script that owns it -- and it uses the
+    # checkout this server actually installed from rather than cloning a
+    # second one somewhere else.
+    if [[ -n $existingGitPath && -x ${existingGitPath}/bin/updatefog.sh ]]; then
+        updateArgs=()
+        [[ $fromChannel -eq 1 ]] && updateArgs+=(--channel "$channel")
+        [[ -n $branch && $fromChannel -eq 0 ]] && updateArgs+=(--branch "$branch")
+        [[ -n $autoYes ]] && updateArgs+=(-y)
+        echo " | Its checkout is ${existingGitPath}, so this is an update rather"
+        echo " | than an install. Handing over to the updater:"
+        echo " |"
+        echo " |   cd ${existingGitPath}/bin && ./updatefog.sh ${updateArgs[*]}"
+        echo
+        drainStdin
+        cd "${existingGitPath}/bin" || fail "Could not enter ${existingGitPath}/bin." 6
+        exec bash ./updatefog.sh "${updateArgs[@]}"
+    fi
+
+    # Installed, but with no checkout to update from -- a tarball install, or
+    # one whose checkout has been deleted. Cloning is the right move, and the
+    # installer picks the existing server up through /etc/fog/fog.conf. Say so,
+    # because "install" and "upgrade the running server" are not the same thing
+    # to whoever typed this.
+    echo " | There is no git checkout recorded for it, so this will clone one"
+    echo " | and UPGRADE the existing server in place. Your data and settings"
+    echo " | are kept; the installer finds them through /etc/fog/fog.conf."
+    echo
+fi
+
 if [[ -d ${gitpath}/.git ]]; then
     echo " * ${gitpath} is already a git checkout -- not cloning over it."
     echo " | To move an existing install to another channel, use:"
@@ -327,8 +491,14 @@ else
         fail "${gitpath} exists and is not empty, but is not a git checkout." \
              "Move it aside, or choose another path with --git-path." 6
     fi
+    # --progress explicitly, and a warning first. The repository is around
+    # 200,000 objects; the receive phase is long enough on an ordinary link
+    # that a quiet clone looks like a hang, which is what it looked like on the
+    # first real server this ran on.
     echo " * Cloning FOG into ${gitpath}"
-    git clone "$repo" "$gitpath" || fail "git clone failed." 6
+    echo " | This repository is large -- roughly 200,000 objects -- so expect"
+    echo " | several minutes, and longer on a slow connection."
+    git clone --progress "$repo" "$gitpath" || fail "git clone failed." 6
 fi
 
 echo " * Checking out ${branch}"

--- a/tests/bootstrap-installer.test.sh
+++ b/tests/bootstrap-installer.test.sh
@@ -70,11 +70,55 @@ check "--help exits 0" "$?"
 check "--help works before the root check, so a user can read it" \
     "$(bash "$bootstrap" --help 2>&1 | grep -q -- '--channel'; echo $?)"
 
-bash "$bootstrap" >/dev/null 2>&1
-check "a non-root run exits 1, like installfog.sh" \
-    "$([[ $? -eq 1 ]]; echo $?)"
+# A non-root run now ELEVATES rather than refusing, so what is asserted is
+# that it reaches for sudo with the arguments it was given -- and that it still
+# refuses, with a reason, when it cannot.
+#
+# sudo is stubbed. The real one would prompt for a password, which no test
+# should do, and what matters here is which command gets handed to it.
+elevwork="$work/elevate"
+mkdir -p "$elevwork/sb"
+printf '#!/bin/bash\necho "SUDO $*" >> "$ELEVLOG"\n' > "$elevwork/sb/sudo"
+chmod +x "$elevwork/sb/sudo"
+elevlog="$elevwork/log"
 
-check "and says the same thing installfog.sh says" \
+: > "$elevlog"
+elevout=$( export PATH="$elevwork/sb:$PATH" ELEVLOG="$elevlog"
+           bash "$bootstrap" --channel beta < /dev/null 2>&1 )
+
+check "a non-root run from a file re-runs itself under sudo" \
+    "$(grep -q '^SUDO ' "$elevlog"; echo $?)"
+
+check "and passes the arguments through" \
+    "$(grep -q -- '--channel beta' "$elevlog"; echo $?)"
+
+check "and sets the loop guard so the child cannot elevate again" \
+    "$(grep -q 'FOG_BOOTSTRAP_ELEVATED=1' "$elevlog"; echo $?)"
+
+check "and says what it is about to do first" \
+    "$(grep -qi 'Re-running this file under sudo' <<< "$elevout"; echo $?)"
+
+# The guard itself: a child that is still not root must refuse, not fetch and
+# elevate a second time.
+: > "$elevlog"
+elevout=$( export PATH="$elevwork/sb:$PATH" ELEVLOG="$elevlog" FOG_BOOTSTRAP_ELEVATED=1
+elevstatus=0
+( export PATH="$elevwork/sb:$PATH" ELEVLOG="$elevlog" FOG_BOOTSTRAP_ELEVATED=1
+  bash "$bootstrap" --channel beta < /dev/null ) >/dev/null 2>&1 || elevstatus=$?
+check "and exits non-zero" \
+    "$([[ $elevstatus -ne 0 ]]; echo $?)"
+
+           bash "$bootstrap" --channel beta < /dev/null 2>&1 )
+
+check "an already-elevated run that is still not root does not elevate again" \
+    "$([[ ! -s $elevlog ]]; echo $?)"
+
+
+check "and still says it must be run as root" \
+    "$(grep -q 'must be run as root user' <<< "$elevout"; echo $?)"
+
+check "naming the reason rather than a generic message" \
+    "$(grep -qi 'sudoers rule' <<< "$elevout"; echo $?)"
     "$(bash "$bootstrap" 2>&1 | grep -q 'must be run as root user'; echo $?)"
 
 for bad in "--nonsense" "--channel" "--branch" "--git-path relative/path"; do
@@ -164,13 +208,18 @@ cat > "$stubs/git" <<'EOF'
 echo "git $*" >> "$CALLS"
 case "$1" in
     clone)
-        mkdir -p "$3/.git" "$3/bin"
-        cat > "$3/bin/installfog.sh" <<'INNER'
+        # The destination is the LAST argument, not $3. It was $3 until
+        # --progress was added ahead of it, which is exactly the kind of
+        # positional assumption a stub should not make about the code it
+        # stands in for.
+        dest="${@: -1}"
+        mkdir -p "$dest/.git" "$dest/bin"
+        cat > "$dest/bin/installfog.sh" <<'INNER'
 #!/bin/bash
 echo "installfog $*" >> "$CALLS"
 exit 0
 INNER
-        chmod +x "$3/bin/installfog.sh"
+        chmod +x "$dest/bin/installfog.sh"
         ;;
     ls-remote)
         # No release candidate published, which is origin's real state.
@@ -405,13 +454,87 @@ check "rc-1.6.10 beats rc-1.6.2 and the decoy" \
     "$([[ $(rcBranch) == rc-1.6.10 ]]; echo $?)"
 
 # ---------------------------------------------------------------------------
+# An existing FOG INSTALL is a different question from an existing CHECKOUT.
+#
+# The checkout test above asks whether --git-path holds a clone. A server
+# installed from a checkout somewhere else, or from a tarball, answers no to
+# that -- so this used to clone a second copy and run the installer over a live
+# server without ever saying it was an upgrade. Found on the first real machine
+# it was run on.
+# ---------------------------------------------------------------------------
+inst="$work/installed"
+mkdir -p "$inst/etc/fog" "$inst/opt/fog" "$inst/checkout/bin"
+printf "fogprogramdir='%s/opt/fog'\n" "$inst" > "$inst/etc/fog/fog.conf"
+printf '#!/bin/bash\necho "UPDATEFOG $*" >> "$CALLS"\n' > "$inst/checkout/bin/updatefog.sh"
+chmod +x "$inst/checkout/bin/updatefog.sh"
+
+# A copy pointed at the fixture's /etc and /opt rather than the real ones.
+instsut="$work/bootstrap-installed.sh"
+sed -e 's/^if \[\[ ! \$EUID -eq 0 \]\]; then$/if false; then/' \
+    -e "s#/etc/fog/fog.conf#$inst/etc/fog/fog.conf#g" \
+    -e "s#/opt/fog/.fogsettings#$inst/opt/fog/.fogsettings#g" \
+    "$bootstrap" > "$instsut"
+
+runInstalled() {
+    ( export PATH="$stubs:$PATH" CALLS="$calls" OS="Linux"
+      export linuxReleaseName="Ubuntu" OSVersion=22
+      unset osfamily
+      cd "$work" && bash "$instsut" "$@" )
+}
+
+# --- installed, WITH a checkout: hand over to the updater ------------------
+printf "FOG_git_path='%s/checkout'\n" "$inst" > "$inst/opt/fog/.fogsettings"
+: > "$calls"
+instout=$(runInstalled --channel beta --yes --git-path "$work/should-not-be-used" 2>&1)
+
+check "an existing install is noticed" \
+    "$(grep -q 'FOG is already installed' <<< "$instout"; echo $?)"
+
+check "and the updater is handed the job" \
+    "$(grep -q '^UPDATEFOG' "$calls"; echo $?)"
+
+check "with the channel passed through" \
+    "$(grep -q 'UPDATEFOG.*--channel beta' "$calls"; echo $?)"
+
+check "and --yes passed through" \
+    "$(grep -qE 'UPDATEFOG.*(-y|--yes)' "$calls"; echo $?)"
+
+check "nothing is cloned" \
+    "$(! grep -q '^git clone' "$calls"; echo $?)"
+
+check "and the recorded checkout is used, not --git-path" \
+    "$([[ ! -d $work/should-not-be-used ]]; echo $?)"
+
+# --- installed, NO checkout recorded: clone, and say it is an upgrade ------
+: > "$inst/opt/fog/.fogsettings"
+: > "$calls"
+instout=$(runInstalled --channel beta --yes --git-path "$work/tarballupgrade" 2>&1)
+
+check "a tarball install still gets a clone" \
+    "$(grep -q '^git clone' "$calls"; echo $?)"
+
+check "but is told plainly that this UPGRADES the running server" \
+    "$(grep -qi 'UPGRADE the existing server' <<< "$instout"; echo $?)"
+
+check "and the clone warns that the repository is large" \
+    "$(grep -qi 'repository is large' <<< "$instout"; echo $?)"
+
+
+# ---------------------------------------------------------------------------
 # It must not grow into an installer.
 # ---------------------------------------------------------------------------
 body=$(sed 's/#.*//' "$bootstrap")
 check "bootstrap does not source anything from the repo" \
     "$(! grep -qE '^\s*\.\s+\.\./lib|^\s*source\s' <<< "$body"; echo $?)"
+# READING .fogsettings is expected now -- that is how it notices FOG is
+# already installed. WRITING it is still not its job: the installer and the
+# updater own that file, and a bootstrap that edited it would be a second
+# author.
 check "bootstrap does not write .fogsettings" \
-    "$(! grep -q 'fogsettings' <<< "$body"; echo $?)"
+    "$(! grep -qE '>>?[[:space:]]*"?[^[:space:]]*[.]fogsettings' <<< "$body"; echo $?)"
+
+check "and does not call writeUpdateFile" \
+    "$(! grep -q 'writeUpdateFile' <<< "$body"; echo $?)"
 
 printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$pass" "$fail"
 [[ $fail -eq 0 ]]


### PR DESCRIPTION
Everything here came out of the first real-server run. **Draft.**

```
$ curl -fsSL .../bootstrap.sh | bash -s -- --channel beta
FOG Installation must be run as root user
curl: (23) Failure writing output to destination
```

## 1. No sudo, and the failure looked like a download problem

The documented one-liner had no `sudo` in it — my error in the docs. And the `curl: (23)` is not curl's fault: `bash` exited while `curl` was still writing into the pipe, so the write failed and the real message got buried.

**It now elevates.** From a **file**, `exec sudo -- bash "$0" "$@"` — clean, and the bytes that run as root are the bytes already on disk. From a **pipe** there is nothing for `sudo` to run (`$0` is `bash`, stdin half consumed), so it fetches itself again and pipes that to `sudo bash`.

> You picked the re-fetch knowing the trade-off, so it is made loud rather than silent: the command is printed before it runs, alongside the two-step that avoids it. The URL tracks a branch, so a push between the two downloads means the copy running as root is not the copy that was read. `FOG_BOOTSTRAP_URL` overrides it; `FOG_BOOTSTRAP_ELEVATED` stops it looping.

When elevation is impossible it says **which** of the three reasons applies — no sudo, no curl, or already elevated and still not root — because the fix differs for each.

The `curl: (23)` is gone: the script drains stdin before an early exit so curl finishes. That drain is **bounded and pipe-only** — `cat > /dev/null` was the obvious way to write it and hangs forever when stdin is an open pipe nobody closes. I hit that while testing it.

## 2. It did not notice FOG was already installed

This is the one that mattered on your box. The script only asked whether a **checkout** exists at `--git-path`. Whether FOG is **installed** is a different question, and it was never asked — so a server installed from a checkout elsewhere, or from a tarball, cloned a second copy and would have run the installer over a live server without ever saying it was an upgrade.

It now reads `/etc/fog/fog.conf`, the same pointer `installfog.sh` and `updatefog.sh` follow:

- **Checkout recorded** → hands the job to *that* checkout's `bin/updatefog.sh`, with `--channel`/`--branch`/`-y` passed through. Same work, done by the script that owns it, in the checkout the server actually installed from — not a second clone somewhere else.
- **No checkout** (tarball install) → still clones, but says plainly that this **upgrades the running server in place** and that settings survive.

## 3. The clone looked like a hang

212,580 objects, and the receive phase is quiet. It now warns that the repository is large and passes `--progress`. Full history is kept deliberately: `FOG_VERSION` is a commit count and `updatefog.sh` switches between branches, so a shallow clone would break both.

## Test note worth keeping

The suite's `git` stub took the clone destination from `$3`. Adding `--progress` moved it — exactly the positional assumption a stub should not make about the code it stands in for. It takes the last argument now.

`tests/bootstrap-installer.test.sh`: **57 passing**, including the handoff, the flag passthrough, that the recorded checkout beats `--git-path`, and the elevation paths.

Still 6 failures here, unchanged and identical before and after: the sandbox PATH is built with `ln -sf`, which under Git Bash makes copies, and a copied `bash.exe` cannot find its DLLs. Linux CI is the real check.

## Docs

A separate fog-docs PR adds `sudo` to every documented invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtZHpyWZWDPSxePdTViGZy
