### PR TITLE
Say when the database has already migrated, and name the dump

### DIFF
--- a/bin/installfog.sh
+++ b/bin/installfog.sh
@@ -1511,6 +1511,10 @@ while [[ -z $blGo ]]; do
                     restoreReports
                     checkWebTier
                     backupDB
+                    # Immediately before the migration, so offerRevert() can
+                    # tell a failure that moved the schema from one that did
+                    # not. See recordPreUpgradeSchema.
+                    recordPreUpgradeSchema
                     updateDB
                     configureStorage
                     # Before configureDHCP, not with the rest of the TFTP

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -279,6 +279,41 @@ offerRevert() {
     echo " | Nothing has been reverted for you. Your customizations were already"
     echo " | restored by this run -- see docs/SUPPORTED_CUSTOMIZATIONS.md -- and"
     echo " | bin/restorekernel.sh --list will show the kernel sets kept for you."
+
+    # THE CODE IS ONLY HALF THE STATE.
+    #
+    # updateDB() migrates the schema, and a great many install steps run after
+    # it -- so a failure is quite likely to be one where the database has
+    # already gone forward. Telling somebody to check out the old commit and
+    # re-run, without saying that, sends old code at a newer schema.
+    #
+    # Said only when it actually happened. recordPreUpgradeSchema() captures
+    # the version immediately before the migration; if the database still
+    # reports that number, nothing moved and the short message above is the
+    # whole truth.
+    #
+    # bin/revertfog.sh is deliberately NOT offered here. It restores a
+    # pre-upgrade 1.5 dump and _dumpNotFifteenReason() refuses anything that
+    # looks like 1.6 -- so pointing at it would send someone to a tool that
+    # turns them away. A manual restore of the dump below is the way back.
+    local nowSchema
+    nowSchema=$(schemaVersionInDB 2>/dev/null)
+    if [[ -n $fogPreUpgradeSchema && -n $nowSchema && $nowSchema != "$fogPreUpgradeSchema" ]]; then
+        echo " |"
+        echo " | THE DATABASE HAS ALREADY BEEN MIGRATED by this run, from schema"
+        echo " | ${fogPreUpgradeSchema} to ${nowSchema}. Moving the checkout back is NOT enough on"
+        echo " | its own -- the older code would run against the newer schema."
+        if [[ -n $fogPreUpgradeDump && -s $fogPreUpgradeDump ]]; then
+            echo " |"
+            echo " | Restore the dump taken immediately before the migration:"
+            echo " |"
+            echo " |     mysql -u ${DB_user} -p ${DB_name} < ${fogPreUpgradeDump}"
+        else
+            echo " |"
+            echo " | No pre-migration dump was written for this run, so there is"
+            echo " | nothing here to restore the schema from."
+        fi
+    fi
     echo
     return 0
 }
@@ -1368,8 +1403,23 @@ backupDB() {
             read
         fi
     else
+        # Published for offerRevert(). A failed install AFTER updateDB() cannot
+        # be undone by moving the checkout back -- the schema has already gone
+        # forward -- and this is the only thing that can undo it. bin/revertfog.sh
+        # deliberately refuses a 1.6 dump, so for an intra-1.6 failure a manual
+        # restore of this file is the way back, and the message has to be able
+        # to name it.
+        fogPreUpgradeDump="$dbbackupfile"
         echo "Done"
     fi
+}
+# The schema version before updateDB() runs, so offerRevert() can tell a
+# failure that migrated the database from one that did not. Called from
+# installfog.sh immediately before the migration; a value here that differs
+# from the one in the database at exit means the schema moved.
+recordPreUpgradeSchema() {
+    fogPreUpgradeSchema=$(schemaVersionInDB 2>/dev/null)
+    return 0
 }
 # Prove the web tier actually renders a page before we trust anything that
 # talks to it. A PHP fatal in the boot chain returns an empty (or truncated)

--- a/tests/revert-offer.test.sh
+++ b/tests/revert-offer.test.sh
@@ -70,6 +70,10 @@ if ! grep -q 'offerRevert()' <<< "$snippet" || ! grep -q 'markInstallCommit()' <
     echo "  test at them -- do not delete the assertions." >&2
     exit 1
 fi
+# offerRevert asks the database what schema it is on. Stubbed: these tests
+# have no mysql, and what is under test is the DECISION, not the query.
+schemaVersionInDB() { echo "$FAKE_SCHEMA_NOW"; }
+
 eval "$snippet"
 
 work=$(mktemp -d)
@@ -364,6 +368,67 @@ check "an unrecognized answer does not exit 0" \
 
 check "a deliberate no is still exit 0" \
     "$(grep -qE '\[Nn\] \| \[Nn\]\[Oo\]\)' <<< "$u"; echo $?)"
