### PR TITLE
A group GRANTS a power schedule; it does not copy one

### DIFF
--- a/docs/adr/0031-referential-integrity-is-declared-in-the-database.md
+++ b/docs/adr/0031-referential-integrity-is-declared-in-the-database.md
@@ -15,7 +15,7 @@ windowskey 2, ldap 6, oidc 8, capone 2, subnetgroup 1 -- are declared in
 core's map and applied by a step in each plugin's own `schema()` in
 `FOGProject/fog-plugins`.
 
-**107 of the map's 122 relationships are declared.** The other 15 are not
+**108 of the map's 123 relationships are declared.** The other 15 are not
 pending work: they carry action `none`, which the map's docblock defines as a
 decision rather than an omission. Nine are audit rows, which MUST NOT
 constrain the thing they record (ADR 0021, `schema.php` step 341); six are

--- a/docs/development/foreign-keys.md
+++ b/docs/development/foreign-keys.md
@@ -603,7 +603,7 @@ half-converted column.
 ## Phase D — plugins, and the direction rule
 
 18 plugin tables ship in `FOGProject/fog-plugins`. All 18 clone cleanly into
-the survey and 25 of the map's 122 relationships live in them.
+the survey and 25 of the map's 123 relationships live in them.
 
 ### Direction is the whole rule
 

--- a/packages/web/commons/schema-constraints.php
+++ b/packages/web/commons/schema-constraints.php
@@ -308,6 +308,19 @@ return [
     // module inherited the number.
     ['child' => 'groupModuleAssoc', 'column' => 'gmaGroupID', 'parent' => 'groups', 'pcolumn' => 'groupID', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 10],
     ['child' => 'groupModuleAssoc', 'column' => 'gmaModuleID', 'parent' => 'modules', 'pcolumn' => 'id', 'class' => 'junction', 'action' => 'CASCADE', 'enabled' => true, 'group' => 10],
+    // ADR 0038: Power Management is the fourth grant. Group 11, created
+    // empty by step 410 so there is nothing to sweep before the flip.
+    //
+    // `satellite` rather than `junction`, and it sits with the grants
+    // above rather than in the satellite block, because it is one of
+    // them: the class is about SHAPE and the placement is about what the
+    // row is for. A schedule references only its group -- there is no
+    // second end to link to -- which is the same shape as
+    // powerManagement.pmHostID one level down. CASCADE for the reason
+    // group 9 gives, with a sharper edge here: an orphan schedule left
+    // against a reused group id would silently start shutting down every
+    // host that inherited the number.
+    ['child' => 'groupPowerManagement', 'column' => 'gpmGroupID', 'parent' => 'groups', 'pcolumn' => 'groupID', 'class' => 'satellite', 'action' => 'CASCADE', 'enabled' => true, 'group' => 11],
     ['child' => 'ldapUserGrant', 'column' => 'lugTargetID', 'parent' => '(lugTargetType)', 'pcolumn' => '-', 'class' => 'poly', 'action' => 'none'],
     ['child' => 'oidcUserGrant', 'column' => 'ougTargetID', 'parent' => '(ougTargetType)', 'pcolumn' => '-', 'class' => 'poly', 'action' => 'none'],
 ];

--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -214,6 +214,19 @@ return [
                 'gmaModuleID' => 'int(11) NOT NULL',
             ],
         ],
+        'groupPowerManagement' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `groupPowerManagement` ( `gpmID` int(11) NOT NULL AUTO_INCREMENT, `gpmGroupID` int(11) NOT NULL, `gpmMin` varchar(50) NOT NULL DEFAULT \'\', `gpmHour` varchar(50) NOT NULL DEFAULT \'\', `gpmDom` varchar(50) NOT NULL DEFAULT \'\', `gpmMonth` varchar(50) NOT NULL DEFAULT \'\', `gpmDow` varchar(50) NOT NULL DEFAULT \'\', `gpmAction` enum(\'shutdown\',\'reboot\',\'wol\') NOT NULL, PRIMARY KEY (`gpmID`), UNIQUE KEY `gpmCron` (`gpmGroupID`,`gpmMin`,`gpmHour`,`gpmDom`,`gpmMonth`,`gpmDow`,`gpmAction`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'gpmID' => 'int(11) NOT NULL',
+                'gpmGroupID' => 'int(11) NOT NULL',
+                'gpmMin' => 'varchar(50) NOT NULL DEFAULT \'\'',
+                'gpmHour' => 'varchar(50) NOT NULL DEFAULT \'\'',
+                'gpmDom' => 'varchar(50) NOT NULL DEFAULT \'\'',
+                'gpmMonth' => 'varchar(50) NOT NULL DEFAULT \'\'',
+                'gpmDow' => 'varchar(50) NOT NULL DEFAULT \'\'',
+                'gpmAction' => 'enum(\'shutdown\',\'reboot\',\'wol\') NOT NULL',
+            ],
+        ],
         'groupPrinterAssoc' => [
             'create' => 'CREATE TABLE IF NOT EXISTS `groupPrinterAssoc` ( `gpaID` int(11) NOT NULL AUTO_INCREMENT, `gpaGroupID` int(11) NOT NULL, `gpaPrinterID` int(11) NOT NULL, `gpaIsDefault` tinyint(1) NOT NULL DEFAULT 0, PRIMARY KEY (`gpaID`), UNIQUE KEY `gpaGroupPrinter` (`gpaGroupID`,`gpaPrinterID`), KEY `gpaPrinterID` (`gpaPrinterID`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -10574,3 +10574,73 @@ $this->schema[] = [
     "ALTER TABLE `moduleStatusByHost` MODIFY `msState` tinyint(1) "
     . "NOT NULL DEFAULT 1",
 ];
+
+// 410
+$this->schema[] = [
+    // ADR 0038: Power Management becomes the fourth grant.
+    //
+    // It was the last control on the group page that still FANNED OUT. Saving
+    // a schedule wrote one `powerManagement` row per host that happened to be
+    // a member at that instant, recorded nothing about where the rows came
+    // from, and so could not be replayed: a host added afterward got no
+    // schedule, a host removed kept one forever, and "Delete All" reached only
+    // the current membership. The group page's own text said "to all hosts in
+    // this group", which was true at the moment of the press and false by the
+    // next membership change.
+    //
+    // THERE IS NO `gpmOndemand` COLUMN, and its absence is the design.
+    // `powerManagement.pmOndemand` marks a row that is not a schedule at all
+    // -- an immediate shutdown, reboot or wake, consumed and deleted on the
+    // next client check-in. That is a TASK: it acts on the membership at the
+    // moment you start it, which is exactly what a task should do and exactly
+    // what a grant must not do. A grant of "shut down immediately" would fire
+    // again for every host that joined the group afterward. Immediate actions
+    // therefore stay a fan-out and move to the task surface; only the
+    // SCHEDULE, which is a standing statement about the group, becomes a row
+    // here.
+    //
+    // The unique key mirrors `powerManagement`.`cron` for the same reason it
+    // exists there: insertBatch() UPSERTS, so saving an identical schedule
+    // twice must be a no-op rather than a second row that fires the same
+    // action a second time.
+    //
+    // Empty on creation and nothing migrated, exactly as steps 403 and 407 did
+    // for the other three grants (decision 18). The rows on hosts today are
+    // indistinguishable from ones an admin set per-host -- that is the whole
+    // defect -- so there is nothing to migrate FROM. Every host keeps
+    // precisely the schedules it has, and a group gains its grant when someone
+    // sets one.
+    "CREATE TABLE IF NOT EXISTS `groupPowerManagement` ( "
+    . "`gpmID` int(11) NOT NULL AUTO_INCREMENT, "
+    . "`gpmGroupID` int(11) NOT NULL, "
+    . "`gpmMin` varchar(50) NOT NULL DEFAULT '', "
+    . "`gpmHour` varchar(50) NOT NULL DEFAULT '', "
+    . "`gpmDom` varchar(50) NOT NULL DEFAULT '', "
+    . "`gpmMonth` varchar(50) NOT NULL DEFAULT '', "
+    . "`gpmDow` varchar(50) NOT NULL DEFAULT '', "
+    . "`gpmAction` enum('shutdown','reboot','wol') NOT NULL, "
+    . "PRIMARY KEY (`gpmID`), "
+    . "UNIQUE KEY `gpmCron` "
+    . "(`gpmGroupID`,`gpmMin`,`gpmHour`,`gpmDom`,`gpmMonth`,`gpmDow`,`gpmAction`) "
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci "
+    . "ROW_FORMAT=DYNAMIC",
+];
+
+// 411
+// The foreign key for the table step 410 just created, per ADR 0031.
+//
+// Group 11, and like groups 7 through 10 it has nothing to sweep first: a
+// table created empty one step earlier cannot hold an orphan.
+//
+// `satellite`, not `junction`, and CASCADE. It matches
+// `powerManagement`.`pmHostID`, which is the same shape one level down: a
+// schedule is wholly owned by the thing it schedules and has no meaning
+// without it. Leaving the row behind would offer a schedule against a group
+// id that has since been reused, and every host in the group that inherited
+// the number would silently start shutting down.
+$this->schema[] =
+    function () {
+        \FOG\Db\SchemaReconciler::applyConstraints(11);
+
+        return true;
+    };

--- a/packages/web/management/js/fog/group/fog.group.edit.js
+++ b/packages/web/management/js/fog/group/fog.group.edit.js
@@ -415,29 +415,34 @@
 
     // ---------------------------------------------------------------
     // POWER MANAGEMENT TAB
-    var powermanagementForm = $('#group-powermanagement-cron-form'),
-        powermanagementFormBtn = $('#powermanagement-send'),
-        powermanagementDeleteBtn = $('#powermanagement-delete'),
+    //
+    // ADR 0038: the grid lists the GROUP'S OWN grants -- one row per schedule
+    // the group grants, not a summary of what its member hosts hold. It reads
+    // ?sub=getGrouppowermanagementList, a page endpoint rather than a REST
+    // route, for the reason GroupManagement::getGrouppowermanagementList()
+    // gives.
+    var powermanagementDeleteBtn = $('#powermanagement-delete'),
         powermanagementDeleteModal = $('#deletepowermanagementmodal'),
-        powermanagementDeleteCancelBtn = $('#deletepowermanagementCancel'),
         powermanagementDeleteConfirmBtn = $('#deletepowermanagementConfirm'),
+        pmGrantDelete = $('#pm-delete'),
         ondemandModalBtn = $('#ondemandBtn'),
+        ondemandModal = $('#ondemandModal'),
         ondemandModalConfirmBtn = $('#ondemandCreateBtn'),
         scheduleModalBtn = $('#scheduleBtn'),
+        scheduleModal = $('#scheduleModal'),
         scheduleModalConfirmBtn = $('#scheduleCreateBtn'),
-        // Insert Form cron elements.
-        minutes = $('.cronmin', powermanagementForm),
-        hours = $('.cronhour', powermanagementForm),
-        dom = $('.crondom', powermanagementForm),
-        month = $('.cronmonth', powermanagementForm),
-        dow = $('.crondow', powermanagementForm),
-        ondemand = $('#scheduleOnDemand', powermanagementForm),
-        action = $('.pmaction', powermanagementForm);
+        instantForm = $('#group-powermanagement-instant-form'),
+        scheduleForm = $('#group-powermanagement-cron-form'),
+        minutes = $('.cronmin', scheduleForm),
+        hours = $('.cronhour', scheduleForm),
+        dom = $('.crondom', scheduleForm),
+        month = $('.cronmonth', scheduleForm),
+        dow = $('.crondow', scheduleForm);
 
     $('.fogcron').cron({
         initial: '* * * * *',
         onChange: function() {
-            vals = $(this).cron('value').split(' ');
+            var vals = $(this).cron('value').split(' ');
             minutes.val(vals[0]);
             hours.val(vals[1]);
             dom.val(vals[2]);
@@ -445,90 +450,140 @@
             dow.val(vals[4]);
         }
     });
