### PR TITLE
Pin fog-plugins v1.6.24: the plugins that match the group split

### DIFF
--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -3496,18 +3496,6 @@ msgid "Group Kernel Arguments"
 msgstr "Gruppe-Kernel Argumente"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "Host Standort"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Standort erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Standort aktualisiert"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Login-Verlauf"
 
@@ -3538,18 +3526,6 @@ msgstr "Gruppenname"
 #, fuzzy
 msgid "Group Name Attribute"
 msgstr "Gruppemmitglieder Attribut"
-
-#, fuzzy
-msgid "Group OU"
-msgstr "Gruppe"
-
-#, fuzzy
-msgid "Group OU Update Success"
-msgstr "Gruppe erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Group OU Updated!"
-msgstr "Gruppe aktualisiert"
 
 #, fuzzy
 msgid "Group Order"
@@ -3584,14 +3560,6 @@ msgstr "Image-Verlauf"
 
 #, fuzzy
 msgid "Group Update Fail"
-msgstr "Gruppe aktualisieren fehlgeschlagen"
-
-#, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Gruppe aktualisieren fehlgeschlagen"
-
-#, fuzzy
-msgid "Group Update OU Fail"
 msgstr "Gruppe aktualisieren fehlgeschlagen"
 
 #, fuzzy
@@ -4624,6 +4592,10 @@ msgstr "Ungültige ID übergeben"
 msgid "Invalid IP"
 msgstr "Ungültige IP"
 
+#, fuzzy
+msgid "Invalid Location selected"
+msgstr "Ungültiger Token übergeben"
+
 msgid "Invalid Login"
 msgstr "ungültiger Login"
 
@@ -4633,6 +4605,10 @@ msgstr "Ungültige MAC-Adresse!"
 #, fuzzy
 msgid "Invalid Multicast Session"
 msgstr "ungültige Multicast-Sitzung"
+
+#, fuzzy
+msgid "Invalid OU selected"
+msgstr "Ausgewählte löschen"
 
 #, fuzzy
 msgid "Invalid Path"
@@ -12093,8 +12069,32 @@ msgstr ""
 #~ msgstr "Imagezuordnung"
 
 #, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "Host Standort"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Standort erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Standort aktualisiert"
+
+#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "Host Standort"
+
+#, fuzzy
+#~ msgid "Group OU"
+#~ msgstr "Gruppe"
+
+#, fuzzy
+#~ msgid "Group OU Update Success"
+#~ msgstr "Gruppe erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Group OU Updated!"
+#~ msgstr "Gruppe aktualisiert"
 
 #, fuzzy
 #~ msgid "Group Printer Configuration"
@@ -12117,6 +12117,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Group Site Updated!"
 #~ msgstr "Gruppe aktualisiert"
+
+#, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Gruppe aktualisieren fehlgeschlagen"
+
+#, fuzzy
+#~ msgid "Group Update OU Fail"
+#~ msgstr "Gruppe aktualisieren fehlgeschlagen"
 
 #, fuzzy
 #~ msgid "Group Update Site Fail"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -3498,18 +3498,6 @@ msgid "Group Kernel Arguments"
 msgstr "Group Kernel Arguments"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "Host Location"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Install / Update Successful!"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Location Updated"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Login History"
 
@@ -3541,18 +3529,6 @@ msgstr "Group Name"
 #, fuzzy
 msgid "Group Name Attribute"
 msgstr "User Name"
-
-#, fuzzy
-msgid "Group OU"
-msgstr "Group"
-
-#, fuzzy
-msgid "Group OU Update Success"
-msgstr "User created"
-
-#, fuzzy
-msgid "Group OU Updated!"
-msgstr "Group added"
 
 #, fuzzy
 msgid "Group Order"
@@ -3587,14 +3563,6 @@ msgstr "Image History"
 
 #, fuzzy
 msgid "Group Update Fail"
-msgstr "Group create failed"
-
-#, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Group create failed"
-
-#, fuzzy
-msgid "Group Update OU Fail"
 msgstr "Group create failed"
 
 #, fuzzy
@@ -4626,6 +4594,10 @@ msgstr "Invalid unit passed"
 msgid "Invalid IP"
 msgstr "Invalid ID"
 
