### PR TITLE
Refuse to upload, install or activate a retired plugin

### DIFF
--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -11732,6 +11732,9 @@ msgstr ""
 msgid "value must be numeric"
 msgstr "Diff Parameter muss numerisch sein"
 
+msgid "was retired in FOG 1.6. A group now grants its snapins, printers, modules and power schedules to every member, hosts added later included, which is what this plugin copied rows to imitate. Its database trigger was removed by the upgrade and must not come back."
+msgstr ""
+
 msgid "weekday"
 msgstr ""
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -11735,6 +11735,9 @@ msgstr ""
 msgid "value must be numeric"
 msgstr "You must enter a name"
 
+msgid "was retired in FOG 1.6. A group now grants its snapins, printers, modules and power schedules to every member, hosts added later included, which is what this plugin copied rows to imitate. Its database trigger was removed by the upgrade and must not come back."
+msgstr ""
+
 msgid "weekday"
 msgstr ""
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -11898,6 +11898,9 @@ msgstr ""
 msgid "value must be numeric"
 msgstr "Evento debe ser una cadena"
 
+msgid "was retired in FOG 1.6. A group now grants its snapins, printers, modules and power schedules to every member, hosts added later included, which is what this plugin copied rows to imitate. Its database trigger was removed by the upgrade and must not come back."
+msgstr ""
+
 msgid "weekday"
 msgstr ""
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -11733,6 +11733,9 @@ msgstr ""
 msgid "value must be numeric"
 msgstr "Diff Parameter muss numerisch sein"
 
+msgid "was retired in FOG 1.6. A group now grants its snapins, printers, modules and power schedules to every member, hosts added later included, which is what this plugin copied rows to imitate. Its database trigger was removed by the upgrade and must not come back."
+msgstr ""
+
 msgid "weekday"
 msgstr ""
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -11721,6 +11721,9 @@ msgstr ""
 msgid "value must be numeric"
 msgstr "Vous devez entrer un nom"
 
+msgid "was retired in FOG 1.6. A group now grants its snapins, printers, modules and power schedules to every member, hosts added later included, which is what this plugin copied rows to imitate. Its database trigger was removed by the upgrade and must not come back."
+msgstr ""
+
 msgid "weekday"
 msgstr ""
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -11362,6 +11362,9 @@ msgstr ""
 msgid "value must be numeric"
 msgstr "Il parametro Diff deve essere numerico"
 
+msgid "was retired in FOG 1.6. A group now grants its snapins, printers, modules and power schedules to every member, hosts added later included, which is what this plugin copied rows to imitate. Its database trigger was removed by the upgrade and must not come back."
+msgstr ""
+
 msgid "weekday"
 msgstr ""
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -11312,6 +11312,9 @@ msgstr "有効な MAC アドレスを入力してください"
 msgid "value must be numeric"
 msgstr "Diff パラメーターは数値で指定してください"
 
+msgid "was retired in FOG 1.6. A group now grants its snapins, printers, modules and power schedules to every member, hosts added later included, which is what this plugin copied rows to imitate. Its database trigger was removed by the upgrade and must not come back."
+msgstr ""
+
 msgid "weekday"
 msgstr ""
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -10089,6 +10089,9 @@ msgstr ""
 msgid "value must be numeric"
 msgstr ""
 
+msgid "was retired in FOG 1.6. A group now grants its snapins, printers, modules and power schedules to every member, hosts added later included, which is what this plugin copied rows to imitate. Its database trigger was removed by the upgrade and must not come back."
+msgstr ""
+
 msgid "weekday"
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -11723,6 +11723,9 @@ msgstr ""
 msgid "value must be numeric"
 msgstr "Você deve digitar um nome"
 
+msgid "was retired in FOG 1.6. A group now grants its snapins, printers, modules and power schedules to every member, hosts added later included, which is what this plugin copied rows to imitate. Its database trigger was removed by the upgrade and must not come back."
+msgstr ""
+
 msgid "weekday"
 msgstr ""
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -11723,6 +11723,9 @@ msgstr ""
 msgid "value must be numeric"
 msgstr "您必须输入一个名称"
 
+msgid "was retired in FOG 1.6. A group now grants its snapins, printers, modules and power schedules to every member, hosts added later included, which is what this plugin copied rows to imitate. Its database trigger was removed by the upgrade and must not come back."
+msgstr ""
+
 msgid "weekday"
 msgstr ""
 

