### PR TITLE
Menu-item params were one iPXE line with a literal backslash-n (#198)

### DIFF
--- a/packages/web/src/Boot/IpxeBootMenu.php
+++ b/packages/web/src/Boot/IpxeBootMenu.php
@@ -2199,11 +2199,18 @@ class IpxeBootMenu extends BootMenuBase
                 }
             }
             $params = trim(implode("\n", (array)$params));
+            // Real newlines, one command per line. This used to be written
+            // with '\n' inside SINGLE quotes, which PHP emits as a literal
+            // backslash-n, so iPXE received one line -- `param sysuuid
+            // ${uuid}\ngoto bootme` -- and stored the whole remainder as the
+            // sysuuid VALUE. That is why the UUID regex on the write side
+            // never matched a menu-item request and only the first request
+            // of a boot (default.ipxe) ever recorded anything (#198).
             $params .= "\n"
-                . 'param sysuuid ${uuid}\n'
-                . 'param sysserial ${serial}\n'
-                . 'param mbserial ${board-serial}\n'
-                . 'param caseasset ${asset}\n'
+                . 'param sysuuid ${uuid}' . "\n"
+                . 'param sysserial ${serial}' . "\n"
+                . 'param mbserial ${board-serial}' . "\n"
+                . 'param caseasset ${asset}' . "\n"
                 . 'goto bootme';
             $Send = self::fastmerge($Send, [$params]);
         }

--- a/tests/fixtures/bootmenu-ipxe-output.golden
+++ b/tests/fixtures/bootmenu-ipxe-output.golden
@@ -589,7 +589,11 @@ param password ${password}
 param keyreg 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.deployimage
 login
 params
@@ -600,7 +604,11 @@ param password ${password}
 param qihost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.multijoin
 login
 params
@@ -611,7 +619,11 @@ param password ${password}
 param sessionJoin 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.quickdel
 login
 params
@@ -622,7 +634,11 @@ param password ${password}
 param delhost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.sysinfo
 kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
 imgfetch init.xz
@@ -759,7 +775,11 @@ param password ${password}
 param keyreg 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.deployimage
 login
 params
@@ -770,7 +790,11 @@ param password ${password}
 param qihost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.multijoin
 login
 params
@@ -781,7 +805,11 @@ param password ${password}
 param sessionJoin 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.quickdel
 login
 params
@@ -792,7 +820,11 @@ param password ${password}
 param delhost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.sysinfo
 kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
 imgfetch init.xz
@@ -859,7 +891,11 @@ param password ${password}
 param keyreg 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.deployimage
 login
 params
@@ -870,7 +906,11 @@ param password ${password}
 param qihost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.multijoin
 login
 params
@@ -881,7 +921,11 @@ param password ${password}
 param sessionJoin 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.quickdel
 login
 params
@@ -892,7 +936,11 @@ param password ${password}
 param delhost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.sysinfo
 kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
 imgfetch init.xz
@@ -963,7 +1011,11 @@ param password ${password}
 param keyreg 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.deployimage
 login
 params
@@ -974,7 +1026,11 @@ param password ${password}
 param qihost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.multijoin
 login
 params
@@ -985,7 +1041,11 @@ param password ${password}
 param sessionJoin 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.quickdel
 login
 params
@@ -996,7 +1056,11 @@ param password ${password}
 param delhost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.sysinfo
 kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
 imgfetch init.xz
@@ -1077,7 +1141,11 @@ param password ${password}
 param approveHost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :bootme
 chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
 goto MENU
@@ -1138,7 +1206,11 @@ param password ${password}
 param keyreg 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.deployimage
 login
 params
@@ -1149,7 +1221,11 @@ param password ${password}
 param qihost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.multijoin
 login
 params
@@ -1160,7 +1236,11 @@ param password ${password}
 param sessionJoin 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.quickdel
 login
 params
@@ -1171,7 +1251,11 @@ param password ${password}
 param delhost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.sysinfo
 kernel custom-bzImage loglevel=4 initrd=custom-init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 nomodeset storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
 imgfetch custom-init.xz
@@ -1233,7 +1317,11 @@ param password ${password}
 param keyreg 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.deployimage
 login
 params
@@ -1244,7 +1332,11 @@ param password ${password}
 param qihost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.multijoin
 login
 params
@@ -1255,7 +1347,11 @@ param password ${password}
 param sessionJoin 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.quickdel
 login
 params
@@ -1266,7 +1362,11 @@ param password ${password}
 param delhost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.sysinfo
 kernel arm_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
 imgfetch arm_init.cpio.gz
@@ -1332,7 +1432,11 @@ param password ${password}
 param keyreg 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.deployimage
 login
 params
@@ -1343,7 +1447,11 @@ param password ${password}
 param qihost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.multijoin
 login
 params
@@ -1354,7 +1462,11 @@ param password ${password}
 param sessionJoin 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.quickdel
 login
 params
@@ -1365,7 +1477,11 @@ param password ${password}
 param delhost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.sysinfo
 kernel arm_custom_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
 imgfetch arm_init.cpio.gz
@@ -1438,7 +1554,11 @@ param password ${password}
 param keyreg 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.deployimage
 login
 params
@@ -1449,7 +1569,11 @@ param password ${password}
 param qihost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.multijoin
 login
 params
@@ -1460,7 +1584,11 @@ param password ${password}
 param sessionJoin 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.quickdel
 login
 params
@@ -1471,7 +1599,11 @@ param password ${password}
 param delhost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.sysinfo
 kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
 imgfetch init.xz
@@ -1538,7 +1670,11 @@ param password ${password}
 param keyreg 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.deployimage
 login
 params
@@ -1549,7 +1685,11 @@ param password ${password}
 param qihost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.multijoin
 login
 params
@@ -1560,7 +1700,11 @@ param password ${password}
 param sessionJoin 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.quickdel
 login
 params
@@ -1571,7 +1715,11 @@ param password ${password}
 param delhost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.sysinfo
 kernel arm_Image loglevel=4 initrd=arm_init.cpio.gz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
 imgfetch arm_init.cpio.gz
@@ -1642,7 +1790,11 @@ param password ${password}
 param keyreg 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.deployimage
 login
 params
@@ -1653,7 +1805,11 @@ param password ${password}
 param qihost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.multijoin
 login
 params
@@ -1664,7 +1820,11 @@ param password ${password}
 param sessionJoin 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.quickdel
 login
 params
@@ -1675,7 +1835,11 @@ param password ${password}
 param delhost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.sysinfo
 kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
 imgfetch init.xz
@@ -1865,7 +2029,11 @@ param password ${password}
 param advLog 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :bootme
 chain -ar http://10.0.0.1/fog/service/ipxe/boot.php##params ||
 goto MENU
@@ -2674,7 +2842,11 @@ param password ${password}
 param keyreg 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.deployimage
 login
 params
@@ -2685,7 +2857,11 @@ param password ${password}
 param qihost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.multijoin
 login
 params
@@ -2696,7 +2872,11 @@ param password ${password}
 param sessionJoin 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.quickdel
 login
 params
@@ -2707,7 +2887,11 @@ param password ${password}
 param delhost 1
 isset ${net1/mac} && param mac1 ${net1/mac} || goto bootme
 isset ${net2/mac} && param mac2 ${net2/mac} || goto bootme
-param sysuuid ${uuid}\nparam sysserial ${serial}\nparam mbserial ${board-serial}\nparam caseasset ${asset}\ngoto bootme
+param sysuuid ${uuid}
+param sysserial ${serial}
+param mbserial ${board-serial}
+param caseasset ${asset}
+goto bootme
 :fog.sysinfo
 kernel bzImage loglevel=4 initrd=init.xz root=/dev/ram0 rw ramdisk_size=275000 web=http://10.0.0.1/fog/ consoleblank=0  rootfstype=ext4 storage=10.0.0.1:/images/ storageip=10.0.0.1 nvme_core.default_ps_max_latency_us=0 setmacto=${setmacto} loglevel=4 mode=sysinfo
 imgfetch init.xz


### PR DESCRIPTION
Follow-up to #1668, independent of #1669 (which is queued and whose branch is locked, hence the separate PR).

The param block `boot.php` appends to every **menu item** was built with `'\n'` inside single quotes, which PHP emits as a literal backslash-n. iPXE received one line, `param sysuuid ${uuid}\nparam sysserial ${serial}\n...\ngoto bootme`, and stored the whole remainder as the `sysuuid` value. Pre-existing for the UUID, which is why only the first request of a boot (from `default.ipxe`) ever recorded it and why the write side needed a UUID regex at all; the new serial params were riding inside the same broken value.

Seen live on the lab VM with #1668 deployed: choosing "Client System Information" booted FOS and stored nothing, and the served script shows the joined line.

Real newlines now, one command per line. The iPXE golden changes in exactly those 46 places, from one joined line to five. `phpstan` unaffected (string literal only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVm9aM4BHJywMoh1eaJMpZ