+#, fuzzy
+msgid "Invalid Location selected"
+msgstr "Invalid token passed"
+
 msgid "Invalid Login"
 msgstr "Invalid Login"
 
@@ -4635,6 +4607,10 @@ msgstr "Invalid MAC Address!"
 #, fuzzy
 msgid "Invalid Multicast Session"
 msgstr "Start Multicast Session"
+
+#, fuzzy
+msgid "Invalid OU selected"
+msgstr "Delete Selected"
 
 #, fuzzy
 msgid "Invalid Path"
@@ -12087,8 +12063,32 @@ msgstr ""
 #~ msgstr "Image Association"
 
 #, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "Host Location"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Install / Update Successful!"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Location Updated"
+
+#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "Host Location"
+
+#, fuzzy
+#~ msgid "Group OU"
+#~ msgstr "Group"
+
+#, fuzzy
+#~ msgid "Group OU Update Success"
+#~ msgstr "User created"
+
+#, fuzzy
+#~ msgid "Group OU Updated!"
+#~ msgstr "Group added"
 
 #, fuzzy
 #~ msgid "Group Printer Configuration"
@@ -12108,6 +12108,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Group Site Updated!"
 #~ msgstr "Group added"
+
+#, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Group create failed"
+
+#, fuzzy
+#~ msgid "Group Update OU Fail"
+#~ msgstr "Group create failed"
 
 #, fuzzy
 #~ msgid "Group Update Site Fail"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3547,18 +3547,6 @@ msgid "Group Kernel Arguments"
 msgstr "Argumentos grupo Kernel"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "Lista de host"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "actualización de servicio no pudo"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "información de LDAP actualizado!"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Camino snapin"
 
@@ -3593,18 +3581,6 @@ msgid "Group Name Attribute"
 msgstr "Nombre de usuario"
 
 #, fuzzy
-msgid "Group OU"
-msgstr "Grupo"
-
-#, fuzzy
-msgid "Group OU Update Success"
-msgstr "creado por el usuario"
-
-#, fuzzy
-msgid "Group OU Updated!"
-msgstr "grupo añadió"
-
-#, fuzzy
 msgid "Group Order"
 msgstr "Grupo"
 
@@ -3637,14 +3613,6 @@ msgstr "replicador de imagen"
 
 #, fuzzy
 msgid "Group Update Fail"
-msgstr "Grupo Error de creación"
-
-#, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Grupo Error de creación"
-
-#, fuzzy
-msgid "Group Update OU Fail"
 msgstr "Grupo Error de creación"
 
 #, fuzzy
@@ -4704,6 +4672,10 @@ msgid "Invalid IP"
 msgstr "identificación invalida"
 
 #, fuzzy
+msgid "Invalid Location selected"
+msgstr "unidad no válida pasó"
+
+#, fuzzy
 msgid "Invalid Login"
 msgstr "carpeta no válida"
 
@@ -4713,6 +4685,10 @@ msgstr ""
 #, fuzzy
 msgid "Invalid Multicast Session"
 msgstr "Iniciar la sesión de multidifusión"
+
+#, fuzzy
+msgid "Invalid OU selected"
+msgstr "Eliminar seleccionado"
 
 #, fuzzy
 msgid "Invalid Path"
@@ -12252,8 +12228,32 @@ msgstr ""
 #~ msgstr "Asociación para la imagen"
 
 #, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "Lista de host"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "actualización de servicio no pudo"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "información de LDAP actualizado!"
+
+#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "Lista de host"
+
+#, fuzzy
+#~ msgid "Group OU"
+#~ msgstr "Grupo"
+
+#, fuzzy
+#~ msgid "Group OU Update Success"
+#~ msgstr "creado por el usuario"
+
+#, fuzzy
+#~ msgid "Group OU Updated!"
+#~ msgstr "grupo añadió"
 
 #, fuzzy
 #~ msgid "Group Printer Configuration"
@@ -12273,6 +12273,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Group Site Updated!"
 #~ msgstr "grupo añadió"
+
+#, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Grupo Error de creación"
+
+#, fuzzy
+#~ msgid "Group Update OU Fail"
+#~ msgstr "Grupo Error de creación"
 
 #, fuzzy
 #~ msgid "Group Update Site Fail"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3496,18 +3496,6 @@ msgid "Group Kernel Arguments"
 msgstr "Gruppe-Kernel Argumente"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "Host Standort"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Standort erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Standort aktualisiert"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Login-Verlauf"
 