--- a/packages/web/src/Items/Plugin.php
+++ b/packages/web/src/Items/Plugin.php
@@ -465,6 +465,37 @@ class Plugin extends FOGController
         return '';
     }
     /**
+     * Why a plugin is retired, or '' if it is not.
+     *
+     * The comparison is on the lowercase name because that is how every other
+     * plugin identity check in this class works (isBundled(), the batch keys
+     * in activationBlockers()), and how schema step 404 matched the row it
+     * deleted.
+     *
+     * @param string $name the plugin name, any case
+     *
+     * @return string translated reason, or '' when the plugin is not retired
+     */
+    public static function retirementReason($name)
+    {
+        $name = strtolower(trim((string)$name));
+        if (!in_array($name, self::RETIRED, true)) {
+            return '';
+        }
+        // Written inside _() as a literal, because the catalog extractor only
+        // finds strings written there -- a reason pulled out of an array
+        // would ship untranslated in every language. With one retired plugin
+        // this is a single return; the day a second is retired it becomes a
+        // switch on $name with one literal per case.
+        return _(
+            'was retired in FOG 1.6. A group now grants its snapins, '
+            . 'printers, modules and power schedules to every member, '
+            . 'hosts added later included, which is what this plugin '
+            . 'copied rows to imitate. Its database trigger was '
+            . 'removed by the upgrade and must not come back.'
+        );
+    }
+    /**
      * Largest plugin archive accepted, before PHP's own upload limits.
      *
      * A plugin is source code. Sixty-four megabytes is already generous for
@@ -481,6 +512,29 @@ class Plugin extends FOGController
      * Install, and short enough that abandoned uploads do not accumulate.
      */
     const STAGING_TTL = 3600;
