### PR TITLE
Match optional route segments longest-first, so the search box works again

### DIFF
--- a/bin/psr4-scan.php
+++ b/bin/psr4-scan.php
@@ -146,6 +146,7 @@ const TABLE = [
     'Route' => 'Router',
     'OpenAPI' => 'Router',
     'HTTPResponseCodes' => 'Router',
+    'LongestFirstRouteParser' => 'Router',
     'Authorization' => 'Auth',
     'CSRF' => 'Auth',
     'SiteScope' => 'Auth',

--- a/packages/web/src/Router/LongestFirstRouteParser.php
+++ b/packages/web/src/Router/LongestFirstRouteParser.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * FastRoute's route parser, with optional segments tried longest-first.
+ *
+ * PHP version 7.4+
+ *
+ * @category LongestFirstRouteParser
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.com/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org/
+ */
+
+namespace FOG\Router;
+
+use FastRoute\RouteParser\Std;
+
+/**
+ * FastRoute's route parser, with optional segments tried longest-first.
+ *
+ * FastRoute expands a route with optional segments into one route per
+ * prefix -- `/a/{b}[/{c}]` becomes `/a/{b}` and `/a/{b}/{c}` -- and Std
+ * returns them SHORTEST first, which is the order they are then matched
+ * in. AltoRouter, which this router replaced, matched the whole route as a
+ * single regex whose optional group is greedy, so the longer form was
+ * always attempted before it was given up.
+ *
+ * The two orders agree until a capture that can contain a slash precedes
+ * an optional segment. `/[search|unisearch]/[*:item]/[i:limit]?` is that
+ * route: `/unisearch/a/5` under shortest-first matches `/{_}/{item:.+?}`
+ * with item=`a/5` and no limit at all, because a lazy quantifier still
+ * runs to the end of the path when nothing after it needs the characters.
+ * The search box searched for "a/5" and found nothing, for every term.
+ *
+ * Reversing the expansion restores the greedy-optional semantics every
+ * route in the table was written against, and costs nothing for routes
+ * where the two orders agree: a longer form that does not match falls
+ * through to the shorter one exactly as before.
+ *
+ * @category LongestFirstRouteParser
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.com/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org/
+ */
+class LongestFirstRouteParser extends Std
+{
+    /**
+     * Parses a route string into its optional-segment variants, longest
+     * first.
+     *
+     * @param string $route The route string.
+     *
+     * @return array
+     */
+    public function parse($route)
+    {
+        return array_reverse(parent::parse($route));
+    }
+}

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -961,7 +961,7 @@ class Route extends FOGBase
          * dispatch, below; an install served from the document root itself
          * wants that prefix empty.
          */
-        self::$router = \FastRoute\simpleDispatcher(
+        self::$router = self::newDispatcher(
             static function (\FastRoute\RouteCollector $r) {
                 self::defineRoutes($r);
             }
@@ -969,6 +969,25 @@ class Route extends FOGBase
         self::setMatches();
         self::runMatches();
         self::printer(self::$data);
+    }
+    /**
+     * Builds the dispatcher every route in this file is matched by.
+     *
+     * One place, so the tests dispatch through the same parser production
+     * does: the route table is written in AltoRouter's syntax and its
+     * optional segments assume a greedy optional group, which FastRoute's
+     * default parser does not give -- see LongestFirstRouteParser.
+     *
+     * @param callable $define Receives the RouteCollector to register into.
+     *
+     * @return \FastRoute\Dispatcher
+     */
+    public static function newDispatcher(callable $define)
+    {
+        return \FastRoute\simpleDispatcher(
+            $define,
+            ['routeParser' => LongestFirstRouteParser::class]
+        );
     }
     /**
      * The configured webroot, normalized with a leading and trailing slash.

--- a/tests/route-table-translates-to-fastroute.test.php
+++ b/tests/route-table-translates-to-fastroute.test.php
@@ -30,7 +30,7 @@ $t = new FogChecks();
 
 $define = new \ReflectionMethod('FOG\Router\Route', 'defineRoutes');
 $define->setAccessible(true);
-$router = \FastRoute\simpleDispatcher(
+$router = \FOG\Router\Route::newDispatcher(
     function (\FastRoute\RouteCollector $r) use ($define) {
         $define->invoke(null, $r);
     }
@@ -111,6 +111,23 @@ $t->check('cancel id=5', '5' === ($vars['id'] ?? null));
 // no-colon literal alternation with no optional marker at all.
 assertFound($t, 'GET /filedeletequeue/current', 'GET', '/filedeletequeue/current');
 assertFound($t, 'GET /filedeletequeue/active', 'GET', '/filedeletequeue/active');
+
+// A `*` capture followed by an OPTIONAL segment. AltoRouter matched the
+// route as one regex whose greedy optional group claimed "/5" and left the
+// lazy `.+?` with "a". FastRoute expands the optional into two routes and
+// its default parser tries the SHORTER first, where `.+?` runs to the end
+// of the path and swallows the limit -- the sidebar search box then
+// searched for "a/5" and matched nothing, for every term. The dispatcher
+// is built by Route::newDispatcher(), which tries the longer form first.
+$vars = assertFound($t, 'unisearch with limit dispatches', 'POST', '/unisearch/a/5');
+$t->check('unisearch item=a', 'a' === ($vars['item'] ?? null));
+$t->check('unisearch limit=5', '5' === ($vars['limit'] ?? null));
+$vars = assertFound($t, 'unisearch without limit dispatches', 'GET', '/unisearch/a');
+$t->check('unisearch bare has no limit', !array_key_exists('limit', $vars));
+// The longer form failing falls through to the shorter one, so a term whose
+// tail is not a number is still the whole term, as it was under AltoRouter.
+$vars = assertFound($t, 'unisearch non-numeric tail dispatches', 'GET', '/unisearch/a/b');
+$t->check('unisearch item=a/b when the tail is not a limit', 'a/b' === ($vars['item'] ?? null));
 
 // The no-colon alternation mechanism itself: dispatching directly (bypassing
 // setMatches()) exposes the throwaway placeholder FastRoute's grammar


### PR DESCRIPTION
**Symptom:** the sidebar universal search returns nothing for any term.

**Cause:** the AltoRouter → FastRoute swap (98159c0a4) changed how an optional segment is matched. AltoRouter ran one regex per route with a greedy optional group; FastRoute expands `[/{limit}]` into two routes and its default parser tries the **shorter** first. The two orders agree until a capture that may contain a slash precedes the optional, and the table has exactly one such route: `/[search|unisearch]/[*:item]/[i:limit]?`. Dispatching `/unisearch/a/5` gave `item="a/5"` and no limit, so the box searched for `%a/5%`.

Probe against the current dispatcher, before this change:

```
/unisearch/a/5 => {"item":"a/5"}          # expected {"item":"a","limit":"5"}
```

**Fix:** `FOG\Router\LongestFirstRouteParser` extends FastRoute's `Std` and reverses the expansion, so the longer form is tried first and falls through to the shorter one when it does not match — the greedy-optional semantics every route in the table was written against. `Route::newDispatcher()` is now the one place the dispatcher is built.

**Test:** `route-table-translates-to-fastroute.test.php` was building its own default dispatcher, which is why it could not see this; it now dispatches through `Route::newDispatcher()`. Added checks: `/unisearch/a/5` → item `a`, limit `5`; `/unisearch/a` → no limit; `/unisearch/a/b` → item `a/b` (non-numeric tail is still the term, as under AltoRouter). Mutation: with `Std` swapped back in, 2 of 35 checks fail. Full suite 306/306, phpstan clean on both configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166dqQEjAs9fhqUw5zCjvxM