@@ -3538,18 +3526,6 @@ msgstr "Gruppenname"
 #, fuzzy
 msgid "Group Name Attribute"
 msgstr "Gruppemmitglieder Attribut"
-
-#, fuzzy
-msgid "Group OU"
-msgstr "Gruppe"
-
-#, fuzzy
-msgid "Group OU Update Success"
-msgstr "Gruppe erfolgreich aktualisiert"
-
-#, fuzzy
-msgid "Group OU Updated!"
-msgstr "Gruppe aktualisiert"
 
 #, fuzzy
 msgid "Group Order"
@@ -3584,14 +3560,6 @@ msgstr "Image-Verlauf"
 
 #, fuzzy
 msgid "Group Update Fail"
-msgstr "Gruppe aktualisieren fehlgeschlagen"
-
-#, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Gruppe aktualisieren fehlgeschlagen"
-
-#, fuzzy
-msgid "Group Update OU Fail"
 msgstr "Gruppe aktualisieren fehlgeschlagen"
 
 #, fuzzy
@@ -4625,6 +4593,10 @@ msgstr "Ungültige ID übergeben"
 msgid "Invalid IP"
 msgstr "Ungültige IP"
 
+#, fuzzy
+msgid "Invalid Location selected"
+msgstr "Ungültiger Token übergeben"
+
 msgid "Invalid Login"
 msgstr "ungültiger Login"
 
@@ -4634,6 +4606,10 @@ msgstr "Ungültige MAC-Adresse!"
 #, fuzzy
 msgid "Invalid Multicast Session"
 msgstr "ungültige Multicast-Sitzung"
+
+#, fuzzy
+msgid "Invalid OU selected"
+msgstr "Ausgewählte löschen"
 
 #, fuzzy
 msgid "Invalid Path"
@@ -12094,8 +12070,32 @@ msgstr ""
 #~ msgstr "Imagezuordnung"
 
 #, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "Host Standort"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Standort erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Standort aktualisiert"
+
+#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "Host Standort"
+
+#, fuzzy
+#~ msgid "Group OU"
+#~ msgstr "Gruppe"
+
+#, fuzzy
+#~ msgid "Group OU Update Success"
+#~ msgstr "Gruppe erfolgreich aktualisiert"
+
+#, fuzzy
+#~ msgid "Group OU Updated!"
+#~ msgstr "Gruppe aktualisiert"
 
 #, fuzzy
 #~ msgid "Group Printer Configuration"
@@ -12118,6 +12118,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Group Site Updated!"
 #~ msgstr "Gruppe aktualisiert"
+
+#, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Gruppe aktualisieren fehlgeschlagen"
+
+#, fuzzy
+#~ msgid "Group Update OU Fail"
+#~ msgstr "Gruppe aktualisieren fehlgeschlagen"
 
 #, fuzzy
 #~ msgid "Group Update Site Fail"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -3499,18 +3499,6 @@ msgid "Group Kernel Arguments"
 msgstr "Arguments Groupe Kernel"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "hôte Lieu"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Installation / Mise à jour réussie!"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Emplacement Mise à jour"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Historique de connexion"
 
@@ -3542,18 +3530,6 @@ msgstr "Nom de groupe"
 #, fuzzy
 msgid "Group Name Attribute"
 msgstr "Nom d'utilisateur"
-
-#, fuzzy
-msgid "Group OU"
-msgstr "Groupe"
-
-#, fuzzy
-msgid "Group OU Update Success"
-msgstr "utilisateur créé"
-
-#, fuzzy
-msgid "Group OU Updated!"
-msgstr "Groupe ajouté"
 
 #, fuzzy
 msgid "Group Order"
@@ -3588,14 +3564,6 @@ msgstr "Histoire de l'image"
 
 #, fuzzy
 msgid "Group Update Fail"
-msgstr "Groupe create a échoué"
-
-#, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Groupe create a échoué"
-
-#, fuzzy
-msgid "Group Update OU Fail"
 msgstr "Groupe create a échoué"
 
 #, fuzzy
