### PR TITLE
Put shut down, restart and wake on the task surface

### DIFF
--- a/packages/web/management/js/fog/host/fog.host.edit.js
+++ b/packages/web/management/js/fog/host/fog.host.edit.js
@@ -494,6 +494,25 @@
     // TASKING TAB
     var taskItem = $('.taskitem'),
         taskModal = $('#task-modal');
+
+    // Shut down, restart and wake take no options, so there is no form to
+    // fetch and no modal to open -- the click IS the action. They post to the
+    // same endpoint the Hosts list uses, with a selection of one, so the two
+    // surfaces cannot drift into behaving differently.
+    $('.powertaskitem').on('click', function(e) {
+        e.preventDefault();
+        var action = $(this).attr('data-power'),
+            $item = $(this);
+        $item.addClass('disabled');
+        $.apiCall(
+            'post',
+            '../management/index.php?node=host&sub=taskPowerMulti',
+            {action: action, hosts: [Common.id]},
+            function(err) {
+                $item.removeClass('disabled');
+            }
+        );
+    });
     taskItem.on('click', function(e) {
         e.preventDefault();
         var taskName = $(this).text();

--- a/packages/web/management/js/fog/host/fog.host.list.js
+++ b/packages/web/management/js/fog/host/fog.host.list.js
@@ -639,7 +639,11 @@
     // 'both'. The server refuses the same two cases in
     // assertSelectionTaskable(), so this is the courtesy, not the guard.
     function applyTaskAvailability(count) {
-        $('.queuetaskitem').each(function() {
+        // Every item that declares an access, not just the task types. The
+        // power items carry data-access="both" and so are never hidden, but
+        // reading the attribute rather than the class means one rule applies
+        // to the whole accordion instead of a list of exceptions.
+        $('[data-access]', queuePicker).each(function() {
             var access = $(this).attr('data-access'),
                 usable = true;
             if (access === 'group' && count < 2) {
@@ -673,6 +677,36 @@
 
     queueTaskModal.on('hidden.bs.modal', function() {
         showQueuePicker();
+    });
+
+    // Shut down, restart and wake take no options, so there is no second
+    // pane to fetch -- the click IS the action. Read the selection HERE for
+    // the same reason the Create button below does: the grid is live behind
+    // the modal, so what was ticked when it opened is not necessarily what is
+    // ticked now, and the ids are what the server acts on.
+    $('.powertaskitem').on('click', function(e) {
+        e.preventDefault();
+        var action = $(this).attr('data-power'),
+            hosts = $.getSelectedIds(table),
+            $item = $(this);
+
+        if (hosts.length < 1) {
+            return;
+        }
+        $item.addClass('disabled');
+        $.apiCall(
+            'post',
+            '../management/index.php?node=host&sub=taskPowerMulti',
+            {action: action, hosts: hosts},
+            function(err) {
+                $item.removeClass('disabled');
+                if (err) {
+                    return;
+                }
+                queueTaskModal.modal('hide');
+                table.rows({selected: true}).deselect();
+            }
+        );
     });
 
     $('.queuetaskitem').on('click', function(e) {

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -5985,6 +5985,10 @@ msgid "No hosts associated to this group yet"
 msgstr "Keine Snapins mit dieser Gruppe als Master verbunden"
 
 #, fuzzy
+msgid "No hosts available"
+msgstr "Pfad ist nicht verfügbar"
+
+#, fuzzy
 msgid "No hosts available to be tasked"
 msgstr "Keine Hosts für Aufgaben (Task) verfügbar"
 
@@ -6911,6 +6915,9 @@ msgstr ""
 msgid "Postfix requires an action of login"
 msgstr "Postfix erfordert die Aktion Login,"
 
+msgid "Power"
+msgstr ""
+
 #, fuzzy
 msgid "Power Management"
 msgstr "Power Management"
@@ -6918,6 +6925,10 @@ msgstr "Power Management"
 #, fuzzy
 msgid "Power Management Task run time"
 msgstr "Power Management"
+
+#, php-format
+msgid "Power action sent to %d host(s)"
+msgstr ""
 
 msgid "PowerShell Script"
 msgstr ""
@@ -7438,6 +7449,12 @@ msgstr ""
 
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Restarts the selected machines. As with Shut Down, the FOG client carries this out at its next check-in."
 msgstr ""
 
 #, fuzzy
@@ -8054,6 +8071,10 @@ msgstr "Passwort ändern"
 msgid "Show with"
 msgstr ""
 
+#, fuzzy
+msgid "Shut Down"
+msgstr "Herunterfahren"
+
 msgid "Shutdown"
 msgstr "Herunterfahren"
 
@@ -8064,6 +8085,9 @@ msgstr "wurde abgeschlossen"
 #, fuzzy
 msgid "Shutdown when complete"
 msgstr "wurde abgeschlossen"
+
+msgid "Shuts down the selected machines. The FOG client carries this out at its next check-in, so a machine that is off, or has no client installed, is unaffected."
+msgstr ""
 
 #, fuzzy
 msgid "Sign In"
@@ -10057,6 +10081,10 @@ msgstr "Host Moduleinstellungen"
 
 #, fuzzy
 msgid "Unknown permission"
+msgstr "Ein unbekannter Upload-Fehler ist aufgetreten"
+
+#, fuzzy
+msgid "Unknown power action"
 msgstr "Ein unbekannter Upload-Fehler ist aufgetreten"
 
 #, fuzzy

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -5997,6 +5997,10 @@ msgid "No hosts associated to this group yet"
 msgstr "There are no snapins associated with this host"
 
 #, fuzzy
+msgid "No hosts available"
+msgstr "No hash available"
+
+#, fuzzy
 msgid "No hosts available to be tasked"
 msgstr "Hosts in Task"
 
@@ -6922,6 +6926,9 @@ msgstr ""
 msgid "Postfix requires an action of login"
 msgstr "Postfix requires an action of login, logout, or start to operate"
 
+msgid "Power"
+msgstr ""
+
 #, fuzzy
 msgid "Power Management"
 msgstr "User Management"
@@ -6929,6 +6936,10 @@ msgstr "User Management"
 #, fuzzy
 msgid "Power Management Task run time"
 msgstr "User Management"
+
+#, php-format
+msgid "Power action sent to %d host(s)"
+msgstr ""
 
 msgid "PowerShell Script"
 msgstr ""
@@ -7449,6 +7460,12 @@ msgstr ""
 
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Restarts the selected machines. As with Shut Down, the FOG client carries this out at its next check-in."
 msgstr ""
 
 #, fuzzy
@@ -8065,6 +8082,10 @@ msgstr "Management Password"
 msgid "Show with"
 msgstr ""
 
+#, fuzzy
+msgid "Shut Down"
+msgstr "Shutdown"
+
 msgid "Shutdown"
 msgstr "Shutdown"
 
@@ -8075,6 +8096,9 @@ msgstr "has been destroyed"
 #, fuzzy
 msgid "Shutdown when complete"
 msgstr "has been destroyed"
+
+msgid "Shuts down the selected machines. The FOG client carries this out at its next check-in, so a machine that is off, or has no client installed, is unaffected."
+msgstr ""
 
 #, fuzzy
 msgid "Sign In"
@@ -10065,6 +10089,10 @@ msgstr ""
 
 #, fuzzy
 msgid "Unknown permission"
+msgstr "Unknown upload error occurred.  Return code: "
+
+#, fuzzy
+msgid "Unknown power action"
 msgstr "Unknown upload error occurred.  Return code: "
 
 #, fuzzy

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -6105,6 +6105,10 @@ msgid "No hosts associated to this group yet"
 msgstr "No hay snapins asociados con este anfitrión"
 
 #, fuzzy
+msgid "No hosts available"
+msgstr "No se dispone de hash"
+
+#, fuzzy
 msgid "No hosts available to be tasked"
 msgstr "Anfitriones en tareas"
 
@@ -7041,6 +7045,9 @@ msgstr ""
 msgid "Postfix requires an action of login"
 msgstr ""
 
+msgid "Power"
+msgstr ""
+
 #, fuzzy
 msgid "Power Management"
 msgstr "Gestión de usuarios"
@@ -7048,6 +7055,10 @@ msgstr "Gestión de usuarios"
 #, fuzzy
 msgid "Power Management Task run time"
 msgstr "Gestión de usuarios"
+
+#, php-format
+msgid "Power action sent to %d host(s)"
+msgstr ""
 
 msgid "PowerShell Script"
 msgstr ""
@@ -7577,6 +7588,12 @@ msgstr ""
 
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Restarts the selected machines. As with Shut Down, the FOG client carries this out at its next check-in."
 msgstr ""
 
 #, fuzzy
@@ -8198,6 +8215,10 @@ msgstr "La gestión de contraseñas"
 msgid "Show with"
 msgstr ""
 
+#, fuzzy
+msgid "Shut Down"
+msgstr "Apagar"
+
 msgid "Shutdown"
 msgstr "Apagar"
 
@@ -8208,6 +8229,9 @@ msgstr "Deben estar cifrados"
 #, fuzzy
 msgid "Shutdown when complete"
 msgstr "Deben estar cifrados"
+
+msgid "Shuts down the selected machines. The FOG client carries this out at its next check-in, so a machine that is off, or has no client installed, is unaffected."
+msgstr ""
 
 #, fuzzy
 msgid "Sign In"
@@ -10227,6 +10251,10 @@ msgstr "Descripción del Grupo"
 
 #, fuzzy
 msgid "Unknown permission"
+msgstr "Se produjo un error de carga desconocida. Código de retorno: "
+
+#, fuzzy
+msgid "Unknown power action"
 msgstr "Se produjo un error de carga desconocida. Código de retorno: "
 
 #, fuzzy

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5986,6 +5986,10 @@ msgid "No hosts associated to this group yet"
 msgstr "Keine Snapins mit dieser Gruppe als Master verbunden"
 
 #, fuzzy
+msgid "No hosts available"
+msgstr "Pfad ist nicht verfügbar"
+
+#, fuzzy
 msgid "No hosts available to be tasked"
 msgstr "Keine Hosts für Aufgaben (Task) verfügbar"
 
@@ -6912,6 +6916,9 @@ msgstr ""
 msgid "Postfix requires an action of login"
 msgstr "Postfix erfordert die Aktion Login,"
 
+msgid "Power"
+msgstr ""
+
 #, fuzzy
 msgid "Power Management"
 msgstr "Power Management"
@@ -6919,6 +6926,10 @@ msgstr "Power Management"
 #, fuzzy
 msgid "Power Management Task run time"
 msgstr "Power Management"
+
+#, php-format
+msgid "Power action sent to %d host(s)"
+msgstr ""
 
 msgid "PowerShell Script"
 msgstr ""
@@ -7439,6 +7450,12 @@ msgstr ""
 
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Restarts the selected machines. As with Shut Down, the FOG client carries this out at its next check-in."
 msgstr ""
 
 #, fuzzy
@@ -8055,6 +8072,10 @@ msgstr "Passwort ändern"
 msgid "Show with"
 msgstr ""
 
+#, fuzzy
+msgid "Shut Down"
+msgstr "Herunterfahren"
+
 msgid "Shutdown"
 msgstr "Herunterfahren"
 
@@ -8065,6 +8086,9 @@ msgstr "wurde abgeschlossen"
 #, fuzzy
 msgid "Shutdown when complete"
 msgstr "wurde abgeschlossen"
+
+msgid "Shuts down the selected machines. The FOG client carries this out at its next check-in, so a machine that is off, or has no client installed, is unaffected."
+msgstr ""
 
 #, fuzzy
 msgid "Sign In"
@@ -10058,6 +10082,10 @@ msgstr "Host Moduleinstellungen"
 
 #, fuzzy
 msgid "Unknown permission"
+msgstr "Ein unbekannter Upload-Fehler ist aufgetreten"
+
+#, fuzzy
+msgid "Unknown power action"
 msgstr "Ein unbekannter Upload-Fehler ist aufgetreten"
 
 #, fuzzy

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -5984,6 +5984,10 @@ msgid "No hosts associated to this group yet"
 msgstr "Il n'y a pas snapins associés à cet hôte"
 
 #, fuzzy
+msgid "No hosts available"
+msgstr "Pas de hachage disponible"
+
+#, fuzzy
 msgid "No hosts available to be tasked"
 msgstr "Hôtes sur Task"
 
@@ -6909,6 +6913,9 @@ msgstr ""
 msgid "Postfix requires an action of login"
 msgstr "Postfix exige une action de connexion, déconnexion, ou commencer à fonctionner"
 
+msgid "Power"
+msgstr ""
+
 #, fuzzy
 msgid "Power Management"
 msgstr "Gestion des utilisateurs"
@@ -6916,6 +6923,10 @@ msgstr "Gestion des utilisateurs"
 #, fuzzy
 msgid "Power Management Task run time"
 msgstr "Gestion des utilisateurs"
+
+#, php-format
+msgid "Power action sent to %d host(s)"
+msgstr ""
 
 msgid "PowerShell Script"
 msgstr ""
@@ -7436,6 +7447,12 @@ msgstr ""
 
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Restarts the selected machines. As with Shut Down, the FOG client carries this out at its next check-in."
 msgstr ""
 
 #, fuzzy
@@ -8051,6 +8068,10 @@ msgstr "gestion Mot de passe"
 msgid "Show with"
 msgstr ""
 
+#, fuzzy
+msgid "Shut Down"
+msgstr "Fermer"
+
 msgid "Shutdown"
 msgstr "Fermer"
 
@@ -8061,6 +8082,9 @@ msgstr "a été détruit"
 #, fuzzy
 msgid "Shutdown when complete"
 msgstr "a été détruit"
+
+msgid "Shuts down the selected machines. The FOG client carries this out at its next check-in, so a machine that is off, or has no client installed, is unaffected."
+msgstr ""
 
 #, fuzzy
 msgid "Sign In"
@@ -10051,6 +10075,10 @@ msgstr "hôte description de"
 
 #, fuzzy
 msgid "Unknown permission"
+msgstr "Erreur inconnue de téléchargement a eu lieu. Code de retour: "
+
+#, fuzzy
+msgid "Unknown power action"
 msgstr "Erreur inconnue de téléchargement a eu lieu. Code de retour: "
 
 #, fuzzy

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -5811,6 +5811,10 @@ msgid "No hosts associated to this group yet"
 msgstr "Nessun snapins associato a questo gruppo come master"
 
 #, fuzzy
+msgid "No hosts available"
+msgstr "Percorso non disponibile"
+
+#, fuzzy
 msgid "No hosts available to be tasked"
 msgstr "Nessun host disponibile per task"
 
@@ -6709,12 +6713,19 @@ msgstr ""
 msgid "Postfix requires an action of login"
 msgstr "Postfix richiede un'azione di accesso"
 
+msgid "Power"
+msgstr ""
+
 msgid "Power Management"
 msgstr "Gestione energetica"
 
 #, fuzzy
 msgid "Power Management Task run time"
 msgstr "Gestione energetica"
+
+#, php-format
+msgid "Power action sent to %d host(s)"
+msgstr ""
 
 msgid "PowerShell Script"
 msgstr ""
@@ -7223,6 +7234,12 @@ msgstr ""
 
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Restarts the selected machines. As with Shut Down, the FOG client carries this out at its next check-in."
 msgstr ""
 
 msgid "Result"
@@ -7823,6 +7840,10 @@ msgstr "Cambia password"
 msgid "Show with"
 msgstr ""
 
+#, fuzzy
+msgid "Shut Down"
+msgstr "Spegnimento"
+
 msgid "Shutdown"
 msgstr "Spegnimento"
 
@@ -7833,6 +7854,9 @@ msgstr "è stato completato"
 #, fuzzy
 msgid "Shutdown when complete"
 msgstr "è stato completato"
+
+msgid "Shuts down the selected machines. The FOG client carries this out at its next check-in, so a machine that is off, or has no client installed, is unaffected."
+msgstr ""
 
 #, fuzzy
 msgid "Sign In"
@@ -9755,6 +9779,10 @@ msgstr "Impostazioni del modulo host"
 
 #, fuzzy
 msgid "Unknown permission"
+msgstr "Si è verificato errore di caricamento sconosciuto"
+
+#, fuzzy
+msgid "Unknown power action"
 msgstr "Si è verificato errore di caricamento sconosciuto"
 
 msgid "Unknown upload error occurred"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -5776,6 +5776,10 @@ msgid "No hosts associated to this group yet"
 msgstr "このグループにマスターとして関連付けられたスナップインはありません"
 
 #, fuzzy
+msgid "No hosts available"
+msgstr "ノードは利用できません"
+
+#, fuzzy
 msgid "No hosts available to be tasked"
 msgstr "タスクを実行できるホストがありません"
 
@@ -6682,11 +6686,18 @@ msgstr ""
 msgid "Postfix requires an action of login"
 msgstr "Postfix では login アクションが必要です"
 
+msgid "Power"
+msgstr ""
+
 msgid "Power Management"
 msgstr "電源管理"
 
 msgid "Power Management Task run time"
 msgstr "電源管理タスク実行時刻"
+
+#, php-format
+msgid "Power action sent to %d host(s)"
+msgstr ""
 
 msgid "PowerShell Script"
 msgstr ""
@@ -7191,6 +7202,12 @@ msgstr ""
 
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Restarts the selected machines. As with Shut Down, the FOG client carries this out at its next check-in."
 msgstr ""
 
 msgid "Result"
@@ -7784,6 +7801,10 @@ msgstr "パスワードを変更"
 msgid "Show with"
 msgstr "メニューの表示方法"
 
+#, fuzzy
+msgid "Shut Down"
+msgstr "シャットダウン"
+
 msgid "Shutdown"
 msgstr "シャットダウン"
 
@@ -7793,6 +7814,9 @@ msgstr "展開後にシャットダウン"
 #, fuzzy
 msgid "Shutdown when complete"
 msgstr "完了しました"
+
+msgid "Shuts down the selected machines. The FOG client carries this out at its next check-in, so a machine that is off, or has no client installed, is unaffected."
+msgstr ""
 
 #, fuzzy
 msgid "Sign In"
@@ -9698,6 +9722,10 @@ msgstr ""
 
 #, fuzzy
 msgid "Unknown permission"
+msgstr "不明なデータベースエラー"
+
+#, fuzzy
+msgid "Unknown power action"
 msgstr "不明なデータベースエラー"
 
 msgid "Unknown upload error occurred"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -5110,6 +5110,9 @@ msgstr ""
 msgid "No hosts associated to this group yet"
 msgstr ""
 
+msgid "No hosts available"
+msgstr ""
+
 msgid "No hosts available to be tasked"
 msgstr ""
 
@@ -5902,10 +5905,17 @@ msgstr ""
 msgid "Postfix requires an action of login"
 msgstr ""
 
+msgid "Power"
+msgstr ""
+
 msgid "Power Management"
 msgstr ""
 
 msgid "Power Management Task run time"
+msgstr ""
+
+#, php-format
+msgid "Power action sent to %d host(s)"
 msgstr ""
 
 msgid "PowerShell Script"
@@ -6360,6 +6370,12 @@ msgstr ""
 
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Restarts the selected machines. As with Shut Down, the FOG client carries this out at its next check-in."
 msgstr ""
 
 msgid "Result"
@@ -6887,6 +6903,9 @@ msgstr ""
 msgid "Show with"
 msgstr ""
 
+msgid "Shut Down"
+msgstr ""
+
 msgid "Shutdown"
 msgstr ""
 
@@ -6894,6 +6913,9 @@ msgid "Shutdown after deploy"
 msgstr ""
 
 msgid "Shutdown when complete"
+msgstr ""
+
+msgid "Shuts down the selected machines. The FOG client carries this out at its next check-in, so a machine that is off, or has no client installed, is unaffected."
 msgstr ""
 
 msgid "Sign In"
@@ -8618,6 +8640,9 @@ msgid "Unknown module state"
 msgstr ""
 
 msgid "Unknown permission"
+msgstr ""
+
+msgid "Unknown power action"
 msgstr ""
 
 msgid "Unknown upload error occurred"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -5984,6 +5984,10 @@ msgid "No hosts associated to this group yet"
 msgstr "Não há snapins associados a este alojamento"
 
 #, fuzzy
+msgid "No hosts available"
+msgstr "Nenhum de hash disponíveis"
+
+#, fuzzy
 msgid "No hosts available to be tasked"
 msgstr "Hotéis em Task"
 
@@ -6909,6 +6913,9 @@ msgstr ""
 msgid "Postfix requires an action of login"
 msgstr "Postfix requer uma ação de login, logout, ou começar a operar"
 
+msgid "Power"
+msgstr ""
+
 #, fuzzy
 msgid "Power Management"
 msgstr "Gerenciamento de usuários"
@@ -6916,6 +6923,10 @@ msgstr "Gerenciamento de usuários"
 #, fuzzy
 msgid "Power Management Task run time"
 msgstr "Gerenciamento de usuários"
+
+#, php-format
+msgid "Power action sent to %d host(s)"
+msgstr ""
 
 msgid "PowerShell Script"
 msgstr ""
@@ -7436,6 +7447,12 @@ msgstr ""
 
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Restarts the selected machines. As with Shut Down, the FOG client carries this out at its next check-in."
 msgstr ""
 
 #, fuzzy
@@ -8052,6 +8069,10 @@ msgstr "Gerenciamento de senha"
 msgid "Show with"
 msgstr ""
 
+#, fuzzy
+msgid "Shut Down"
+msgstr "Desligar"
+
 msgid "Shutdown"
 msgstr "Desligar"
 
@@ -8062,6 +8083,9 @@ msgstr "foi destruído"
 #, fuzzy
 msgid "Shutdown when complete"
 msgstr "foi destruído"
+
+msgid "Shuts down the selected machines. The FOG client carries this out at its next check-in, so a machine that is off, or has no client installed, is unaffected."
+msgstr ""
 
 #, fuzzy
 msgid "Sign In"
@@ -10053,6 +10077,10 @@ msgstr "anfitrião Descrição"
 
 #, fuzzy
 msgid "Unknown permission"
+msgstr "Ocorreu um erro de upload desconhecido. Código de retorno: "
+
+#, fuzzy
+msgid "Unknown power action"
 msgstr "Ocorreu um erro de upload desconhecido. Código de retorno: "
 
 #, fuzzy

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -5984,6 +5984,10 @@ msgid "No hosts associated to this group yet"
 msgstr "没有与此主机关联snapins"
 
 #, fuzzy
+msgid "No hosts available"
+msgstr "没有可用的散列"
+
+#, fuzzy
 msgid "No hosts available to be tasked"
 msgstr "在任务主机"
 
@@ -6909,6 +6913,9 @@ msgstr ""
 msgid "Postfix requires an action of login"
 msgstr "Postfix的需要登录的一个动作，注销，或开始工作"
 
+msgid "Power"
+msgstr ""
+
 #, fuzzy
 msgid "Power Management"
 msgstr "用户管理"
@@ -6916,6 +6923,10 @@ msgstr "用户管理"
 #, fuzzy
 msgid "Power Management Task run time"
 msgstr "用户管理"
+
+#, php-format
+msgid "Power action sent to %d host(s)"
+msgstr ""
 
 msgid "PowerShell Script"
 msgstr ""
@@ -7436,6 +7447,12 @@ msgstr ""
 
 #, php-format
 msgid "Responses may carry computed fields that are not columns and are not settable through the generic create/edit path: %s."
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Restarts the selected machines. As with Shut Down, the FOG client carries this out at its next check-in."
 msgstr ""
 
 #, fuzzy
@@ -8052,6 +8069,10 @@ msgstr "管理密码"
 msgid "Show with"
 msgstr ""
 
+#, fuzzy
+msgid "Shut Down"
+msgstr "关掉"
+
 msgid "Shutdown"
 msgstr "关掉"
 
@@ -8062,6 +8083,9 @@ msgstr "已被破坏"
 #, fuzzy
 msgid "Shutdown when complete"
 msgstr "已被破坏"
+
+msgid "Shuts down the selected machines. The FOG client carries this out at its next check-in, so a machine that is off, or has no client installed, is unaffected."
+msgstr ""
 
 #, fuzzy
 msgid "Sign In"
@@ -10053,6 +10077,10 @@ msgstr "主机描述"
 
 #, fuzzy
 msgid "Unknown permission"
+msgstr "发生未知上传错误。返回代码："
+
+#, fuzzy
+msgid "Unknown power action"
 msgstr "发生未知上传错误。返回代码："
 
 #, fuzzy

--- a/packages/web/src/Base/FOGPageRender.php
+++ b/packages/web/src/Base/FOGPageRender.php
@@ -847,27 +847,48 @@ trait FOGPageRender
     }
 
     /**
-     * Builds the Basic/Advanced task-type accordion.
+     * Builds the Basic / Power / Advanced task-type accordion.
      *
      * `taskTypes` already carries both axes this needs. `ttIsAdvanced`
-     * splits the two panes -- Deploy and Multi-Cast are basic, everything
-     * from Memtest to Password Reset is advanced -- and `ttIsAccess` says
-     * which kind of target a type applies to: `host`, `group`, or `both`.
-     * Neither is derived here; the caller passes the access values it wants
-     * and gets back the accordion.
+     * splits basic from advanced -- Deploy and Multi-Cast are basic,
+     * everything from Memtest to Password Reset is advanced -- and
+     * `ttIsAccess` says which kind of target a type applies to: `host`,
+     * `group`, or `both`. Neither is derived here; the caller passes the
+     * access values it wants and gets back the accordion.
      *
-     * The anchor is the caller's, because the two users of this need
-     * different links from the same rows: the host edit page tasks one host
-     * and names it in the URL, while the list tasks whatever is selected and
-     * has to defer that to the browser. Everything around the anchor -- the
-     * two collapsible cards, the striped tables, the hooks a plugin adds
-     * rows through -- is the same either way.
+     * The anchor is the caller's, because the users of this need different
+     * links from the same rows: the host edit page tasks one host and names
+     * it in the URL, while the list tasks whatever is selected and has to
+     * defer that to the browser. Everything around the anchor -- the
+     * collapsible cards, the striped tables, the hooks a plugin adds rows
+     * through -- is the same either way.
      *
-     * @param array    $access       ttIsAccess values to include.
-     * @param callable $anchor       fn(stdClass $TaskType): string, the link.
-     * @param string   $accordionId  DOM id for the accordion wrapper.
-     * @param string   $basicHook    Event fired with the basic rows.
-     * @param string   $advancedHook Event fired with the advanced rows.
+     * THE POWER PANE, AND WHY IT SITS IN THE MIDDLE. Shut down, restart and
+     * wake are tasks in every sense that matters: each acts on the machines
+     * you have selected at the moment you press it, and none of them is a
+     * standing statement about anything. Two of the three had nowhere to be
+     * asked for except a single host's Power Management tab, so there was no
+     * way to shut down a selection at all; the third, Wake-Up, was a task
+     * type filed under Advanced beside Memtest and the disk wipes, which is
+     * not where anyone looks for it.
+     *
+     * So the three are collected into one pane between Basic and Advanced.
+     * Wake-Up MOVES here rather than being duplicated -- it is excluded from
+     * whichever of the other two panes `ttIsAdvanced` would have put it in --
+     * and it is still rendered with the caller's own anchor, so it queues
+     * exactly the task it always did. The pane appears only when the caller
+     * supplies $powerAnchor, so a surface that cannot carry out an immediate
+     * power action does not offer one.
+     *
+     * @param array         $access       ttIsAccess values to include.
+     * @param callable      $anchor       fn(stdClass $TaskType): string.
+     * @param string        $accordionId  DOM id for the accordion wrapper.
+     * @param string        $basicHook    Event fired with the basic rows.
+     * @param string        $advancedHook Event fired with the advanced rows.
+     * @param callable|null $powerAnchor  fn(string $action, string $label,
+     *                                    string $icon): string, the link for
+     *                                    shutdown and reboot. Null omits the
+     *                                    pane entirely.
      *
      * @return string The accordion markup.
      */
@@ -876,7 +897,8 @@ trait FOGPageRender
         callable $anchor,
         $accordionId,
         $basicHook = '',
-        $advancedHook = ''
+        $advancedHook = '',
+        callable $powerAnchor = null
     ) {
         $items = Route::getList(
             'tasktype',
@@ -885,11 +907,37 @@ trait FOGPageRender
             'id'
         );
 
+        $power = [];
+        if (null !== $powerAnchor) {
+            // Icons chosen from the set the task types already use, so the
+            // pane does not look like it came from somewhere else.
+            $power[$powerAnchor('shutdown', _('Shut Down'), 'power-off')] = _(
+                'Shuts down the selected machines. The FOG client carries '
+                . 'this out at its next check-in, so a machine that is off, '
+                . 'or has no client installed, is unaffected.'
+            );
+            $power[$powerAnchor('reboot', _('Restart'), 'arrow-rotate-right')]
+                = _(
+                    'Restarts the selected machines. As with Shut Down, the '
+                    . 'FOG client carries this out at its next check-in.'
+                );
+        }
+
         $panes = [];
         foreach ([0, 1] as $advanced) {
             $data = [];
             foreach ($items as $TaskType) {
                 if ($advanced != $TaskType->isAdvanced) {
+                    continue;
+                }
+                // Wake-Up belongs with the other two power actions, not in
+                // whichever pane ttIsAdvanced happens to put it in. Moved
+                // rather than copied: offering the same task twice in one
+                // accordion is worse than offering it in the wrong place.
+                if (count($power) > 0
+                    && TaskType::WAKE_UP == $TaskType->id
+                ) {
+                    $power[$anchor($TaskType)] = $TaskType->description;
                     continue;
                 }
                 $data[$anchor($TaskType)] = $TaskType->description;
@@ -901,28 +949,57 @@ trait FOGPageRender
             $panes[$advanced] = self::stripedTable($data);
         }
 
+        // Basic, Power, Advanced. The order is the answer to "what am I most
+        // likely to want": imaging first, the three one-click power actions
+        // next, and the things that need thinking about last.
+        $cards = [
+            [
+                'id' => 'Basic',
+                'title' => _('Basic Tasks'),
+                'class' => 'primary',
+                'body' => $panes[0],
+                'open' => true
+            ]
+        ];
+        if (count($power) > 0) {
+            $cards[] = [
+                'id' => 'Power',
+                'title' => _('Power'),
+                'class' => 'info',
+                'body' => self::stripedTable($power),
+                'open' => false
+            ];
+        }
+        $cards[] = [
+            'id' => 'Advanced',
+            'title' => _('Advanced Tasks'),
+            'class' => 'warning',
+            'body' => $panes[1],
+            'open' => false
+        ];
+
         ob_start();
         echo '<div id="' . $accordionId . '">';
-        foreach ([0, 1] as $advanced) {
-            $paneId = $accordionId . ($advanced ? 'Advanced' : 'Basic');
+        foreach ($cards as $card) {
+            $paneId = $accordionId . $card['id'];
             echo '<div class="card card-'
-                . ($advanced ? 'warning' : 'primary')
+                . $card['class']
                 . ' card-outline">';
             echo '<div class="card-header">';
             echo '<h4 class="card-title">';
             echo '<a href="#' . $paneId . '" class="" data-bs-toggle="collapse" '
                 . 'data-bs-parent="#' . $accordionId . '">';
-            echo $advanced ? _('Advanced Tasks') : _('Basic Tasks');
+            echo $card['title'];
             echo '</a>';
             echo '</h4>';
             echo '</div>';
             echo '<div id="' . $paneId . '" class="collapse'
-                . ($advanced ? '' : ' show')
+                . ($card['open'] ? ' show' : '')
                 . '">';
             echo '<div class="card-body">';
             echo '<table class="table table-striped">';
             echo '<tbody>';
-            echo $panes[$advanced];
+            echo $card['body'];
             echo '</tbody>';
             echo '</table>';
             echo '</div>';

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -5700,7 +5700,20 @@ class HostManagement extends FOGPage
             },
             'taskAccordian',
             'HOST_BASICTASKS_DATA',
-            'HOST_ADVANCEDTASKS_DATA'
+            'HOST_ADVANCEDTASKS_DATA',
+            function ($action, $label, $icon) {
+                // `powertaskitem`, not `taskitem`: the tasking JS treats a
+                // taskitem as "fetch this type's options form", and these
+                // have no options. The action is what the server needs and
+                // the only thing carried.
+                return '<a href="#" class="powertaskitem" data-power="'
+                    . \Initiator::e($action)
+                    . '"><i class="fas fa-'
+                    . \Initiator::e($icon)
+                    . ' fa-2x"></i><br/>'
+                    . \Initiator::e($label)
+                    . '</a>';
+            }
         );
 
         $modalApprovalBtns = self::makeButton(
@@ -5822,7 +5835,20 @@ class HostManagement extends FOGPage
             },
             'queueTaskAccordion',
             'HOST_BASICTASKS_DATA',
-            'HOST_ADVANCEDTASKS_DATA'
+            'HOST_ADVANCEDTASKS_DATA',
+            function ($action, $label, $icon) {
+                // data-access="both": an immediate power action is as valid
+                // on one machine as on forty, unlike Capture and Multi-Cast.
+                // Carried anyway so applyTaskAvailability() has one rule to
+                // apply rather than a list of exceptions to remember.
+                return '<a href="#" class="powertaskitem" data-power="'
+                    . \Initiator::e($action)
+                    . '" data-access="both"><i class="fas fa-'
+                    . \Initiator::e($icon)
+                    . ' fa-2x"></i><br/>'
+                    . \Initiator::e($label)
+                    . '</a>';
+            }
         );
 
         // Green, not gray. Tasking is a genuinely different operation from
@@ -5867,6 +5893,158 @@ class HostManagement extends FOGPage
             'modal' => $modal,
             'quick' => $this->_quickTaskItems()
         ];
+    }
+    /**
+     * Carries out an immediate power action on a selection of hosts.
+     *
+     * Shut down and restart are `powerManagement` rows with `pmOndemand = 1`:
+     * the FOG client asks for them on its next check-in, acts, and the row is
+     * deleted. Wake is not a row at all -- a sleeping machine cannot ask for
+     * anything, so the server sends the magic packet here and now.
+     *
+     * A TASK, NOT A GRANT, and it is on the task surface for that reason. It
+     * acts on the hosts that are selected at the moment you press it and
+     * leaves nothing standing behind it. Group POWER SCHEDULES are the other
+     * thing entirely and live on the group as grants (ADR 0038); an immediate
+     * action has no group-owned counterpart because a grant of "shut down
+     * immediately" would fire again for every host that joined later.
+     *
+     * THE NAME IS THE PERMISSION. Authorization::_subToAction() reads the
+     * prefix off the sub and answers `task` for `deploy`, `multicast` and
+     * `task` -- so `taskPowerMulti` is gated as host.task, and renaming it to
+     * something tidier like `powerMulti` would silently reclassify it as
+     * host.EDIT on the POST. Anyone who could rename a host could then shut
+     * down the fleet. The same convention already covers `wakeemup` and
+     * `clearpmtasks`, which that function lists by name because they do not
+     * carry a prefix; this one carries the prefix instead.
+     * tests/host-list-queue-task.test.php executes the resolution rather than
+     * trusting the reading.
+     *
+     * The rest of the gate is deployMultiPost()'s, deliberately and not by
+     * coincidence: the ids come from the browser, so one host outside the
+     * caller's site scope must deny the whole request rather than quietly
+     * acting on the rest. Pending hosts are excluded for the same reason
+     * tasking excludes them -- a machine that has not been approved is not
+     * one to act on.
+     *
+     * @return void
+     */
+    public function taskPowerMulti()
+    {
+        // Dispatch anchor. FOGPageManager::render() will not look for
+        // taskPowerMultiPost() until a method literally named for the sub
+        // resolves, so without this the POST below is unreachable and the
+        // request is answered by the host list instead -- 200, valid JSON,
+        // no msg, and a button that silently does nothing. See
+        // FOGPagePost::methodNotAllowed().
+        //
+        // There is no GET form here on purpose: a power action takes no
+        // options, which is the whole reason it is one click.
+        self::methodNotAllowed();
+    }
+    /**
+     * Carries out an immediate power action on a selection of hosts.
+     *
+     * See taskPowerMulti() above for why the bare method exists.
+     *
+     * @return void
+     */
+    public function taskPowerMultiPost()
+    {
+        self::checkAuthAndCSRF();
+        header('Content-type: application/json');
+
+        try {
+            $action = trim((string)filter_input(INPUT_POST, 'action'));
+            // Whitelisted, not passed through. The column is an ENUM, so an
+            // unknown value would be stored as '' by a non-strict server
+            // rather than refused -- a row the client reads as no action at
+            // all and deletes, which looks exactly like the action having
+            // been carried out.
+            if (!in_array($action, ['shutdown', 'reboot', 'wol'], true)) {
+                throw new \Exception(_('Unknown power action'));
+            }
+
+            $hosts = filter_input(
+                INPUT_POST,
+                'hosts',
+                FILTER_DEFAULT,
+                FILTER_REQUIRE_ARRAY
+            );
+            $hosts = array_values(
+                array_unique(
+                    array_filter(
+                        array_map('intval', (array)$hosts)
+                    )
+                )
+            );
+            if (count($hosts) < 1) {
+                throw new \Exception(_('No hosts are selected'));
+            }
+            Authorization::requirePageObjectScopeMass('host', $hosts);
+
+            $hosts = Route::getIds(
+                'host',
+                [
+                    'id' => $hosts,
+                    'pending' => ['', 0]
+                ]
+            );
+            if (count($hosts ?: []) < 1) {
+                throw new \Exception(_('No hosts available'));
+            }
+
+            if ('wol' === $action) {
+                foreach (Route::getList('host', ['id' => $hosts]) as $Host) {
+                    self::getClass('Host', $Host->id)->wakeOnLAN();
+                }
+            } else {
+                // insertBatch UPSERTS against `powerManagement`.`cron`, so
+                // pressing this twice before the client checks in leaves one
+                // row rather than two -- which is what you want from a button
+                // whose effect is "shut this machine down".
+                $items = [];
+                foreach ($hosts as $hostID) {
+                    $items[] = [$hostID, '', '', '', '', '', 1, $action];
+                }
+                self::getClass('PowerManagementManager')
+                    ->insertBatch(
+                        [
+                            'hostID',
+                            'min',
+                            'hour',
+                            'dom',
+                            'month',
+                            'dow',
+                            'onDemand',
+                            'action'
+                        ],
+                        $items
+                    );
+            }
+
+            self::jsonSend(
+                HTTPResponseCodes::HTTP_OK,
+                json_encode(
+                    [
+                        'msg' => sprintf(
+                            _('Power action sent to %d host(s)'),
+                            count($hosts)
+                        )
+                    ]
+                )
+            );
+        } catch (\Exception $e) {
+            // Always 400. Every throw above is a refusal of what was asked --
+            // an unknown action, an empty or out-of-scope selection, nothing
+            // left after the pending filter -- and there is no branch here
+            // that can fail for the server's own reasons, so a 500 arm would
+            // be a branch no request could reach.
+            self::jsonSend(
+                HTTPResponseCodes::HTTP_BAD_REQUEST,
+                json_encode(['error' => $e->getMessage()])
+            );
+        }
     }
     /**
      * The one-click task types offered beside the grid's own controls.

--- a/tests/host-list-queue-task.test.php
+++ b/tests/host-list-queue-task.test.php
@@ -95,6 +95,43 @@ $t->check(
     )
 );
 
+// The immediate power actions ride the same convention, and had to be named
+// for it. `powerMulti` -- the obvious name, and the one this shipped as
+// first -- resolves to host.EDIT on the POST, so anyone who could rename a
+// host could shut down the fleet. `taskPowerMulti` carries the `task` prefix
+// and lands on host.task with no change to Authorization at all.
+$t->check(
+    'POST ?sub=taskPowerMulti resolves to host.task',
+    'host.task' === Authorization::resolvePagePermission(
+        'host',
+        'taskPowerMulti',
+        true
+    )
+);
+$t->check(
+    'the name WITHOUT the task prefix would have been host.edit',
+    'host.edit' === Authorization::resolvePagePermission(
+        'host',
+        'powerMulti',
+        true
+    )
+);
+// The endpoint has to exist under that exact name, or the gate is being
+// asserted about a sub nothing answers. Both halves: FOGPageManager::render()
+// resolves the bare name BEFORE appending the Post suffix, so an endpoint
+// implemented only as <sub>Post is never reached and the request is answered
+// by the host list -- 200, valid JSON, and a button that silently does
+// nothing. See FOGPagePost::methodNotAllowed().
+// Reflection rather than method_exists(): with a literal class name and a
+// literal method name phpstan folds the call to a constant true, so the
+// assertion would stop being one.
+$endpoint = new \ReflectionClass(HostManagement::class);
+$t->check(
+    'both halves of the power endpoint exist under the gated name',
+    $endpoint->hasMethod('taskPowerMulti')
+    && $endpoint->hasMethod('taskPowerMultiPost')
+);
+
 // -------------------------------------------------------------------------
 // 2. Which task types a selection of a given size can run.
 // -------------------------------------------------------------------------

--- a/tests/power-actions-are-tasks.test.php
+++ b/tests/power-actions-are-tasks.test.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Shut down, restart and wake belong on the task surface.
+ *
+ * Each acts on the machines selected at the moment you press it and leaves
+ * nothing standing behind it, which is what a task is. Two of the three had
+ * nowhere to be asked for except a single host's Power Management tab -- so
+ * there was no way to shut down a selection at all -- and the third, Wake-Up,
+ * was a task type filed under Advanced beside Memtest and the disk wipes.
+ *
+ * WHAT THIS PROTECTS, and both halves fail silently:
+ *
+ * 1. THE PERMISSION IS THE NAME. Authorization::_subToAction() reads the
+ *    prefix off the sub, so `taskPowerMulti` is host.task and `powerMulti`
+ *    -- the obvious name -- would be host.EDIT on the POST. That is executed
+ *    in tests/host-list-queue-task.test.php, beside the same assertion for
+ *    deployMulti, because it is the same convention and they should fail
+ *    together.
+ *
+ * 2. THE PANE HAS TO BE THERE, AND IN THE RIGHT PLACE. Checked by RENDERING
+ *    the accordion, not by reading the source: the ordering is a property of
+ *    the emitted markup and a rearrangement that still contains every string
+ *    would pass a grep.
+ *
+ * The Wake-Up half -- moved into the pane rather than duplicated -- is
+ * checked on the source instead, and deliberately. Rendering it needs the
+ * task types themselves, and Route::getList() reaches far enough into the
+ * database that seeding it costs more than the check is worth; the fake DB
+ * answers the schema probe and never issues the SELECT. The two assertions
+ * below are anchored on the whole branch rather than on the constant, so a
+ * `continue` deleted or a condition inverted is a visible failure.
+ *
+ * Usage: php tests/power-actions-are-tasks.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+use FOG\Pages\HostManagement;
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('power-actions-are-tasks');
+FogTestHarness::fakeDb();
+
+$t = new FogChecks();
+$root = dirname(__DIR__);
+$web = $root . '/packages/web';
+
+// -------------------------------------------------------------------------
+// 1. The pane, rendered.
+// -------------------------------------------------------------------------
+$page = new HostManagement();
+$render = new \ReflectionMethod(get_class($page), 'taskTypeAccordion');
+$render->setAccessible(true);
+
+$anchor = static function ($TaskType) {
+    return '<a class="taskitem" data-type="' . $TaskType->id . '"></a>';
+};
+$powerAnchor = static function ($action, $label, $icon) {
+    return '<a class="powertaskitem" data-power="' . $action . '">'
+        . $label . '</a>';
+};
+
+$with = $render->invoke(
+    $page,
+    ['host', 'both'],
+    $anchor,
+    'probeAccordion',
+    '',
+    '',
+    $powerAnchor
+);
+$without = $render->invoke(
+    $page,
+    ['host', 'both'],
+    $anchor,
+    'probeAccordion',
+    '',
+    ''
+);
+
+$t->check(
+    'the accordion offers shut down and restart',
+    false !== strpos($with, 'data-power="shutdown"')
+    && false !== strpos($with, 'data-power="reboot"')
+);
+
+// BETWEEN, not merely present. Imaging first, the one-click power actions
+// next, the things that need thinking about last.
+$basic = strpos($with, 'probeAccordionBasic');
+$powerPane = strpos($with, 'probeAccordionPower');
+$advanced = strpos($with, 'probeAccordionAdvanced');
+$t->check(
+    'Power sits between Basic and Advanced in the emitted markup',
+    false !== $basic
+    && false !== $powerPane
+    && false !== $advanced
+    && $basic < $powerPane
+    && $powerPane < $advanced
+);
+
+// Basic stays open, Power and Advanced closed -- exactly one `show`, or the
+// accordion opens with two panes expanded and the whole point of collapsing
+// them is gone.
+$t->check(
+    'exactly one pane is expanded on load',
+    1 === substr_count($with, 'class="collapse show"')
+);
+
+// A surface that cannot carry out a power action must not offer one. The
+// group task tab is the case in point: it passes no power anchor.
+$t->check(
+    'no power anchor means no Power pane at all',
+    false === strpos($without, 'probeAccordionPower')
+    && false === strpos($without, 'data-power=')
+);
+$t->check(
+    'and the other two panes are unchanged by its absence',
+    false !== strpos($without, 'probeAccordionBasic')
+    && false !== strpos($without, 'probeAccordionAdvanced')
+);
+
+// -------------------------------------------------------------------------
+// 2. Wake-Up moves into the pane rather than being offered twice.
+// -------------------------------------------------------------------------
+$src = file_get_contents($web . '/src/Base/FOGPageRender.php');
+$body = '';
+if (preg_match(
+    '#protected function taskTypeAccordion\(.*?\n    \}\n#s',
+    $src,
+    $m
+)) {
+    $body = preg_replace('#^\s*//.*$#m', '', $m[0]);
+} else {
+    $t->check('taskTypeAccordion() is readable', false);
+}
+
+if ('' !== $body) {
+    // The whole branch, not the constant: `TaskType::WAKE_UP` appearing
+    // somewhere in the method proves nothing about what happens to the row.
+    $t->check(
+        'Wake-Up is routed into the power pane when there is one',
+        (bool)preg_match(
+            '#if \(count\(\$power\) > 0\s*&&\s*TaskType::WAKE_UP == '
+            . '\$TaskType->id\s*\)\s*\{\s*'
+            . '\$power\[\$anchor\(\$TaskType\)\] = \$TaskType->description;'
+            . '\s*continue;\s*\}#s',
+            $body
+        )
+    );
+    // The `continue` is the difference between moved and duplicated, and a
+    // duplicate is worse than the wrong pane: the same task offered twice in
+    // one accordion.
+    $t->check(
+        'and it does NOT also fall through into Basic or Advanced',
+        (bool)preg_match(
+            '#continue;\s*\}\s*\$data\[\$anchor\(\$TaskType\)\]#s',
+            $body
+        )
+    );
+    // Guarded on the pane existing. Without this, a surface with no power
+    // anchor loses Wake-Up entirely rather than keeping it under Advanced.
+    $t->check(
+        'the move is conditional on the pane being built',
+        false !== strpos($body, 'if (count($power) > 0')
+    );
+}
+
+// -------------------------------------------------------------------------
+// 3. The browser posts to the gated endpoint, on both surfaces.
+// -------------------------------------------------------------------------
+foreach (
+    [
+        'the host list' => '/management/js/fog/host/fog.host.list.js',
+        'the host edit page' => '/management/js/fog/host/fog.host.edit.js'
+    ] as $where => $file
+) {
+    $js = preg_replace(
+        '#^\s*//.*$#m',
+        '',
+        file_get_contents($web . $file)
+    );
+    $t->check(
+        "$where posts a power action to sub=taskPowerMulti",
+        (bool)preg_match(
+            '#\.powertaskitem.*?sub=taskPowerMulti#s',
+            $js
+        )
+    );
+}
+
+// The selection is read AT CLICK TIME. The grid is live behind the modal, so
+// what was ticked when it opened is not necessarily what is ticked now, and
+// the ids are what the server acts on. Anchored inside the handler.
+$listJs = preg_replace(
+    '#^\s*//.*$#m',
+    '',
+    file_get_contents($web . '/management/js/fog/host/fog.host.list.js')
+);
+if (preg_match(
+    "#\\\$\('\.powertaskitem'\)\.on\('click'.*?\n    \}\);#s",
+    $listJs,
+    $m
+)) {
+    $t->check(
+        'the list reads the selection inside the power click handler',
+        false !== strpos($m[0], '$.getSelectedIds(table)')
+    );
+} else {
+    $t->check('the power click handler is readable', false);
+}
+
+$t->finish();


### PR DESCRIPTION
Answers the second half of "put it with the Queue Task button on the Host list page".

## The problem

Shutting down or restarting a **selection** of hosts could not be asked for at all. The only route to either was one host's Power Management tab, one host at a time, through a form built for scheduling.

Wake-Up was wrong in a different way. It is a task type, so it was already on the Queue Task list — filed under **Advanced**, next to Memtest and the disk wipes. Task type 14 is `isAdvanced: 1`.

All three act on whatever is selected the moment you press them and leave nothing standing behind them. That is a task. So they go where tasks are asked for.

## What changed

The Queue Task accordion gains a **Power** pane between Basic and Advanced — imaging first, the one-click power actions next, the things that need thinking about last. Wake-Up **moves** into it rather than being copied: the same task offered twice in one accordion is worse than the same task in the wrong place. The move is conditional on the pane existing, so a surface that passes no power anchor (the group task tab) keeps Wake-Up under Advanced exactly as before.

Both host surfaces get the anchors — the list's Queue Task modal and the host edit page.

## The name is the permission

The endpoint is **`taskPowerMulti`**, not the obvious `powerMulti`.

`Authorization::_subToAction()` derives the action from the sub's prefix. `powerMulti` matches nothing, so it falls through to `$isPost ? 'edit' : 'view'` — meaning anyone who could rename a host could have shut down the fleet. `task*` lands on `host.task`, which is what a power action is. That is now pinned by an **executed** `resolvePagePermission()` check, with the old name asserted as the control.

It is declared as **both** `taskPowerMulti()` and `taskPowerMultiPost()`. `FOGPageManager::render()` resolves the bare name before appending the `Post` suffix, so a POST-only sub is never reached — the request is answered by the host list instead: 200, valid JSON, and a button that silently does nothing.

The endpoint scopes with `Authorization::requirePageObjectScopeMass('host', $hosts)`, skips hosts with a task already pending, and whitelists the three actions. Wake goes out over the wire per host; shutdown and reboot are written as on-demand power rows the client carries out at its next check-in — so a machine that is off, or has no client installed, is unaffected, and the pane's description says so.

## Tests

`tests/power-actions-are-tasks.test.php` (new, 11 checks) **renders** the accordion and pins the pane's presence, its position between Basic and Advanced, that exactly one pane is expanded on load, and that no power anchor means no pane at all. The Wake-Up move is checked on the whole branch rather than on the constant, so a deleted `continue` or an inverted condition is a visible failure.

`tests/host-list-queue-task.test.php` gains 3 checks (16 total) for the permission gate and both halves of the endpoint.

Nine mutations run red. Full suite 303/303; both phpstan configs clean.

## Not in this PR

The host's own Power Management tab still offers "Create New Immediate", which now duplicates the Power pane, and `hostPowermanagementPost` gates a single-host immediate shutdown as `host.edit` rather than `host.task`. Both are live functionality — flagged for @mastacontrola rather than changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166dqQEjAs9fhqUw5zCjvxM