### PR TITLE
Take the immediate power action off the edit-gated sub

### DIFF
--- a/packages/web/management/js/fog/host/fog.host.edit.js
+++ b/packages/web/management/js/fog/host/fog.host.edit.js
@@ -1110,18 +1110,12 @@
 
     // The form Control elements of Power Management.
     var powermanagementForm = $('#host-powermanagement-cron-form'),
-        powermanagementFormBtn = $('#powermanagement-send'),
         // Insert Form cron elements.
         minutes = $('.cronmin', powermanagementForm),
         hours = $('.cronhour', powermanagementForm),
         dom = $('.crondom', powermanagementForm),
         month = $('.cronmonth', powermanagementForm),
         dow = $('.crondow', powermanagementForm),
-        instantModal = $('#ondemandModal'),
-        instantBtn = $('#ondemandBtn'),
-        instantModalCancelBtn = $('#ondemandCancelBtn'),
-        instantModalCreateBtn = $('#ondemandCreateBtn'),
-        instantForm = $('#host-powermanagement-instant-form'),
         scheduleModal = $('#scheduleModal'),
         scheduleBtn = $('#scheduleBtn'),
         scheduleModalCancelBtn = $('#scheduleCancelBtn'),
@@ -1144,24 +1138,6 @@
     powermanagementForm.on('submit', function(e) {
         e.preventDefault();
     });
-    powermanagementFormBtn.on('click', function() {
-        powermanagementFormBtn.prop('disabled', true);
-        powermanagementForm.processForm(function(err) {
-            powermanagementFormBtn.prop('disabled', false);
-            if (err) {
-                return;
-            }
-            minutes.val('');
-            hours.val('');
-            dom.val('');
-            month.val('');
-            dow.val('');
-            action.val('');
-            specialCrons.val('');
-            ondemand.prop('checked', false).trigger('change');
-        });
-    });
-
     // The Power Management List element.
     function onPMSelect(selected) {
         var disable = selected.count() == 0;
@@ -1200,32 +1176,10 @@
         }
     });
 
-    instantBtn.on('click', function(e) {
-        e.preventDefault();
-        instantModal.modal('show');
-    });
     scheduleBtn.on('click', function(e) {
         e.preventDefault();
         scheduleModal.modal('show');
     });
-    instantModal.registerModal(
-        function(e) {
-            instantModalCreateBtn.on('click', function() {
-                $(this).prop('disabled', true);
-                instantForm.processForm(function(err) {
-                    instantModalCreateBtn.prop('disabled', false);
-                    if (err) {
-                        return;
-                    }
-                    instantModal.modal('hide');
-                    powermanagementTable.draw(false);
-                });
-            });
-        },
-        function(e) {
-            $(this).modal('hide');
-        }
-    );
     scheduleModal.registerModal(
         function(e) {
             scheduleModalCreateBtn.on('click', function() {
@@ -1247,8 +1201,6 @@
 
     pmdelete.on('click', function(e) {
         scheduleBtn.prop('disabled', true);
-        instantBtn.prop('disabled', true);
-
 
         var method = $(this).attr('method'),
             action = $(this).attr('action'),
@@ -1259,7 +1211,6 @@
             };
         $.apiCall(method,action,opts,function(err) {
             scheduleBtn.prop('disabled', false);
-            instantBtn.prop('disabled', false);
             if (err) {
                 return;
             }

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -2905,17 +2905,16 @@ class HostManagement extends FOGPage
             []
         ];
         $buttons = '';
-        $splitButtons = self::makeSplitButton(
+        // A plain button, not a split button. The second half of the split
+        // was "Create New Immediate", and an immediate shut down, restart or
+        // wake is a TASK: it acts on the machine now and leaves nothing
+        // behind it. It is asked for from Queue Task on this same page, in
+        // the Power pane, alongside every other one-off. This tab is for
+        // SCHEDULES, which is what its card says it is.
+        $scheduleButton = self::makeButton(
             'scheduleBtn',
             _('Create New Scheduled'),
-            [
-                [
-                    'id' => 'ondemandBtn',
-                    'text' => _('Create New Immediate')
-                ]
-            ],
-            'right',
-            'primary'
+            'btn btn-primary float-end'
         );
         $props = ' method="post" action="'
             . self::makeTabUpdateURL(
@@ -2927,18 +2926,6 @@ class HostManagement extends FOGPage
             'pm-delete',
             _('Delete selected'),
             'btn btn-danger float-start',
-            $props
-        );
-        $ondemandModalBtns = self::makeButton(
-            'ondemandCancelBtn',
-            _('Cancel'),
-            'btn btn-outline-secondary float-start',
-            'data-bs-dismiss="modal"'
-        );
-        $ondemandModalBtns .= self::makeButton(
-            'ondemandCreateBtn',
-            _('Create'),
-            'btn btn-outline-secondary float-end',
             $props
         );
         $scheduleModalBtns = self::makeButton(
@@ -2960,17 +2947,13 @@ class HostManagement extends FOGPage
         echo '</h4>';
         echo '</div>';
         echo '<div class="card-body">';
-        $this->render(12, 'host-powermanagement-table', $buttons.$splitButtons);
+        $this->render(
+            12,
+            'host-powermanagement-table',
+            $buttons . $scheduleButton
+        );
         echo '</div>';
         echo '<div class="card-footer">';
-        echo self::makeModal(
-            'ondemandModal',
-            _('Create Immediate Power task'),
-            $this->newPMDisplay(true),
-            $ondemandModalBtns,
-            '',
-            'info'
-        );
         echo self::makeModal(
             'scheduleModal',
             _('Create Scheduled Power task'),
@@ -2983,7 +2966,22 @@ class HostManagement extends FOGPage
         echo '</div>';
     }
     /**
-     * Host power management post.
+     * Host power management post: create and delete SCHEDULES.
+     *
+     * Nothing here fires an immediate action, and that is the point. This
+     * sub is named `powermanagement`, which Authorization::_subToAction()
+     * resolves to host.EDIT on a POST -- so anything reachable through it is
+     * gated as "may change this host's settings". A schedule is exactly
+     * that, and it matches the group side, where granting one is group.edit.
+     *
+     * An immediate shut down, restart or wake is not: it acts on the machine
+     * now. Those live on taskPowerMulti, whose `task` prefix puts them
+     * behind host.TASK, and are asked for from Queue Task. Two paths used to
+     * create an on-demand row here -- `pmaddod`, behind "Create New
+     * Immediate", and a `pmupdate` branch that no page had posted to in
+     * years but that could still flip a saved schedule to on-demand. Both
+     * are gone, and the insert pins onDemand to 0 rather than trusting that
+     * they stay gone.
      *
      * @return void
      */
@@ -2991,63 +2989,7 @@ class HostManagement extends FOGPage
     {
         self::checkAuthAndCSRF();
         $flags = ['flags' => FILTER_REQUIRE_ARRAY];
-        if (isset($_POST['pmupdate'])) {
-            $items = filter_input_array(
-                INPUT_POST,
-                [
-                    'scheduleCronMin' => $flags,
-                    'scheduleCronHour' => $flags,
-                    'scheduleCronDOM' => $flags,
-                    'scheduleCronMonth' => $flags,
-                    'scheduleCronDOW' => $flags,
-                    'pmid' => $flags,
-                    'onDemand' => $flags,
-                    'action' => $flags
-                ]
-            );
-            extract($items);
-            if (!$action) {
-                throw new \Exception(
-                    _('You must select an action to perform')
-                );
-            }
-            $items = [];
-            foreach ((array)$pmid as $index => &$pm) {
-                $onDemandItem = array_search(
-                    $pm,
-                    (array)$onDemand
-                );
-                $items[] = [
-                    $pm,
-                    $this->obj->get('id'),
-                    FOGCron::_sanitizeCronField($scheduleCronMin[$index]),
-                    FOGCron::_sanitizeCronField($scheduleCronHour[$index]),
-                    FOGCron::_sanitizeCronField($scheduleCronDOM[$index]),
-                    FOGCron::_sanitizeCronField($scheduleCronMonth[$index]),
-                    FOGCron::_sanitizeCronField($scheduleCronDOW[$index]),
-                    $onDemandItem !== false ? 1 : 0,
-                    $action[$index]
-                ];
-                unset($pm);
-            }
-            self::getClass('PowerManagementManager')
-                ->insertBatch(
-                    [
-                        'id',
-                        'hostID',
-                        'min',
-                        'hour',
-                        'dom',
-                        'month',
-                        'dow',
-                        'onDemand',
-                        'action'
-                    ],
-                    $items
-                );
-        }
-        if (isset($_POST['pmadd']) || isset($_POST['pmaddod'])) {
-            $onDemand = (int)isset($_POST['pmaddod']);
+        if (isset($_POST['pmadd'])) {
             $min = trim(
                 (string)filter_input(
                     INPUT_POST,
@@ -3084,17 +3026,11 @@ class HostManagement extends FOGPage
                     'action'
                 )
             );
-            if ($onDemand && $action === 'wol') {
-                $this->obj->wakeOnLAN();
-                return;
-            }
-            if (!$onDemand) {
-                $min = FOGCron::_sanitizeCronField($min);
-                $hour = FOGCron::_sanitizeCronField($hour);
-                $dom = FOGCron::_sanitizeCronField($dom);
-                $month = FOGCron::_sanitizeCronField($month);
-                $dow = FOGCron::_sanitizeCronField($dow);
-            }
+            $min = FOGCron::_sanitizeCronField($min);
+            $hour = FOGCron::_sanitizeCronField($hour);
+            $dom = FOGCron::_sanitizeCronField($dom);
+            $month = FOGCron::_sanitizeCronField($month);
+            $dow = FOGCron::_sanitizeCronField($dow);
             self::getClass('PowerManagement')
                 ->set('hostID', $this->obj->get('id'))
                 ->set('min', $min)
@@ -3102,7 +3038,13 @@ class HostManagement extends FOGPage
                 ->set('dom', $dom)
                 ->set('month', $month)
                 ->set('dow', $dow)
-                ->set('onDemand', $onDemand)
+                // Always a schedule. This sub is gated host.EDIT by the
+                // naming convention in Authorization::_subToAction(), and an
+                // on-demand row is an immediate shut down of the machine --
+                // which is a task, and belongs behind host.TASK. The one
+                // endpoint that creates them is taskPowerMulti, whose name
+                // is what puts it there.
+                ->set('onDemand', 0)
                 ->set('action', $action)
                 ->save();
         }

--- a/tests/power-actions-are-tasks.test.php
+++ b/tests/power-actions-are-tasks.test.php
@@ -22,6 +22,16 @@
  *    the emitted markup and a rearrangement that still contains every string
  *    would pass a grep.
  *
+ * 3. THE HOST'S POWER MANAGEMENT TAB DOES NOT OFFER AN IMMEDIATE ACTION.
+ *    Not a tidiness rule -- a permission one. `hostPowermanagementPost` is
+ *    reached as sub=powermanagement, which _subToAction() resolves to
+ *    host.EDIT on a POST, so anything reachable through it is gated as "may
+ *    change this host's settings". A schedule is that. An immediate shut
+ *    down is not, and it had two ways in: `pmaddod` behind "Create New
+ *    Immediate", and a `pmupdate` branch no page had posted to in years
+ *    that could still flip a saved schedule to on-demand. Both are checked
+ *    for here, and so is the literal 0 the insert now pins.
+ *
  * The Wake-Up half -- moved into the pane rather than duplicated -- is
  * checked on the source instead, and deliberately. Rendering it needs the
  * task types themselves, and Route::getList() reaches far enough into the
@@ -216,5 +226,92 @@ if (preg_match(
 } else {
     $t->check('the power click handler is readable', false);
 }
+
+// -------------------------------------------------------------------------
+// 4. The host's Power Management tab is schedules only.
+// -------------------------------------------------------------------------
+$host = new HostManagement();
+$obj = \FOG\Base\FOGCore::getClass('Host');
+$obj->set('id', 5);
+$objProp = new \ReflectionProperty(get_class($host), 'obj');
+$objProp->setAccessible(true);
+$objProp->setValue($host, $obj);
+
+ob_start();
+$host->hostPowermanagement();
+$tab = (string)ob_get_clean();
+
+// The control. newPMDisplay(true) is the form that carries the on-demand
+// marker, so its absence below is a fact about the page rather than about
+// the string never having existed.
+$pmDisplay = new \ReflectionMethod(get_class($host), 'newPMDisplay');
+$pmDisplay->setAccessible(true);
+$t->check(
+    'the immediate form is what carries the pmaddod marker',
+    false !== strpos((string)$pmDisplay->invoke($host, true), 'pmaddod')
+);
+$t->check(
+    'the tab renders the schedule form',
+    false !== strpos($tab, 'name="pmadd"')
+);
+$t->check(
+    'and no form on it posts an immediate action',
+    false === strpos($tab, 'pmaddod')
+);
+$t->check(
+    'there is no immediate control to press',
+    false === strpos($tab, 'ondemandModal')
+    && false === strpos($tab, 'ondemandBtn')
+);
+
+// The server half. The render above covers what the page offers; these
+// cover what the endpoint would accept from a hand-made POST, which is the
+// part that actually matters for a permission.
+$hostSrc = (string)file_get_contents($web . '/src/Pages/HostManagement.php');
+$postAt = strpos($hostSrc, 'public function hostPowermanagementPost()');
+$method = '';
+if (false !== $postAt) {
+    $open = strpos($hostSrc, '{', $postAt);
+    $depth = 0;
+    for ($i = $open; $i < strlen($hostSrc); $i++) {
+        if ('{' === $hostSrc[$i]) {
+            $depth++;
+        } elseif ('}' === $hostSrc[$i]) {
+            $depth--;
+            if (0 === $depth) {
+                $method = substr($hostSrc, $open, $i - $open + 1);
+                break;
+            }
+        }
+    }
+}
+$t->check('the endpoint body is readable', '' !== $method);
+$t->check(
+    'the endpoint has no on-demand branch left',
+    '' !== $method
+    && false === strpos($method, 'pmaddod')
+    && false === strpos($method, 'pmupdate')
+);
+$t->check(
+    'and it writes a literal 0, not whatever the request asked for',
+    '' !== $method
+    && (bool)preg_match("#->set\('onDemand', 0\)#", $method)
+);
+// Both sides of the boundary in one place, so the pair reads as the rule it
+// is rather than as two unrelated facts: the edit-gated sub takes
+// schedules, the task-gated one takes immediate actions.
+$t->check(
+    'the immediate endpoint is still the task-gated one',
+    'task' === FogTestHarness::callStatic(
+        'Authorization',
+        '_subToAction',
+        ['taskPowerMulti', true]
+    )
+    && 'edit' === FogTestHarness::callStatic(
+        'Authorization',
+        '_subToAction',
+        ['powermanagement', true]
+    )
+);
 
 $t->finish();


### PR DESCRIPTION
Follow-on to #1661, closing the permission gap it left behind.

## The gap

`taskPowerMulti` gates an immediate shut down as **host.task** — the `task` prefix is what puts it there, via `Authorization::_subToAction()`.

The host's **Power Management** tab was still offering the same act through `sub=powermanagement`, which the same convention resolves to **host.edit** on a POST. Same action, two permissions, and the weaker one reachable by anyone who could rename a host.

## Two ways in, both closed

- **`pmaddod`**, behind *Create New Immediate*. The button, its modal and the branch that read it are gone; the split button is now a plain one, because there is nothing left to split. The insert pins `onDemand` to a **literal 0** rather than to what the request asked for, so the branch cannot creep back.
- **A `pmupdate` branch** that no page in the webroot had posted to in years and that could still flip a saved schedule to on-demand. Removed rather than left: "dead" here meant "no UI", not "unreachable" — it was one hand-made POST away.

## Why the sub is *not* renamed

The obvious symmetric fix is to rename this sub so it gates as `host.task` too. With the immediate paths gone, that would be wrong. What is left on it is *create a schedule* and *delete a schedule*, which is genuinely an edit of the host — and the identical operation on a group is `group.edit`. Renaming would put host schedule editing on a different permission from the group's, which is the inconsistency this PR removes rather than one to introduce.

## Nothing is lost from the page

**Queue Task** on the same host offers all three actions in its Power pane (#1661). The tab is schedules only now, which is what its card has always claimed to be.

## Also

A dead click handler in `fog.host.edit.js` bound to `#powermanagement-send`, an element the page has never emitted. It called `ondemand` and `specialCrons`, neither declared anywhere in that file, so it would have thrown a `ReferenceError` had it ever fired — and the only thing that could have produced an `ondemand` control was the modal this PR removes.

## Tests

`tests/power-actions-are-tasks.test.php` gains 8 checks (19 total):

- The tab is **rendered** and asserted to carry the schedule form and no on-demand marker, with `newPMDisplay(true)` invoked as the control that proves the marker is a real string and not one that never existed.
- The endpoint body is extracted by brace counting and asserted to hold no on-demand branch and the literal `0`.
- Both sides of the permission boundary asserted together by **running** `_subToAction()`, so the pair reads as the rule it is.

Three mutations run red: the modal put back, `onDemand` read from the request again, the `pmupdate` branch restored. Full suite 304/304, both phpstan configs clean.

Docs: FOGProject/fog-docs#174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166dqQEjAs9fhqUw5zCjvxM