@@ -4627,6 +4595,10 @@ msgstr "unité non valide passé"
 msgid "Invalid IP"
 msgstr "ID invalide"
 
+#, fuzzy
+msgid "Invalid Location selected"
+msgstr "jeton non valide transmis"
+
 msgid "Invalid Login"
 msgstr "Identifiant invalide"
 
@@ -4636,6 +4608,10 @@ msgstr "Invalid Adresse MAC!"
 #, fuzzy
 msgid "Invalid Multicast Session"
 msgstr "Démarrez Multicast session"
+
+#, fuzzy
+msgid "Invalid OU selected"
+msgstr "Supprimer sélectionnée"
 
 #, fuzzy
 msgid "Invalid Path"
@@ -12073,8 +12049,32 @@ msgstr ""
 #~ msgstr "Association Image"
 
 #, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "hôte Lieu"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Installation / Mise à jour réussie!"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Emplacement Mise à jour"
+
+#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "hôte Lieu"
+
+#, fuzzy
+#~ msgid "Group OU"
+#~ msgstr "Groupe"
+
+#, fuzzy
+#~ msgid "Group OU Update Success"
+#~ msgstr "utilisateur créé"
+
+#, fuzzy
+#~ msgid "Group OU Updated!"
+#~ msgstr "Groupe ajouté"
 
 #, fuzzy
 #~ msgid "Group Printer Configuration"
@@ -12094,6 +12094,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Group Site Updated!"
 #~ msgstr "Groupe ajouté"
+
+#, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Groupe create a échoué"
+
+#, fuzzy
+#~ msgid "Group Update OU Fail"
+#~ msgstr "Groupe create a échoué"
 
 #, fuzzy
 #~ msgid "Group Update Site Fail"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -3410,18 +3410,6 @@ msgid "Group Kernel Arguments"
 msgstr "Argomenti Gruppo Kernel"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "Host Luoghi"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Modifica posizione riuscita"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Posizione aggiornata!"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "Accesso Storia"
 
@@ -3454,18 +3442,6 @@ msgid "Group Name Attribute"
 msgstr "Attributo membro del gruppo"
 
 #, fuzzy
-msgid "Group OU"
-msgstr "Gruppo"
-
-#, fuzzy
-msgid "Group OU Update Success"
-msgstr "Aggiornamento del gruppo completato"
-
-#, fuzzy
-msgid "Group OU Updated!"
-msgstr "Gruppo aggiornato!"
-
-#, fuzzy
 msgid "Group Order"
 msgstr "Gruppo"
 
@@ -3496,14 +3472,6 @@ msgid "Group Task History"
 msgstr "Storia immagine"
 
 msgid "Group Update Fail"
-msgstr "Aggiornamento gruppo non riuscito"
-
-#, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Aggiornamento gruppo non riuscito"
-
-#, fuzzy
-msgid "Group Update OU Fail"
 msgstr "Aggiornamento gruppo non riuscito"
 
 msgid "Group Update Success"
@@ -4496,6 +4464,10 @@ msgstr "ID non valido passato"
 msgid "Invalid IP"
 msgstr "IP non valido"
 
+#, fuzzy
+msgid "Invalid Location selected"
+msgstr "Token non valido passato"
+
 msgid "Invalid Login"
 msgstr "Login non valido"
 
@@ -4504,6 +4476,10 @@ msgstr "Non valido Indirizzo MAC!"
 
 msgid "Invalid Multicast Session"
 msgstr "Sessione multicast non valida"
+
+#, fuzzy
+msgid "Invalid OU selected"
+msgstr "Cancella selezionato"
 
 #, fuzzy
 msgid "Invalid Path"
@@ -11715,8 +11691,32 @@ msgstr ""
 #~ msgstr "Associazione immagine"
 
 #, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "Host Luoghi"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Modifica posizione riuscita"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Posizione aggiornata!"
+
+#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "Host Luoghi"
+
+#, fuzzy
+#~ msgid "Group OU"
+#~ msgstr "Gruppo"
+
+#, fuzzy
+#~ msgid "Group OU Update Success"
+#~ msgstr "Aggiornamento del gruppo completato"
+
+#, fuzzy
+#~ msgid "Group OU Updated!"
+#~ msgstr "Gruppo aggiornato!"
 
 #, fuzzy
 #~ msgid "Group Printer Configuration"
