### PR TITLE
plugin-development: a tab on the Group page must be a grant

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -1089,6 +1089,21 @@ clobbered, because there was no way to say *leave this host alone*. Both were
 converted to this seam in fog-plugins #36 and are the worked example to copy:
 `AddLocationHost::massEditFields()` / `massEditApply()`.
 
+**A tab on the Group page must be a grant.** Since the group split (ADR 0038)
+the Group page carries only what a group *grants* to its members — snapins,
+printers, modules, power schedules. Those are set-shaped: two groups'
+contributions union instead of fighting, and a host added later receives them
+without anyone re-saving. A plugin that injects a tab on `node=group` through
+`PLUGINS_INJECT_TABDATA` must offer that same shape. If your value is a single
+field a host holds one of — a location, an OU, a flag — it is not a grant, and
+pushing it from a group tab is exactly the write-to-every-member loop this
+seam replaced. Put it on `HOST_MASSEDIT_*` and inject your host tab on
+`node=host` only. Core cannot check this for you (a tab is opaque HTML), so
+the rule is enforced by review, and the tell is visible: `FOGPage::tabFields()`
+does not draw the Plugins tab at all when nothing injects for a node, and a
+stock 1.6 install shows no Plugins tab on the Group page. If yours puts one
+there, ask whether what it holds is a grant.
+
 **Contribute a field** — fired when the Mass Edit form is built, and again
 when it is applied, with the same arguments both times so the two can never
 disagree about which keys exist:


### PR DESCRIPTION
After ADR 0038 the Group page carries only what a group **grants** its members — snapins, printers, modules, power schedules: set-shaped, union-able, reaching hosts added later. `location` and `ou` used to put a push-to-all tab there; fog-plugins #36 moved them to `HOST_MASSEDIT_*` (pinned by #1670).

Core cannot police what a plugin's tab contains (a tab is opaque HTML), so this writes the convention down in §9b next to the seam it points at, with the observable tell: `FOGPage::tabFields()` draws no Plugins tab when nothing injects for a node, so a stock 1.6 install shows no Plugins tab on the Group page.

Docs only. fog-docs carries the identical paragraph in its copy (PR linked below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166dqQEjAs9fhqUw5zCjvxM