### PR TITLE
Search: rank prefix matches first, match the term literally, take ?q=

### DIFF
--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -5377,12 +5377,15 @@ function setupUniversalSearch() {
     maximumSelectionSize: 1,
     ajax: {
       delay: 250,
-      url: function(params)  {
-        return baseURL + '/' + params.term + '/' + resultLimit;
-      },
+      url: baseURL,
       type: method,
       dataType: 'json',
       cache: false,
+      // Body fields, not path segments: a term may contain / ? # or %,
+      // none of which survives a trip through the URL path.
+      data: function(params) {
+        return {q: params.term, limit: resultLimit};
+      },
       processResults: function (data) {
         var results = [];
 

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1083,9 +1083,6 @@ msgstr "%s ist erforderlich"
 msgid "An optional last column may list associations to create, using the format \"label:value|value;label:value\". Values may be ids or names; unknown references are skipped with a warning rather than failing the row."
 msgstr ""
 
-msgid "An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
-msgstr ""
-
 #, fuzzy
 msgid "An ou already exists with this name!"
 msgstr "Eine Gruppe mit diesem Namen ist bereits vorhanden!"
@@ -5522,6 +5519,9 @@ msgstr "Maximale Clients"
 msgid "Max Size"
 msgstr "Max. Größe"
 
+msgid "Maximum rows per class; 0 or absent means no cap."
+msgstr ""
+
 #, fuzzy
 msgid "Member"
 msgstr "Mitglieder"
@@ -7810,6 +7810,9 @@ msgstr "Suchbereich"
 msgid "Search every class at once"
 msgstr ""
 
+msgid "Search every class at once (path form)"
+msgstr ""
+
 msgid "Search results returned false"
 msgstr "Die Suche lieferte kein passendes Ergebnis"
 
@@ -9129,6 +9132,9 @@ msgstr "Text"
 msgid "Text to match against the id and name. A few classes match more: host also on MAC, storagenode on node hostname, setting on value."
 msgstr ""
 
+msgid "Text to match against the name (and the id, when the text is a whole number). Matched literally: % and _ are not wildcards."
+msgstr ""
+
 #, fuzzy
 msgid "That certificate is not available on this server."
 msgstr "Es gibt keine Gruppen auf diesem Server."
@@ -9422,6 +9428,9 @@ msgstr "Objekt"
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
 msgstr ""
 
+msgid "The older spelling of /unisearch?q=. An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
+msgstr ""
+
 msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
@@ -9511,6 +9520,13 @@ msgid "The storage groups associated storage node is not valid"
 msgstr "Der einer/mehrere Speichergruppen zugeordnete Speicherknoten ist ungültig"
 
 msgid "The task finishes on the client with nobody at the keyboard"
+msgstr ""
+
+msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
+msgstr ""
+
+#, php-format
+msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
 msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1087,9 +1087,6 @@ msgstr "%s is required"
 msgid "An optional last column may list associations to create, using the format \"label:value|value;label:value\". Values may be ids or names; unknown references are skipped with a warning rather than failing the row."
 msgstr ""
 
-msgid "An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
-msgstr ""
-
 #, fuzzy
 msgid "An ou already exists with this name!"
 msgstr "An image already exists with this name!"
@@ -5534,6 +5531,9 @@ msgstr "Max Clients"
 msgid "Max Size"
 msgstr "Max Size"
 
+msgid "Maximum rows per class; 0 or absent means no cap."
+msgstr ""
+
 #, fuzzy
 msgid "Member"
 msgstr "Members"
@@ -7821,6 +7821,9 @@ msgstr "Search"
 msgid "Search every class at once"
 msgstr ""
 
+msgid "Search every class at once (path form)"
+msgstr ""
+
 msgid "Search results returned false"
 msgstr ""
 
@@ -9138,6 +9141,9 @@ msgstr "Text"
 msgid "Text to match against the id and name. A few classes match more: host also on MAC, storagenode on node hostname, setting on value."
 msgstr ""
 
+msgid "Text to match against the name (and the id, when the text is a whole number). Matched literally: % and _ are not wildcards."
+msgstr ""
+
 #, fuzzy
 msgid "That certificate is not available on this server."
 msgstr "There are no groups on this server."
@@ -9431,6 +9437,9 @@ msgstr "Object"
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
 msgstr ""
 
+msgid "The older spelling of /unisearch?q=. An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
+msgstr ""
+
 msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
@@ -9520,6 +9529,13 @@ msgid "The storage groups associated storage node is not valid"
 msgstr "The storage groups associated storage node is not valid"
 
 msgid "The task finishes on the client with nobody at the keyboard"
+msgstr ""
+
+msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
+msgstr ""
+
+#, php-format
+msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
 msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1101,9 +1101,6 @@ msgstr "%s se requiere"
 msgid "An optional last column may list associations to create, using the format \"label:value|value;label:value\". Values may be ids or names; unknown references are skipped with a warning rather than failing the row."
 msgstr ""
 
-msgid "An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
-msgstr ""
-
 #, fuzzy
 msgid "An ou already exists with this name!"
 msgstr "Una imagen ya existe con este nombre!"
@@ -5634,6 +5631,9 @@ msgstr "Clientela"
 msgid "Max Size"
 msgstr "Tamaño máximo:"
 
+msgid "Maximum rows per class; 0 or absent means no cap."
+msgstr ""
+
 #, fuzzy
 msgid "Member"
 msgstr "miembros"
@@ -7950,6 +7950,9 @@ msgstr "Buscar"
 msgid "Search every class at once"
 msgstr ""
 
+msgid "Search every class at once (path form)"
+msgstr ""
+
 msgid "Search results returned false"
 msgstr ""
 
@@ -9302,6 +9305,9 @@ msgstr "Siguiente"
 msgid "Text to match against the id and name. A few classes match more: host also on MAC, storagenode on node hostname, setting on value."
 msgstr ""
 
+msgid "Text to match against the name (and the id, when the text is a whole number). Matched literally: % and _ are not wildcards."
+msgstr ""
+
 #, fuzzy
 msgid "That certificate is not available on this server."
 msgstr "No hay grupos en este servidor."
@@ -9594,6 +9600,9 @@ msgstr "Objeto"
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
 msgstr ""
 
+msgid "The older spelling of /unisearch?q=. An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
+msgstr ""
+
 msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
@@ -9683,6 +9692,13 @@ msgid "The storage groups associated storage node is not valid"
 msgstr ""
 
 msgid "The task finishes on the client with nobody at the keyboard"
+msgstr ""
+
+msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
+msgstr ""
+
+#, php-format
+msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
 msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1083,9 +1083,6 @@ msgstr "%s ist erforderlich"
 msgid "An optional last column may list associations to create, using the format \"label:value|value;label:value\". Values may be ids or names; unknown references are skipped with a warning rather than failing the row."
 msgstr ""
 
-msgid "An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
-msgstr ""
-
 #, fuzzy
 msgid "An ou already exists with this name!"
 msgstr "Eine Gruppe mit diesem Namen ist bereits vorhanden!"
@@ -5523,6 +5520,9 @@ msgstr "Maximale Clients"
 msgid "Max Size"
 msgstr "Max. Größe"
 
+msgid "Maximum rows per class; 0 or absent means no cap."
+msgstr ""
+
 #, fuzzy
 msgid "Member"
 msgstr "Mitglieder"
@@ -7811,6 +7811,9 @@ msgstr "Suchbereich"
 msgid "Search every class at once"
 msgstr ""
 
+msgid "Search every class at once (path form)"
+msgstr ""
+
 msgid "Search results returned false"
 msgstr "Die Suche lieferte kein passendes Ergebnis"
 
@@ -9130,6 +9133,9 @@ msgstr "Text"
 msgid "Text to match against the id and name. A few classes match more: host also on MAC, storagenode on node hostname, setting on value."
 msgstr ""
 
+msgid "Text to match against the name (and the id, when the text is a whole number). Matched literally: % and _ are not wildcards."
+msgstr ""
+
 #, fuzzy
 msgid "That certificate is not available on this server."
 msgstr "Es gibt keine Gruppen auf diesem Server."
@@ -9423,6 +9429,9 @@ msgstr "Objekt"
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
 msgstr ""
 
+msgid "The older spelling of /unisearch?q=. An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
+msgstr ""
+
 msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
@@ -9512,6 +9521,13 @@ msgid "The storage groups associated storage node is not valid"
 msgstr "Der einer/mehrere Speichergruppen zugeordnete Speicherknoten ist ungültig"
 
 msgid "The task finishes on the client with nobody at the keyboard"
+msgstr ""
+
+msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
+msgstr ""
+
+#, php-format
+msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
 msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1088,9 +1088,6 @@ msgstr "%s est requis"
 msgid "An optional last column may list associations to create, using the format \"label:value|value;label:value\". Values may be ids or names; unknown references are skipped with a warning rather than failing the row."
 msgstr ""
 
-msgid "An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
-msgstr ""
-
 #, fuzzy
 msgid "An ou already exists with this name!"
 msgstr "Une image existe déjà avec ce nom!"
@@ -5522,6 +5519,9 @@ msgstr "Les clients de Max"
 msgid "Max Size"
 msgstr "Max Taille"
 
+msgid "Maximum rows per class; 0 or absent means no cap."
+msgstr ""
+
 #, fuzzy
 msgid "Member"
 msgstr "Membres"
@@ -7807,6 +7807,9 @@ msgstr "Chercher"
 msgid "Search every class at once"
 msgstr ""
 
+msgid "Search every class at once (path form)"
+msgstr ""
+
 msgid "Search results returned false"
 msgstr ""
 
@@ -9123,6 +9126,9 @@ msgstr "Texte"
 msgid "Text to match against the id and name. A few classes match more: host also on MAC, storagenode on node hostname, setting on value."
 msgstr ""
 
+msgid "Text to match against the name (and the id, when the text is a whole number). Matched literally: % and _ are not wildcards."
+msgstr ""
+
 #, fuzzy
 msgid "That certificate is not available on this server."
 msgstr "Il n'y a pas de groupes sur ce serveur."
@@ -9416,6 +9422,9 @@ msgstr "Objet"
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
 msgstr ""
 
+msgid "The older spelling of /unisearch?q=. An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
+msgstr ""
+
 msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
@@ -9505,6 +9514,13 @@ msgid "The storage groups associated storage node is not valid"
 msgstr "Le nœud de stockage des groupes de stockage associé est pas valide"
 
 msgid "The task finishes on the client with nobody at the keyboard"
+msgstr ""
+
+msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
+msgstr ""
+
+#, php-format
+msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
 msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1059,9 +1059,6 @@ msgstr "%s è richiesto"
 msgid "An optional last column may list associations to create, using the format \"label:value|value;label:value\". Values may be ids or names; unknown references are skipped with a warning rather than failing the row."
 msgstr ""
 
-msgid "An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
-msgstr ""
-
 #, fuzzy
 msgid "An ou already exists with this name!"
 msgstr "Esiste già un gruppo con questo nome!"
@@ -5354,6 +5351,9 @@ msgstr "clienti max"
 msgid "Max Size"
 msgstr "Dimensione massima"
 
+msgid "Maximum rows per class; 0 or absent means no cap."
+msgstr ""
+
 #, fuzzy
 msgid "Member"
 msgstr "Utenti"
@@ -7584,6 +7584,9 @@ msgstr "Scope di ricerca"
 msgid "Search every class at once"
 msgstr ""
 
+msgid "Search every class at once (path form)"
+msgstr ""
+
 msgid "Search results returned false"
 msgstr "Risultati di ricerca che restituiscono false"
 
@@ -8845,6 +8848,9 @@ msgstr "Testo"
 msgid "Text to match against the id and name. A few classes match more: host also on MAC, storagenode on node hostname, setting on value."
 msgstr ""
 
+msgid "Text to match against the name (and the id, when the text is a whole number). Matched literally: % and _ are not wildcards."
+msgstr ""
+
 #, fuzzy
 msgid "That certificate is not available on this server."
 msgstr "Non ci sono gruppi su questo server"
@@ -9136,6 +9142,9 @@ msgstr "oggetto"
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
 msgstr ""
 
+msgid "The older spelling of /unisearch?q=. An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
+msgstr ""
+
 msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
@@ -9225,6 +9234,13 @@ msgid "The storage groups associated storage node is not valid"
 msgstr "Il nodo di archiviazione gruppi di archiviazione associato non è valido"
 
 msgid "The task finishes on the client with nobody at the keyboard"
+msgstr ""
+
+msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
+msgstr ""
+
+#, php-format
+msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
 msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1043,9 +1043,6 @@ msgstr "ユーザー名は必須です！"
 msgid "An optional last column may list associations to create, using the format \"label:value|value;label:value\". Values may be ids or names; unknown references are skipped with a warning rather than failing the row."
 msgstr ""
 
-msgid "An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
-msgstr ""
-
 #, fuzzy
 msgid "An ou already exists with this name!"
 msgstr "この名前のグループは既に存在します！"
@@ -5317,6 +5314,9 @@ msgstr "最大クライアント数"
 msgid "Max Size"
 msgstr "最大サイズ"
 
+msgid "Maximum rows per class; 0 or absent means no cap."
+msgstr ""
+
 #, fuzzy
 msgid "Member"
 msgstr "メンバー"
@@ -7547,6 +7547,9 @@ msgstr "検索範囲"
 msgid "Search every class at once"
 msgstr ""
 
+msgid "Search every class at once (path form)"
+msgstr ""
+
 msgid "Search results returned false"
 msgstr "検索結果が false を返しました"
 
@@ -8789,6 +8792,9 @@ msgstr "テキスト"
 msgid "Text to match against the id and name. A few classes match more: host also on MAC, storagenode on node hostname, setting on value."
 msgstr ""
 
+msgid "Text to match against the name (and the id, when the text is a whole number). Matched literally: % and _ are not wildcards."
+msgstr ""
+
 #, fuzzy
 msgid "That certificate is not available on this server."
 msgstr "このサーバーにはグループがありません"
@@ -9080,6 +9086,9 @@ msgstr "オブジェクト"
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
 msgstr ""
 
+msgid "The older spelling of /unisearch?q=. An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
+msgstr ""
+
 msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
@@ -9171,6 +9180,13 @@ msgid "The storage groups associated storage node is not valid"
 msgstr "ストレージグループに関連付けられたストレージノードが無効です"
 
 msgid "The task finishes on the client with nobody at the keyboard"
+msgstr ""
+
+msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
+msgstr ""
+
+#, php-format
+msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
 msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -938,9 +938,6 @@ msgstr ""
 msgid "An optional last column may list associations to create, using the format \"label:value|value;label:value\". Values may be ids or names; unknown references are skipped with a warning rather than failing the row."
 msgstr ""
 
-msgid "An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
-msgstr ""
-
 msgid "An ou already exists with this name!"
 msgstr ""
 
@@ -4713,6 +4710,9 @@ msgstr ""
 msgid "Max Size"
 msgstr ""
 
+msgid "Maximum rows per class; 0 or absent means no cap."
+msgstr ""
+
 msgid "Member"
 msgstr ""
 
@@ -6682,6 +6682,9 @@ msgstr ""
 msgid "Search every class at once"
 msgstr ""
 
+msgid "Search every class at once (path form)"
+msgstr ""
+
 msgid "Search results returned false"
 msgstr ""
 
@@ -7782,6 +7785,9 @@ msgstr ""
 msgid "Text to match against the id and name. A few classes match more: host also on MAC, storagenode on node hostname, setting on value."
 msgstr ""
 
+msgid "Text to match against the name (and the id, when the text is a whole number). Matched literally: % and _ are not wildcards."
+msgstr ""
+
 msgid "That certificate is not available on this server."
 msgstr ""
 
@@ -8048,6 +8054,9 @@ msgstr ""
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
 msgstr ""
 
+msgid "The older spelling of /unisearch?q=. An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
+msgstr ""
+
 msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
@@ -8131,6 +8140,13 @@ msgid "The storage groups associated storage node is not valid"
 msgstr ""
 
 msgid "The task finishes on the client with nobody at the keyboard"
+msgstr ""
+
+msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
+msgstr ""
+
+#, php-format
+msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
 msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1087,9 +1087,6 @@ msgstr "%s é necessária"
 msgid "An optional last column may list associations to create, using the format \"label:value|value;label:value\". Values may be ids or names; unknown references are skipped with a warning rather than failing the row."
 msgstr ""
 
-msgid "An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
-msgstr ""
-
 #, fuzzy
 msgid "An ou already exists with this name!"
 msgstr "Uma imagem já existe com este nome!"
@@ -5521,6 +5518,9 @@ msgstr "Clientes Max"
 msgid "Max Size"
 msgstr "Max Size"
 
+msgid "Maximum rows per class; 0 or absent means no cap."
+msgstr ""
+
 #, fuzzy
 msgid "Member"
 msgstr "Membros"
@@ -7808,6 +7808,9 @@ msgstr "Pesquisa"
 msgid "Search every class at once"
 msgstr ""
 
+msgid "Search every class at once (path form)"
+msgstr ""
+
 msgid "Search results returned false"
 msgstr ""
 
@@ -9125,6 +9128,9 @@ msgstr "Texto"
 msgid "Text to match against the id and name. A few classes match more: host also on MAC, storagenode on node hostname, setting on value."
 msgstr ""
 
+msgid "Text to match against the name (and the id, when the text is a whole number). Matched literally: % and _ are not wildcards."
+msgstr ""
+
 #, fuzzy
 msgid "That certificate is not available on this server."
 msgstr "Não existem grupos neste servidor."
@@ -9418,6 +9424,9 @@ msgstr "Objeto"
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
 msgstr ""
 
+msgid "The older spelling of /unisearch?q=. An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
+msgstr ""
+
 msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
@@ -9507,6 +9516,13 @@ msgid "The storage groups associated storage node is not valid"
 msgstr "O nó de armazenamento grupos de armazenamento associado não é válido"
 
 msgid "The task finishes on the client with nobody at the keyboard"
+msgstr ""
+
+msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
+msgstr ""
+
+#, php-format
+msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
 msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1087,9 +1087,6 @@ msgstr "%s是必需的"
 msgid "An optional last column may list associations to create, using the format \"label:value|value;label:value\". Values may be ids or names; unknown references are skipped with a warning rather than failing the row."
 msgstr ""
 
-msgid "An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
-msgstr ""
-
 #, fuzzy
 msgid "An ou already exists with this name!"
 msgstr "图像已经存在具有此名称！"
@@ -5521,6 +5518,9 @@ msgstr "最大客户"
 msgid "Max Size"
 msgstr "最大尺寸"
 
+msgid "Maximum rows per class; 0 or absent means no cap."
+msgstr ""
+
 #, fuzzy
 msgid "Member"
 msgstr "会员"
@@ -7808,6 +7808,9 @@ msgstr "搜索"
 msgid "Search every class at once"
 msgstr ""
 
+msgid "Search every class at once (path form)"
+msgstr ""
+
 msgid "Search results returned false"
 msgstr ""
 
@@ -9125,6 +9128,9 @@ msgstr "文本"
 msgid "Text to match against the id and name. A few classes match more: host also on MAC, storagenode on node hostname, setting on value."
 msgstr ""
 
+msgid "Text to match against the name (and the id, when the text is a whole number). Matched literally: % and _ are not wildcards."
+msgstr ""
+
 #, fuzzy
 msgid "That certificate is not available on this server."
 msgstr "有此服务器上没有组。"
@@ -9418,6 +9424,9 @@ msgstr "目的"
 msgid "The objects to apply these values to. An empty or absent list matches nothing and edits nothing."
 msgstr ""
 
+msgid "The older spelling of /unisearch?q=. An optional trailing integer caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Also reachable as /search."
+msgstr ""
+
 msgid "The order this group's snapins run in. A host runs its own snapins first, then the ones granted here, in this order. Order only changes execution when \"Abort snapin sequence on failure\" is enabled for the task."
 msgstr ""
 
@@ -9507,6 +9516,13 @@ msgid "The storage groups associated storage node is not valid"
 msgstr "存储组相关联的存储节点无效"
 
 msgid "The task finishes on the client with nobody at the keyboard"
+msgstr ""
+
+msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
+msgstr ""
+
+#, php-format
+msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
 msgid "The trust anchor, published as ca.cert.der. Every fog-client pins this one."

--- a/packages/web/src/Router/OpenAPI.php
+++ b/packages/web/src/Router/OpenAPI.php
@@ -2960,22 +2960,58 @@ class OpenAPI extends FOGBase
                     $json(['type' => 'object'], _('Log contents.'))
                 )
             ],
+            '/unisearch' => [
+                'get' => self::_op(
+                    '',
+                    'unisearch',
+                    _('Search every class at once'),
+                    _('The term goes in q. limit caps results PER CLASS, not '
+                        . 'overall, and this route is not paged -- there is no '
+                        . 'nextUrl to follow. Within a class, names that start '
+                        . 'with the term sort first. Both fields may also be '
+                        . 'sent as POST body fields. Also reachable as /search.'),
+                    $json(['type' => 'object'], _('Grouped matches.')),
+                    [
+                        [
+                            'name' => 'q',
+                            'in' => 'query',
+                            'required' => true,
+                            'schema' => ['type' => 'string'],
+                            'description' => _('Text to match against the name '
+                                . '(and the id, when the text is a whole number). '
+                                . 'Matched literally: % and _ are not wildcards.')
+                        ],
+                        [
+                            'name' => 'limit',
+                            'in' => 'query',
+                            'required' => false,
+                            'schema' => ['type' => 'integer', 'minimum' => 0],
+                            'description' => _('Maximum rows per class; 0 or '
+                                . 'absent means no cap.')
+                        ]
+                    ]
+                )
+            ],
             '/unisearch/{item}' => [
                 'parameters' => [
                     [
                         'name' => 'item',
                         'in' => 'path',
                         'required' => true,
-                        'schema' => ['type' => 'string']
+                        'schema' => ['type' => 'string'],
+                        'description' => _('The term. Because it is a path '
+                            . 'segment, a term containing / ? # or % cannot '
+                            . 'travel this way; use /unisearch?q= instead.')
                     ]
                 ],
                 'get' => self::_op(
                     '',
                     'unisearch',
-                    _('Search every class at once'),
-                    _('An optional trailing integer caps results PER CLASS, not '
-                        . 'overall, and this route is not paged -- there is no '
-                        . 'nextUrl to follow. Also reachable as /search.'),
+                    _('Search every class at once (path form)'),
+                    _('The older spelling of /unisearch?q=. An optional trailing '
+                        . 'integer caps results PER CLASS, not overall, and this '
+                        . 'route is not paged -- there is no nextUrl to follow. '
+                        . 'Also reachable as /search.'),
                     $json(['type' => 'object'], _('Grouped matches.'))
                 )
             ],

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -143,6 +143,20 @@ class Route extends FOGBase
      */
     const IGNORED_PARAM_PREFIX = '_ignore';
     /**
+     * Entries of $searchPages that unisearch() does not query.
+     *
+     * $searchPages is the list of nodes that render a list page, and it is
+     * what plugins register into; "searchable" rides on it because a node
+     * with a grid is, with one exception, a node worth a search bucket. The
+     * exception is spelled here rather than as a second list plugins would
+     * also have to know about: a task's name is its host's, so every hit
+     * would duplicate the host bucket with rows that disappear when the
+     * task completes.
+     *
+     * @var array
+     */
+    const UNSEARCHABLE = ['task'];
+    /**
      * Validated plugin routes, or null before the hook has been fired.
      *
      * @var array|null
@@ -1530,6 +1544,13 @@ class Route extends FOGBase
         // omitted when the caller lacks it, so this route discloses
         // nothing they could not already list.
         self::_registerRoute($r, 'GET', '/system/savedfiltertargets', [__CLASS__, 'savedfiltertargets'], 'savedfiltertargets');
+        // The term as ?q= (or a POST body field), with ?limit=. The path
+        // form below needs a capture that may contain a slash -- which is
+        // what made #1673 possible -- and leaves `?`, `#` and `%` in a term
+        // to the URL parser. This form has neither problem and is what the
+        // sidebar search box sends; the path form stays for callers that
+        // already use it.
+        self::_registerRoute($r, 'GET|POST', '/[search|unisearch]', [__CLASS__, 'unisearch'], 'unisearch');
         self::_registerRoute($r, 'GET|POST', '/[search|unisearch]/[*:item]/[i:limit]?', [__CLASS__, 'unisearch'], 'unisearch');
         self::_registerRoute($r, 'PUT|POST', "{$expandedw}/join", [__CLASS__, 'joining'], 'join');
         self::_registerRoute($r, 'GET', '/availablekernels', [__CLASS__, 'availablekernels'], 'kernelUpdate');
@@ -4651,9 +4672,25 @@ class Route extends FOGBase
      *
      * @return void
      */
-    public static function unisearch($item, $limit = 0)
+    public static function unisearch($item = null, $limit = 0)
     {
         try {
+            if (null === $item) {
+                // The query form. queryParam() rather than filter_input():
+                // on a routed path the latter sees nothing (see queryParam).
+                // The POST body is the fallback because the sidebar box
+                // sends its fields there.
+                $item = self::queryParam('q');
+                if (null === $item) {
+                    $item = filter_input(INPUT_POST, 'q');
+                }
+                $item = (string)$item;
+                $limit = self::queryParam('limit');
+                if (null === $limit) {
+                    $limit = filter_input(INPUT_POST, 'limit');
+                }
+                $limit = (int)$limit;
+            }
             if (empty(trim($limit))) {
                 $limit = 0;
             }
@@ -4667,7 +4704,7 @@ class Route extends FOGBase
                 ['searchPages' => &self::$searchPages]
             );
             foreach (self::$searchPages as &$search) {
-                if ($search == 'task') {
+                if (in_array($search, self::UNSEARCHABLE, true)) {
                     continue;
                 }
                 // Skip entities the acting user may not view; unknown
@@ -4785,17 +4822,35 @@ class Route extends FOGBase
             return null;
         }
         $item = trim($item);
-        $like = '%' . $item . '%';
+        // LIKE's own metacharacters, escaped so the term is matched
+        // literally: "100%" must not match everything and "a_c" must not
+        // match "abc". The escape character is '!' rather than the
+        // backslash default because under NO_BACKSLASH_ESCAPES a backslash
+        // is not an escape at all, and spelling ESCAPE '\\' is then two
+        // characters, which MySQL rejects.
+        $escaped = strtr($item, ['!' => '!!', '%' => '!%', '_' => '!_']);
+        $like = '%' . $escaped . '%';
         $idCol = $classVars['databaseFields']['id'];
         $nameCol = $classVars['databaseFields']['name'];
 
         $j = $w = $g = '';
-        $params = ['item1' => $like, 'item2' => $like];
+        // :prefix ranks: a name that STARTS with the term sorts before one
+        // that merely contains it, so the five rows a LIMIT keeps are the
+        // five a person typing that term meant.
+        $params = ['item2' => $like, 'prefix' => $escaped . '%'];
+        // The id is matched only by a term that could be one, and then
+        // exactly. `id LIKE '%lab%'` cast every row's id to a string to
+        // fail, on every keystroke, on the largest tables.
+        $idArm = '';
+        if (ctype_digit($item)) {
+            $idArm = "`{$idCol}` = :item1 OR ";
+            $params['item1'] = $item;
+        }
         switch ($class) {
             case 'host':
                 $j = "LEFT OUTER JOIN `hostMAC`
                 ON `hosts`.`hostID` = `hostMAC`.`hmHostID`";
-                $w = " OR `hostMAC`.`hmMAC` LIKE :item3";
+                $w = " OR `hostMAC`.`hmMAC` LIKE :item3 ESCAPE '!'";
                 $params['item3'] = $like;
                 $g = "GROUP BY `hosts`.`hostName`";
                 break;
@@ -4819,11 +4874,11 @@ class Route extends FOGBase
                 // the two drift nothing fails -- the values just quietly
                 // become findable again. Calling the real predicate keeps
                 // one rule in one place.
-                $w = " OR `settingValue` LIKE :item3";
+                $w = " OR `settingValue` LIKE :item3 ESCAPE '!'";
                 $params['item3'] = $like;
                 break;
             case 'storagenode':
-                $w = " OR `ngmHostname` LIKE :item3";
+                $w = " OR `ngmHostname` LIKE :item3 ESCAPE '!'";
                 $params['item3'] = $like;
         }
 
@@ -4847,12 +4902,12 @@ class Route extends FOGBase
         $sql = "SELECT `{$idCol}`,`{$nameCol}`
             FROM `{$classVars['databaseTable']}`
         {$j}
-        WHERE (`{$idCol}` LIKE :item1
-        OR `{$nameCol}` LIKE :item2
+        WHERE ({$idArm}`{$nameCol}` LIKE :item2 ESCAPE '!'
         {$w})"
         . (null === $scopeWhere ? '' : " AND {$scopeWhere}")
         . "
-        {$g}";
+        {$g}
+        ORDER BY (`{$nameCol}` LIKE :prefix ESCAPE '!') DESC, `{$nameCol}` ASC";
         if ($limit > 0) {
             $sql .= " LIMIT " . (int)$limit;
         }
@@ -4882,10 +4937,9 @@ class Route extends FOGBase
             //
             // Recomputed here rather than asked of the query, because SQL
             // cannot say which OR arm matched. stripos is the same
-            // substring test the bound '%term%' performs. Where the two
-            // can disagree -- a term containing % or _, which LIKE treats
-            // as a wildcard and stripos does not -- the disagreement drops
-            // the row, which is the safe direction.
+            // substring test the bound '%term%' performs now that LIKE's
+            // metacharacters are escaped above; before that a term with %
+            // or _ made the two disagree.
             if ('setting' === $class) {
                 $sid = (string)$val[$idCol];
                 $skey = (string)$val[$nameCol];

--- a/tests/class-search-searches-its-class.test.php
+++ b/tests/class-search-searches-its-class.test.php
@@ -111,7 +111,7 @@ function searchStripComments($code)
 }
 
 $search = searchMethodBody($src, 'public static function search($class, $item)');
-$uni = searchMethodBody($src, 'public static function unisearch($item, $limit = 0)');
+$uni = searchMethodBody($src, 'public static function unisearch($item = null, $limit = 0)');
 $rows = searchMethodBody($src, 'private static function _searchRows(');
 
 $t->check('_searchRows() exists', '' !== $rows);

--- a/tests/unisearch-ranks-and-escapes.test.php
+++ b/tests/unisearch-ranks-and-escapes.test.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * The search box's query, as _searchRows() actually builds it.
+ *
+ * Three things the sidebar search got wrong before this was written, each
+ * of which a static grep of the source could pass while the query was
+ * broken, so this test captures the SQL and the bound parameters the fake
+ * database is handed and asserts on those:
+ *
+ *  1. The term was interpolated into LIKE unescaped, so "100%" matched
+ *     every row and "a_c" matched "abc".
+ *  2. The id column was matched with LIKE '%term%' for every term, which
+ *     casts each row's id to a string to fail on a term like "lab".
+ *  3. There was no ORDER BY, so the five rows a LIMIT kept were whichever
+ *     five InnoDB found first, not the ones starting with the term.
+ *
+ * Plus the query form of the route: /unisearch?q=term&limit=n, which is
+ * what the box sends now that the term no longer travels in the path.
+ *
+ * PHP version 7.4+
+ */
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('unisearch-ranks');
+$db = FogTestHarness::fakeDb();
+$t = new FogChecks();
+
+/**
+ * The queries the fake database was handed. A class rather than an array
+ * captured by reference so the reads below are typed by last(), not
+ * narrowed to the empty literal the static analyser sees assigned.
+ */
+final class QueryCapture
+{
+    /** @var array<int, array{sql: string, params: array<string, mixed>}> */
+    private $list = [];
+
+    /**
+     * @param string               $sql    The statement.
+     * @param array<string, mixed> $params Its bound parameters.
+     *
+     * @return void
+     */
+    public function add($sql, array $params)
+    {
+        $this->list[] = ['sql' => $sql, 'params' => $params];
+    }
+
+    /**
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->list);
+    }
+
+    /**
+     * @return array{sql: string, params: array<string, mixed>}
+     */
+    public function last()
+    {
+        $n = count($this->list);
+        return $n > 0 ? $this->list[$n - 1] : ['sql' => '', 'params' => []];
+    }
+
+    /**
+     * @return void
+     */
+    public function reset()
+    {
+        $this->list = [];
+    }
+}
+$cap = new QueryCapture();
+$db->responder = function ($sql, $params) use ($cap) {
+    if (false === stripos($sql, 'LIKE :item2')) {
+        return null;
+    }
+    $cap->add($sql, $params);
+    return [];
+};
+
+$rows = new \ReflectionMethod('FOG\Router\Route', '_searchRows');
+$rows->setAccessible(true);
+
+// --- 1. Escaping ---------------------------------------------------------
+$cap->reset();
+$rows->invoke(null, 'host', '100%_!', 5);
+$t->check('a host search issued one query', 1 === $cap->count());
+$q = $cap->last();
+$t->check(
+    'LIKE metacharacters in the term are escaped with !',
+    '%100!%!_!!%' === ($q['params']['item2'] ?? null)
+);
+$t->check(
+    'every LIKE names its escape character',
+    substr_count($q['sql'], 'LIKE :item2 ESCAPE \'!\'') === 1
+    && substr_count($q['sql'], 'LIKE :item3 ESCAPE \'!\'') === 1
+    && substr_count($q['sql'], 'LIKE :prefix ESCAPE \'!\'') === 1
+);
+$t->check(
+    'the MAC arm receives the same escaped term',
+    '%100!%!_!!%' === ($q['params']['item3'] ?? null)
+);
+
+// --- 2. The id arm -------------------------------------------------------
+$t->check(
+    'a non-numeric term does not touch the id column',
+    false === strpos($q['sql'], '`hostID` = :item1')
+    && false === strpos($q['sql'], '`hostID` LIKE')
+    && !array_key_exists('item1', $q['params'])
+);
+$cap->reset();
+$rows->invoke(null, 'host', '42', 5);
+$q = $cap->last();
+$t->check(
+    'a whole-number term matches the id exactly',
+    false !== strpos($q['sql'], '`hostID` = :item1 OR `hostName` LIKE :item2')
+    && '42' === ($q['params']['item1'] ?? null)
+);
+$t->check(
+    'the id arm is inside the parenthesised match clause',
+    1 === preg_match('/WHERE \(`hostID` = :item1 OR /', $q['sql'])
+);
+
+// --- 3. Ranking ----------------------------------------------------------
+$cap->reset();
+$rows->invoke(null, 'image', 'lab', 5);
+$q = $cap->last();
+$t->check(
+    'prefix matches sort first, then by name',
+    false !== strpos(
+        $q['sql'],
+        "ORDER BY (`imageName` LIKE :prefix ESCAPE '!') DESC, `imageName` ASC"
+    )
+);
+$t->check(
+    'the prefix parameter is the escaped term with a trailing wildcard only',
+    'lab%' === ($q['params']['prefix'] ?? null)
+);
+$t->check(
+    'ORDER BY precedes the LIMIT',
+    strpos($q['sql'], 'ORDER BY') < strpos($q['sql'], 'LIMIT 5')
+);
+// hosts GROUP BY the name; the ORDER BY must follow it, not split it.
+$cap->reset();
+$rows->invoke(null, 'host', 'lab', 5);
+$q = $cap->last();
+$t->check(
+    'on hosts the ORDER BY follows the GROUP BY',
+    strpos($q['sql'], 'GROUP BY `hosts`.`hostName`') < strpos($q['sql'], 'ORDER BY')
+);
+
+// --- 4. The query form of the route ----------------------------------------
+$t->check(
+    'unisearch() takes no arguments for the query form',
+    (new \ReflectionMethod('FOG\Router\Route', 'unisearch'))
+        ->getParameters()[0]->isDefaultValueAvailable()
+);
+$dispatcher = \FOG\Router\Route::newDispatcher(function ($r) {
+    $define = new \ReflectionMethod('FOG\Router\Route', 'defineRoutes');
+    $define->setAccessible(true);
+    $define->invoke(null, $r);
+});
+foreach (['/unisearch', '/search'] as $uri) {
+    $res = $dispatcher->dispatch('POST', $uri);
+    $vars = $res[2] ?? [];
+    $t->check(
+        "$uri dispatches to unisearch with no path term",
+        \FastRoute\Dispatcher::FOUND === $res[0]
+        && 'unisearch' === ($res[1]['name'] ?? null)
+        && !array_key_exists('item', $vars)
+    );
+}
+// And the JS sends it that way: body fields, not path segments.
+$js = (string)file_get_contents(
+    __DIR__ . '/../packages/web/management/js/fog/fog.common.js'
+);
+$fn = strpos($js, 'function setupUniversalSearch()');
+$body = substr($js, $fn, strpos($js, "\n}\n", $fn) - $fn);
+$t->check(
+    'the sidebar box posts q and limit as fields',
+    false !== strpos($body, 'return {q: params.term, limit: resultLimit};')
+    && false !== strpos($body, 'url: baseURL,')
+    && false === strpos($body, "baseURL + '/'")
+);
+
+$t->finish();

--- a/tests/unisearch-ranks-and-escapes.test.php
+++ b/tests/unisearch-ranks-and-escapes.test.php
@@ -28,7 +28,7 @@ $t = new FogChecks();
 /**
  * The queries the fake database was handed. A class rather than an array
  * captured by reference so the reads below are typed by last(), not
- * narrowed to the empty literal the static analyser sees assigned.
+ * narrowed to the empty literal the static analyzer sees assigned.
  */
 final class QueryCapture
 {


### PR DESCRIPTION
Follow-up to #1673, the pass Tom asked for on the universal search. Four changes, all in `_searchRows()` and the route that reaches it:

- **Ranking.** `ORDER BY (name LIKE 'term%') DESC, name`. With a `LIMIT` and no `ORDER BY`, the five rows shown for `lab` were whichever five InnoDB found first, not `lab01`/`lab02`.
- **Literal matching.** LIKE metacharacters in the term are escaped with `ESCAPE '!'` (the backslash default is not an escape under `NO_BACKSLASH_ESCAPES`), so `100%` no longer matches every row and `a_c` no longer matches `abc`.
- **Numeric-only id match.** The id column is matched only by a whole-number term, and then exactly. `id LIKE '%lab%'` cast every row's id to a string to fail, on every keystroke.
- **`/unisearch?q=term&limit=n`**, or the same two POST body fields, which the sidebar box now sends. The path form needed a slash-capable capture (what made #1673 possible) and leaves `? # %` in a term to the URL parser. The path form stays for existing callers; OpenAPI describes both.

`task` is now `Route::UNSEARCHABLE` with its reason. A second "searchable" list was considered and not built: `$searchPages` is what plugins register into, and a list they would also have to know about would silently drop every plugin from the search box.

**Verified:** the generated SQL run on a throwaway MySQL 8.0 under `ONLY_FULL_GROUP_BY` (hosts `GROUP BY` + the `ORDER BY` expression): `lab` → lab01, lab02, alab, zlab; `100%` → only `100%done`; `a_c` → only `a_c`; `2` → id 2 plus name/MAC matches. New test `unisearch-ranks-and-escapes.test.php` captures the SQL and bound params; reverting escaping / ORDER BY / the numeric id guard fails 2 / 3 / 1 checks. Suite 307/307, phpstan clean on both configs.

Docs: fog-docs #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166dqQEjAs9fhqUw5zCjvxM