@@ -11739,6 +11739,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Group Site Updated!"
 #~ msgstr "Gruppo aggiornato!"
+
+#, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Aggiornamento gruppo non riuscito"
+
+#, fuzzy
+#~ msgid "Group Update OU Fail"
+#~ msgstr "Aggiornamento gruppo non riuscito"
 
 #, fuzzy
 #~ msgid "Group Update Site Fail"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -3385,18 +3385,6 @@ msgid "Group Kernel Arguments"
 msgstr "グループカーネル引数"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "グループの関連付け"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "ロケーションを更新しました"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "ロケーションを更新しました！"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "ログイン履歴"
 
@@ -3429,18 +3417,6 @@ msgid "Group Name Attribute"
 msgstr "グループメンバー属性"
 
 #, fuzzy
-msgid "Group OU"
-msgstr "グループ"
-
-#, fuzzy
-msgid "Group OU Update Success"
-msgstr "グループの更新に成功しました"
-
-#, fuzzy
-msgid "Group OU Updated!"
-msgstr "グループを更新しました！"
-
-#, fuzzy
 msgid "Group Order"
 msgstr "グループ"
 
@@ -3471,14 +3447,6 @@ msgid "Group Task History"
 msgstr "イメージ履歴"
 
 msgid "Group Update Fail"
-msgstr "グループの更新に失敗しました"
-
-#, fuzzy
-msgid "Group Update Location Fail"
-msgstr "グループの更新に失敗しました"
-
-#, fuzzy
-msgid "Group Update OU Fail"
 msgstr "グループの更新に失敗しました"
 
 msgid "Group Update Success"
@@ -4462,6 +4430,10 @@ msgstr "無効な ID が渡されました"
 msgid "Invalid IP"
 msgstr "無効な IP"
 
+#, fuzzy
+msgid "Invalid Location selected"
+msgstr "無効なトークンが渡されました"
+
 msgid "Invalid Login"
 msgstr "無効なログイン"
 
@@ -4470,6 +4442,10 @@ msgstr "無効な MAC アドレスです！"
 
 msgid "Invalid Multicast Session"
 msgstr "無効なマルチキャストセッション"
+
+#, fuzzy
+msgid "Invalid OU selected"
+msgstr "Initrd をインストール"
 
 msgid "Invalid Path"
 msgstr "無効なパス"
@@ -12094,8 +12070,32 @@ msgstr ""
 #~ msgstr "グループイメージの関連付け"
 
 #, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "グループの関連付け"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "ロケーションを更新しました"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "ロケーションを更新しました！"
+
+#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "グループ管理"
+
+#, fuzzy
+#~ msgid "Group OU"
+#~ msgstr "グループ"
+
+#, fuzzy
+#~ msgid "Group OU Update Success"
+#~ msgstr "グループの更新に成功しました"
+
+#, fuzzy
+#~ msgid "Group OU Updated!"
+#~ msgstr "グループを更新しました！"
 
 #~ msgid "Group Power Management Remove"
 #~ msgstr "グループ電源管理を削除"
@@ -12127,6 +12127,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Group Site Updated!"
 #~ msgstr "サイトを更新しました！"
+
+#, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "グループの更新に失敗しました"
+
+#, fuzzy
+#~ msgid "Group Update OU Fail"
+#~ msgstr "グループの更新に失敗しました"
 
 #, fuzzy
 #~ msgid "Group Update Site Fail"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -3016,15 +3016,6 @@ msgstr ""
 msgid "Group Kernel Arguments"
 msgstr ""
 
-msgid "Group Location"
-msgstr ""
-
-msgid "Group Location Update Success"
-msgstr ""
-
-msgid "Group Location Updated!"
-msgstr ""
-
 msgid "Group Login History"
 msgstr ""
 
@@ -3052,15 +3043,6 @@ msgstr ""
 msgid "Group Name Attribute"
 msgstr ""
 
-msgid "Group OU"
-msgstr ""
-
-msgid "Group OU Update Success"
-msgstr ""
-
-msgid "Group OU Updated!"
-msgstr ""
-
 msgid "Group Order"
 msgstr ""
 
@@ -3086,12 +3068,6 @@ msgid "Group Task History"
 msgstr ""
 
 msgid "Group Update Fail"
-msgstr ""
-
-msgid "Group Update Location Fail"
-msgstr ""
-
-msgid "Group Update OU Fail"
 msgstr ""
 
 msgid "Group Update Success"
@@ -3952,6 +3928,9 @@ msgstr ""
 msgid "Invalid IP"
 msgstr ""
 
+msgid "Invalid Location selected"
+msgstr ""
+
 msgid "Invalid Login"
 msgstr ""
 
@@ -3959,6 +3938,9 @@ msgid "Invalid MAC Address!"
 msgstr ""
 
 msgid "Invalid Multicast Session"
+msgstr ""
+
+msgid "Invalid OU selected"
 msgstr ""
 
 msgid "Invalid Path"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -3498,18 +3498,6 @@ msgid "Group Kernel Arguments"
 msgstr "Argumentos Grupo Kernel"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "anfitrião Localização"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "Instalar / Atualizar sucesso!"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "Localização Atualizado"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "História de login"
 
@@ -3541,18 +3529,6 @@ msgstr "Nome do grupo"
 #, fuzzy
 msgid "Group Name Attribute"
 msgstr "Nome de usuário"
-
-#, fuzzy
-msgid "Group OU"
-msgstr "Grupo"
-
-#, fuzzy
-msgid "Group OU Update Success"
-msgstr "usuário criado"
-
-#, fuzzy
-msgid "Group OU Updated!"
-msgstr "grupo adicionado"
 
 #, fuzzy
 msgid "Group Order"
@@ -3587,14 +3563,6 @@ msgstr "História imagem"
 
 #, fuzzy
 msgid "Group Update Fail"
-msgstr "Grupo Criar falhou"
-
-#, fuzzy
-msgid "Group Update Location Fail"
-msgstr "Grupo Criar falhou"
-
-#, fuzzy
-msgid "Group Update OU Fail"
 msgstr "Grupo Criar falhou"
 
 #, fuzzy
@@ -4626,6 +4594,10 @@ msgstr "unidade inválido passado"
 msgid "Invalid IP"
 msgstr "ID Inválido"
 
+#, fuzzy
+msgid "Invalid Location selected"
+msgstr "Token inválido passado"
+
 msgid "Invalid Login"
 msgstr "Login inválido"
 
@@ -4635,6 +4607,10 @@ msgstr "Inválido Endereço MAC!"
 #, fuzzy
 msgid "Invalid Multicast Session"
 msgstr "Iniciar Sessão Multicast"
+
+#, fuzzy
+msgid "Invalid OU selected"
+msgstr "Delete Selected"
 
 #, fuzzy
 msgid "Invalid Path"
@@ -12075,8 +12051,32 @@ msgstr ""
 #~ msgstr "Associação imagem"
 
 #, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "anfitrião Localização"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "Instalar / Atualizar sucesso!"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "Localização Atualizado"
+
+#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "anfitrião Localização"
+
+#, fuzzy
+#~ msgid "Group OU"
+#~ msgstr "Grupo"
+
+#, fuzzy
+#~ msgid "Group OU Update Success"
+#~ msgstr "usuário criado"
+
+#, fuzzy
+#~ msgid "Group OU Updated!"
+#~ msgstr "grupo adicionado"
 
 #, fuzzy
 #~ msgid "Group Printer Configuration"
@@ -12096,6 +12096,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Group Site Updated!"
 #~ msgstr "grupo adicionado"
+
+#, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "Grupo Criar falhou"
+
+#, fuzzy
+#~ msgid "Group Update OU Fail"
+#~ msgstr "Grupo Criar falhou"
 
 #, fuzzy
 #~ msgid "Group Update Site Fail"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -3498,18 +3498,6 @@ msgid "Group Kernel Arguments"
 msgstr "集团内核参数"
 
 #, fuzzy
-msgid "Group Location"
-msgstr "主机位置"
-
-#, fuzzy
-msgid "Group Location Update Success"
-msgstr "安装/升级成功！"
-
-#, fuzzy
-msgid "Group Location Updated!"
-msgstr "更新位置"
-
-#, fuzzy
 msgid "Group Login History"
 msgstr "登录历史记录"
 
@@ -3541,18 +3529,6 @@ msgstr "组名称"
 #, fuzzy
 msgid "Group Name Attribute"
 msgstr "用户名"
-
-#, fuzzy
-msgid "Group OU"
-msgstr "组"
-
-#, fuzzy
-msgid "Group OU Update Success"
-msgstr "用户创建"
-
-#, fuzzy
-msgid "Group OU Updated!"
-msgstr "集团补充"
 
 #, fuzzy
 msgid "Group Order"
@@ -3587,14 +3563,6 @@ msgstr "历史形象"
 
 #, fuzzy
 msgid "Group Update Fail"
-msgstr "集团创建失败"
-
-#, fuzzy
-msgid "Group Update Location Fail"
-msgstr "集团创建失败"
-
-#, fuzzy
-msgid "Group Update OU Fail"
 msgstr "集团创建失败"
 
 #, fuzzy
@@ -4626,6 +4594,10 @@ msgstr "无效的单元传递"
 msgid "Invalid IP"
 msgstr "无效的ID"
 
+#, fuzzy
+msgid "Invalid Location selected"
+msgstr "无效的令牌传递"
+
 msgid "Invalid Login"
 msgstr "登录无效"
 
@@ -4635,6 +4607,10 @@ msgstr "无效的MAC地址！"
 #, fuzzy
 msgid "Invalid Multicast Session"
 msgstr "开始多播会话"
+
+#, fuzzy
+msgid "Invalid OU selected"
+msgstr "删除所选"
 
 #, fuzzy
 msgid "Invalid Path"
@@ -12075,8 +12051,32 @@ msgstr ""
 #~ msgstr "图像协会"
 
 #, fuzzy
+#~ msgid "Group Location"
+#~ msgstr "主机位置"
+
+#, fuzzy
+#~ msgid "Group Location Update Success"
+#~ msgstr "安装/升级成功！"
+
+#, fuzzy
+#~ msgid "Group Location Updated!"
+#~ msgstr "更新位置"
+
+#, fuzzy
 #~ msgid "Group Mappings"
 #~ msgstr "主机位置"
+
+#, fuzzy
+#~ msgid "Group OU"
+#~ msgstr "组"
+
+#, fuzzy
+#~ msgid "Group OU Update Success"
+#~ msgstr "用户创建"
+
+#, fuzzy
+#~ msgid "Group OU Updated!"
+#~ msgstr "集团补充"
 
 #, fuzzy
 #~ msgid "Group Printer Configuration"
@@ -12096,6 +12096,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "Group Site Updated!"
 #~ msgstr "集团补充"
+
+#, fuzzy
+#~ msgid "Group Update Location Fail"
+#~ msgstr "集团创建失败"
+
+#, fuzzy
+#~ msgid "Group Update OU Fail"
+#~ msgstr "集团创建失败"
 
 #, fuzzy
 #~ msgid "Group Update Site Fail"

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -144,7 +144,7 @@ class System
         // installer reads this to pick which release to download, so a given
         // FOG release ships a known set of plugins rather than whatever the
         // default branch held on the day someone installed.
-        define('FOG_PLUGINS_VERSION', 'v1.6.23');
+        define('FOG_PLUGINS_VERSION', 'v1.6.24');
         // GH-850: FOG_BASE_DIR is now installer-driven. Initiator loads
         // commons/fogpaths.php (written from the installer's $fogprogramdir)
         // before the autoloader runs, so in a normal boot these are already


### PR DESCRIPTION
The webroot has carried the mass edit plugin seam since #1628 and the Group page's push-to-all controls have been gone since #1651 — but the plugins laid beside it came from `v1.6.23`, cut **before** fog-plugins #35, #36 and #37 landed.

Read on the maintainer's server this morning (deployed 06:35, schema 413): `HostManagement.php` has the seam; `lib/plugins/location/` still has `AddLocationGroup.php`, no `HOST_MASSEDIT_*` registration, and `persistentgroups/` is still on disk. So: location and ou still showed their group tabs, nothing filled the mass edit's Plugins tab (which hides itself when empty, so it looked as though the feature did not exist), and the retired plugin was still installable.

[fog-plugins v1.6.24](https://github.com/FOGProject/fog-plugins/releases/tag/v1.6.24) is those three merged changes. This is the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166dqQEjAs9fhqUw5zCjvxM