+    /**
+     * Plugins FOG has retired, and will not install or activate again.
+     *
+     * Lowercase plugin names. retirementReason() carries the text shown to the
+     * admin, which says what replaced the plugin rather than only that it is
+     * gone. A plugin is retired when core does the job it existed for and the
+     * plugin's own mechanism would now do harm -- not when it is merely old.
+     *
+     * Why a list in core and not just deletion from fog-plugins. Bundled
+     * plugins are re-laid on every upgrade, so removing one from fog-plugins
+     * removes its code. The external root is deliberately never touched by
+     * the installer, so an admin who copied a plugin there keeps it across
+     * the upgrade, and its install() runs on demand. For persistentgroups
+     * that install() re-creates the `persistentGroups` trigger the upgrade
+     * just dropped (schema step 404, ADR 0038 decision 14) -- one click undoes
+     * the retirement, silently, and the trigger goes back to copying a domain
+     * password between hosts (decision 15). The release note is the other
+     * half of the answer; this is the half that does not depend on anyone
+     * having read it.
+     *
+     * @var array
+     */
+    const RETIRED = ['persistentgroups'];
     /**
      * Where an uploaded plugin waits between preview and confirmation.
      *
@@ -635,6 +689,14 @@ class Plugin extends FOGController
                     $top . '/config/plugin.config.php'
                 )
             );
+        }
+        // Refused by NAME, before extraction, so a retired plugin's code never
+        // lands in the external root at all -- not even un-installed. Once it
+        // is on disk, discovery writes its row and the install button exists;
+        // this is the check that means the button never appears.
+        $retired = self::retirementReason($top);
+        if ('' !== $retired) {
+            return $fail(sprintf('%s %s', $top, $retired));
         }
         // A bundled plugin of the same name always wins (_getDirs() refuses
         // the external copy), so an archive that collides with one would
@@ -923,6 +985,16 @@ class Plugin extends FOGController
         $available = array_merge($active, array_keys($batch));
         $blockers = [];
         foreach ($batch as $name => $row) {
+            // Retirement first, before anything about the code on disk is
+            // consulted. The case this guards is a retired plugin whose code
+            // IS present -- copied into the external root, where the upgrade
+            // does not reach -- and whose install() would undo what the
+            // upgrade did. See RETIRED.
+            $retired = self::retirementReason($name);
+            if ('' !== $retired) {
+                $blockers[$name] = $retired;
+                continue;
+            }
             // Checked before the manifest, because there is no manifest to
             // read: readManifest() on a missing directory returns empty
             // fog_min/fog_max, compatError() then finds nothing wrong, and a

--- a/tests/retired-plugins-refuse-install.test.php
+++ b/tests/retired-plugins-refuse-install.test.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * A retired plugin cannot be uploaded, installed or activated.
+ *
+ * ADR 0038 decision 14 retired persistentgroups by dropping its trigger and
+ * its row (schema step 404). The ADR also named the one hole the drop alone
+ * leaves: the external plugin root is never touched by the installer, so an
+ * admin who copied the plugin there keeps its code across the upgrade, and
+ * its install() re-creates the trigger on demand. One click undoes the
+ * retirement, silently, and the trigger goes back to copying a domain
+ * password between hosts (decision 15). "Either refuse it or say so in the
+ * release notes; silently doing neither is not defensible." This is the
+ * refusal.
+ *
+ * WHAT THIS DRIVES, and why each half is executed rather than grepped:
+ *
+ *   1. activationBlockers() names a retired plugin as blocked, with the
+ *      retirement as the reason -- and does so BEFORE the "no code on disk"
+ *      check, because the case that matters is a retired plugin whose code
+ *      IS present. The control is a non-retired row with no code, which must
+ *      still be refused for the old reason: that proves the fake reached the
+ *      loop and the retirement branch did not swallow everything.
+ *   2. Both install and activate route through the same refusal. A retirement
+ *      that only one of them honors is a retirement with a second door.
+ *   3. stageArchive() refuses an upload by NAME, before extraction, so the
+ *      code never lands in the external root and no install button ever
+ *      appears for it. Built against a real .tar.gz, because the name is
+ *      read off the archive's own top-level directory.
+ *   4. The lookup is case-insensitive, matching how schema step 404 found the
+ *      row it deleted and how every other identity check in Plugin works.
+ *
+ * Usage: php tests/retired-plugins-refuse-install.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+use FOG\Items\Plugin;
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('retired-plugins-refuse-install');
+$db = FogTestHarness::fakeDb();
+
+$t = new FogChecks();
+$web = dirname(__DIR__) . '/packages/web';
+
+// -------------------------------------------------------------------------
+// 4. The lookup itself.
+// -------------------------------------------------------------------------
+$reason = Plugin::retirementReason('persistentgroups');
+$t->check('persistentgroups is retired', '' !== $reason);
+$t->check(
+    'the reason says what replaced it, not only that it is gone',
+    false !== stripos($reason, 'grant')
+    && false !== stripos($reason, 'trigger')
+);
+$t->check(
+    'the lookup is case-insensitive',
+    $reason === Plugin::retirementReason('PersistentGroups')
+    && $reason === Plugin::retirementReason(' persistentgroups ')
+);
+$t->check(
+    'a plugin that is not retired has no reason',
+    '' === Plugin::retirementReason('location')
+    && '' === Plugin::retirementReason('')
+);
+
+// -------------------------------------------------------------------------
+// 1. activationBlockers(), against two rows: one retired, one merely missing.
+// -------------------------------------------------------------------------
+$db->pdo->rowCount = 2;
+$db->pdo->rowFactory = function (array $columns, $n) {
+    $row = FogFakePdo::defaultRow($columns, $n);
+    $row['pID'] = $n;
+    $row['pName'] = 1 === $n ? 'PersistentGroups' : 'helloworld';
+    $row['pState'] = 0;
+    $row['pInstalled'] = 0;
+    // Neither has code on disk. For the retired one that must not be the
+    // reason given -- retirement is checked first, because the real case
+    // is code that IS on disk in the external root.
+    $row['pLocation'] = '/nonexistent/' . strtolower($row['pName']);
+    return $row;
+};
+$blockers = Plugin::activationBlockers([1, 2]);
+$db->pdo->rowFactory = null;
+
+$t->check(
+    'the retired plugin is blocked',
+    isset($blockers['persistentgroups'])
+);
+$t->check(
+    'and the reason is the retirement, not the missing code',
+    isset($blockers['persistentgroups'])
+    && $blockers['persistentgroups'] === $reason
+);
+$t->check(
+    'a non-retired plugin with no code is still refused for that reason (control)',
+    isset($blockers['helloworld'])
+    && 'has no code on disk' === $blockers['helloworld']
+);
+
+// -------------------------------------------------------------------------
+// 2. Install and activate both go through the refusal.
+// -------------------------------------------------------------------------
+$page = (string)file_get_contents($web . '/src/Pages/PluginManagement.php');
+foreach (['installPost', 'activatePost'] as $method) {
+    $at = strpos($page, 'public function ' . $method . '()');
+    $body = '';
+    if (false !== $at) {
+        $open = strpos($page, '{', $at);
+        $depth = 0;
+        for ($i = $open; $i < strlen($page); $i++) {
+            if ('{' === $page[$i]) {
+                $depth++;
+            } elseif ('}' === $page[$i]) {
+                if (0 === --$depth) {
+                    $body = substr($page, $open, $i - $open + 1);
+                    break;
+                }
+            }
+        }
+    }
+    $t->check(
+        "$method refuses blocked plugins before touching the database",
+        '' !== $body
+        && false !== strpos($body, '$this->_refuseBlocked($plugins);')
+        && strpos($body, '_refuseBlocked') < strpos($body, 'PluginManager')
+    );
+}
+$t->check(
+    '_refuseBlocked asks activationBlockers, which is where retirement lives',
+    (bool)preg_match(
+        '#function _refuseBlocked\(\$plugins\)\s*\{\s*\$blockers = Plugin::activationBlockers#s',
+        $page
+    )
+);
+
+// -------------------------------------------------------------------------
+// 3. The upload path, against a real archive.
+// -------------------------------------------------------------------------
+/**
+ * Builds a minimal plugin archive with the given top-level directory name.
+ *
+ * @param string $dir  scratch directory to build in
+ * @param string $name the plugin (top-level directory) name
+ *
+ * @return string path to the .tar.gz
+ */
+function buildArchive($dir, $name)
+{
+    $tree = $dir . '/' . $name . '/config';
+    @mkdir($tree, 0700, true);
+    file_put_contents(
+        $tree . '/plugin.config.php',
+        "<?php\nreturn ['name' => '$name', 'fog_min' => '1.6.0'];\n"
+    );
+    $tar = $dir . '/' . $name . '.tar';
+    @unlink($tar);
+    @unlink($tar . '.gz');
+    $phar = new \PharData($tar);
+    $phar->buildFromDirectory($dir . '/' . $name . '/../', '#/' . $name . '/#');
+    $phar->compress(\Phar::GZ);
+    unset($phar);
+    return $tar . '.gz';
+}
+
+$scratch = sys_get_temp_dir() . '/fog-retired-' . bin2hex(random_bytes(4));
+@mkdir($scratch, 0700, true);
+$archive = buildArchive($scratch, 'persistentgroups');
+$result = Plugin::stageArchive($archive, 'persistentgroups.tar.gz');
+$t->check(
+    'uploading the retired plugin is refused',
+    isset($result['error'])
+    && false !== strpos($result['error'], 'persistentgroups')
+    && false !== stripos($result['error'], 'retired')
+);
+// The control: the same archive under a non-retired name must get PAST the
+// retirement check. Whatever it fails on next, it must not be this.
+$control = Plugin::stageArchive(
+    buildArchive($scratch, 'zzretireprobe'),
+    'zzretireprobe.tar.gz'
+);
+$t->check(
+    'a non-retired archive is not refused as retired (control)',
+    !isset($control['error'])
+    || false === stripos($control['error'], 'retired')
+);
+Plugin::purgeStaging();
+// Remove what this test built. sys_get_temp_dir() is used because the
+// archive has to be readable by PharData under a real path; nothing large.
+$rm = function ($p) use (&$rm) {
+    foreach (glob($p . '/*') ?: [] as $f) {
+        is_dir($f) ? $rm($f) : @unlink($f);
+    }
+    @rmdir($p);
+};
+$rm($scratch);
+
+$t->finish();


### PR DESCRIPTION
Closes the hole ADR 0038 decision 14 named and left open.

## The hole

Schema step 404 drops the `persistentGroups` trigger and the plugin's row. But the **external plugin root is deliberately never touched by the installer**, so an admin who copied `persistentgroups` there keeps its code across the upgrade — and its `install()` re-creates the trigger. One click undoes the retirement, silently, and the trigger goes back to copying a domain join password between hosts (decision 15).

The ADR's own words: *refuse it or say so in the release notes; silently doing neither is not defensible.* This is the refusal. The release note is the other half, and does not depend on anyone having read it.

## The change

`Plugin::RETIRED` names the plugins core will not run again; `retirementReason()` carries the text, which says what **replaced** the plugin rather than only that it is gone. Two places ask it:

| Where | When | Why there |
|---|---|---|
| `activationBlockers()` | install and activate — both already route through `_refuseBlocked()` | Checked **first**, before "has no code on disk", because the case this exists for is a retired plugin whose code *is* present. |
| `stageArchive()` | upload, by the archive's top-level directory name, **before extraction** | The code never lands in the external root, discovery never writes its row, and the install button never appears. |

The reason text is a literal inside `_()` rather than a value in the constant, because the catalog extractor only finds strings written there.

## Tests

`tests/retired-plugins-refuse-install.test.php` (12 checks) **runs** both paths:

- The blocker against a fake `plugins` table holding one retired row and one merely-missing row. The second is the control: it must still be refused for *"has no code on disk"*, which proves the loop was reached and the retirement branch did not swallow everything.
- The upload against a **real `.tar.gz`** whose top-level directory is `persistentgroups/`, with the same archive under a non-retired name as the control.

Five mutations run red: blocker check removed; blocker check moved *after* the no-code check; upload refusal removed; lookup made case-sensitive; list emptied. Suite 305/305, both phpstan configs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166dqQEjAs9fhqUw5zCjvxM