-    // When On Demand checked remove the cron layout.
-    ondemand.on('change', function(e) {
-        if (!this.checked) {
-            return;
+
+    // No select callback: the delete button posts the ticked ids and an empty
+    // post is a no-op, which is how the host page's identical grid behaves.
+    // A disable-on-empty handler here would have to agree with registerTable's
+    // notion of "selected" on first draw, and getting that wrong leaves the
+    // button dead rather than merely unhelpful.
+    var powermanagementTable = $('#group-powermanagement-table').registerTable(null, {
+        columns: [
+            {data: 'id'},
+            {data: 'action'}
+        ],
+        columnDefs: [
+            {
+                targets: 0,
+                // The five cron fields joined for display. escapeHtml on each
+                // rather than $.escapedColumn on the column, because the cell
+                // is built from five values and there is no single one to
+                // escape.
+                render: function(data, type, row) {
+                    return escapeHtml(row.min)
+                        + ' '
+                        + escapeHtml(row.hour)
+                        + ' '
+                        + escapeHtml(row.dom)
+                        + ' '
+                        + escapeHtml(row.month)
+                        + ' '
+                        + escapeHtml(row.dow);
+                }
+            }
+        ],
+        rowId: 'id',
+        processing: true,
+        serverSide: true,
+        ajax: {
+            url: '../management/index.php?node='
+                + Common.node
+                + '&sub=getGrouppowermanagementList&id='
+                + Common.id,
+            type: 'post'
         }
-        $(this).parents('.card-body').find('.form-group:eq(0)').find(':input').prop('disabled', true);
-    });
-    ondemand.on('change', function(e) {
-        if (this.checked) {
-            return;
-        }
-        $(this).parents('.card-body').find('.form-group:eq(0)').find(':input').prop('disabled', false);
     });
 
-    powermanagementForm.on('submit', function(e) {
+    scheduleForm.on('submit', function(e) {
         e.preventDefault();
     });
-    powermanagementFormBtn.on('click', function() {
-        powermanagementFormBtn.prop('disabled', true);
-        powermanagementForm.processForm(function(err) {
-            powermanagementFormBtn.prop('disabled', false);
+    instantForm.on('submit', function(e) {
+        e.preventDefault();
+    });
+
+    // New scheduled grant.
+    scheduleModalBtn.on('click', function(e) {
+        e.preventDefault();
+        scheduleModal.modal('show');
+    });
+    scheduleModal.registerModal(
+        function(e) {
+            scheduleModalConfirmBtn.on('click', function() {
+                $(this).prop('disabled', true);
+                scheduleForm.processForm(function(err) {
+                    scheduleModalConfirmBtn.prop('disabled', false);
+                    if (err) {
+                        return;
+                    }
+                    scheduleModal.modal('hide');
+                    powermanagementTable.draw(false);
+                });
+            });
+        },
+        function(e) {
+            $(this).modal('hide');
+        }
+    );
+
+    // New immediate task. Still a fan-out, so it changes nothing in the grid
+    // above -- no redraw, because no grant was created.
+    ondemandModalBtn.on('click', function(e) {
+        e.preventDefault();
+        ondemandModal.modal('show');
+    });
+    ondemandModal.registerModal(
+        function(e) {
+            ondemandModalConfirmBtn.on('click', function() {
+                $(this).prop('disabled', true);
+                instantForm.processForm(function(err) {
+                    ondemandModalConfirmBtn.prop('disabled', false);
+                    if (err) {
+                        return;
+                    }
+                    ondemandModal.modal('hide');
+                });
+            });
+        },
+        function(e) {
+            $(this).modal('hide');
+        }
+    );
+
+    // Revoke the ticked grants.
+    pmGrantDelete.on('click', function(e) {
+        e.preventDefault();
+        var method = $(this).attr('method'),
+            action = $(this).attr('action'),
+            toDel = $.getSelectedIds(powermanagementTable),
+            opts = {
+                pmremove: 1,
+                remgrants: toDel
+            };
+        $.apiCall(method, action, opts, function(err) {
             if (err) {
                 return;
             }
-            minutes.val('');
-            hours.val('');
-            dom.val('');
-            month.val('');
-            dow.val('');
-            action.val('');
-            specialCrons.val('');
-            ondemand.prop('checked', false).trigger('change');
+            powermanagementTable.draw(false);
+            powermanagementTable.rows({selected: true}).deselect();
         });
     });
-    // Powermanagement delete confirmation modal.
+
+    // The legacy sweep: member hosts' OWN rows, not this group's grants.
     powermanagementDeleteBtn.on('click', function(e) {
         e.preventDefault();
         powermanagementDeleteModal.modal('show');
     });
-
-    // Modal Confirmed
     powermanagementDeleteConfirmBtn.on('click', function(e) {
         e.preventDefault();
-        // Our Powermanagement Items.
         var method = $(this).attr('method'),
             action = $(this).attr('action'),
             opts = {
                 pmdelete: 1
             };
-        $.apiCall(method,action,opts,function(err) {
+        $.apiCall(method, action, opts, function(err) {
             if (err) {
                 return;
             }
             powermanagementDeleteModal.modal('hide');
-        });
-    });
-    // New ondemand element.
-    ondemandModalBtn.on('click', function(e) {
-        e.preventDefault();
-        $('#ondemandModal').modal('show');
-    });
-    ondemandModalConfirmBtn.on('click', function(e) {
-        e.preventDefault();
-        var form = $('#group-powermanagement-instant-form');
-        form.processForm(function(err) {
-            if (err) {
-                return;
-            }
-            $('#ondemandModal').modal('hide');
-        });
-    });
-    // New scheduled element.
-    scheduleModalBtn.on('click', function(e) {
-        e.preventDefault();
-        $('#scheduleModal').modal('show');
-    });
-    scheduleModalConfirmBtn.on('click', function(e) {
-        e.preventDefault();
-        var form = $('#group-powermanagement-cron-form');
-        form.processForm(function(err) {
-            if (err) {
-                return;
-            }
-            $('#scheduleModal').modal('hide');
         });
     });
 

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1737,6 +1737,10 @@ msgstr ""
 msgid "Clear one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Clear schedules from member hosts"
+msgstr "plane Power"
+
 msgid "Click"
 msgstr "Klicken Sie"
 
@@ -2139,6 +2143,10 @@ msgid "Create New Windows Key"
 msgstr "Neuen Drucker erstellen"
 
 #, fuzzy
+msgid "Create Scheduled Power grant"
+msgstr "plane Power"
+
+#, fuzzy
 msgid "Create Scheduled Power task"
 msgstr "plane Power"
 
@@ -2347,13 +2355,6 @@ msgstr "Verzögert"
 
 msgid "Delete"
 msgstr "Löschen"
-
-#, fuzzy
-msgid "Delete All"
-msgstr "Löschen fehlgeschlagen"
-
-msgid "Delete All Powermanagement Items"
-msgstr ""
 
 #, fuzzy
 msgid "Delete Fail"
@@ -2775,6 +2776,9 @@ msgid "Every file was uploaded."
 msgstr "Keine Datei wurde hochgeladen"
 
 msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
+
+msgid "Every host in this group runs these schedules, including hosts added later. Nothing is written onto a host; a host keeps its own schedules as well."
 msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
@@ -3270,6 +3274,9 @@ msgstr "FOG-Forum"
 msgid "Found"
 msgstr "Gefundene"
 
+msgid "Found a group wake on lan grant that should run."
+msgstr ""
+
 msgid "Found a scheduled task that should run."
 msgstr ""
 
@@ -3403,6 +3410,10 @@ msgid "Got in line at"
 msgstr ""
 
 #, fuzzy
+msgid "Grant sent to group"
+msgstr "Ausgewählte Speichergruppen hinzufügen"
+
+#, fuzzy
 msgid "Granted To"
 msgstr "Erstellt von"
 
@@ -3534,6 +3545,10 @@ msgstr "Gruppe aktualisiert"
 #, fuzzy
 msgid "Group Order"
 msgstr "Gruppe"
+
+#, fuzzy
+msgid "Group Power Management Task run time"
+msgstr "Power Management"
 
 msgid "Group Primary Disk"
 msgstr "Primäre Festplatte der Gruppe"
@@ -6916,6 +6931,10 @@ msgid "Power Management"
 msgstr "Power Management"
 
 #, fuzzy
+msgid "Power Management Grants"
+msgstr "Power Management"
+
+#, fuzzy
 msgid "Power Management Task run time"
 msgstr "Power Management"
 
@@ -9582,7 +9601,13 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
+msgstr ""
+
+msgid "This deletes the power management schedules held by the hosts that are in this group right now. It does NOT touch this group's grants, and it also removes schedules those hosts were given individually."
 msgstr ""
 
 msgid "This directory does not advertise support for nested group chaining, so the chain strategy would match nothing. Use the expand strategy instead."
@@ -9759,9 +9784,6 @@ msgstr ""
 
 msgid "This will allow you to configure how services"
 msgstr "Hiermit können Sie konfigurieren, "
-
-msgid "This will delete all powermanagement items from all hosts in this group"
-msgstr ""
 
 msgid "This would leave no account able to administer FOG without its identity provider."
 msgstr ""
@@ -10202,9 +10224,6 @@ msgid "Use extreme caution with this setting"
 msgstr "Seien Sie seeehr vorsichtig mit diesen Einstellungen"
 
 msgid "Use processEvent instead"
-msgstr ""
-
-msgid "Use the buttons below to create a new power management task to all hosts in this group."
 msgstr ""
 
 #, fuzzy
@@ -11844,10 +11863,6 @@ msgstr ""
 #~ msgstr "Benutzer hinzufügen fehlgeschlagen!"
 
 #, fuzzy
-#~ msgid "Add selected to group"
-#~ msgstr "Ausgewählte Speichergruppen hinzufügen"
-
-#, fuzzy
 #~ msgid "Administrator Group"
 #~ msgstr "Admingruppe"
 
@@ -11904,6 +11919,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "Pfad ist nicht verfügbar"
+
+#, fuzzy
+#~ msgid "Delete All"
+#~ msgstr "Löschen fehlgeschlagen"
 
 #, fuzzy
 #~ msgid "Deprecated."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1739,6 +1739,10 @@ msgstr ""
 msgid "Clear one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Clear schedules from member hosts"
+msgstr "Scheduler"
+
 msgid "Click"
 msgstr "Click"
 
@@ -2142,6 +2146,10 @@ msgid "Create New Windows Key"
 msgstr "Create New %s"
 
 #, fuzzy
+msgid "Create Scheduled Power grant"
+msgstr "Scheduler"
+
+#, fuzzy
 msgid "Create Scheduled Power task"
 msgstr "Scheduler"
 
@@ -2350,13 +2358,6 @@ msgstr "Delayed"
 
 msgid "Delete"
 msgstr "Delete"
-
-#, fuzzy
-msgid "Delete All"
-msgstr "Delete file data"
-
-msgid "Delete All Powermanagement Items"
-msgstr ""
 
 #, fuzzy
 msgid "Delete Fail"
@@ -2777,6 +2778,9 @@ msgid "Every file was uploaded."
 msgstr "No file was uploaded"
 
 msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
+
+msgid "Every host in this group runs these schedules, including hosts added later. Nothing is written onto a host; a host keeps its own schedules as well."
 msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
@@ -3272,6 +3276,9 @@ msgstr "FOG Forums"
 msgid "Found"
 msgstr ""
 
+msgid "Found a group wake on lan grant that should run."
+msgstr ""
+
 msgid "Found a scheduled task that should run."
 msgstr ""
 
@@ -3403,6 +3410,10 @@ msgstr "Location Updated"
 
 msgid "Got in line at"
 msgstr ""
+
+#, fuzzy
+msgid "Grant sent to group"
+msgstr "Remove selected snapins"
 
 #, fuzzy
 msgid "Granted To"
@@ -3537,6 +3548,10 @@ msgstr "Group added"
 #, fuzzy
 msgid "Group Order"
 msgstr "Group"
+
+#, fuzzy
+msgid "Group Power Management Task run time"
+msgstr "User Management"
 
 msgid "Group Primary Disk"
 msgstr "Group Primary Disk"
@@ -6927,6 +6942,10 @@ msgid "Power Management"
 msgstr "User Management"
 
 #, fuzzy
+msgid "Power Management Grants"
+msgstr "User Management"
+
+#, fuzzy
 msgid "Power Management Task run time"
 msgstr "User Management"
 
@@ -9590,7 +9609,13 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
+msgstr ""
+
+msgid "This deletes the power management schedules held by the hosts that are in this group right now. It does NOT touch this group's grants, and it also removes schedules those hosts were given individually."
 msgstr ""
 
 msgid "This directory does not advertise support for nested group chaining, so the chain strategy would match nothing. Use the expand strategy instead."
@@ -9766,9 +9791,6 @@ msgid "This tells the client to force reboots for host name changing and AD Join
 msgstr ""
 
 msgid "This will allow you to configure how services"
-msgstr ""
-
-msgid "This will delete all powermanagement items from all hosts in this group"
 msgstr ""
 
 msgid "This would leave no account able to administer FOG without its identity provider."
@@ -10210,9 +10232,6 @@ msgid "Use extreme caution with this setting"
 msgstr ""
 
 msgid "Use processEvent instead"
-msgstr ""
-
-msgid "Use the buttons below to create a new power management task to all hosts in this group."
 msgstr ""
 
 #, fuzzy
@@ -11844,10 +11863,6 @@ msgstr ""
 #~ msgstr "Add snapin failed!"
 
 #, fuzzy
-#~ msgid "Add selected to group"
-#~ msgstr "Remove selected snapins"
-
-#, fuzzy
 #~ msgid "Administrator Group"
 #~ msgstr "Modify Group"
 
@@ -11901,6 +11916,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "No hash available"
+
+#, fuzzy
+#~ msgid "Delete All"
+#~ msgstr "Delete file data"
 
 #, fuzzy
 #~ msgid "Deprecated."

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1757,6 +1757,10 @@ msgstr ""
 msgid "Clear one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Clear schedules from member hosts"
+msgstr "Programador"
+
 msgid "Click"
 msgstr "Hacer clic"
 
@@ -2161,6 +2165,10 @@ msgid "Create New Windows Key"
 msgstr "Crear nuevo grupo"
 
 #, fuzzy
+msgid "Create Scheduled Power grant"
+msgstr "Programador"
+
+#, fuzzy
 msgid "Create Scheduled Power task"
 msgstr "Programador"
 
@@ -2375,13 +2383,6 @@ msgstr "Retrasado"
 
 msgid "Delete"
 msgstr "Borrar"
-
-#, fuzzy
-msgid "Delete All"
-msgstr "Eliminar los datos del archivo"
-
-msgid "Delete All Powermanagement Items"
-msgstr ""
 
 #, fuzzy
 msgid "Delete Fail"
@@ -2811,6 +2812,9 @@ msgid "Every file was uploaded."
 msgstr "Ningún archivo fue subido"
 
 msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
+
+msgid "Every host in this group runs these schedules, including hosts added later. Nothing is written onto a host; a host keeps its own schedules as well."
 msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
@@ -3321,6 +3325,9 @@ msgstr "Foros FOG"
 msgid "Found"
 msgstr ""
 
+msgid "Found a group wake on lan grant that should run."
+msgstr ""
+
 msgid "Found a scheduled task that should run."
 msgstr ""
 
@@ -3452,6 +3459,10 @@ msgstr "información de LDAP actualizado!"
 
 msgid "Got in line at"
 msgstr ""
+
+#, fuzzy
+msgid "Grant sent to group"
+msgstr "Impresora"
 
 #, fuzzy
 msgid "Granted To"
@@ -3587,6 +3598,10 @@ msgstr "grupo añadió"
 #, fuzzy
 msgid "Group Order"
 msgstr "Grupo"
+
+#, fuzzy
+msgid "Group Power Management Task run time"
+msgstr "Gestión de usuarios"
 
 msgid "Group Primary Disk"
 msgstr "Disco de grupo primario"
@@ -7046,6 +7061,10 @@ msgid "Power Management"
 msgstr "Gestión de usuarios"
 
 #, fuzzy
+msgid "Power Management Grants"
+msgstr "Gestión de usuarios"
+
+#, fuzzy
 msgid "Power Management Task run time"
 msgstr "Gestión de usuarios"
 
@@ -9756,7 +9775,13 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
+msgstr ""
+
+msgid "This deletes the power management schedules held by the hosts that are in this group right now. It does NOT touch this group's grants, and it also removes schedules those hosts were given individually."
 msgstr ""
 
 msgid "This directory does not advertise support for nested group chaining, so the chain strategy would match nothing. Use the expand strategy instead."
@@ -9928,9 +9953,6 @@ msgid "This tells the client to force reboots for host name changing and AD Join
 msgstr ""
 
 msgid "This will allow you to configure how services"
-msgstr ""
-
-msgid "This will delete all powermanagement items from all hosts in this group"
 msgstr ""
 
 msgid "This would leave no account able to administer FOG without its identity provider."
@@ -10373,9 +10395,6 @@ msgid "Use extreme caution with this setting"
 msgstr ""
 
 msgid "Use processEvent instead"
-msgstr ""
-
-msgid "Use the buttons below to create a new power management task to all hosts in this group."
 msgstr ""
 
 #, fuzzy
@@ -12007,10 +12026,6 @@ msgstr ""
 #~ msgstr "Añadir fallidos SNAPin!"
 
 #, fuzzy
-#~ msgid "Add selected to group"
-#~ msgstr "Impresora"
-
-#, fuzzy
 #~ msgid "Administrator Group"
 #~ msgstr "modificar Grupo"
 
@@ -12061,6 +12076,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "No se dispone de hash"
+
+#, fuzzy
+#~ msgid "Delete All"
+#~ msgstr "Eliminar los datos del archivo"
 
 #, fuzzy
 #~ msgid "Deprecated."

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1737,6 +1737,10 @@ msgstr ""
 msgid "Clear one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Clear schedules from member hosts"
+msgstr "plane Power"
+
 msgid "Click"
 msgstr "Klicken Sie"
 
@@ -2139,6 +2143,10 @@ msgid "Create New Windows Key"
 msgstr "Neuen Drucker erstellen"
 
 #, fuzzy
+msgid "Create Scheduled Power grant"
+msgstr "plane Power"
+
+#, fuzzy
 msgid "Create Scheduled Power task"
 msgstr "plane Power"
 
@@ -2347,13 +2355,6 @@ msgstr "Verzögert"
 
 msgid "Delete"
 msgstr "Löschen"
-
-#, fuzzy
-msgid "Delete All"
-msgstr "Löschen fehlgeschlagen"
-
-msgid "Delete All Powermanagement Items"
-msgstr ""
 
 #, fuzzy
 msgid "Delete Fail"
@@ -2775,6 +2776,9 @@ msgid "Every file was uploaded."
 msgstr "Keine Datei wurde hochgeladen"
 
 msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
+
+msgid "Every host in this group runs these schedules, including hosts added later. Nothing is written onto a host; a host keeps its own schedules as well."
 msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
@@ -3270,6 +3274,9 @@ msgstr "FOG-Forum"
 msgid "Found"
 msgstr "Gefundene"
 
+msgid "Found a group wake on lan grant that should run."
+msgstr ""
+
 msgid "Found a scheduled task that should run."
 msgstr ""
 
@@ -3403,6 +3410,10 @@ msgid "Got in line at"
 msgstr ""
 
 #, fuzzy
+msgid "Grant sent to group"
+msgstr "Ausgewählte Speichergruppen hinzufügen"
+
+#, fuzzy
 msgid "Granted To"
 msgstr "Erstellt von"
 
@@ -3534,6 +3545,10 @@ msgstr "Gruppe aktualisiert"
 #, fuzzy
 msgid "Group Order"
 msgstr "Gruppe"
+
+#, fuzzy
+msgid "Group Power Management Task run time"
+msgstr "Power Management"
 
 msgid "Group Primary Disk"
 msgstr "Primäre Festplatte der Gruppe"
@@ -6917,6 +6932,10 @@ msgid "Power Management"
 msgstr "Power Management"
 
 #, fuzzy
+msgid "Power Management Grants"
+msgstr "Power Management"
+
+#, fuzzy
 msgid "Power Management Task run time"
 msgstr "Power Management"
 
@@ -9583,7 +9602,13 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
+msgstr ""
+
+msgid "This deletes the power management schedules held by the hosts that are in this group right now. It does NOT touch this group's grants, and it also removes schedules those hosts were given individually."
 msgstr ""
 
 msgid "This directory does not advertise support for nested group chaining, so the chain strategy would match nothing. Use the expand strategy instead."
@@ -9760,9 +9785,6 @@ msgstr ""
 
 msgid "This will allow you to configure how services"
 msgstr "Hiermit können Sie konfigurieren, "
-
-msgid "This will delete all powermanagement items from all hosts in this group"
-msgstr ""
 
 msgid "This would leave no account able to administer FOG without its identity provider."
 msgstr ""
@@ -10203,9 +10225,6 @@ msgid "Use extreme caution with this setting"
 msgstr "Seien Sie seeehr vorsichtig mit diesen Einstellungen"
 
 msgid "Use processEvent instead"
-msgstr ""
-
-msgid "Use the buttons below to create a new power management task to all hosts in this group."
 msgstr ""
 
 #, fuzzy
@@ -11845,10 +11864,6 @@ msgstr ""
 #~ msgstr "Benutzer hinzufügen fehlgeschlagen!"
 
 #, fuzzy
-#~ msgid "Add selected to group"
-#~ msgstr "Ausgewählte Speichergruppen hinzufügen"
-
-#, fuzzy
 #~ msgid "Administrator Group"
 #~ msgstr "Admingruppe"
 
@@ -11905,6 +11920,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "Pfad ist nicht verfügbar"
+
+#, fuzzy
+#~ msgid "Delete All"
+#~ msgstr "Löschen fehlgeschlagen"
 
 #, fuzzy
 #~ msgid "Deprecated."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1741,6 +1741,10 @@ msgstr ""
 msgid "Clear one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Clear schedules from member hosts"
+msgstr "Planificateur"
+
 msgid "Click"
 msgstr "Cliquez"
 
@@ -2143,6 +2147,10 @@ msgid "Create New Windows Key"
 msgstr "Créer un nouveau %s"
 
 #, fuzzy
+msgid "Create Scheduled Power grant"
+msgstr "Planificateur"
+
+#, fuzzy
 msgid "Create Scheduled Power task"
 msgstr "Planificateur"
 
@@ -2351,13 +2359,6 @@ msgstr "Différé"
 
 msgid "Delete"
 msgstr "Effacer"
-
-#, fuzzy
-msgid "Delete All"
-msgstr "Supprimer les données de fichiers"
-
-msgid "Delete All Powermanagement Items"
-msgstr ""
 
 #, fuzzy
 msgid "Delete Fail"
@@ -2778,6 +2779,9 @@ msgid "Every file was uploaded."
 msgstr "Aucun fichier a été téléchargé"
 
 msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
+
+msgid "Every host in this group runs these schedules, including hosts added later. Nothing is written onto a host; a host keeps its own schedules as well."
 msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
@@ -3273,6 +3277,9 @@ msgstr "BROUILLARD Forums"
 msgid "Found"
 msgstr ""
 
+msgid "Found a group wake on lan grant that should run."
+msgstr ""
+
 msgid "Found a scheduled task that should run."
 msgstr ""
 
@@ -3404,6 +3411,10 @@ msgstr "Emplacement Mise à jour"
 
 msgid "Got in line at"
 msgstr ""
+
+#, fuzzy
+msgid "Grant sent to group"
+msgstr "Imprimante"
 
 #, fuzzy
 msgid "Granted To"
@@ -3538,6 +3549,10 @@ msgstr "Groupe ajouté"
 #, fuzzy
 msgid "Group Order"
 msgstr "Groupe"
+
+#, fuzzy
+msgid "Group Power Management Task run time"
+msgstr "Gestion des utilisateurs"
 
 msgid "Group Primary Disk"
 msgstr "Primary Disk Group"
@@ -6914,6 +6929,10 @@ msgid "Power Management"
 msgstr "Gestion des utilisateurs"
 
 #, fuzzy
+msgid "Power Management Grants"
+msgstr "Gestion des utilisateurs"
+
+#, fuzzy
 msgid "Power Management Task run time"
 msgstr "Gestion des utilisateurs"
 
@@ -9575,7 +9594,13 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
+msgstr ""
+
+msgid "This deletes the power management schedules held by the hosts that are in this group right now. It does NOT touch this group's grants, and it also removes schedules those hosts were given individually."
 msgstr ""
 
 msgid "This directory does not advertise support for nested group chaining, so the chain strategy would match nothing. Use the expand strategy instead."
@@ -9751,9 +9776,6 @@ msgid "This tells the client to force reboots for host name changing and AD Join
 msgstr ""
 
 msgid "This will allow you to configure how services"
-msgstr ""
-
-msgid "This will delete all powermanagement items from all hosts in this group"
 msgstr ""
 
 msgid "This would leave no account able to administer FOG without its identity provider."
@@ -10196,9 +10218,6 @@ msgid "Use extreme caution with this setting"
 msgstr ""
 
 msgid "Use processEvent instead"
-msgstr ""
-
-msgid "Use the buttons below to create a new power management task to all hosts in this group."
 msgstr ""
 
 #, fuzzy
@@ -11830,10 +11849,6 @@ msgstr ""
 #~ msgstr "Ajouter SnapIn a échoué!"
 
 #, fuzzy
-#~ msgid "Add selected to group"
-#~ msgstr "Imprimante"
-
-#, fuzzy
 #~ msgid "Administrator Group"
 #~ msgstr "Modifier Groupe"
 
@@ -11887,6 +11902,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "Pas de hachage disponible"
+
+#, fuzzy
+#~ msgid "Delete All"
+#~ msgstr "Supprimer les données de fichiers"
 
 #, fuzzy
 #~ msgid "Deprecated."

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1694,6 +1694,10 @@ msgstr ""
 msgid "Clear one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Clear schedules from member hosts"
+msgstr "Pianifica spegnimento"
+
 msgid "Click"
 msgstr "Click"
 
@@ -2082,6 +2086,10 @@ msgid "Create New Windows Key"
 msgstr "Crea nuova stampante"
 
 #, fuzzy
+msgid "Create Scheduled Power grant"
+msgstr "Pianifica spegnimento"
+
+#, fuzzy
 msgid "Create Scheduled Power task"
 msgstr "Pianifica spegnimento"
 
@@ -2288,13 +2296,6 @@ msgstr "Ritardato"
 
 msgid "Delete"
 msgstr "cancellare"
-
-#, fuzzy
-msgid "Delete All"
-msgstr "Cancellare i file"
-
-msgid "Delete All Powermanagement Items"
-msgstr ""
 
 #, fuzzy
 msgid "Delete Fail"
@@ -2709,6 +2710,9 @@ msgid "Every file was uploaded."
 msgstr "Nessun file è stato caricato"
 
 msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
+
+msgid "Every host in this group runs these schedules, including hosts added later. Nothing is written onto a host; a host keeps its own schedules as well."
 msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
@@ -3190,6 +3194,9 @@ msgstr "FOG Forum"
 msgid "Found"
 msgstr "Trovato"
 
+msgid "Found a group wake on lan grant that should run."
+msgstr ""
+
 msgid "Found a scheduled task that should run."
 msgstr ""
 
@@ -3317,6 +3324,10 @@ msgstr "Posizione aggiornata!"
 
 msgid "Got in line at"
 msgstr ""
+
+#, fuzzy
+msgid "Grant sent to group"
+msgstr "Aggiungi gruppo di archiviazione selezionato"
 
 #, fuzzy
 msgid "Granted To"
@@ -3448,6 +3459,10 @@ msgstr "Gruppo aggiornato!"
 #, fuzzy
 msgid "Group Order"
 msgstr "Gruppo"
+
+#, fuzzy
+msgid "Group Power Management Task run time"
+msgstr "Gestione energetica"
 
 msgid "Group Primary Disk"
 msgstr "Gruppo di dischi primario"
@@ -6713,6 +6728,10 @@ msgid "Power Management"
 msgstr "Gestione energetica"
 
 #, fuzzy
+msgid "Power Management Grants"
+msgstr "Gestione energetica"
+
+#, fuzzy
 msgid "Power Management Task run time"
 msgstr "Gestione energetica"
 
@@ -9292,7 +9311,13 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
+msgstr ""
+
+msgid "This deletes the power management schedules held by the hosts that are in this group right now. It does NOT touch this group's grants, and it also removes schedules those hosts were given individually."
 msgstr ""
 
 msgid "This directory does not advertise support for nested group chaining, so the chain strategy would match nothing. Use the expand strategy instead."
@@ -9464,9 +9489,6 @@ msgstr ""
 
 msgid "This will allow you to configure how services"
 msgstr "Ciò consentirà di configurare come servizi"
-
-msgid "This will delete all powermanagement items from all hosts in this group"
-msgstr ""
 
 msgid "This would leave no account able to administer FOG without its identity provider."
 msgstr ""
@@ -9899,9 +9921,6 @@ msgid "Use extreme caution with this setting"
 msgstr "Usa la massima attenzione con questa impostazione"
 
 msgid "Use processEvent instead"
-msgstr ""
-
-msgid "Use the buttons below to create a new power management task to all hosts in this group."
 msgstr ""
 
 #, fuzzy
@@ -11468,10 +11487,6 @@ msgstr ""
 #~ msgstr "Aggiunta utente fallita!"
 
 #, fuzzy
-#~ msgid "Add selected to group"
-#~ msgstr "Aggiungi gruppo di archiviazione selezionato"
-
-#, fuzzy
 #~ msgid "Administrator Group"
 #~ msgstr "Gruppo amministrativo"
 
@@ -11528,6 +11543,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "Percorso non disponibile"
+
+#, fuzzy
+#~ msgid "Delete All"
+#~ msgstr "Cancellare i file"
 
 #, fuzzy
 #~ msgid "Deprecated."

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1678,6 +1678,10 @@ msgstr "すべてのフィールドをクリアしますか？"
 msgid "Clear one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Clear schedules from member hosts"
+msgstr "電源管理をスケジュール"
+
 msgid "Click"
 msgstr "クリック"
 
@@ -2066,6 +2070,10 @@ msgid "Create New Windows Key"
 msgstr "新しい Windows キー"
 
 #, fuzzy
+msgid "Create Scheduled Power grant"
+msgstr "電源管理をスケジュール"
+
+#, fuzzy
 msgid "Create Scheduled Power task"
 msgstr "電源管理をスケジュール"
 
@@ -2274,14 +2282,6 @@ msgstr "遅延"
 
 msgid "Delete"
 msgstr "削除"
-
-#, fuzzy
-msgid "Delete All"
-msgstr "削除に失敗しました"
-
-#, fuzzy
-msgid "Delete All Powermanagement Items"
-msgstr "新しい電源管理タスク"
 
 msgid "Delete Fail"
 msgstr "削除に失敗しました"
@@ -2695,6 +2695,9 @@ msgid "Every file was uploaded."
 msgstr "ファイルはアップロードされませんでした"
 
 msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
+
+msgid "Every host in this group runs these schedules, including hosts added later. Nothing is written onto a host; a host keeps its own schedules as well."
 msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
@@ -3167,6 +3170,10 @@ msgstr "FOG フォーラム"
 msgid "Found"
 msgstr "見つかりました"
 
+#, fuzzy
+msgid "Found a group wake on lan grant that should run."
+msgstr "実行予定の Wake-on-LAN タスクが見つかりました。"
+
 msgid "Found a scheduled task that should run."
 msgstr "実行予定のスケジュールタスクが見つかりました。"
 
@@ -3293,6 +3300,10 @@ msgstr "ロケーションを更新しました！"
 
 msgid "Got in line at"
 msgstr "キューに登録されました:"
+
+#, fuzzy
+msgid "Grant sent to group"
+msgstr "選択したストレージグループを追加"
 
 #, fuzzy
 msgid "Granted To"
@@ -3423,6 +3434,10 @@ msgstr "グループを更新しました！"
 #, fuzzy
 msgid "Group Order"
 msgstr "グループ"
+
+#, fuzzy
+msgid "Group Power Management Task run time"
+msgstr "電源管理タスク実行時刻"
 
 msgid "Group Primary Disk"
 msgstr "グループプライマリディスク"
@@ -6685,6 +6700,10 @@ msgstr "Postfix では login アクションが必要です"
 msgid "Power Management"
 msgstr "電源管理"
 
+#, fuzzy
+msgid "Power Management Grants"
+msgstr "電源管理"
+
 msgid "Power Management Task run time"
 msgstr "電源管理タスク実行時刻"
 
@@ -9238,7 +9257,13 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
+msgstr ""
+
+msgid "This deletes the power management schedules held by the hosts that are in this group right now. It does NOT touch this group's grants, and it also removes schedules those hosts were given individually."
 msgstr ""
 
 msgid "This directory does not advertise support for nested group chaining, so the chain strategy would match nothing. Use the expand strategy instead."
@@ -9410,9 +9435,6 @@ msgstr ""
 
 msgid "This will allow you to configure how services"
 msgstr "ここではサービスの動作を設定できます"
-
-msgid "This will delete all powermanagement items from all hosts in this group"
-msgstr ""
 
 msgid "This would leave no account able to administer FOG without its identity provider."
 msgstr ""
@@ -9843,9 +9865,6 @@ msgid "Use extreme caution with this setting"
 msgstr "この設定は十分注意して使用してください"
 
 msgid "Use processEvent instead"
-msgstr ""
-
-msgid "Use the buttons below to create a new power management task to all hosts in this group."
 msgstr ""
 
 #, fuzzy
@@ -11448,10 +11467,6 @@ msgstr ""
 #~ msgid "Add selected rules"
 #~ msgstr "選択したルールを追加"
 
-#, fuzzy
-#~ msgid "Add selected to group"
-#~ msgstr "選択したストレージグループを追加"
-
 #~ msgid "Additional MACs"
 #~ msgstr "追加の MAC アドレス"
 
@@ -11690,6 +11705,14 @@ msgstr ""
 
 #~ msgid "Delayed Start"
 #~ msgstr "遅延開始"
+
+#, fuzzy
+#~ msgid "Delete All"
+#~ msgstr "削除に失敗しました"
+
+#, fuzzy
+#~ msgid "Delete All Powermanagement Items"
+#~ msgstr "新しい電源管理タスク"
 
 #~ msgid "Delete Selected Items"
 #~ msgstr "選択した項目を削除"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1502,6 +1502,9 @@ msgstr ""
 msgid "Clear one of your preferences"
 msgstr ""
 
+msgid "Clear schedules from member hosts"
+msgstr ""
+
 msgid "Click"
 msgstr ""
 
@@ -1841,6 +1844,9 @@ msgstr ""
 msgid "Create New Windows Key"
 msgstr ""
 
+msgid "Create Scheduled Power grant"
+msgstr ""
+
 msgid "Create Scheduled Power task"
 msgstr ""
 
@@ -2023,12 +2029,6 @@ msgid "Delayed"
 msgstr ""
 
 msgid "Delete"
-msgstr ""
-
-msgid "Delete All"
-msgstr ""
-
-msgid "Delete All Powermanagement Items"
 msgstr ""
 
 msgid "Delete Fail"
@@ -2396,6 +2396,9 @@ msgid "Every file was uploaded."
 msgstr ""
 
 msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
+
+msgid "Every host in this group runs these schedules, including hosts added later. Nothing is written onto a host; a host keeps its own schedules as well."
 msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
@@ -2819,6 +2822,9 @@ msgstr ""
 msgid "Found"
 msgstr ""
 
+msgid "Found a group wake on lan grant that should run."
+msgstr ""
+
 msgid "Found a scheduled task that should run."
 msgstr ""
 
@@ -2938,6 +2944,9 @@ msgstr ""
 msgid "Got in line at"
 msgstr ""
 
+msgid "Grant sent to group"
+msgstr ""
+
 msgid "Granted To"
 msgstr ""
 
@@ -3044,6 +3053,9 @@ msgid "Group OU Updated!"
 msgstr ""
 
 msgid "Group Order"
+msgstr ""
+
+msgid "Group Power Management Task run time"
 msgstr ""
 
 msgid "Group Primary Disk"
@@ -5905,6 +5917,9 @@ msgstr ""
 msgid "Power Management"
 msgstr ""
 
+msgid "Power Management Grants"
+msgstr ""
+
 msgid "Power Management Task run time"
 msgstr ""
 
@@ -8193,7 +8208,13 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
+msgstr ""
+
+msgid "This deletes the power management schedules held by the hosts that are in this group right now. It does NOT touch this group's grants, and it also removes schedules those hosts were given individually."
 msgstr ""
 
 msgid "This directory does not advertise support for nested group chaining, so the chain strategy would match nothing. Use the expand strategy instead."
@@ -8361,9 +8382,6 @@ msgid "This tells the client to force reboots for host name changing and AD Join
 msgstr ""
 
 msgid "This will allow you to configure how services"
-msgstr ""
-
-msgid "This will delete all powermanagement items from all hosts in this group"
 msgstr ""
 
 msgid "This would leave no account able to administer FOG without its identity provider."
@@ -8744,9 +8762,6 @@ msgid "Use extreme caution with this setting"
 msgstr ""
 
 msgid "Use processEvent instead"
-msgstr ""
-
-msgid "Use the buttons below to create a new power management task to all hosts in this group."
 msgstr ""
 
 msgid "Use the default init"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1740,6 +1740,10 @@ msgstr ""
 msgid "Clear one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Clear schedules from member hosts"
+msgstr "Scheduler"
+
 msgid "Click"
 msgstr "Clique"
 
@@ -2142,6 +2146,10 @@ msgid "Create New Windows Key"
 msgstr "Criar novo %s"
 
 #, fuzzy
+msgid "Create Scheduled Power grant"
+msgstr "Scheduler"
+
+#, fuzzy
 msgid "Create Scheduled Power task"
 msgstr "Scheduler"
 
@@ -2350,13 +2358,6 @@ msgstr "atrasado"
 
 msgid "Delete"
 msgstr "Excluir"
-
-#, fuzzy
-msgid "Delete All"
-msgstr "Apagar dados de arquivo"
-
-msgid "Delete All Powermanagement Items"
-msgstr ""
 
 #, fuzzy
 msgid "Delete Fail"
@@ -2777,6 +2778,9 @@ msgid "Every file was uploaded."
 msgstr "Nenhum arquivo foi transferido"
 
 msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
+
+msgid "Every host in this group runs these schedules, including hosts added later. Nothing is written onto a host; a host keeps its own schedules as well."
 msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
@@ -3272,6 +3276,9 @@ msgstr "FOG Fóruns"
 msgid "Found"
 msgstr ""
 
+msgid "Found a group wake on lan grant that should run."
+msgstr ""
+
 msgid "Found a scheduled task that should run."
 msgstr ""
 
@@ -3403,6 +3410,10 @@ msgstr "Localização Atualizado"
 
 msgid "Got in line at"
 msgstr ""
+
+#, fuzzy
+msgid "Grant sent to group"
+msgstr "Impressora"
 
 #, fuzzy
 msgid "Granted To"
@@ -3537,6 +3548,10 @@ msgstr "grupo adicionado"
 #, fuzzy
 msgid "Group Order"
 msgstr "Grupo"
+
+#, fuzzy
+msgid "Group Power Management Task run time"
+msgstr "Gerenciamento de usuários"
 
 msgid "Group Primary Disk"
 msgstr "Primary Disk grupo"
@@ -6914,6 +6929,10 @@ msgid "Power Management"
 msgstr "Gerenciamento de usuários"
 
 #, fuzzy
+msgid "Power Management Grants"
+msgstr "Gerenciamento de usuários"
+
+#, fuzzy
 msgid "Power Management Task run time"
 msgstr "Gerenciamento de usuários"
 
@@ -9577,7 +9596,13 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
+msgstr ""
+
+msgid "This deletes the power management schedules held by the hosts that are in this group right now. It does NOT touch this group's grants, and it also removes schedules those hosts were given individually."
 msgstr ""
 
 msgid "This directory does not advertise support for nested group chaining, so the chain strategy would match nothing. Use the expand strategy instead."
@@ -9753,9 +9778,6 @@ msgid "This tells the client to force reboots for host name changing and AD Join
 msgstr ""
 
 msgid "This will allow you to configure how services"
-msgstr ""
-
-msgid "This will delete all powermanagement items from all hosts in this group"
 msgstr ""
 
 msgid "This would leave no account able to administer FOG without its identity provider."
@@ -10198,9 +10220,6 @@ msgid "Use extreme caution with this setting"
 msgstr ""
 
 msgid "Use processEvent instead"
-msgstr ""
-
-msgid "Use the buttons below to create a new power management task to all hosts in this group."
 msgstr ""
 
 #, fuzzy
@@ -11832,10 +11851,6 @@ msgstr ""
 #~ msgstr "Adicionar snap-in falhou!"
 
 #, fuzzy
-#~ msgid "Add selected to group"
-#~ msgstr "Impressora"
-
-#, fuzzy
 #~ msgid "Administrator Group"
 #~ msgstr "modificar Grupo"
 
@@ -11889,6 +11904,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "Nenhum de hash disponíveis"
+
+#, fuzzy
+#~ msgid "Delete All"
+#~ msgstr "Apagar dados de arquivo"
 
 #, fuzzy
 #~ msgid "Deprecated."

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1740,6 +1740,10 @@ msgstr ""
 msgid "Clear one of your preferences"
 msgstr ""
 
+#, fuzzy
+msgid "Clear schedules from member hosts"
+msgstr "调度"
+
 msgid "Click"
 msgstr "点击"
 
@@ -2142,6 +2146,10 @@ msgid "Create New Windows Key"
 msgstr "新建%s"
 
 #, fuzzy
+msgid "Create Scheduled Power grant"
+msgstr "调度"
+
+#, fuzzy
 msgid "Create Scheduled Power task"
 msgstr "调度"
 
@@ -2350,13 +2358,6 @@ msgstr "延迟"
 
 msgid "Delete"
 msgstr "删除"
-
-#, fuzzy
-msgid "Delete All"
-msgstr "删除的文件数据"
-
-msgid "Delete All Powermanagement Items"
-msgstr ""
 
 #, fuzzy
 msgid "Delete Fail"
@@ -2777,6 +2778,9 @@ msgid "Every file was uploaded."
 msgstr "没有文件被上传"
 
 msgid "Every filter the CALLING user may see on that grid: their own, every global one, and any shared with them by name, through a user group, or through a role. There is no user in the path and no way to name one. mayShareGlobally reports whether the caller holds savedfilter.create, so a client can omit the \"everyone\" option rather than offer it and fail on save."
+msgstr ""
+
+msgid "Every host in this group runs these schedules, including hosts added later. Nothing is written onto a host; a host keeps its own schedules as well."
 msgstr ""
 
 msgid "Every preference belonging to the CALLING user, as a key/value map. There is no user in the path and no way to name one: the id comes from the session, so this cannot read anybody else's. Values are opaque strings the server does not interpret."
@@ -3272,6 +3276,9 @@ msgstr "FOG论坛"
 msgid "Found"
 msgstr ""
 
+msgid "Found a group wake on lan grant that should run."
+msgstr ""
+
 msgid "Found a scheduled task that should run."
 msgstr ""
 
@@ -3403,6 +3410,10 @@ msgstr "更新位置"
 
 msgid "Got in line at"
 msgstr ""
+
+#, fuzzy
+msgid "Grant sent to group"
+msgstr "打印机"
 
 #, fuzzy
 msgid "Granted To"
@@ -3537,6 +3548,10 @@ msgstr "集团补充"
 #, fuzzy
 msgid "Group Order"
 msgstr "组"
+
+#, fuzzy
+msgid "Group Power Management Task run time"
+msgstr "用户管理"
 
 msgid "Group Primary Disk"
 msgstr "集团主磁盘"
@@ -6914,6 +6929,10 @@ msgid "Power Management"
 msgstr "用户管理"
 
 #, fuzzy
+msgid "Power Management Grants"
+msgstr "用户管理"
+
+#, fuzzy
 msgid "Power Management Task run time"
 msgstr "用户管理"
 
@@ -9577,7 +9596,13 @@ msgstr ""
 msgid "This account is for API access only and cannot sign in."
 msgstr ""
 
+msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
+msgstr ""
+
+msgid "This deletes the power management schedules held by the hosts that are in this group right now. It does NOT touch this group's grants, and it also removes schedules those hosts were given individually."
 msgstr ""
 
 msgid "This directory does not advertise support for nested group chaining, so the chain strategy would match nothing. Use the expand strategy instead."
@@ -9753,9 +9778,6 @@ msgid "This tells the client to force reboots for host name changing and AD Join
 msgstr ""
 
 msgid "This will allow you to configure how services"
-msgstr ""
-
-msgid "This will delete all powermanagement items from all hosts in this group"
 msgstr ""
 
 msgid "This would leave no account able to administer FOG without its identity provider."
@@ -10198,9 +10220,6 @@ msgid "Use extreme caution with this setting"
 msgstr ""
 
 msgid "Use processEvent instead"
-msgstr ""
-
-msgid "Use the buttons below to create a new power management task to all hosts in this group."
 msgstr ""
 
 #, fuzzy
@@ -11832,10 +11851,6 @@ msgstr ""
 #~ msgstr "添加管理单元失败！"
 
 #, fuzzy
-#~ msgid "Add selected to group"
-#~ msgstr "打印机"
-
-#, fuzzy
 #~ msgid "Administrator Group"
 #~ msgstr "修改组"
 
@@ -11889,6 +11904,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Database connection unavailable"
 #~ msgstr "没有可用的散列"
+
+#, fuzzy
+#~ msgid "Delete All"
+#~ msgstr "删除的文件数据"
 
 #, fuzzy
 #~ msgid "Deprecated."

--- a/packages/web/src/Assign/Resolver.php
+++ b/packages/web/src/Assign/Resolver.php
@@ -358,6 +358,185 @@ class Resolver extends FOGBase
         return $resolved;
     }
     /**
+     * Resolves the power-management SCHEDULES for each host.
+     *
+     * ADR 0038. Host-direct `powerManagement` rows unioned with the grants of
+     * every group the host belongs to, in the order decision 6 sets.
+     *
+     * SCHEDULES ONLY -- `pmOndemand` rows are excluded, and that is not a
+     * filter for convenience. An on-demand row is an immediate shutdown,
+     * reboot or wake that the client consumes and deletes on its next
+     * check-in: it is a task, acting on the membership at the moment it was
+     * created, and it has no group-granted counterpart to union with. There
+     * is no `gpmOndemand` column for the same reason.
+     *
+     * EVERY ACTION IS RETURNED, `wol` included, and the caller filters. Two
+     * very different consumers read these rows -- the FOG client, which runs
+     * shutdown and reboot itself on a Quartz cron, and TaskScheduler, which
+     * sends the magic packet for `wol` because a sleeping machine cannot ask
+     * for anything. Filtering here would mean two resolvers, and two orderings
+     * that drift; the same reasoning the class docblock gives for there being
+     * one of these at all.
+     *
+     * THE IDENTITY OF A SCHEDULE IS ITS CRON PLUS ITS ACTION, which is what
+     * deduplication keys on. That is the same key `powerManagement`.`cron` and
+     * `groupPowerManagement`.`gpmCron` are unique on, and it is the only key
+     * that means anything: two rows saying "reboot at 03:00" are one
+     * instruction however many places they arrived from, and running the
+     * second would reboot a machine that had just come back up.
+     *
+     * @param array $hostIDs the hosts to resolve for
+     *
+     * @return array hostID => [['cron' => string, 'action' => string], ...].
+     *               Every host id passed in is a key, with an empty array when
+     *               it has nothing; see resolveSnapins() for why.
+     * @throws \RuntimeException on any query failure
+     */
+    public static function resolvePowerManagement(array $hostIDs)
+    {
+        $hostIDs = self::_ids($hostIDs);
+        if (count($hostIDs) < 1) {
+            return [];
+        }
+        $resolved = [];
+        $direct = [];
+        $rows = self::_rows(
+            'SELECT `pmHostID`, `pmMin`, `pmHour`, `pmDom`, `pmMonth`, '
+            . '`pmDow`, `pmAction` FROM `powerManagement` '
+            . 'WHERE `pmHostID` IN (' . implode(',', $hostIDs) . ') '
+            // `= 0` rather than `<> 1`: the column is NOT NULL DEFAULT 0, so
+            // there is no third state to be careful about, and an explicit
+            // equality is what an index can use.
+            . 'AND `pmOndemand` = 0 '
+            . 'ORDER BY `pmHostID`, `pmID`'
+        );
+        foreach ($rows as $row) {
+            $direct[(int)$row['pmHostID']][] = self::_schedule($row, 'pm');
+        }
+
+        list($groupsByHost, $groupIDs) = self::_membership($hostIDs);
+        $byGroup = [];
+        if (count($groupIDs) > 0) {
+            $rows = self::_rows(
+                'SELECT `gpmGroupID`, `gpmMin`, `gpmHour`, `gpmDom`, '
+                . '`gpmMonth`, `gpmDow`, `gpmAction` '
+                . 'FROM `groupPowerManagement` '
+                . 'WHERE `gpmGroupID` IN (' . implode(',', $groupIDs) . ') '
+                . 'ORDER BY `gpmID`'
+            );
+            foreach ($rows as $row) {
+                $byGroup[(int)$row['gpmGroupID']][] = self::_schedule(
+                    $row,
+                    'gpm'
+                );
+            }
+        }
+        $ordered = self::_orderedGroupIDs($groupIDs);
+
+        foreach ($hostIDs as $hostID) {
+            $out = [];
+            $seen = [];
+            foreach ($direct[$hostID] ?? [] as $schedule) {
+                $key = $schedule['cron'] . '|' . $schedule['action'];
+                if (isset($seen[$key])) {
+                    continue;
+                }
+                $seen[$key] = true;
+                $out[] = $schedule;
+            }
+            foreach ($ordered as $groupID) {
+                if (!isset($groupsByHost[$hostID][$groupID])) {
+                    continue;
+                }
+                foreach ($byGroup[$groupID] ?? [] as $schedule) {
+                    $key = $schedule['cron'] . '|' . $schedule['action'];
+                    if (isset($seen[$key])) {
+                        continue;
+                    }
+                    $seen[$key] = true;
+                    $out[] = $schedule;
+                }
+            }
+            $resolved[$hostID] = $out;
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Joins five cron fields into the one expression everything else reads.
+     *
+     * PUBLIC because it is the only implementation. The host table and the
+     * group table must format the same five fields identically -- the
+     * deduplication key in resolvePowerManagement() is the formatted string,
+     * so a stray space would make one schedule look like two and run it twice
+     * -- and the group page's grid has to show the admin the same expression
+     * the client will be given. GroupPowerManagement::getCron() calls this
+     * rather than repeating it.
+     *
+     * `-1` for the weekday becomes `7`. FOG's own cron picker writes -1 for
+     * Sunday and Quartz, which the client schedules against, will not take it.
+     * Client\PM::json() normalized it inline and nothing else did, which is
+     * how the server-side WOL path came to disagree with the client one.
+     *
+     * THE is_numeric() GUARD IS A BUG FIX, not defensive padding. The inline
+     * version read `if ($dow < 0)`, and on PHP 8 `'*' < 0` is TRUE: comparing
+     * a non-numeric string with a number casts the NUMBER to string, and '*'
+     * (42) sorts below '0' (48). So every schedule with a wildcard weekday --
+     * which is every daily schedule anyone has ever set -- was handed to the
+     * client as `... 7`, meaning Sundays only. On PHP 7.4 the same expression
+     * is false, because that version cast the string to int instead, so the
+     * defect appeared when a server was upgraded past PHP 8 and nothing about
+     * FOG changed. Verified both ways, 2026-09-01.
+     *
+     * @param string $min   the minute field
+     * @param string $hour  the hour field
+     * @param string $dom   the day-of-month field
+     * @param string $month the month field
+     * @param string $dow   the day-of-week field
+     *
+     * @return string the five-field cron expression
+     */
+    public static function cronExpression($min, $hour, $dom, $month, $dow)
+    {
+        $dow = trim((string)$dow);
+        if (is_numeric($dow) && (int)$dow < 0) {
+            $dow = 7;
+        }
+
+        return sprintf(
+            '%s %s %s %s %s',
+            trim((string)$min),
+            trim((string)$hour),
+            trim((string)$dom),
+            trim((string)$month),
+            $dow
+        );
+    }
+
+    /**
+     * Turns one schedule row into a cron expression and an action.
+     *
+     * @param array  $row    the row, as an associative array
+     * @param string $prefix the column prefix, `pm` or `gpm`
+     *
+     * @return array ['cron' => string, 'action' => string]
+     */
+    private static function _schedule(array $row, $prefix)
+    {
+        return [
+            'cron' => self::cronExpression(
+                $row[$prefix . 'Min'],
+                $row[$prefix . 'Hour'],
+                $row[$prefix . 'Dom'],
+                $row[$prefix . 'Month'],
+                $row[$prefix . 'Dow']
+            ),
+            'action' => (string)$row[$prefix . 'Action']
+        ];
+    }
+
+    /**
      * Reads group membership for a set of hosts.
      *
      * Straight off `groupMembers`, for the transitive-filter reason in the

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -130,7 +130,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 409);
+        define('FOG_SCHEMA', 411);
         define('FOG_BCACHE_VER', 359);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/src/Client/PM.php
+++ b/packages/web/src/Client/PM.php
@@ -13,6 +13,7 @@
 
 namespace FOG\Client;
 
+use FOG\Assign\Resolver;
 use FOG\Router\Route;
 
 /**
@@ -62,41 +63,29 @@ class PM extends FOGClient
                 'action' => ['shutdown', 'reboot']
             ]
         );
-        $PMFind = [
-            'hostID' => self::$Host->get('id'),
-            'onDemand' => [0, ''],
-            'action' => ['shutdown', 'reboot']
-        ];
-        $PMTasks = Route::getList(
-            'powermanagement',
-            $PMFind
-        );
+        // ADR 0038: the schedules come from the resolver, so a host gets its
+        // own rows AND every schedule granted by a group it belongs to. The
+        // on-demand half above stays a direct read: it is a task the client
+        // consumes and deletes, not a standing statement about the host, and
+        // it has no group-granted counterpart to union with.
+        //
+        // `wol` is dropped here and only here. The resolver returns every
+        // action because TaskScheduler needs the wake ones -- a sleeping
+        // machine cannot ask for anything, so the server sends the packet --
+        // but handing `wol` to a running client would schedule it to wake
+        // itself, which is either a no-op or, on a machine that suspends
+        // between now and then, a cron the client can no longer run.
+        $hostID = (int)self::$Host->get('id');
+        $resolved = Resolver::resolvePowerManagement([$hostID]);
         $data = [
             'onDemand' => $action,
             'tasks' => [],
         ];
-        foreach ($PMTasks as $PMTask) {
-            $min = trim($PMTask->min);
-            $hour = trim($PMTask->hour);
-            $dom = trim($PMTask->dom);
-            $month = trim($PMTask->month);
-            $dow = trim($PMTask->dow);
-            if ($dow < 0) {
-                $dow = 7;
+        foreach ($resolved[$hostID] ?? [] as $schedule) {
+            if ('wol' === $schedule['action']) {
+                continue;
             }
-            $cron = sprintf(
-                '%s %s %s %s %s',
-                $min,
-                $hour,
-                $dom,
-                $month,
-                $dow
-            );
-            $action = $PMTask->action;
-            $data['tasks'][] = [
-                'cron' => $cron,
-                'action' => $action
-            ];
+            $data['tasks'][] = $schedule;
         }
         return $data;
     }

--- a/packages/web/src/Items/GroupPowerManagement.php
+++ b/packages/web/src/Items/GroupPowerManagement.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * The group power-management grant class.
+ *
+ * PHP version 7.4+
+ *
+ * @category GroupPowerManagement
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Items;
+
+use FOG\Assign\Resolver;
+use FOG\Base\FOGController;
+use FOG\Util\Timer;
+
+/**
+ * The group power-management grant class.
+ *
+ * A row here says "this group runs this action on this schedule", and every
+ * member gets it -- including hosts added afterward. Nothing is written onto
+ * a host; what a given machine actually runs is computed at read time by
+ * Assign\Resolver::resolvePowerManagement() (ADR 0038).
+ *
+ * THERE IS NO `onDemand` FIELD, and its absence is deliberate. The host-level
+ * PowerManagement class has one because an immediate shutdown, reboot or wake
+ * is a row the client consumes and deletes on its next check-in. That is a
+ * TASK -- it acts on the membership at the moment you start it -- and a grant
+ * of "shut down immediately" would fire again for every host that joined the
+ * group later. Only the SCHEDULE, which is a standing statement about the
+ * group, lives here.
+ *
+ * @category GroupPowerManagement
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class GroupPowerManagement extends FOGController
+{
+    /**
+     * The group power-management grant table.
+     *
+     * @var string
+     */
+    protected $databaseTable = 'groupPowerManagement';
+    /**
+     * The group power-management grant fields and common names.
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'gpmID',
+        'groupID' => 'gpmGroupID',
+        'min' => 'gpmMin',
+        'hour' => 'gpmHour',
+        'dom' => 'gpmDom',
+        'month' => 'gpmMonth',
+        'dow' => 'gpmDow',
+        'action' => 'gpmAction'
+    ];
+    /**
+     * The required fields.
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'groupID',
+        'action'
+    ];
+    /**
+     * Get's the group object.
+     *
+     * @return object
+     */
+    public function getGroup()
+    {
+        return new Group($this->get('groupID'));
+    }
+    /**
+     * The timer this grant fires on.
+     *
+     * Mirrors PowerManagement::getTimer(), RAW -- the `-1` weekday is NOT
+     * normalized to `7` here, and that asymmetry with getCron() is deliberate.
+     * Timer is FOG's own cron evaluator and reads -1 the way FOG's cron picker
+     * writes it; the 7 exists only for Quartz, which is what the FOG client
+     * schedules against. Normalizing for the server-side evaluator would move
+     * Sunday.
+     *
+     * @return object
+     */
+    public function getTimer()
+    {
+        return new Timer(
+            trim((string)$this->get('min')),
+            trim((string)$this->get('hour')),
+            trim((string)$this->get('dom')),
+            trim((string)$this->get('month')),
+            trim((string)$this->get('dow'))
+        );
+    }
+    /**
+     * Wakes every host this grant reaches.
+     *
+     * Membership is read at FIRE time, which is the whole point of the grant:
+     * a host added to the group after the schedule was set is woken by it, and
+     * a host removed is not. The old fan-out could do neither -- it wrote one
+     * row per host at the moment of the press and nothing afterward changed
+     * what it reached.
+     *
+     * @return void
+     */
+    public function wakeOnLAN()
+    {
+        $this->getGroup()->wakeOnLAN();
+    }
+    /**
+     * The cron expression this grant fires on.
+     *
+     * Delegates rather than joining the fields itself. The resolver's
+     * deduplication key IS the formatted string, so the expression the group
+     * page shows an admin and the expression the client is handed have to come
+     * out of one piece of code -- see Assign\Resolver::cronExpression().
+     *
+     * @return string the five-field cron expression
+     */
+    public function getCron()
+    {
+        return Resolver::cronExpression(
+            $this->get('min'),
+            $this->get('hour'),
+            $this->get('dom'),
+            $this->get('month'),
+            $this->get('dow')
+        );
+    }
+}

--- a/packages/web/src/Managers/GroupPowerManagementManager.php
+++ b/packages/web/src/Managers/GroupPowerManagementManager.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * The group power-management grant manager class.
+ *
+ * PHP version 7.4+
+ *
+ * @category GroupPowerManagementManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Managers;
+
+use FOG\Base\FOGManagerController;
+
+/**
+ * The group power-management grant manager class.
+ *
+ * @category GroupPowerManagementManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class GroupPowerManagementManager extends FOGManagerController
+{
+    /**
+     * The wake grants, as objects the scheduler can time and fire.
+     *
+     * A DIRECT READ, for the reason Assign\Resolver's class docblock sets
+     * out at length: FOGController::buildQuery() walks the field-relationship
+     * declarations transitively, and any query whose class chain reaches Host
+     * picks up `AND hostMAC.hmPrimary = '1'` in its WHERE rather than its ON.
+     * That would silently drop grants whose groups contain a host with no
+     * primary MAC -- and a wake grant is precisely the thing you set on
+     * machines whose MACs you are least sure about.
+     *
+     * Only `wol`. A group-granted shutdown or reboot is run by the FOG client
+     * on each member, which reads it through Client\PM; the server has
+     * nothing to send and would only duplicate it. A wake is the one action a
+     * sleeping machine cannot perform for itself.
+     *
+     * Ids first, then objects, rather than hydrating from the row: the id is
+     * all that is needed to decide whether to instantiate, and the scheduler
+     * runs this every tick against a table that is usually empty.
+     *
+     * @return array GroupPowerManagement objects, ascending by id
+     * @throws \RuntimeException when the query failed
+     */
+    public function wakeGrants()
+    {
+        $res = self::$DB->query(
+            "SELECT `gpmID` FROM `groupPowerManagement` "
+            . "WHERE `gpmAction` = 'wol' ORDER BY `gpmID`"
+        );
+        if (false !== $res->error) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Group power-management read failed: %s',
+                    (string)$res->error
+                )
+            );
+        }
+        $rows = (array)$res->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
+        $grants = [];
+        foreach ($rows as $row) {
+            $grants[] = self::getClass('GroupPowerManagement', $row['gpmID']);
+        }
+
+        return $grants;
+    }
+}

--- a/packages/web/src/Pages/GroupManagement.php
+++ b/packages/web/src/Pages/GroupManagement.php
@@ -671,16 +671,54 @@ class GroupManagement extends FOGPage
         $this->assocPost('addModule', 'removeModule');
     }
     /**
-     * Display the group PM stuff.
+     * Display the group Power Management grants.
+     *
+     * ADR 0038: this tab GRANTS a schedule, it does not copy one.
+     *
+     * It used to write one `powerManagement` row per host that happened to be
+     * a member at the moment you pressed the button, and record nothing about
+     * where those rows came from. A host added afterward got no schedule, a
+     * host removed kept one forever, and "Delete All" reached only the current
+     * membership. The tab's own text said "to all hosts in this group", which
+     * was true for one instant and wrong from the next membership change on.
+     *
+     * The grid lists the GROUP'S OWN grants -- not a summary of what its
+     * members hold. What a given machine actually runs is its own schedules
+     * unioned with the grants of every group it is in, resolved at read time
+     * by Assign\Resolver::resolvePowerManagement(). The host's own Power
+     * Management tab remains the answer to "what is THIS machine scheduled to
+     * do".
+     *
+     * IMMEDIATE ACTIONS ARE STILL A FAN-OUT, and that is correct rather than
+     * an omission. An immediate shutdown, reboot or wake acts on the
+     * membership at the moment you start it, which is what a task should do; a
+     * GRANT of "shut down immediately" would fire again for every host that
+     * joined the group later. There is no `gpmOndemand` column for that
+     * reason.
      *
      * @return void
      */
     public function groupPowermanagement()
     {
+        $this->headerData = [
+            _('Cron Schedule'),
+            _('Action')
+        ];
+        $this->attributes = [
+            [],
+            []
+        ];
+        $props = ' method="post" action="'
+            . self::makeTabUpdateURL(
+                'group-powermanagement',
+                $this->obj->get('id')
+            )
+            . '" ';
         $buttons = self::makeButton(
-            'powermanagement-delete',
-            _('Delete All'),
-            'btn btn-danger float-start'
+            'pm-delete',
+            _('Delete selected'),
+            'btn btn-danger float-start',
+            $props
         );
         $splitButtons = self::makeSplitButton(
             'scheduleBtn',
@@ -703,7 +741,8 @@ class GroupManagement extends FOGPage
         $ondemandModalBtns .= self::makeButton(
             'ondemandCreateBtn',
             _('Create'),
-            'btn btn-outline-secondary float-end'
+            'btn btn-outline-secondary float-end',
+            $props
         );
         $scheduleModalBtns = self::makeButton(
             'scheduleCancelBtn',
@@ -714,18 +753,21 @@ class GroupManagement extends FOGPage
         $scheduleModalBtns .= self::makeButton(
             'scheduleCreateBtn',
             _('Create'),
-            'btn btn-outline-secondary float-end'
+            'btn btn-outline-secondary float-end',
+            $props
         );
+        // The legacy sweep. Kept, and deliberately NOT relabeled as a way to
+        // clear the grants above: it does the opposite thing. Grants live on
+        // the group and are removed with "Delete selected"; this reaches into
+        // the member hosts and deletes the rows THEY hold, which on an
+        // upgraded server is where every schedule this tab ever created ended
+        // up. Without it there is no way to undo a pre-1.6 fan-out short of
+        // opening each host in turn.
         $modaldeleteBtns = self::makeButton(
             'deletepowermanagementConfirm',
             _('Confirm'),
             'btn btn-outline-secondary float-end',
-            ' method="post" action="'
-            . self::makeTabUpdateURL(
-                'group-powermanagement',
-                $this->obj->get('id')
-            )
-            . '" '
+            $props
         );
         $modaldeleteBtns .= self::makeButton(
             'deletepowermanagementCancel',
@@ -733,56 +775,93 @@ class GroupManagement extends FOGPage
             'btn btn-outline-secondary float-start',
             'data-bs-dismiss="modal"'
         );
-        $modalondemand = self::makeModal(
-            'ondemandModal',
-            _('Create Immediate Power task'),
-            $this->newPMDisplay(true),
-            $ondemandModalBtns,
-            '',
-            'info'
-        );
-        $modalschedule = self::makeModal(
-            'scheduleModal',
-            _('Create Scheduled Power task'),
-            $this->newPMDisplay(false),
-            $scheduleModalBtns,
-            '',
-            'primary'
-        );
-        $modaldelete = self::makeModal(
-            'deletepowermanagementmodal',
-            _('Delete All Powermanagement Items'),
-            _(
-                'This will delete all powermanagement '
-                . 'items from all hosts in this group'
-            ),
-            $modaldeleteBtns,
-            '',
-            'warning'
+        $sweepButton = self::makeButton(
+            'powermanagement-delete',
+            _('Clear schedules from member hosts'),
+            'btn btn-outline-danger float-start'
         );
         echo '<!-- Power Management -->';
         echo '<div class="card card-primary card-outline">';
         echo '<div class="card-header">';
         echo '<h4 class="card-title">';
-        echo _('Power Management');
+        echo _('Power Management Grants');
         echo '</h4>';
-        echo '</div>';
-        echo '<div class="card-body">';
         echo '<p class="form-text">';
         echo _(
-            'Use the buttons below to create a new power management task to all '
-            . 'hosts in this group.'
+            'Every host in this group runs these schedules, including hosts '
+            . 'added later. Nothing is written onto a host; a host keeps its '
+            . 'own schedules as well.'
         );
         echo '</p>';
         echo '</div>';
+        echo '<div class="card-body">';
+        $this->render(
+            12,
+            'group-powermanagement-table',
+            $buttons . $splitButtons
+        );
+        echo '</div>';
         echo '<div class="card-footer">';
-        echo $buttons;
-        echo $splitButtons;
-        echo $modalondemand;
-        echo $modalschedule;
-        echo $modaldelete;
+        echo $sweepButton;
+        echo self::makeModal(
+            'ondemandModal',
+            _('Create Immediate Power task'),
+            '<p class="form-text">'
+            . _(
+                'This acts on the hosts that are in the group right now. It '
+                . 'is a task, not a grant: a host added afterward is not '
+                . 'affected.'
+            )
+            . '</p>'
+            . $this->newPMDisplay(true),
+            $ondemandModalBtns,
+            '',
+            'info'
+        );
+        echo self::makeModal(
+            'scheduleModal',
+            _('Create Scheduled Power grant'),
+            $this->newPMDisplay(false),
+            $scheduleModalBtns,
+            '',
+            'primary'
+        );
+        echo self::makeModal(
+            'deletepowermanagementmodal',
+            _('Clear schedules from member hosts'),
+            _(
+                'This deletes the power management schedules held by the '
+                . 'hosts that are in this group right now. It does NOT touch '
+                . 'this group\'s grants, and it also removes schedules those '
+                . 'hosts were given individually.'
+            ),
+            $modaldeleteBtns,
+            '',
+            'warning'
+        );
         echo '</div>';
         echo '</div>';
+    }
+    /**
+     * Gets this group's power management grants for the grid.
+     *
+     * Route::listem() rather than a REST route: `grouppowermanagement` is
+     * deliberately NOT in Route::$validClasses, exactly as
+     * `groupsnapinassociation` and `groupmoduleassociation` are not. listem()
+     * validates nothing itself -- that list gates the HTTP API surface -- so
+     * a page can drive its own grid off a table without the grant becoming a
+     * new public endpoint and a new permission to grant.
+     *
+     * @return void
+     */
+    public function getGrouppowermanagementList()
+    {
+        Route::listem(
+            'grouppowermanagement',
+            ['groupID' => $this->obj->get('id')]
+        );
+        echo Route::getData();
+        exit;
     }
     /**
      * Modify the power management stuff.
@@ -792,7 +871,7 @@ class GroupManagement extends FOGPage
     public function groupPowermanagementPost()
     {
         self::checkAuthAndCSRF();
-        $hostIDs = (array)$this->obj->get('hosts');
+        $groupID = (int)$this->obj->get('id');
         if (isset($_POST['pmadd']) || isset($_POST['pmaddod'])) {
             $onDemand = (int)isset($_POST['pmaddod']);
             $min = trim((string)filter_input(INPUT_POST, 'scheduleCronMin'));
@@ -804,50 +883,83 @@ class GroupManagement extends FOGPage
             if (!$action) {
                 throw new \Exception(_('You must select an action to perform'));
             }
-            $items = [];
-            if ($onDemand && $action === 'wol') {
-                $this->obj->wakeOnLAN();
+            if ($onDemand) {
+                // STILL A FAN-OUT, and correctly so -- an immediate action is
+                // a task against the membership at this instant. Wake is the
+                // one the server performs itself, because a sleeping machine
+                // cannot ask for anything.
+                $hostIDs = (array)$this->obj->get('hosts');
+                if ('wol' === $action) {
+                    $this->obj->wakeOnLAN();
+                    return;
+                }
+                $items = [];
+                foreach ($hostIDs as $hostID) {
+                    $items[] = [
+                        $hostID,
+                        $min,
+                        $hour,
+                        $dom,
+                        $month,
+                        $dow,
+                        1,
+                        $action
+                    ];
+                }
+                if (count($items) > 0) {
+                    self::getClass('PowerManagementManager')
+                        ->insertBatch(
+                            [
+                                'hostID',
+                                'min',
+                                'hour',
+                                'dom',
+                                'month',
+                                'dow',
+                                'onDemand',
+                                'action'
+                            ],
+                            $items
+                        );
+                }
                 return;
             }
-            if (!$onDemand) {
-                $min = FOGCron::_sanitizeCronField($min);
-                $hour = FOGCron::_sanitizeCronField($hour);
-                $dom = FOGCron::_sanitizeCronField($dom);
-                $month = FOGCron::_sanitizeCronField($month);
-                $dow = FOGCron::_sanitizeCronField($dow);
-            }
-            foreach ((array)$hostIDs as &$hostID) {
-                $items[] = [
-                    $hostID,
-                    $min,
-                    $hour,
-                    $dom,
-                    $month,
-                    $dow,
-                    $onDemand,
-                    $action
-                ];
-                unset($hostID);
-            }
-            $fields = [
-                'hostID',
-                'min',
-                'hour',
-                'dom',
-                'month',
-                'dow',
-                'onDemand',
-                'action'
-            ];
-            if (count($items) > 0) {
-                self::getClass('PowerManagementManager')
-                    ->insertBatch($fields, $items);
-            }
+            // ONE ROW, ABOUT THE GROUP. Not one per member.
+            self::getClass('GroupPowerManagement')
+                ->set('groupID', $groupID)
+                ->set('min', FOGCron::_sanitizeCronField($min))
+                ->set('hour', FOGCron::_sanitizeCronField($hour))
+                ->set('dom', FOGCron::_sanitizeCronField($dom))
+                ->set('month', FOGCron::_sanitizeCronField($month))
+                ->set('dow', FOGCron::_sanitizeCronField($dow))
+                ->set('action', $action)
+                ->save();
+        }
+        if (isset($_POST['pmremove'])) {
+            $flags = ['flags' => FILTER_REQUIRE_ARRAY];
+            $grantIDs = filter_input_array(
+                INPUT_POST,
+                ['remgrants' => $flags]
+            );
+            $grantIDs = (array)($grantIDs['remgrants'] ?? []);
+            // Scoped to THIS group as well as to the ids. The ids arrive from
+            // the browser, and a grant id is not a secret -- without the
+            // groupID clause a crafted post would revoke another group's
+            // schedule.
+            Route::deletemass(
+                'grouppowermanagement',
+                [
+                    'id' => $grantIDs,
+                    'groupID' => $groupID
+                ]
+            );
         }
         if (isset($_POST['pmdelete'])) {
+            // The legacy sweep -- member hosts' own rows, not this group's
+            // grants. See groupPowermanagement().
             Route::deletemass(
                 'powermanagement',
-                ['hostID' => $hostIDs]
+                ['hostID' => (array)$this->obj->get('hosts')]
             );
         }
     }

--- a/packages/web/src/Service/TaskScheduler.php
+++ b/packages/web/src/Service/TaskScheduler.php
@@ -209,7 +209,18 @@ class TaskScheduler extends FOGService
                 }
             );
             $ptaskcount = $PMTasks->recordsFiltered;
-            $taskCount = $staskcount + $ptaskcount;
+
+            // Group-granted wake schedules (ADR 0038), read HERE rather than
+            // at the loop below so they are inside the count. The early
+            // `no tasks found` return is what made this necessary: a server
+            // whose only wake schedule is a group grant has no host rows at
+            // all, and the daemon would have thrown before ever reaching the
+            // grant loop -- a schedule that silently never fires.
+            $GroupPMGrants = self::getClass('GroupPowerManagementManager')
+                ->wakeGrants();
+            $gtaskcount = count($GroupPMGrants);
+
+            $taskCount = $staskcount + $ptaskcount + $gtaskcount;
             if ($taskCount <= 0) {
                 throw new \Exception(' * No tasks found!');
             }
@@ -352,6 +363,51 @@ class TaskScheduler extends FOGService
                         ' | %s %s',
                         _('Task sent to'),
                         $Task->getHost()->get('name')
+                    )
+                );
+            }
+            // Group-granted wake schedules (ADR 0038).
+            //
+            // A SEPARATE LOOP, NOT AN ADDITION TO THE RESOLVER'S OUTPUT.
+            // Assign\Resolver::resolvePowerManagement() answers "what does
+            // THIS host run", which is the right question for the client and
+            // the wrong one here: answering it for a wake would mean asking it
+            // of every host on the server on every tick, to find the handful
+            // whose group happens to fire this minute. The grant is the unit
+            // that has a timer, so the grant is what is iterated, and
+            // membership is expanded only once one is due.
+            //
+            // Only `wol`. A group-granted shutdown or reboot is carried out by
+            // the FOG client on each member, which gets it from the resolver
+            // through Client\PM -- the server has nothing to send. A wake is
+            // the one action a sleeping machine cannot perform for itself.
+            foreach ($GroupPMGrants as $Task) {
+                $Timer = $Task->getTimer();
+                self::outall(
+                    ' * '
+                    . _('Group Power Management Task run time')
+                    . ': '
+                    . $Timer->toString()
+                );
+                self::outall(
+                    sprintf(
+                        ' * %s ',
+                        $Timer->shouldRunNowCheck()
+                    )
+                );
+                if (!$Timer->shouldRunNow()) {
+                    continue;
+                }
+                self::outall(
+                    ' * '
+                    . _('Found a group wake on lan grant that should run.')
+                );
+                $Task->wakeOnLAN();
+                self::outall(
+                    sprintf(
+                        ' | %s %s',
+                        _('Grant sent to group'),
+                        $Task->getGroup()->get('name')
                     )
                 );
             }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -129,7 +129,7 @@ parameters:
 		-
 			message: '#^Variable \$this might not be defined\.$#'
 			identifier: variable.undefined
-			count: 379
+			count: 381
 			path: packages/web/commons/schema.php
 
 		-

--- a/tests/assign-resolver.test.php
+++ b/tests/assign-resolver.test.php
@@ -228,6 +228,8 @@ $need = [
     'groupPrinterAssoc',
     'moduleStatusByHost',
     'groupModuleAssoc',
+    'powerManagement',
+    'groupPowerManagement',
 ];
 foreach ($need as $table) {
     if (!isset($expected[$table]['create'])) {
@@ -500,6 +502,157 @@ $defaulted = \FOG\Assign\Resolver::resolveModules([12]);
 $check(
     'a module row inserted without a state resolves as enabled',
     ($defaulted[12] ?? []) === [960]
+);
+
+/*
+ * 20-27: power management, the fourth grant (ADR 0038).
+ *
+ * A schedule is the one grant whose IDENTITY is a composite -- a cron
+ * expression plus an action -- rather than an id, so the dedup key is a
+ * string this resolver builds. That is the thing worth seeding a database
+ * for: every way of getting it wrong produces a list that still looks like a
+ * list of schedules.
+ *
+ * host 10 (groups 3 'zebra' order 1, 1 'middle' order 5, 2 'aaa-last' order 9):
+ *   direct  pmID 1  `0 2 * * *` reboot        <- first
+ *           pmID 2  `30 3 * * *` shutdown     <- second
+ *           pmID 3  `0 4 * * *` shutdown  ON DEMAND -- must NOT appear
+ *   grants  group 3 `15 1 * * *` wol          <- third (zebra resolves first)
+ *           group 3 `0 2 * * *` reboot        -- identical to the host's, so
+ *                                                deduped away
+ *           group 1 `45 5 * * -1` shutdown    <- fourth, dow normalized to 7
+ *           group 2 `15 1 * * *` wol          -- same as group 3's, deduped
+ *
+ * The ids fight the answer here too: taking the group rows in gpmID order
+ * without the group ordering would put middle's 45-past before zebra's, and
+ * ordering groups by id would put middle(1) before zebra(3).
+ */
+$pdo->exec(
+    "INSERT INTO `powerManagement` "
+    . "(`pmID`,`pmHostID`,`pmMin`,`pmHour`,`pmDom`,`pmMonth`,`pmDow`,"
+    . "`pmAction`,`pmOndemand`) VALUES "
+    . "(1,10,'0','2','*','*','*','reboot',0),"
+    . "(2,10,'30','3','*','*','*','shutdown',0),"
+    . "(3,10,'0','4','*','*','*','shutdown',1)"
+);
+$pdo->exec(
+    "INSERT INTO `groupPowerManagement` "
+    . "(`gpmID`,`gpmGroupID`,`gpmMin`,`gpmHour`,`gpmDom`,`gpmMonth`,`gpmDow`,"
+    . "`gpmAction`) VALUES "
+    . "(1,1,'45','5','*','*','-1','shutdown'),"
+    . "(2,3,'15','1','*','*','*','wol'),"
+    . "(3,3,'0','2','*','*','*','reboot'),"
+    . "(4,2,'15','1','*','*','*','wol')"
+);
+
+$pm = \FOG\Assign\Resolver::resolvePowerManagement([10, 11, 12, 13]);
+$flat = static function ($list) {
+    return array_map(
+        static function ($s) {
+            return $s['cron'] . '|' . $s['action'];
+        },
+        (array)$list
+    );
+};
+
+// 20: host-direct first, in pmID order, then the groups in resolved order.
+$check(
+    'schedules resolve host-direct first, then groups in decision-6 order',
+    $flat($pm[10] ?? []) === [
+        '0 2 * * *|reboot',
+        '30 3 * * *|shutdown',
+        '15 1 * * *|wol',
+        '45 5 * * 7|shutdown'
+    ]
+);
+
+// 21: the on-demand row is not a schedule. Asserted on its own rather than
+// left implicit in check 20, because it is the one exclusion that would look
+// like a working resolver -- the client would simply shut a machine down at
+// 04:00 every day forever, having been handed a task as a cron.
+$check(
+    'an on-demand host row is excluded from the resolved schedules',
+    !in_array('0 4 * * *|shutdown', $flat($pm[10] ?? []), true)
+);
+
+// 22: the identical cron+action reached host 10 both directly and from group
+// 3, and appears once at the HOST's position. A dedup keyed on anything else
+// -- the row id, the action alone -- gives a different list.
+$check(
+    'a schedule reached directly and by grant appears once, at the host position',
+    1 === count(
+        array_keys($flat($pm[10] ?? []), '0 2 * * *|reboot', true)
+    )
+);
+
+// 23: groups 3 and 2 grant the SAME wol schedule. Two groups, one
+// instruction: waking a machine twice is harmless, but rebooting one twice is
+// not, and the dedup has to be a property of the resolver rather than of
+// which action it happens to be.
+$check(
+    'the same schedule granted by two groups appears once',
+    1 === count(array_keys($flat($pm[10] ?? []), '15 1 * * *|wol', true))
+);
+
+// 24: `wol` comes back. The resolver serves both the client (which wants
+// shutdown and reboot) and TaskScheduler (which wants wake), so filtering
+// here would mean a second resolver and a second ordering.
+$check(
+    'wol schedules are returned rather than filtered by the resolver',
+    in_array('15 1 * * *|wol', $flat($pm[10] ?? []), true)
+);
+
+// 25: a -1 weekday becomes 7. FOG's cron picker writes -1 for Sunday and
+// Quartz -- what the FOG client schedules against -- refuses it, so a
+// Sunday-night shutdown would silently never run.
+$check(
+    'a -1 weekday is normalized to 7 in the cron expression',
+    in_array('45 5 * * 7|shutdown', $flat($pm[10] ?? []), true)
+);
+
+// 25b: a WILDCARD weekday survives. This is its own check because it is its
+// own bug, and one that only appears on PHP 8: the inline version this
+// replaced read `if ($dow < 0)`, and `'*' < 0` is TRUE there -- comparing a
+// non-numeric string with a number casts the NUMBER to string, and '*' (42)
+// sorts below '0' (48). Every daily schedule was therefore handed to the
+// client as `... 7`, Sundays only, on any server running PHP 8. On 7.4 the
+// same expression is false. Nothing about FOG had to change for a working
+// schedule to stop running; the server just had to be upgraded.
+$check(
+    'a wildcard weekday is left alone rather than rewritten to 7',
+    in_array('30 3 * * *|shutdown', $flat($pm[10] ?? []), true)
+    && !in_array('30 3 * * 7|shutdown', $flat($pm[10] ?? []), true)
+);
+
+// 26: a host with nothing anywhere is still a key, for the reason
+// resolveSnapins() gives.
+$check(
+    'a host with no schedules is still a key, with an empty list',
+    array_key_exists(12, $pm) && [] === $pm[12]
+);
+
+// 27: host 13 has no `hosts` row at all -- the manager-bypass property. A
+// read that went through a manager would pick up `hostMAC.hmPrimary = '1'`
+// in its WHERE and drop it, and a machine that quietly stops shutting down
+// reports itself to nobody.
+$check(
+    'a host present only in the association tables still resolves its grants',
+    $flat($pm[13] ?? []) === ['15 1 * * *|wol', '0 2 * * *|reboot']
+);
+
+// 28: the decision-9 gate on this resolver's own table.
+$pdo->exec('DROP TABLE `groupPowerManagement`');
+$threw = false;
+$message = '';
+try {
+    \FOG\Assign\Resolver::resolvePowerManagement([10]);
+} catch (\RuntimeException $e) {
+    $threw = true;
+    $message = $e->getMessage();
+}
+$check(
+    'a failed schedule read throws rather than resolving to nothing',
+    $threw && 0 === strpos($message, 'Assignment resolution failed')
 );
 
 // The decision-9 gate again, on the table this resolver added. Same reason:

--- a/tests/fixtures/upgrade-rehearsal-baseline.txt
+++ b/tests/fixtures/upgrade-rehearsal-baseline.txt
@@ -1,5 +1,5 @@
-  constraints declared and applicable here: 82
-  constraints actually present:             80
+  constraints declared and applicable here: 83
+  constraints actually present:             81
   MISSING:                                  2
     fk_hostMAC_hmHostID                      CASCADE     orphan rows: 0
     fk_nfsGroupMembers_ngmGroupID            RESTRICT    orphan rows: 1

--- a/tests/foreign-key-map.test.php
+++ b/tests/foreign-key-map.test.php
@@ -350,6 +350,12 @@ $expected = [
     // reasoning as group 9.
     'groupModuleAssoc.gmaGroupID',
     'groupModuleAssoc.gmaModuleID',
+    // Group 11 -- Power Management, the fourth grant. `satellite` rather
+    // than junction: a schedule references only its group, there being no
+    // second end to link to. CASCADE, with a sharper edge than group 9's:
+    // an orphan schedule left against a reused group id would silently
+    // start shutting down every host that inherited the number.
+    'groupPowerManagement.gpmGroupID',
     // Plugin groups, named for the plugin rather than numbered. Each
     // lands in that plugin's own repo, in an appended step of its
     // manager's schema(); see fog-plugins tests/foreign-keys.test.php,

--- a/tests/group-power-management-is-a-grant.test.php
+++ b/tests/group-power-management-is-a-grant.test.php
@@ -1,0 +1,341 @@
+<?php
+/**
+ * Power Management is a GRANT, not a fan-out (ADR 0038).
+ *
+ * It was the last control on the group page that still copied. Saving a
+ * schedule wrote one `powerManagement` row per host that happened to be a
+ * member at that instant and recorded nothing about where the rows came from,
+ * so a host added afterward got no schedule, a host removed kept one forever,
+ * and nothing could replay it. The tab's own text said "to all hosts in this
+ * group", which was true for one instant.
+ *
+ * tests/assign-resolver.test.php proves the RESOLUTION against a real
+ * database -- ordering, deduplication, the on-demand exclusion. This file
+ * pins the things a seeded database cannot see: that there is no on-demand
+ * column to make a grant fire twice, that each consumer reads through the
+ * resolver rather than around it, and that the write path creates one row
+ * about the group instead of one row per member.
+ *
+ * EVERY FAILURE HERE IS SILENT. A regression does not raise: it writes rows
+ * that look exactly like the ones an admin set by hand, on whichever hosts
+ * were members at the time, and the only symptom is a machine that shuts
+ * itself down months later with nothing to explain why.
+ *
+ * Usage: php tests/group-power-management-is-a-grant.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+
+$fails = [];
+$checks = 0;
+$check = static function ($what, $ok) use (&$checks, &$fails) {
+    $checks++;
+    if (!$ok) {
+        $fails[] = $what;
+    }
+};
+
+// Comments stripped before any behavioral grep: this file's own reasoning
+// names every symbol it looks for, and so does the code's.
+$strip = static function ($php) {
+    $out = '';
+    foreach (token_get_all($php) as $token) {
+        if (is_array($token)
+            && in_array($token[0], [T_COMMENT, T_DOC_COMMENT], true)
+        ) {
+            continue;
+        }
+        $out .= is_array($token) ? $token[1] : $token;
+    }
+    return $out;
+};
+
+// ---------------------------------------------------------------------
+// 1. The table, and the column that must not exist.
+
+$manifest = include $web . '/commons/schema-expected.php';
+$table = $manifest['tables']['groupPowerManagement'] ?? null;
+$check(
+    'commons/schema-expected.php declares groupPowerManagement',
+    is_array($table)
+);
+if (is_array($table)) {
+    $columns = array_keys($table['columns'] ?? []);
+    $check(
+        'the grant table carries the five cron fields, the group and the action',
+        [] === array_diff(
+            [
+                'gpmID',
+                'gpmGroupID',
+                'gpmMin',
+                'gpmHour',
+                'gpmDom',
+                'gpmMonth',
+                'gpmDow',
+                'gpmAction'
+            ],
+            $columns
+        )
+    );
+    // The absence IS the design. An on-demand action is a task against the
+    // membership at the moment it is created; a GRANT of "shut down
+    // immediately" would fire again for every host that joined afterward.
+    $check(
+        'the grant table has NO on-demand column',
+        !in_array('gpmOndemand', $columns, true)
+    );
+    // Identity is cron plus action, and it is unique. insertBatch() upserts,
+    // so without this saving the same schedule twice is a second row that
+    // reboots the machine a second time.
+    $check(
+        'the grant table is unique on group + cron + action',
+        false !== strpos(
+            (string)($table['create'] ?? ''),
+            'UNIQUE KEY `gpmCron` (`gpmGroupID`,`gpmMin`,`gpmHour`,'
+            . '`gpmDom`,`gpmMonth`,`gpmDow`,`gpmAction`)'
+        )
+    );
+}
+
+// The foreign key. An orphan schedule against a reused group id would
+// silently start shutting down every host that inherited the number.
+$constraints = include $web . '/commons/schema-constraints.php';
+$fk = null;
+foreach ((array)$constraints as $row) {
+    if (($row['child'] ?? '') === 'groupPowerManagement') {
+        $fk = $row;
+        break;
+    }
+}
+$check(
+    'the grant table declares a CASCADE foreign key to groups, enabled',
+    is_array($fk)
+    && 'gpmGroupID' === ($fk['column'] ?? '')
+    && 'groups' === ($fk['parent'] ?? '')
+    && 'CASCADE' === ($fk['action'] ?? '')
+    && true === ($fk['enabled'] ?? false)
+);
+
+// ---------------------------------------------------------------------
+// 2. The resolver is the only way in.
+
+$resolver = $strip(file_get_contents($web . '/src/Assign/Resolver.php'));
+$check(
+    'Assign\\Resolver exposes resolvePowerManagement()',
+    false !== strpos(
+        $resolver,
+        'public static function resolvePowerManagement(array $hostIDs)'
+    )
+);
+$check(
+    'the resolver reads groupPowerManagement directly, not through a manager',
+    false !== strpos($resolver, 'FROM `groupPowerManagement` ')
+);
+
+// ---------------------------------------------------------------------
+// 3. The client reads through the resolver, and drops wol.
+
+$pm = $strip(file_get_contents($web . '/src/Client/PM.php'));
+$check(
+    'Client\\PM asks the resolver for the schedules',
+    false !== strpos($pm, 'Resolver::resolvePowerManagement(')
+);
+// The old direct read. A host that kept it would see only its OWN rows and
+// none of its groups' -- a grant that silently reaches nothing, which is
+// indistinguishable from a group with no schedules set.
+$check(
+    'Client\\PM no longer lists powermanagement rows for its schedules',
+    false === strpos($pm, "'onDemand' => [0, '']")
+);
+// Handing a running client `wol` schedules it to wake itself.
+$check(
+    'Client\\PM drops wol from what it hands the client',
+    (bool)preg_match(
+        "#'wol'\s*===\s*\\\$schedule\['action'\]#",
+        $pm
+    )
+);
+
+// ---------------------------------------------------------------------
+// 4. The scheduler expands group wake grants -- and counts them.
+
+$sched = $strip(file_get_contents($web . '/src/Service/TaskScheduler.php'));
+$check(
+    'TaskScheduler reads the group wake grants',
+    false !== strpos($sched, 'wakeGrants()')
+);
+// ORDER IS LOAD-BEARING. The daemon throws ' * No tasks found!' when the
+// count is zero, so a server whose only wake schedule is a group grant would
+// bail before reaching the loop -- a schedule that never fires, with a log
+// line saying everything is fine.
+$readAt = strpos($sched, 'wakeGrants()');
+$countAt = strpos($sched, '$taskCount <= 0');
+$check(
+    'the grants are read BEFORE the no-tasks-found check, and counted',
+    false !== $readAt
+    && false !== $countAt
+    && $readAt < $countAt
+    && false !== strpos($sched, '$staskcount + $ptaskcount + $gtaskcount')
+);
+
+$mgr = $strip(
+    file_get_contents($web . '/src/Managers/GroupPowerManagementManager.php')
+);
+// Only wake. A group-granted shutdown or reboot is run by the FOG client on
+// each member; sending it from here as well would do it twice.
+$check(
+    'wakeGrants() selects only the wol grants',
+    (bool)preg_match(
+        "#`gpmAction`\s*=\s*'wol'#",
+        $mgr
+    )
+);
+
+// ---------------------------------------------------------------------
+// 5. The write path: one row about the group, not one per member.
+
+$group = file_get_contents($web . '/src/Pages/GroupManagement.php');
+$post = '';
+if (preg_match(
+    '#public function groupPowermanagementPost\(\).*?\n    \}\n#s',
+    $group,
+    $m
+)) {
+    $post = $strip('<?php ' . $m[0]);
+} else {
+    $fails[] = 'GroupManagement::groupPowermanagementPost() is gone';
+    $checks++;
+}
+
+if ('' !== $post) {
+    $check(
+        'a scheduled save creates a GroupPowerManagement row',
+        false !== strpos($post, "getClass('GroupPowerManagement')")
+        && false !== strpos($post, "->set('groupID', \$groupID)")
+    );
+    // THE FAN-OUT MUST BE REACHABLE ONLY FROM THE ON-DEMAND BRANCH. The old
+    // code built one PowerManagementManager row per member for BOTH cases,
+    // and that is the exact defect: a schedule copied onto whoever was a
+    // member at the time.
+    //
+    // The branch body is EXTRACTED, not merely located. An order-only test --
+    // `if ($onDemand)` appears before the insertBatch -- passes just as
+    // happily on `if (true)`, or on a branch that no longer closes before the
+    // grant, which is the shape that reintroduces the fan-out. Counting
+    // braces is what makes "inside" mean inside.
+    $onDemandAt = strpos($post, 'if ($onDemand)');
+    $branch = '';
+    if (false !== $onDemandAt) {
+        $open = strpos($post, '{', $onDemandAt);
+        if (false !== $open) {
+            $depth = 0;
+            for ($i = $open, $n = strlen($post); $i < $n; $i++) {
+                if ('{' === $post[$i]) {
+                    $depth++;
+                } elseif ('}' === $post[$i]) {
+                    $depth--;
+                    if (0 === $depth) {
+                        $branch = substr($post, $open, $i - $open + 1);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    $check(
+        'the per-host fan-out is INSIDE the on-demand branch',
+        '' !== $branch
+        && false !== strpos($branch, "getClass('PowerManagementManager')")
+    );
+    $check(
+        'the grant is created OUTSIDE the on-demand branch',
+        '' !== $branch
+        && false === strpos($branch, "getClass('GroupPowerManagement')")
+        && false !== strpos($post, "getClass('GroupPowerManagement')")
+    );
+    // And the branch must not fall through: without the return, an immediate
+    // action would fan out AND leave a standing grant behind it.
+    //
+    // Anchored on the END of the branch, not on `return;` appearing anywhere
+    // inside it. The wake arm has an early return of its own, so a bare
+    // strpos() is satisfied by that one and passes with the closing return
+    // deleted -- which is precisely the fall-through this is here to catch.
+    // Found by running that mutation.
+    $check(
+        'the on-demand branch ENDS in a return rather than falling through',
+        '' !== $branch
+        && (bool)preg_match('#return;\s*\}$#', $branch)
+    );
+    // Ids arrive from the browser and a grant id is not a secret, so the
+    // revoke must be scoped to this group as well as to the ids -- otherwise
+    // a crafted post revokes another group's schedule.
+    $check(
+        'revoking a grant is scoped to this group, not to the ids alone',
+        (bool)preg_match(
+            "#deletemass\(\s*'grouppowermanagement',\s*\[\s*'id'\s*=>\s*"
+            . "\\\$grantIDs,\s*'groupID'\s*=>\s*\\\$groupID#s",
+            $post
+        )
+    );
+}
+
+// The tab must not be listing the members' rows. `hosts` in the grid query
+// would make it a summary of what the members hold, which is what the whole
+// change is getting away from.
+$list = '';
+if (preg_match(
+    '#public function getGrouppowermanagementList\(\).*?\n    \}\n#s',
+    $group,
+    $m
+)) {
+    $list = $strip('<?php ' . $m[0]);
+}
+$check(
+    'the grid lists the GROUP\'S grants, scoped by groupID',
+    (bool)preg_match(
+        "#listem\(\s*'grouppowermanagement',\s*\[\s*'groupID'#s",
+        $list
+    )
+);
+// Not a new REST route. groupsnapinassociation and groupmoduleassociation
+// are not in $validClasses either; that list gates the HTTP API surface, and
+// a page driving its own grid does not need to widen it.
+$route = file_get_contents($web . '/src/Router/Route.php');
+if (preg_match(
+    '#public static \$validClasses = \[(.*?)\];#s',
+    $route,
+    $m
+)) {
+    $check(
+        'the grant did not become a public API route',
+        false === strpos($m[1], "'grouppowermanagement'")
+    );
+} else {
+    $fails[] = 'Route::$validClasses could not be read';
+    $checks++;
+}
+
+if ($fails) {
+    fwrite(STDERR, "FAIL group-power-management-is-a-grant:\n");
+    foreach ($fails as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    fwrite(
+        STDERR,
+        sprintf("%d of %d checks failed\n", count($fails), $checks)
+    );
+    exit(1);
+}
+
+printf("PASS  group power management is a grant: %d checks\n", $checks);
+exit(0);


### PR DESCRIPTION
ADR 0038's fourth and last grant. The group page's **Power Management** tab was
the only control that still fanned out: saving a schedule wrote one
`powerManagement` row per host that happened to be a member at that instant and
recorded nothing about where the rows came from. A host added afterward got no
schedule, a host removed kept one forever, *Delete all* reached only the current
membership, and nothing could replay any of it.

## What lands

| | |
|---|---|
| Schema 410 | `groupPowerManagement` — group, five cron fields, action |
| Schema 411 | its foreign key, constraint group 11, `satellite`/CASCADE |
| `Assign\Resolver::resolvePowerManagement()` | host-direct ∪ every group's grants, decision-6 order |
| `Client\PM::json()` | reads the resolver; drops `wol` |
| `TaskScheduler` | expands group **wake** grants, reading membership at fire time |
| Group page | a grant grid, `Delete selected`, and the immediate action kept as a task |

**The identity of a schedule is its cron expression plus its action.** That is
what deduplication keys on and what both tables are unique on: two groups both
saying "reboot at 03:00" is one instruction, and running it twice would reboot a
machine that had just come back up.

## There is no `gpmOndemand` column, and that is the design

An immediate shutdown, reboot or wake acts on the membership at the moment you
start it — which is what a task should do. A standing *grant* of "shut down
immediately" would fire again for every host that joined the group later. So
immediate actions stay a fan-out, in their own branch of the post handler, and
the test **extracts that branch** rather than merely locating it.

## Two things that would have failed silently

- **The resolver returns every action; each consumer filters.** The client never
  sees `wol` (handing a running machine a schedule to wake itself is either a
  no-op or a cron it cannot run); the scheduler expands only the wake grants.
- **Those grants are read before the daemon's `no tasks found` check** and
  included in its count. A server whose only wake schedule is a group grant
  would otherwise bail before reaching the loop, with a log line saying
  everything was fine.

## No new API route

The grid reads through `Route::listem()`. `grouppowermanagement` is deliberately
**not** in `Route::$validClasses`, exactly as `groupsnapinassociation` and
`groupmoduleassociation` are not — that list gates the HTTP API surface, and a
page driving its own grid does not need to widen it. Revoking a grant is scoped
to the group as well as to the ids, since a grant id is not a secret.

*Clear schedules from member hosts* is kept and relabeled. It is **not** an undo
for the grants: it deletes the rows the *members* hold, which on an upgraded
server is where every schedule this tab ever created ended up.

## Fixed on the way through: daily schedules were Sunday-only on PHP 8

Found by the new resolver test. A schedule with a `*` weekday was handed to the
client as `... 7`, meaning Sunday. The normalization read `if ($dow < 0)`, and
`'*' < 0` is **true** on PHP 8 — comparing a non-numeric string with a number
casts the *number* to string, and `*` (42) sorts below `0` (48). On PHP 7.4 the
same expression is false, so a working daily schedule stopped running when a
server upgraded its PHP and nothing about FOG changed. Verified both ways
against `php:7.4-cli` and 8.3.

Wake schedules were never affected — the server sends those and never ran the
comparison. `dev-branch` has an `is_int()` guard here and so never had this bug;
no port needed.

Nothing is migrated. The rows on hosts today are indistinguishable from ones an
admin set per-host — that is the whole defect — so there is nothing to migrate
*from*, exactly as steps 403 and 407 decided for the other three grants.

## Tests

**30 resolver checks against a real database** (ordering, both dedup paths, the
on-demand exclusion, the wildcard weekday, the decision-9 throw) and **20 static
checks** for what a seeded database cannot see.

Every mutation was run and each turns its test red: restoring the weekday bug,
dropping the on-demand exclusion, removing either dedup, reversing grant order,
ignoring group order, adding the on-demand column, disabling the FK, handing
`wol` to the client, not counting the grants, waking every action, unscoping the
revoke, exposing the API route, neutering the branch condition, and letting the
branch fall through.

**Two checks were rewritten because the first cut passed a mutation**: the
branch test was order-only (`if (true)` would have passed), and the
fall-through test was satisfied by the wake arm's own `return;`.

`sh tests/run-all.sh` → 302 passed, 0 failed. phpstan clean on both configs.

Docs: FOGProject/fog-docs#174