+
+
+# ---------------------------------------------------------------------------
+# The code is only half the state.
+#
+# updateDB() migrates the schema and many install steps run after it, so a
+# failure is quite likely to be one where the database has already moved.
+# Telling somebody to check out the old commit and re-run, without saying so,
+# sends old code at a newer schema.
+#
+# Said only when it actually happened -- the common case is a failure before
+# the migration, and a warning there would be false.
+# ---------------------------------------------------------------------------
+record "$first"
+
+fogPreUpgradeSchema=""
+FAKE_SCHEMA_NOW="270"
+fogPreUpgradeDump=""
+check "no recorded pre-migration schema means no database warning" \
+    "$(! grep -qi 'DATABASE HAS ALREADY BEEN MIGRATED' <<< "$(offerRevert 1)"; echo $?)"
+
+fogPreUpgradeSchema="270"
+FAKE_SCHEMA_NOW="270"
+check "a schema that did not move means no database warning" \
+    "$(! grep -qi 'DATABASE HAS ALREADY BEEN MIGRATED' <<< "$(offerRevert 1)"; echo $?)"
+
+fogPreUpgradeSchema="270"
+FAKE_SCHEMA_NOW="284"
+dbout=$(offerRevert 1)
+check "a schema that DID move is reported" \
+    "$(grep -qi 'DATABASE HAS ALREADY BEEN MIGRATED' <<< "$dbout"; echo $?)"
+
+check "and both schema numbers are named" \
+    "$(grep -q '270 to 284' <<< "$dbout"; echo $?)"
+
+check "and it says the checkout alone is not enough" \
+    "$(grep -qi 'NOT enough' <<< "$dbout"; echo $?)"
+
+# With a dump, name it. Without one, say there is none rather than pointing at
+# a file that is not there.
+dumpfile="$work/fog_sql_test.sql"
+echo "-- dump" > "$dumpfile"
+fogPreUpgradeDump="$dumpfile"
+DB_user=fogmaster
+DB_name=fog
+check "the pre-migration dump is named when there is one" \
+    "$(grep -q "$dumpfile" <<< "$(offerRevert 1)"; echo $?)"
+
+fogPreUpgradeDump=""
+check "and its absence is stated rather than implied" \
+    "$(grep -qi 'No pre-migration dump was written' <<< "$(offerRevert 1)"; echo $?)"
+
+# revertfog.sh restores a pre-upgrade 1.5 dump and refuses anything that looks
+# like 1.6 (_dumpNotFifteenReason). Pointing at it here would send someone to a
+# tool that turns them away.
+fogPreUpgradeDump="$dumpfile"
+check "revertfog.sh is not offered for an intra-1.6 failure" \
+    "$(! grep -q 'revertfog' <<< "$(offerRevert 1)"; echo $?)"
+
+fogPreUpgradeSchema=""
+FAKE_SCHEMA_NOW=""
 
 
 printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$pass" "$fail"


### PR DESCRIPTION
Part of #1659.

`offerRevert()` told people to move the checkout back and re-run, and said **nothing about the database**. `updateDB()` runs early and a long tail of install steps follows it, so a failure is quite likely to be one where the schema has already gone forward — and following that advice then runs older code against a newer schema.

## It now says so, and only when it happened

`recordPreUpgradeSchema()` captures the version immediately before the migration. If the database still reports that number at exit, nothing moved and the short message is the whole truth. Where it did move:

```
 | THE DATABASE HAS ALREADY BEEN MIGRATED by this run, from schema
 | 270 to 284. Moving the checkout back is NOT enough on
 | its own -- the older code would run against the newer schema.
 |
 | Restore the dump taken immediately before the migration:
 |
 |     mysql -u fogmaster -p fog < /home/fogDBbackups/fog_sql_....sql
```

`backupDB()` publishes that path for the purpose — it was a `local`, so nothing outside the function could see it. Where no dump was written, it says that instead of naming a file that is not there.

## `revertfog.sh` is deliberately not offered

It restores a pre-upgrade **1.5** dump, and `_dumpNotFifteenReason()` refuses anything carrying a 1.6-only table, column, or foreign key. Pointing at it here would send somebody to a tool that turns them away. An intra-1.6 rollback is a manual restore today — filed as #1659 rather than decided inside this PR.

## Not a duplicate of revertfog.sh

Worth stating, since it looks like one: `revertfog.sh` restores a database, a web tree and kernels and does **no git work at all**. `offerRevert()` names a commit and does nothing. Neither can do the other's job.

## Tests

`tests/revert-offer.test.sh`: 46 assertions. The valuable ones are the silences — no recorded schema, and a schema that did not move, both produce no database warning. Also covers that both numbers are named, that the dump is named when present and its absence stated when not, and that `revertfog` is never mentioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtZHpyWZWDPSxePdTViGZy
