### PR TITLE
fix: write U-Boot pxelinux.cfg files under the TFTP root, not the kernel dir

### DIFF
--- a/docs/UBOOT_ARM_BOOT.md
+++ b/docs/UBOOT_ARM_BOOT.md
@@ -153,6 +153,13 @@ Two things this depends on that the direct-`wget` path does not:
   FOG's kernel-upload feature already uses to reach a TFTP root that may not
   be the web server itself -- if kernel uploads to ARM boards already work,
   these are already configured.
+- **`FOG_TFTP_ROOT_DIR` must be the directory tftpd serves from.** The
+  installer sets it (`/tftpboot` on most distributions) and the file is
+  written to `pxelinux.cfg/` under it, because that is where `pxe get` looks:
+  tftpd-hpa runs chrooted to this directory and cannot serve anything outside
+  it. It is deliberately not `FOG_TFTP_PXE_KERNEL_DIR`, which is the
+  HTTP-served kernel directory under the web root; the first version of this
+  sync wrote there, so the file existed and TFTP timed out on it anyway.
 - **Failures here are silent by design.** An unreachable TFTP host must never
   block queuing, canceling, or completing a task, so every failure is logged
   through FOG's fault log rather than surfaced to whoever triggered the task.

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -11756,6 +11756,7 @@ class Config
         define('TFTP_FTP_USERNAME', \"${SVC_user}\");
         define('TFTP_FTP_PASSWORD', '${SVC_password}');
         define('TFTP_PXE_KERNEL_DIR', \"${webdirdest}/service/ipxe/\");
+        define('TFTP_ROOT_DIR', \"${tftpdirdst}\");
         define('PXE_KERNEL', 'bzImage');
         define('PXE_KERNEL_RAMDISK', 275000);
         define('USE_SLOPPY_NAME_LOOKUPS', true);

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -10644,3 +10644,25 @@ $this->schema[] =
 
         return true;
     };
+
+// 412
+$this->schema[] = [
+    // U-Boot's `pxe get` fetches pxelinux.cfg/01-<mac> relative to the TFTP
+    // root, and tftpd-hpa serves chrooted to that root (-s $tftpdirdst). Until
+    // this step UbootTftpSync wrote under FOG_TFTP_PXE_KERNEL_DIR, which is the
+    // HTTP-served kernel directory (<webroot>/service/ipxe/), outside the
+    // chroot -- so the file existed and TFTP could never serve it (forums
+    // topic 18229). The root is distro-dependent (/tftpboot, /var/lib/tftpboot,
+    // /srv/tftp, ...) and only the installer knows it, so it publishes it as
+    // TFTP_ROOT_DIR the same way it publishes TFTP_PXE_KERNEL_DIR; the
+    // defined() guard is for a tree updated by git pull with a config.class.php
+    // the installer has not regenerated yet.
+    "INSERT IGNORE INTO `globalSettings` "
+    . "(`settingKey`,`settingDesc`,`settingValue`,`settingCategory`) "
+    . "VALUES "
+    . "('FOG_TFTP_ROOT_DIR','The directory the TFTP server serves from "
+    . "(its chroot). U-Boot boards without wget fetch their "
+    . "pxelinux.cfg/01-<mac> boot file from here.','"
+    . (defined('TFTP_ROOT_DIR') ? TFTP_ROOT_DIR : '/tftpboot')
+    . "','TFTP Server')",
+];

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -130,7 +130,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 411);
+        define('FOG_SCHEMA', 412);
         define('FOG_BCACHE_VER', 359);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/src/Boot/UbootTftpSync.php
+++ b/packages/web/src/Boot/UbootTftpSync.php
@@ -32,10 +32,12 @@ use FOG\Router\Route;
  * made this necessary and UbootBootMenu's class doc for the design this
  * sits beside rather than inside.
  *
- * The write target is FOG_TFTP_PXE_KERNEL_DIR over SSH/SFTP
- * (FOG_TFTP_HOST + FOG_TFTP_FTP_USERNAME/PASSWORD), the same mechanism
- * FOGPage.php's kernel-upload action already uses for the same reason: the
- * TFTP root can be a remote storage node, not the web server.
+ * The write target is pxelinux.cfg under FOG_TFTP_ROOT_DIR -- the directory
+ * tftpd actually serves (its chroot), NOT FOG_TFTP_PXE_KERNEL_DIR, which is
+ * the HTTP-served kernel directory and invisible to a chrooted tftpd -- over
+ * SSH/SFTP (FOG_TFTP_HOST + FOG_TFTP_FTP_USERNAME/PASSWORD), the same
+ * mechanism FOGPage.php's kernel-upload action already uses for the same
+ * reason: the TFTP root can be a remote storage node, not the web server.
  *
  * Two ways this gets called, both intentionally cheap for the common case
  * where nothing here is in use at all (no hosts with MACs, or a fleet with
@@ -82,12 +84,12 @@ class UbootTftpSync extends FOGBase
      */
     private static function _connect()
     {
-        list($tftpHost, $tftpUser, $tftpPass, $kernelDir) = self::getSetting(
+        list($tftpHost, $tftpUser, $tftpPass, $tftpRoot) = self::getSetting(
             [
                 'FOG_TFTP_HOST',
                 'FOG_TFTP_FTP_USERNAME',
                 'FOG_TFTP_FTP_PASSWORD',
-                'FOG_TFTP_PXE_KERNEL_DIR',
+                'FOG_TFTP_ROOT_DIR',
             ]
         );
         self::$FOGSSH->username = $tftpUser;
@@ -98,7 +100,7 @@ class UbootTftpSync extends FOGBase
                 _('Unable to connect to TFTP server over SSH')
             );
         }
-        $dir = '/' . trim((string)$kernelDir, '/') . '/pxelinux.cfg';
+        $dir = '/' . trim((string)$tftpRoot, '/') . '/pxelinux.cfg';
         if (!self::$FOGSSH->exists($dir)) {
             self::$FOGSSH->sftp_mkdir($dir);
         }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -129,7 +129,7 @@ parameters:
 		-
 			message: '#^Variable \$this might not be defined\.$#'
 			identifier: variable.undefined
-			count: 381
+			count: 382
 			path: packages/web/commons/schema.php
 
 		-

--- a/tests/uboot-tftp-sync.test.php
+++ b/tests/uboot-tftp-sync.test.php
@@ -141,7 +141,7 @@ foreach (
 
 /*
  * _connect(): the SSH handshake, the dir path built from
- * FOG_TFTP_PXE_KERNEL_DIR, and mkdir-only-if-missing.
+ * FOG_TFTP_ROOT_DIR, and mkdir-only-if-missing.
  *
  * No ssh2 extension needed -- same technique as
  * tests/fogssh-delete-terminates.test.php: FOGSSH has no constructor, and
@@ -274,7 +274,9 @@ $tftpSettings = [
     'FOG_TFTP_HOST' => 'tftp.example.test',
     'FOG_TFTP_FTP_USERNAME' => 'fogtftp',
     'FOG_TFTP_FTP_PASSWORD' => 's3cret',
-    'FOG_TFTP_PXE_KERNEL_DIR' => '/tftpboot/',
+    'FOG_TFTP_ROOT_DIR' => '/srv/tftp/',
+    // The HTTP kernel dir: the path the sync must NOT build from (topic 18229).
+    'FOG_TFTP_PXE_KERNEL_DIR' => '/var/www/html/fog/service/ipxe/',
 ];
 $db->responder = function ($sql, $params) use ($tftpSettings) {
     if (false !== stripos($sql, 'FROM `globalSettings`')) {
@@ -295,8 +297,8 @@ FogTestHarness::setStatic('FOGBase', 'FOGSSH', $fakeFs);
 $dir = FogTestHarness::callStatic('FOG\Boot\UbootTftpSync', '_connect');
 
 $t->check(
-    'the pxelinux.cfg dir is built from FOG_TFTP_PXE_KERNEL_DIR',
-    '/tftpboot/pxelinux.cfg' === $dir
+    'the pxelinux.cfg dir is built from FOG_TFTP_ROOT_DIR, not the kernel dir',
+    '/srv/tftp/pxelinux.cfg' === $dir
 );
 $t->check(
     'the SSH credentials are read from the TFTP settings',


### PR DESCRIPTION
## Problem

`UbootTftpSync` (#1536) wrote `pxelinux.cfg/01-<mac>` under `FOG_TFTP_PXE_KERNEL_DIR`, which is the HTTP-served kernel directory (`<webroot>/service/ipxe/`). tftpd-hpa serves chrooted to the TFTP root (`-s $tftpdirdst`), so the file existed and `pxe get` could never fetch it. This is the `Loading: T T T T` timeout in forums topic 18229.

## Fix

- The installer publishes `TFTP_ROOT_DIR` (from `$tftpdirdst`, which is distro-dependent) into `config.class.php` next to `TFTP_PXE_KERNEL_DIR`.
- Schema step 412 seeds `FOG_TFTP_ROOT_DIR` in the TFTP Server settings category, defaulting to that constant (`/tftpboot` if the constant is not defined yet). `FOG_SCHEMA` bumped to 412.
- `UbootTftpSync::_connect()` builds `pxelinux.cfg` under `FOG_TFTP_ROOT_DIR`.
- `docs/UBOOT_ARM_BOOT.md` documents the new setting and why it is not the kernel dir.

## Verification

- `tests/run-all.sh`: 304 passed, 0 failed.
- Both phpstan configs: no errors.
- Mutation: switching the read back to `FOG_TFTP_PXE_KERNEL_DIR` fails `tests/uboot-tftp-sync.test.php` (the canned settings now carry both directories with different values).

Not field-validated on a Pi; Jeremy on the forum thread is the board that will prove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJkXwZLwjLrGmhwSzcYAcm