### PR TITLE
Seed the 1.6.0 release notes with the persistentgroups disclosure

### DIFF
--- a/docs/release-notes/1.6.0.md
+++ b/docs/release-notes/1.6.0.md
@@ -1,0 +1,41 @@
+# FOG 1.6.0 release notes
+
+Assembled here as the release is built, one section per item that a reader
+upgrading from 1.5 needs to hear in plain language rather than find in a
+changelog line. The GitHub release body for 1.6.0 is composed from this file.
+
+### The persistentgroups plugin copied Active Directory join passwords between hosts
+
+FOG 1.6 retires the `persistentgroups` plugin: a group now grants its snapins,
+printers, client modules and power schedules to every member, including hosts
+added later, which is what the plugin existed to imitate. The upgrade drops the
+plugin's database trigger and its row, and 1.6 refuses to install or activate
+it again.
+
+There is one thing about that plugin you should know if you ever ran it.
+
+The trigger copied a fixed list of columns from a group's template host onto
+each host that joined the group. **That list included `hostADPass`, the
+Active Directory join password.** So on any server where the plugin was
+installed, adding a host to a group could copy the template host's domain join
+credential onto that host — in the database, below the web application, with
+no entry in the history log. This has been true for as long as the plugin has
+existed.
+
+What it did **not** do: the credential never left your FOG server's own
+database, and it was already readable there to anything that could read the
+`hosts` table. This is a notification, not a security advisory.
+
+Why we are telling you anyway: if you rotate a domain join account, you need
+to know that the old credential may be sitting on hosts you never edited by
+hand, and nothing in the FOG interface would have shown you that. The copy
+happened only on "clean" adds — hosts that shared no printer or module setting
+with the template — so the affected set is not "every host in the group," and
+it cannot be worked out from the UI after the fact.
+
+What to do: if you used `persistentgroups` and have rotated, or intend to
+rotate, an AD join account, treat every host that was ever a member of a
+persistentgroups-managed group as possibly carrying the template's old
+credential, and reset `hostADPass` on those hosts. **Hosts → select them →
+Edit selected hosts → Active Directory** does this across a selection in one
+action.


### PR DESCRIPTION
ADR 0038 decision 15: the retirement of `persistentgroups` must tell admins, in plain language, that the plugin's trigger copied `hostADPass` — the AD join password — from a group's template host onto hosts that joined the group.

There was no release-notes file to put that in, so this creates `docs/release-notes/1.6.0.md` as the file the 1.6.0 GitHub release body is composed from, seeded with that one section. Maintainer-approved wording (2026-09-02).

Companion: fog-docs carries the same disclosure as a warning callout on the 1.6 Plugins page with a pointer from Group Management; #1666 is the refusal that stops the plugin being reinstalled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166dqQEjAs9fhqUw5zCjvxM