### PR TITLE
Registration asks the firmware before creating a host (#198)

### DIFF
--- a/docs/adr/0039-a-booting-machine-is-identified-by-firmware-second.md
+++ b/docs/adr/0039-a-booting-machine-is-identified-by-firmware-second.md
@@ -70,6 +70,16 @@ sure, and only when told to.**
    validated on every write (Aisle 019).
 6. **The four columns get indexes** (schema step 413). The lookup runs on
    every boot request and `inventory` had none.
+7. **Registration asks the firmware too** (added 2026-09-02). FOS already
+   sends the UUID with every registration and now sends all four fields.
+   `Registration::regExists()` resolves them through the same rule under
+   the same setting. A known MAC still wins and still refuses, in every
+   mode. When the MAC finds nothing and the firmware finds exactly one
+   host, `log` writes the line and registers a new host as before, and
+   `enforce` adds the machine's MACs to that host and answers "already
+   registered", the same answer a known MAC gets: the machine is that
+   host with a new NIC. `SmbiosIdentity::registrationAction()` holds the
+   gating so it is provable with three integers.
 
 ## Why log mode first
 
@@ -98,6 +108,16 @@ toggle and a revert.
   client, whose requests carry the same field names with different
   contents. It would run a wasted query per inventory POST that could not
   change the answer.
+- **Refuse, but do not attach, at registration in enforce mode.** Safer by
+  one step, and it leaves the administrator adding the new MAC to the old
+  host by hand, which is the exact chore the identity exists to remove. The
+  attach happens only in enforce, only when no host owns the MAC, and is
+  audited under `host.register`.
+- **Let a MAC-less machine register.** The bench case, one USB NIC shared
+  across many machines, is detectable now but not registrable: a host must
+  own a unique primary MAC. That is a change to the hosts table's
+  uniqueness rule and to everything that assumes a MAC, and it is its own
+  decision.
 - **Overwrite serials at boot.** Would hide the iPXE-versus-dmidecode
   disagreements that log mode exists to surface, by ping-ponging the value
   between the two writers.
@@ -106,6 +126,8 @@ toggle and a revert.
 
 - A CSV-imported host becomes firmware-findable after its first PXE boot,
   not its first image.
+- A machine whose NIC was replaced keeps its host record on re-registration
+  under `enforce`, instead of becoming a duplicate.
 - The error log gains two new line shapes, both prefixed `FOG host
   identity`. Documentation for the setting should point administrators at
   them.

--- a/packages/web/src/Base/SmbiosIdentity.php
+++ b/packages/web/src/Base/SmbiosIdentity.php
@@ -156,6 +156,47 @@ final class SmbiosIdentity
         return $filter;
     }
     /**
+     * What registration does with a firmware match (#198).
+     *
+     * Registration used to know only the MAC, so a machine whose NIC was
+     * replaced came back as a brand-new host and its old record -- image,
+     * groups, snapins, AD join -- became a leftover. Now the firmware is
+     * asked as well. This decides what its answer is worth, on its own so
+     * the gating can be proven with three integers and no database:
+     *
+     *   'none'   nothing to say: the mode is off, the firmware found no
+     *            host, or it found the same host the MAC found.
+     *   'log'    write the disagreement and let the MAC decide, as before.
+     *            Every outcome in log mode, and an enforce-mode disagreement
+     *            where the MAC DID find a host: a known MAC is never
+     *            overruled at registration, because "already registered as
+     *            Y" is at worst an inconvenience while re-pointing Y's MACs
+     *            is not.
+     *   'attach' enforce mode, the MAC found nothing, the firmware found
+     *            exactly one host: this machine IS that host with a new
+     *            NIC. Its MACs are added to the host and the registration
+     *            is answered "already registered", the same answer a known
+     *            MAC gets.
+     *
+     * @param string $mode     the FOG_HOST_IDENTIFY_SMBIOS value, lowercased
+     * @param int    $macID    host the MACs resolved to, 0 for none
+     * @param int    $smbiosID host the firmware resolved to, 0 for none
+     *
+     * @return string 'none', 'log' or 'attach'
+     */
+    public static function registrationAction($mode, $macID, $smbiosID)
+    {
+        $macID = (int)$macID;
+        $smbiosID = (int)$smbiosID;
+        if (!in_array($mode, ['log', 'enforce'], true) || $smbiosID < 1) {
+            return 'none';
+        }
+        if ($macID > 0) {
+            return $macID === $smbiosID ? 'none' : 'log';
+        }
+        return $mode === 'enforce' ? 'attach' : 'log';
+    }
+    /**
      * Pick the one host the reported identifiers point at, or nothing.
      *
      * The rules, each of which exists because its absence has already

--- a/packages/web/src/Boot/Registration.php
+++ b/packages/web/src/Boot/Registration.php
@@ -15,6 +15,9 @@ namespace FOG\Boot;
 
 use FOG\Audit\Audit;
 use FOG\Base\FOGBase;
+use FOG\Base\SmbiosIdentity;
+use FOG\Items\Host;
+use FOG\Managers\HostManager;
 use FOG\Items\TaskType;
 use FOG\Router\Route;
 
@@ -129,9 +132,32 @@ class Registration extends FOGBase
      */
     public function regExists($check = false)
     {
+        // The firmware is asked first and acted on last (#198). Resolving
+        // it before the MAC costs one indexed query and lets a disagreement
+        // be logged whichever way the MAC goes; SmbiosIdentity::
+        // registrationAction() says what the answer is worth.
+        $mode = strtolower(
+            trim((string)self::getSetting('FOG_HOST_IDENTIFY_SMBIOS'))
+        );
+        $smbios = $this->_smbiosFromRequest();
+        $smbiosID = 0;
+        if (in_array($mode, ['log', 'enforce'], true)
+            && strlen(implode('', $smbios))
+        ) {
+            $smbiosID = (int)HostManager::resolveHostBySmbios($smbios);
+        }
         try {
             self::getClass('HostManager')->getHostByMacAddresses($this->PriMAC);
+            if (!self::$Host->isValid()) {
+                self::getClass('HostManager')->getHostByMacAddresses($this->MACs);
+            }
             if (self::$Host->isValid()) {
+                $this->_smbiosOutcome(
+                    $mode,
+                    $smbios,
+                    $smbiosID,
+                    (int)self::$Host->get('id')
+                );
                 throw new \Exception(
                     sprintf(
                         _('This machine already registered as %s'),
@@ -139,8 +165,7 @@ class Registration extends FOGBase
                     )
                 );
             }
-            self::getClass('HostManager')->getHostByMacAddresses($this->MACs);
-            if (self::$Host->isValid()) {
+            if ($this->_smbiosOutcome($mode, $smbios, $smbiosID, 0) === 'attach') {
                 throw new \Exception(
                     sprintf(
                         _('This machine already registered as %s'),
@@ -156,6 +181,96 @@ class Registration extends FOGBase
             throw new \Exception('#!ok');
         }
         return false;
+    }
+    /**
+     * The firmware fields FOS sent with the registration (#198).
+     *
+     * FOS base64-encodes every registration field, so these are decoded
+     * here rather than through stripAndDecode(), which HTML-escapes what
+     * it decodes -- the same trap as a credential escaped before its hash
+     * compare. An older FOS sends only the UUID, and a value that is not
+     * base64 at all is kept as sent; SmbiosIdentity drops what is empty.
+     *
+     * @return array field => canonicalized value, every field present
+     */
+    private function _smbiosFromRequest()
+    {
+        $smbios = [];
+        foreach (SmbiosIdentity::FIELDS as $field) {
+            $raw = (string)(filter_input(INPUT_POST, $field) ?: '');
+            $decoded = base64_decode(str_replace(' ', '+', $raw), true);
+            $smbios[$field] = SmbiosIdentity::canonicalize(
+                $decoded === false ? $raw : $decoded
+            );
+        }
+        return $smbios;
+    }
+    /**
+     * Log, and in enforce mode act on, the firmware's answer (#198).
+     *
+     * 'attach' is the only outcome with a side effect: the registering
+     * machine's MACs are added to the host the firmware named, that host
+     * becomes self::$Host, and an audit header records it under the same
+     * host.register type a new host gets, because from the administrator's
+     * side it is the same event -- a machine came in through registration
+     * and left with a record. The MACs are known to belong to no host at
+     * this point, or the MAC lookup would have found one.
+     *
+     * @param string $mode     the setting, lowercased
+     * @param array  $smbios   the fields as sent
+     * @param int    $smbiosID host the firmware resolved to, 0 for none
+     * @param int    $macID    host the MACs resolved to, 0 for none
+     *
+     * @return string the SmbiosIdentity::registrationAction() taken
+     */
+    private function _smbiosOutcome($mode, array $smbios, $smbiosID, $macID)
+    {
+        $action = SmbiosIdentity::registrationAction($mode, $macID, $smbiosID);
+        if ($action === 'none') {
+            return $action;
+        }
+        $SmbiosHost = new Host($smbiosID);
+        $fields = [];
+        foreach (SmbiosIdentity::usable($smbios) as $k => $v) {
+            $fields[] = "$k=$v";
+        }
+        $macs = array_merge([$this->PriMAC], (array)$this->MACs);
+        error_log(
+            sprintf(
+                'FOG host identity (registration, %s): MAC %s resolved %s; '
+                . 'SMBIOS resolved "%s" (id %d) on %s; %s',
+                $mode,
+                implode(',', $macs),
+                $macID
+                    ? sprintf('"%s" (id %d)', self::$Host->get('name'), $macID)
+                    : 'no host',
+                $SmbiosHost->get('name'),
+                $smbiosID,
+                implode(', ', $fields),
+                $action === 'attach'
+                    ? 'MACs attached to it, registration answered as existing'
+                    : ($macID
+                        ? 'MAC kept'
+                        : 'registering as a new host (log mode)')
+            )
+        );
+        if ($action === 'attach') {
+            Audit::record([
+                'type' => 'host.register',
+                'authSource' => Audit::SOURCE_ANONYMOUS,
+                'subjectType' => 'host',
+                'subjectID' => $smbiosID,
+                'subjectLabel' => (string)$SmbiosHost->get('name'),
+                'renderable' => 1,
+                'text' => sprintf(
+                    'firmware identity: attached %s',
+                    implode(',', $macs)
+                )
+            ]);
+            $SmbiosHost->addMAC($macs);
+            self::$Host = $SmbiosHost;
+        }
+        return $action;
     }
     /**
      * Perform the registration.

--- a/tests/smbios-host-identity.test.php
+++ b/tests/smbios-host-identity.test.php
@@ -22,6 +22,9 @@
  *      into both serials scores once.
  *   4. The winner must hold the top score alone. A tie is "no opinion".
  *   5. The asset tag breaks a tie but cannot win by itself.
+ *   6. Registration acts on the firmware only in enforce mode and only when
+ *      the MAC found nothing; a known MAC is never overruled, and log mode
+ *      never attaches.
  *
  * DB-free: SmbiosIdentity is pure by design so this file can drive it
  * with arrays. HostManager::resolveHostBySmbios() only adds the query and
@@ -175,5 +178,22 @@ $t->check(
         $tagged
     ) === 11
 );
+
+// 6. Registration gating.
+foreach ([
+    ['enforce', 0, 7, 'attach', 'enforce, MAC unknown, firmware unique: attach'],
+    ['log', 0, 7, 'log', 'log mode never attaches'],
+    ['off', 0, 7, 'none', 'off says nothing'],
+    ['', 0, 7, 'none', 'missing setting is off'],
+    ['enforce', 3, 7, 'log', 'a known MAC is never overruled, even in enforce'],
+    ['enforce', 7, 7, 'none', 'agreement is silence'],
+    ['enforce', 0, 0, 'none', 'no firmware match is silence'],
+    ['log', 3, 7, 'log', 'log mode logs a disagreement'],
+] as [$mode, $macID, $smbiosID, $want, $label]) {
+    $t->check(
+        "registration: $label",
+        SmbiosIdentity::registrationAction($mode, $macID, $smbiosID) === $want
+    );
+}
 
 $t->finish();


### PR DESCRIPTION
Follow-on to #1668. Registration knew only the MAC, so a machine whose NIC was replaced registered as a duplicate host and its old record became a leftover. FOS has sent the firmware UUID with every registration for years and nothing read it.

**What changes**

- `Registration::regExists()` resolves the SMBIOS fields FOS sends through `HostManager::resolveHostBySmbios()`, under the same `FOG_HOST_IDENTIFY_SMBIOS` setting, and logs disagreements with the same `FOG host identity` prefix as the boot path.
- A known MAC still wins and still refuses, in every mode.
- MAC unknown, firmware finds exactly one host: `log` writes the line and registers a new host as today; `enforce` adds the machine's MACs to that host, writes a `host.register` audit header naming it, and answers "already registered as X".
- The gating is `SmbiosIdentity::registrationAction()`, pure, with eight new checks in `tests/smbios-host-identity.test.php`. Both mutants (log mode attaching; a known MAC overruled) go red.
- Fields are base64-decoded directly, not through `stripAndDecode()`, which HTML-escapes what it decodes.
- ADR 0039 gains decision 7 and two rejected alternatives.

**Not changed:** a machine with no MAC of its own still cannot register. That is the hosts-table uniqueness rule and its own decision.

**FOS side:** FOGProject/fos PR adds `sysserial`, `mbserial` and `caseasset` to both registration requests. This server change accepts their absence, so it can merge first.

**Verified:** both phpstan passes, `smbios-host-identity` (41), `credentials-are-not-html-escaped`, `audit-invariants` (40), iPXE golden, psr4 scan. Lab registration run against the VM follows once deployed.

`route.class.php` untouched: registration is a `service/*.php` endpoint, not a REST route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVm9aM4BHJywMoh1eaJMpZ