### PR TITLE
ADR 0038 records the fourth grant, and the rehearsal it was waiting on

### DIFF
--- a/docs/adr/0038-a-group-grants-it-does-not-copy.md
+++ b/docs/adr/0038-a-group-grants-it-does-not-copy.md
@@ -2,9 +2,15 @@
 
 ## Status
 
-**accepted** 2026-09-01. No code has been written for it yet — this ADR
-deliberately proposed none in the pass that produced it — and **the whole
-change targets 1.6.0**, not a 1.6.0/1.6.x split.
+**accepted** 2026-09-01, and **built** — every work unit in the proposal's
+§2.5 table is merged, plus a fourth grant this ADR did not originally name
+(see *A fourth grant arrived after acceptance*, below the Status block).
+**The whole change targets 1.6.0**, not a 1.6.0/1.6.x split.
+
+The sentence that stood here said no code had been written. That was true on
+the day this was accepted and has not been since. It is replaced rather than
+struck through, because a status line is the one part of an ADR that gets read
+on its own.
 
 The proposal's own earlier recommendation was to split it across two releases,
 and the maintainer overturned that with an argument this ADR records because it
@@ -144,6 +150,38 @@ mention — `locationAssoc` (`:58`), `printerAssoc` (`:63`), `snapinAssoc`
 **creates a snapin job and runs them** (`:78`, `:86`). So on a server with this
 plugin, adding a host to a group is not only a configuration change: it starts
 work on the machine.
+
+## A fourth grant arrived after acceptance
+
+Decision 1 splits a group's contents by lifetime, and Decision 3 admits modules
+as the third grant. A fourth was put to the same test and passed it: **power
+schedules**.
+
+A schedule is declarative and set-shaped in exactly the way the other three
+are. "Shut down at 22:00 on weeknights" is a standing statement about the
+members; several groups can hold one without contradicting each other; and the
+union of two schedules is a machine that does both — which is a meaningful
+answer, and precisely what a location or an OU cannot give, which is why those
+went to mass edit instead (Decision 13). So it is a grant:
+`groupPowerManagement`, schema steps 410 and 411, resolved by
+`FOG\Assign\Resolver::resolvePowerManagement()` beside the other three.
+
+An **immediate** shut down, restart or wake is not a grant. It acts on the
+membership at the instant it is pressed and leaves nothing standing behind it,
+which is Decision 1's definition of a task — and a standing grant of "shut down
+immediately" would fire again for every machine that ever joined the group.
+
+Two things this changes elsewhere in the document, recorded here rather than
+edited into every sentence that counts the grants:
+
+- Decision 16a requirement 5's Grants column counts **four** kinds, not three.
+- Decision 8's resolver gains a fourth entry point.
+
+Building it also surfaced a live defect older than any of this work: a weekday
+of `*` reached the FOG client as `... 7`, meaning Sundays only, on any PHP 8
+server. `'*' < 0` is true on PHP 8 and false on PHP 7.4, so every daily power
+schedule silently stopped running when a server's PHP was upgraded and nothing
+about FOG itself changed.
 
 ## Decision
 

--- a/docs/development/group-split.md
+++ b/docs/development/group-split.md
@@ -693,8 +693,26 @@ Still open:
    (UNKNOWN-4), so any change to the empty-case spelling is a client-visible
    change. Confirm the trace on a real mode-`ar` host before shipping the
    printer resolver — that is the one piece UNKNOWN-4 could not observe.
-2. **A migration rehearsal** on a 1.5-origin dump, per
-   `docs/development/upgrade-rehearsal.md`, for step 405.
+2. ~~**A migration rehearsal** on a 1.5-origin dump, per
+   `docs/development/upgrade-rehearsal.md`, for step 405.~~ **Done
+   2026-09-02**, and widened to cover steps 410/411 as well since power
+   schedules became the fourth grant. `bin/upgrade-rehearsal-lab.sh` on both
+   profiles (`reh_1510`, `reh_site`), planted at schema 278 and upgraded to
+   412: 81 of 83 constraints present, and the two refusals are the harness's
+   own deliberate plants (`fk_hostMAC_hmHostID`, structural;
+   `fk_nfsGroupMembers_ngmGroupID`, an orphan) — the pair that prove the run
+   is not passing vacuously. All seven foreign keys across the four grant
+   tables landed:
+
+   ```
+   groupSnapinAssoc      gsaGroupID -> groups     gsaSnapinID  -> snapins
+   groupPrinterAssoc     gpaGroupID -> groups     gpaPrinterID -> printers
+   groupModuleAssoc      gmaGroupID -> groups     gmaModuleID  -> modules
+   groupPowerManagement  gpmGroupID -> groups
+   ```
+
+   The counts match `tests/fixtures/upgrade-rehearsal-baseline.txt` exactly,
+   so the CI decay gate is measuring the same database this run did.
 
 ### 2.5 Release targeting — **decided: all of it in 1.6.0**
 


### PR DESCRIPTION
Docs and a lab run. No product code.

## The ADR had drifted from the code

**The Status line said no code had been written.** True the day it was accepted; not since — every unit in the proposal's §2.5 table is merged. Replaced rather than struck through, because a status line is the one part of an ADR that gets read on its own.

**It also knows about three grants. There are four.** Power schedules were put to Decision 1's test after acceptance and passed: a schedule is declarative and set-shaped, several groups can hold one without contradicting each other, and the union of two schedules is a machine that does both — a meaningful answer, and exactly what a location or an OU cannot give, which is why those went to mass edit under Decision 13.

An **immediate** shut down is not a grant and is not offered as one: it acts on the membership at the instant it is pressed, which is Decision 1's own definition of a task.

Written as its own section rather than edited into every sentence that counts the grants, with the two knock-ons named: 16a requirement 5's Grants column counts four, and Decision 8's resolver gains a fourth entry point. The PHP 8 `'*' < 0` defect is recorded there too, since it was found building it.

## The rehearsal the tracker was still waiting on

`docs/development/group-split.md` §2.4 listed "a migration rehearsal on a 1.5-origin dump, for step 405" as still open. Run now, and widened to 410/411 since power schedules arrived after that line was written.

`bin/upgrade-rehearsal-lab.sh`, both profiles (`reh_1510`, `reh_site`), planted at schema **278** and upgraded to **412**:

- **81 of 83** constraints present.
- The **two refusals are the harness's own deliberate plants** — `fk_hostMAC_hmHostID` (structural) and `fk_nfsGroupMembers_ngmGroupID` (an orphan). That pair is what proves the run is not passing vacuously; a run with zero refusals would mean the seed never landed.
- All **seven** foreign keys across the four grant tables landed on a 1.5.10-era database:

```
groupSnapinAssoc      gsaGroupID -> groups     gsaSnapinID  -> snapins
groupPrinterAssoc     gpaGroupID -> groups     gpaPrinterID -> printers
groupModuleAssoc      gmaGroupID -> groups     gmaModuleID  -> modules
groupPowerManagement  gpmGroupID -> groups
```

The counts match `tests/fixtures/upgrade-rehearsal-baseline.txt` exactly, so the CI decay gate is measuring the same database this run did.

Suite 304/304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166dqQEjAs9fhqUw5zCjvxM