### PR TITLE
Give certificates you bring a blessed home: /etc/fog/customizations/pki

### DIFF
--- a/docs/PKI_ZONES.md
+++ b/docs/PKI_ZONES.md
@@ -518,6 +518,45 @@ sudo helper depends on.
 > carry on as the *web* key — so an ACME renewal writing it no longer changes
 > what `certDecrypt()` reads.
 
+### Where to put a certificate you brought
+
+`/etc/fog/customizations/pki/`, recorded as `PKI_custom_dir`. It is a **sibling**
+of `$(_pkiRootDir)`, not a directory inside it, and that is the whole mechanism:
+`_externallyManagedLeaf()` asks whether the canonical path resolves inside the
+web zone, so anything here answers "the admin's" with no flag to set and nothing
+that can go stale. A `custom/` directory *under* `/etc/fog/pki` would answer the
+opposite and be regenerated over.
+
+The installer creates it, and `restorecon`s it — which is also the fix for the
+SELinux footgun above, since a directory FOG creates carries the right label
+instead of whatever an arbitrary location happened to have.
+
+**Drop a pair in and re-run the installer.** Two names:
+
+```
+/etc/fog/customizations/pki/web-leaf.pem
+/etc/fog/customizations/pki/web-leaf.key
+```
+
+`_detectExternalCertManagement()` finds them (signal 0), `createSSLCA()` points
+`PKI_web_vhost_cert`/`PKI_web_vhost_key` at them, and FOG stops re-issuing that
+leaf. Nothing to edit.
+
+Both files are required, and they have to be a genuine pair — compared by subject
+public key, not by RSA modulus, so an EC key is judged correctly (GH-1393). A
+missing or mismatched key is **not** adopted: FOG's own leaf still serves, while
+adopting one would point the vhost at a certificate the web server cannot start
+with. Other filenames are not guessed at; record the path explicitly instead, as
+above.
+
+`/etc/fog/customizations` is not `$fogprogramdir/customizations`, and the two run
+in opposite directions — FOG writes the `/opt` one (copies of your files, made
+before a run rebuilds the tree they lived in), and only reads the `/etc` one.
+There is a `readme.txt` in each saying so. Keys and certificates are on the `/etc`
+side for the reason the PKI tree itself moved there; kernels and boot images stay
+under `/opt` because the FHS does not put binaries in `/etc`. See
+[ADR 0040](adr/0040-certificates-you-bring-live-in-a-customizations-tree.md).
+
 ## Let's Encrypt and ACME
 
 **FOG does not run an ACME client and will not.** Use `certbot`, `acme.sh`, or
@@ -576,6 +615,13 @@ acme.sh --issue -d fog.example.com -w /var/www/html    # HTTP-01, docroot
 
 **Install into the paths FOG already serves from**, rather than acme.sh's own
 default cert store, so nothing else needs to change:
+
+> Simpler, and the route the walkthrough in fog-docs now takes: install to
+> `/etc/fog/customizations/pki/web-leaf.{pem,key}` instead and re-run the
+> installer, which finds the pair and points the canonical paths at it. See
+> "Where to put a certificate you brought" above. The in-tree form below still
+> works and needs no installer run, which is why it is kept.
+
 ```bash
 acme.sh --install-cert -d fog.example.com \
     --key-file       /opt/fog/pki/web/leaf/.webLeaf.key \

--- a/docs/adr/0040-certificates-you-bring-live-in-a-customizations-tree.md
+++ b/docs/adr/0040-certificates-you-bring-live-in-a-customizations-tree.md
@@ -1,0 +1,146 @@
+# Certificates you bring live in /etc/fog/customizations/pki
+
+## Status
+
+accepted, and implemented on `working-1.6` as `_customPkiDir()` /
+`_customPkiPair()` / `_ensureCustomizationsTree()` in `lib/common/functions.sh`,
+with `PKI_custom_dir` recorded in `.fogsettings` and signal 0 of
+`_detectExternalCertManagement()`.
+
+## Context
+
+[ADR 0024](0024-fogsettings-unified-key-model.md) settled how FOG uses a
+certificate it did not issue: the `PKI_*` key names a **canonical** path, and the
+administrator either makes that path resolve to their file or records their own
+path in it. `_externallyManagedLeaf()` then answers "is this leaf mine?" by
+asking whether the canonical path resolves inside the web zone. That mechanism
+works and is not in question here.
+
+What was missing is a **place**. "Outside the web zone" is anywhere at all, so
+every document that explains this had to invent its own example directory —
+`/etc/pki/fog/`, `/etc/letsencrypt/live/…`, `~/.acme.sh/` — and a reader
+following one of them has no way to tell whether the location mattered. The
+observable cost: fog-docs#178 shipped a Cloudflare recipe installing into
+`/etc/fog/pki/web/leaf/`, which is *inside* the web zone, so FOG read the leaf as
+its own and would have regenerated over it. Nothing was wrong with the
+mechanism; there was nowhere obvious to point it at.
+
+Two smaller problems came with that. A hand-made symlink into an arbitrary
+directory inherits **that directory's** SELinux label
+(`docs/PKI_ZONES.md`, "Certificate paths"), which can leave the web tier unable
+to read the key it is pointed at. And there was no answer to "where do I put this
+so an upgrade does not eat it" that did not require reading the installer.
+
+## Decision
+
+**`/etc/fog/customizations/pki/`**, recorded as `PKI_custom_dir` in
+`.fogsettings`.
+
+Three properties are load-bearing.
+
+**It is a SIBLING of `$(_pkiRootDir)`, never a directory inside it.** This is the
+whole mechanism rather than tidiness: `_externallyManagedLeaf()` compares against
+the web zone directory, so a sibling answers "the administrator's" with no new
+state to record, no flag to forget, and no change to the detection at all. A
+subdirectory of `/etc/fog/pki` would answer the opposite, which is exactly the
+mistake #178 made.
+
+**The default is derived from `_pkiRootDir()`, not hardcoded.** It is
+`$(dirname "$(_pkiRootDir)")/customizations/pki`, which on a default install is
+the `/etc/fog/customizations/pki` above. Hardcoding `/etc/fog` would mean every
+shell test that reached `_ensureCustomizationsTree()` created that directory on
+whatever machine the suite ran on; the tests already relocate `PKI_root_dir`, and
+this follows it for free.
+
+**A dropped-in pair is adopted, with no `.fogsettings` edit.** `web-leaf.pem` and
+`web-leaf.key` in that directory are signal 0 of
+`_detectExternalCertManagement()`, and `createSSLCA()`'s existing
+detect-then-`_linkCanonical()` step points the canonical paths at them. So the
+whole procedure is "put the files there, re-run the installer" — the thing an
+administrator would guess, made correct.
+
+Adoption requires **both** files, and requires them to actually be a pair
+(`_certKeyPairMatches()`, comparing the subject public key rather than an RSA
+modulus, per GH-1393). Declining is the safe direction: FOG's own leaf still
+serves, whereas adopting a leaf whose key is missing or mismatched points the
+vhost at a certificate the web server cannot start with.
+
+**Two names, not a glob.** A glob would have to choose between candidates on its
+own, and the run where it chooses wrong repoints the vhost without saying so. An
+administrator whose files are named something else records the path explicitly,
+which is the route that already existed.
+
+## The /etc versus /opt split
+
+`$fogprogramdir/customizations` already exists and is **not** this. The two run in
+opposite directions, and the `readme.txt` in each says so:
+
+| | `/opt/fog/customizations` | `/etc/fog/customizations` |
+|---|---|---|
+| Written by | FOG | the administrator |
+| Purpose | copies FOG makes of the admin's files before a run rebuilds the tree they lived in, and restores after | an input FOG only reads |
+| Holds | `ipxe-bg/`, `ipxe-legacy/`, `kernel-backups/` | `pki/` |
+
+The split by root is the one ADR 0037 already made for FOG's own PKI: `/etc` is
+for small, secret, irreplaceable configuration a backup policy and a
+config-management run are meant to capture; `/opt/<pkg>` is for a package's own
+static files, and the FHS does not permit binaries under `/etc` — which is what
+keeps kernels and iPXE backgrounds on the `/opt` side. Unifying the two into one
+directory would have to break one of those two rationales.
+
+## Consequences
+
+- `.fogsettings`' own "Derived -- do not edit" header was **wrong** and is
+  corrected. It said the installer "recomputes these every run, so editing a path
+  here moves nothing", which is true of most canonical keys and false of the
+  three that matter: `_resolveWebLeafPaths()` resets `PKI_web_vhost_cert` only
+  while it holds one of four known-FOG defaults, and `createWebIntermediateCA()`
+  treats `PKI_web_trust_chain` the same way. An administrator who believed the
+  header had no way to discover the recorded-path route worked.
+- `/etc/fog/customizations` is created on every install and gets `restorecon -RF`,
+  for the reason `_migratePkiTree()` does it: a tree whose labels change the first
+  time somebody runs a relabel is worse than one that is already right. This is
+  what removes the label footgun above.
+- Neither `readme.txt` is overwritten once present. A run that rewrote it would
+  discard the note somebody left for the next person, in the one directory that
+  exists for the administrator's own use.
+- `PKI_custom_dir` is resolved through `_customPkiDir()` before being recorded, so
+  a relocated value is preserved rather than overwritten. (Contrast
+  `PKI_client_encrypt_key`/`_cert` immediately above it in `writeUpdateFile()`,
+  which are hard-reassigned and therefore lose an admin path from
+  `--client-cert`/`--client-key` on the next run. That is a defect, filed
+  separately, not a pattern to copy.)
+
+## Alternatives rejected
+
+**`/etc/fog/pki/custom/`, inside the tree.** The obvious reading of "put custom
+certs with the certs", and it inverts the detection: everything under the PKI root
+is FOG's by definition, so a leaf there would be regenerated over. Making it an
+exception would mean `_externallyManagedLeaf()` growing a carve-out, which is the
+one function that must stay a single unambiguous question.
+
+**`/etc/fog/certs/`.** Shorter, and it was the first proposal. Rejected because
+`$fogprogramdir/customizations` already exists for admin-related material: a
+second word for the same idea means an administrator has to learn which of
+`certs`, `custom` and `customizations` holds what. Matching the existing name
+costs nothing and the readmes can then explain one concept.
+
+**One unified tree for all customizations, in either root.** Attractive, and the
+right long-term shape for the rest of `docs/SUPPORTED_CUSTOMIZATIONS.md`, but it
+cannot be one *location*: see the split above. Filed as its own issue, since it
+also has to decide whether one directory can be both an input and an output.
+
+**Leave it to the documentation.** Zero code, and it is what was tried. The recipe
+in #178 is the evidence: with no blessed location, each document picks one, and
+picking wrong is silent.
+
+## References
+
+- [ADR 0024](0024-fogsettings-unified-key-model.md) — canonical paths, and why
+  the filesystem carries the indirection
+- [ADR 0036](0036-the-web-tier-changes-pki-through-a-fixed-verb-set.md) — why the
+  web UI cannot simply be handed a path
+- [ADR 0037](0037-the-pki-tree-lives-in-etc.md) — the /etc versus /opt reasoning
+  this reuses
+- `docs/PKI_ZONES.md` — "Certificate paths" and the acme.sh recipe
+- fog-docs#178 — the recipe that motivated this

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -7493,7 +7493,7 @@ writeUpdateFile() {
             SVC_user)                 printf '\n## SVC -- FOG own system account and host services\n' ;;
             PKI_sb_enabled)           printf '\n## PKI -- certificate authorities and trust\n' ;;
             PKI_root_ca_cert)
-                printf '\n## Derived -- mostly recomputed, three are yours to point\n'
+                printf '\n## Derived -- do not edit\n'
                 printf '## Canonical certificate paths. The installer recomputes most of these\n'
                 printf '## every run, so editing one here moves nothing.\n'
                 printf '##\n'
@@ -8068,7 +8068,7 @@ _migratePkiTree() {
 # /etc/fog/customizations is the /etc counterpart of the existing
 # $fogprogramdir/customizations, and the two run in OPPOSITE directions. FOG
 # writes $fogprogramdir/customizations: it copies the admin's files there before
-# a run rebuilds the tree they lived in, and restores from it afterwards. Nothing
+# a run rebuilds the tree they lived in, and restores from it afterward. Nothing
 # but the admin writes /etc/fog/customizations -- it is an input, and FOG only
 # reads it.
 #
@@ -8147,7 +8147,7 @@ There is a second customizations directory, and it is not this one:
                             makes of your files before a run rebuilds the tree
                             they lived in -- the iPXE boot menu background,
                             replaced iPXE binaries, previous kernel
-                            generations -- and FOG restores from it afterwards.
+                            generations -- and FOG restores from it afterward.
 
 Why two: keys and certificates are small, secret and irreplaceable, so they
 belong under /etc, which is what a backup policy and a config-management run
@@ -8166,7 +8166,7 @@ ETCREADME
 This directory is written BY FOG. You do not need to put anything here.
 
 Before a run rebuilds a tree that might hold something of yours, FOG copies
-what it finds into here, and restores it afterwards:
+what it finds into here, and restores it afterward:
 
   ipxe-bg/          the iPXE boot menu background image
   ipxe-legacy/      iPXE binaries you replaced in the TFTP tree

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -7121,6 +7121,10 @@ writeUpdateFile() {
         # copy of the default, and so an install that predates the move keeps
         # working off its recorded (empty -> compat symlink) value.
         PKI_root_dir="$(_pkiRootDir)"
+        # Idempotent, and it PRESERVES a relocated value rather than
+        # overwriting it: _customPkiDir() echoes $PKI_custom_dir when that is
+        # already set, and only falls back to the default when it is not.
+        PKI_custom_dir="$(_customPkiDir)"
         PKI_client_encrypt_key="$(_pkiZoneDir client)/leaf/.srvprivate.key"
         PKI_client_encrypt_cert="$(_pkiZoneDir client)/leaf/.srvpublic.crt"
     fi
@@ -7339,6 +7343,14 @@ writeUpdateFile() {
         # material live. NOT where FOG's CAs live any more, which is the whole
         # reason the old name (sslpath) had to go.
         PKI_client_cert_dir
+        # Where the admin drops certificates and keys they brought themselves:
+        # /etc/fog/customizations/pki, a SIBLING of PKI_root_dir rather than a
+        # directory inside it. That is load-bearing -- _externallyManagedLeaf()
+        # answers "the admin manages this leaf" for anything resolving outside
+        # the web zone, so a sibling needs no flag and nothing that can go
+        # stale. Relocatable, like PKI_root_dir, so the shell tests can point it
+        # at a scratch directory.
+        PKI_custom_dir
         # --- canonical paths (records) ---
         #
         # The trust anchor: what ca.cert.der publishes and what fog-client pins.
@@ -7481,11 +7493,20 @@ writeUpdateFile() {
             SVC_user)                 printf '\n## SVC -- FOG own system account and host services\n' ;;
             PKI_sb_enabled)           printf '\n## PKI -- certificate authorities and trust\n' ;;
             PKI_root_ca_cert)
-                printf '\n## Derived -- do not edit\n'
-                printf '## Canonical certificate paths. The installer recomputes these every\n'
-                printf '## run, so editing a path here moves nothing. To use a certificate FOG\n'
-                printf '## did not issue, leave the path alone and make it resolve to your file\n'
-                printf '## (a symlink is enough) -- FOG then reads the target and leaves it be.\n'
+                printf '\n## Derived -- mostly recomputed, three are yours to point\n'
+                printf '## Canonical certificate paths. The installer recomputes most of these\n'
+                printf '## every run, so editing one here moves nothing.\n'
+                printf '##\n'
+                printf '## The exceptions are PKI_web_vhost_cert, PKI_web_vhost_key and\n'
+                printf '## PKI_web_trust_chain. To serve a certificate FOG did not issue you may\n'
+                printf '## either leave those alone and make each path resolve to your file (a\n'
+                printf '## symlink is enough), or set them to where your files really are -- the\n'
+                printf '## installer only resets one of them while it still holds a default of\n'
+                printf '## its own. Either way FOG stops re-issuing that leaf.\n'
+                printf '##\n'
+                printf '## Simplest of all: drop web-leaf.pem and web-leaf.key into\n'
+                printf '## PKI_custom_dir above and re-run the installer, which finds the pair\n'
+                printf '## and points these at it for you.\n'
                 ;;
         esac
     }
@@ -8041,6 +8062,181 @@ _migratePkiTree() {
     # rather than ship a tree whose labels change under them later.
     command -v restorecon >/dev/null 2>&1 && restorecon -RF "$target" >>$error_log 2>&1
     return 0
+}
+# Where an administrator drops material they brought themselves.
+#
+# /etc/fog/customizations is the /etc counterpart of the existing
+# $fogprogramdir/customizations, and the two run in OPPOSITE directions. FOG
+# writes $fogprogramdir/customizations: it copies the admin's files there before
+# a run rebuilds the tree they lived in, and restores from it afterwards. Nothing
+# but the admin writes /etc/fog/customizations -- it is an input, and FOG only
+# reads it.
+#
+# The split by root is the same one ADR 0037 made for FOG's own PKI. /etc is for
+# small, secret, irreplaceable configuration that a backup policy and a
+# config-management run are meant to capture; /opt/<pkg> is for a package's own
+# static files, and the FHS does not allow binaries under /etc -- which is what
+# keeps kernels and iPXE backgrounds on the /opt side.
+#
+# The PKI subdirectory is a SIBLING of $(_pkiRootDir), never a subdirectory of
+# it, and that is the entire mechanism rather than a tidiness preference:
+# _externallyManagedLeaf() decides "is this leaf FOG's or the admin's" by asking
+# whether the canonical path resolves inside the web zone. A sibling answers
+# "the admin's" with no new state to record and nothing that can go stale.
+_customPkiDir() {
+    local root="${PKI_custom_dir:-}"
+    # Derived from _pkiRootDir() rather than hardcoded to /etc/fog, so that
+    # relocating the PKI tree relocates this alongside it. On a default install
+    # that is /etc/fog/pki -> /etc/fog -> /etc/fog/customizations/pki, which is
+    # the documented path. It also keeps the shell tests off the host: they
+    # already point PKI_root_dir at a scratch directory, and without this a run
+    # that reached _ensureCustomizationsTree would mkdir the real
+    # /etc/fog/customizations on whatever box the suite ran on.
+    [[ -n $root ]] || root="$(dirname "$(_pkiRootDir)")/customizations/pki"
+    echo "${root%/}"
+}
+# The two readme files, and the directories that hold them.
+#
+# Idempotent, and it does NOT overwrite a readme an admin has edited: the file is
+# written only when absent. A run that rewrote it would be a run that discards
+# the note somebody left for the next person, which is the opposite of what a
+# directory for the admin's own files should do.
+#
+# Both readmes are written, not just the /etc one, because the pair only makes
+# sense read together -- "why are there two of these" is the question the files
+# exist to answer, and a server upgraded from before this change has the /opt
+# directory already and would otherwise get no explanation at all.
+_ensureCustomizationsTree() {
+    local etcdir customdir optdir
+    # Derived from _customPkiDir() rather than hardcoded, so that setting
+    # PKI_custom_dir relocates BOTH the pki directory and its parent. The shell
+    # tests depend on that: a hardcoded /etc/fog/customizations here would have
+    # every test run mkdir into the real host filesystem.
+    etcdir="$(dirname "$(_customPkiDir)")"
+    customdir="$(_customPkiDir)"
+    _resolveCustomizationsDir
+    optdir="$customizationsDir"
+    # 0755: the web tier traverses neither of these, but an admin reads them, and
+    # the PKI subdirectory below tightens to 0700 on its own.
+    mkdir -p "$etcdir" "$customdir" >>$error_log 2>&1 || return 1
+    chmod 0755 "$etcdir" >>$error_log 2>&1
+    # A private key lands here, so the directory is no more open than the web
+    # zone's own leaf/ directory is.
+    chmod 0700 "$customdir" >>$error_log 2>&1
+    [[ -n $optdir ]] && mkdir -p "$optdir" >>$error_log 2>&1
+    if [[ ! -f "$etcdir/readme.txt" ]]; then
+        cat > "$etcdir/readme.txt" <<'ETCREADME'
+This directory is for configuration you supply yourself.
+
+FOG only READS what is here. Nothing in an install or an update writes or
+removes your files, so anything you put here survives every run.
+
+  pki/    certificates and private keys you brought -- from your own CA, from
+          Let's Encrypt or another ACME client, or purchased. FOG treats a
+          certificate here as yours: it will not re-issue it, re-key it, or
+          change the permissions on its private key.
+
+          To use one, make FOG's canonical path resolve to your file, or record
+          your path in the matching PKI_ key in .fogsettings. Either works.
+          See https://docs.fogproject.org/lets-encrypt-setup for a worked
+          example.
+
+There is a second customizations directory, and it is not this one:
+
+  /opt/fog/customizations   written BY FOG, not by you. It holds copies FOG
+                            makes of your files before a run rebuilds the tree
+                            they lived in -- the iPXE boot menu background,
+                            replaced iPXE binaries, previous kernel
+                            generations -- and FOG restores from it afterwards.
+
+Why two: keys and certificates are small, secret and irreplaceable, so they
+belong under /etc, which is what a backup policy and a config-management run
+already capture. Kernels and boot images are large, rebuildable binaries, and
+the filesystem standard does not put binaries under /etc. FOG's own PKI moved
+to /etc/fog/pki for the same reason.
+
+Note that pki/ here sits BESIDE /etc/fog/pki, not inside it. That is what makes
+FOG treat what you put here as yours: anything under /etc/fog/pki is read as a
+certificate FOG issued and manages, and would be regenerated over.
+ETCREADME
+        chmod 0644 "$etcdir/readme.txt" >>$error_log 2>&1
+    fi
+    if [[ -n $optdir && ! -f "$optdir/readme.txt" ]]; then
+        cat > "$optdir/readme.txt" <<'OPTREADME'
+This directory is written BY FOG. You do not need to put anything here.
+
+Before a run rebuilds a tree that might hold something of yours, FOG copies
+what it finds into here, and restores it afterwards:
+
+  ipxe-bg/          the iPXE boot menu background image
+  ipxe-legacy/      iPXE binaries you replaced in the TFTP tree
+  kernel-backups/   previous kernel and init generations, newest kept first.
+                    bin/restorekernel.sh restores from these.
+
+If a restore ever fails, your files are still here -- nothing is deleted on the
+way through.
+
+There is a second customizations directory, and it works the other way round:
+
+  /etc/fog/customizations   written by YOU, only read by FOG. That is where
+                            certificates and private keys you supply go, under
+                            pki/.
+
+Why two: keys and certificates are small, secret and irreplaceable, so they
+belong under /etc, which is what a backup policy already captures. Kernels and
+boot images are large, rebuildable binaries, and the filesystem standard does
+not put binaries under /etc.
+OPTREADME
+        chmod 0644 "$optdir/readme.txt" >>$error_log 2>&1
+    fi
+    # cp/cat inherit this process's context, and /etc/fog/customizations should
+    # carry etc_t the way /etc/fog/pki does -- see _migratePkiTree() for why this
+    # is done now rather than left for whoever next runs a relabel.
+    command -v restorecon >/dev/null 2>&1 && restorecon -RF "$etcdir" >>$error_log 2>&1
+    return 0
+}
+# Whether $1 (a certificate) and $2 (a private key) are actually a pair.
+#
+# Compares the SUBJECT PUBLIC KEY, not an RSA modulus. `openssl rsa -modulus`
+# cannot read an EC or Ed25519 key at all, so a modulus comparison reports "does
+# not match" for a perfectly good pair and, worse, reports it identically to a
+# genuine mismatch -- GH-1393. `openssl x509 -pubkey` and `openssl pkey -pubout`
+# are algorithm-agnostic and answer the question actually being asked.
+#
+# Returns 1 when either file is missing or openssl cannot read one. That is the
+# safe direction here: every caller uses this to decide whether to ADOPT a pair,
+# and "I could not prove these match" must not adopt.
+_certKeyPairMatches() {
+    local cert="$1" key="$2" certpub keypub
+    [[ -n $cert && -f $cert && -n $key && -f $key ]] || return 1
+    command -v openssl >/dev/null 2>&1 || return 1
+    certpub=$(openssl x509 -pubkey -noout -in "$cert" 2>/dev/null)
+    keypub=$(openssl pkey -pubout -in "$key" 2>/dev/null)
+    [[ -n $certpub && -n $keypub && $certpub == "$keypub" ]]
+}
+# The admin-supplied web leaf pair, if there is a usable one.
+#
+# Echoes the certificate path and then the key path, one per line, and returns 0.
+# Returns 1 and echoes nothing when the pair is absent, incomplete or mismatched.
+#
+# Two documented names, not a glob. A glob would have to choose between several
+# candidates on its own -- and the run where it chooses wrong is a run that
+# points the vhost at the wrong certificate without saying so. An admin whose
+# files are named something else records the path in .fogsettings instead, which
+# is the explicit route and needs no guessing.
+#
+# ${PKI_web_trust_chain} is deliberately NOT part of the pair test. A leaf that
+# chains to a publicly-trusted root needs no chain file from us for the browser
+# to be happy, and createWebIntermediateCA() already honors an admin's chain
+# path on every run. Requiring one here would decline perfectly good setups.
+_customPkiPair() {
+    local dir cert key
+    dir="$(_customPkiDir)"
+    cert="${dir}/web-leaf.pem"
+    key="${dir}/web-leaf.key"
+    _certKeyPairMatches "$cert" "$key" || return 1
+    echo "$cert"
+    echo "$key"
 }
 # Single source of truth for the PKI layout, one directory per zone under
 # _pkiRootDir, each split by its callers into ca/ (the zone's own CA) and leaf/
@@ -9809,7 +10005,26 @@ _resolveVhostNames() {
 # nothing. Vhost drift is likewise only advisory: an admin may have edited the
 # vhost for reasons that have nothing to do with the certificate.
 _detectExternalCertManagement() {
-    local p leaf vhostcert
+    local p leaf vhostcert customdir
+    # 0. A leaf and its key dropped into the customizations tree, under the two
+    #    documented names. This is the only signal that fires when FOG is not
+    #    already pointed at the admin's file and the vhost does not name it
+    #    either -- i.e. the admin did the simplest possible thing, put the files
+    #    somewhere FOG told them to and re-ran the installer. Everything below
+    #    needs one of those two to have happened first.
+    #
+    #    BOTH files, and they must actually be a pair. Adopting a leaf whose key
+    #    is missing or mismatched points the vhost at a certificate the web
+    #    server cannot start with, which is a worse outcome than not adopting:
+    #    FOG's own leaf still works, so declining leaves a serving server.
+    #
+    #    The caller asks _customPkiPair() the same question again rather than
+    #    reading a variable set here, because this function is called in a
+    #    command substitution -- anything it assigns dies with the subshell.
+    if _customPkiPair >/dev/null; then
+        echo "$(_customPkiDir)/web-leaf.pem is a certificate you supplied, with a matching key"
+        return 0
+    fi
     # 1. FOG pointed at a file inside an ACME client's tree. The most direct
     #    evidence available -- somebody already told FOG to use their leaf.
     for p in "${PKI_web_vhost_key}" "${PKI_web_vhost_cert}"; do
@@ -9942,11 +10157,24 @@ createSSLCA() {
     # that used to do the damage silently, so the safe behavior has to be the
     # DEFAULT rather than an answer. Everything needed is already on disk: the
     # vhost names the files and the certificate names itself.
+    _ensureCustomizationsTree
     if ! _externallyManagedLeaf; then
-        local extReason="" extCert="" extKey=""
+        local extReason="" extCert="" extKey="" customPair=""
         if extReason=$(_detectExternalCertManagement); then
-            extCert=$(_vhostCertPath)
-            extKey=$(_vhostKeyPath)
+            # Signal 0 first, and it wins outright: a pair sitting in the
+            # customizations tree is the admin saying which certificate to use,
+            # and neither the vhost nor ${PKI_web_vhost_cert} can point at it yet
+            # -- that is what this run is for. Asked again here because the
+            # detector runs in a command substitution and cannot hand anything
+            # back except its reason string.
+            customPair=$(_customPkiPair) && {
+                extCert=$(echo "$customPair" | sed -n 1p)
+                extKey=$(echo "$customPair" | sed -n 2p)
+            }
+            if [[ -z $extCert ]]; then
+                extCert=$(_vhostCertPath)
+                extKey=$(_vhostKeyPath)
+            fi
             # Fall back to whatever FOG was already pointed at -- signal 1 of
             # the detector is exactly the case where those ARE the admin's
             # files and the vhost may not exist yet.

--- a/tests/external-cert-detection.test.sh
+++ b/tests/external-cert-detection.test.sh
@@ -53,6 +53,10 @@ reset_env() {
     etcconf=""; PKI_client_cert_dir="$WORK/ssl"; PKI_root_ca_cert="$WORK/ssl/ca.pem"; PKI_web_trust_chain=""
     PKI_web_vhost_cert="$WORK/ssl/leaf.pem"; PKI_web_vhost_key="$WORK/ssl/leaf.key"
     PKI_web_cert_publicly_trusted=""
+    # Never the real /etc/fog/customizations/pki: signal 0 of the detector
+    # reads this directory, so an unset value would have every case below
+    # answer out of the host filesystem.
+    PKI_custom_dir="$WORK/custom-pki"
     error_log="$WORK/error.log"
 }
 
@@ -208,7 +212,7 @@ check "$(_vhostCertPath)" "$WORK/foreign/fullchain.pem" "H: KeyFile listed first
 managedNow="$(sed -n '/local -a managedKeys=(/,/^    )/p' "$FUNCS" \
     | sed -e 's/#.*$//' -e 's/local -a managedKeys=(//' -e 's/)//' \
     | tr -s ' \n' '\n\n' | grep -vE '^$')"
-for k in PKI_web_vhost_cert PKI_web_vhost_key; do
+for k in PKI_web_vhost_cert PKI_web_vhost_key PKI_custom_dir; do
     if printf '%s\n' "$managedNow" | grep -qxF "$k"; then
         ok "I: $k is in managedKeys"
     else
@@ -274,6 +278,74 @@ if _detectExternalCertManagement >/dev/null; then
     ok "K2: the bare leaf alone genuinely does not chain (K is a real test)"
 else
     bad "K2: the bare leaf verified without its intermediate; K proves nothing"
+fi
+
+
+echo "== signal 0: a pair dropped into the customizations tree is adopted =="
+
+# The blessed custom directory. A cert here is the admin's by construction --
+# it is a SIBLING of the PKI tree, so _externallyManagedLeaf() reads it as
+# external with no flag to record. Build one genuine self-signed pair, plus a
+# second unrelated key to prove the pair test is real.
+mkdir -p "$WORK/custom-pki"
+openssl req -x509 -newkey rsa:2048 -nodes -subj "/CN=fog.example.org" \
+    -keyout "$WORK/custom-pki/web-leaf.key" -out "$WORK/custom-pki/web-leaf.pem" \
+    -days 1 >/dev/null 2>&1
+openssl genrsa -out "$WORK/custom-pki/unrelated.key" 2048 >/dev/null 2>&1
+
+# L. Both files present and a genuine pair -- the whole point of the feature.
+reset_env
+if _detectExternalCertManagement >/dev/null; then
+    ok "L: a matching pair in PKI_custom_dir is detected"
+else
+    bad "L: a matching pair in PKI_custom_dir was not detected"
+fi
+
+# L2. And the caller can get the paths back. The detector runs in a command
+#     substitution, so it cannot hand them over -- _customPkiPair() is what the
+#     adoption site asks instead, and if it ever stops agreeing with the
+#     detector the vhost gets pointed at the wrong file.
+reset_env
+if pair=$(_customPkiPair) \
+    && [[ $(echo "$pair" | sed -n 1p) == "$WORK/custom-pki/web-leaf.pem" ]] \
+    && [[ $(echo "$pair" | sed -n 2p) == "$WORK/custom-pki/web-leaf.key" ]]; then
+    ok "L2: _customPkiPair returns the cert then the key"
+else
+    bad "L2: _customPkiPair did not return the pair the detector fired on"
+fi
+
+# M. A leaf with no key beside it. MUST NOT fire: adopting it points the vhost
+#    at a certificate the web server cannot start with, and FOG's own leaf was
+#    working. Declining leaves a serving server, which is the safe direction.
+reset_env
+mv "$WORK/custom-pki/web-leaf.key" "$WORK/custom-pki/web-leaf.key.hidden"
+if _detectExternalCertManagement >/dev/null; then
+    bad "M: fired on a leaf with no key, which would break the web server"
+else
+    ok "M: a leaf with no key is not adopted"
+fi
+mv "$WORK/custom-pki/web-leaf.key.hidden" "$WORK/custom-pki/web-leaf.key"
+
+# N. A key that is not the leaf's. Same reasoning as M, and the case a modulus
+#    comparison would get wrong for an EC pair -- see _certKeyPairMatches().
+reset_env
+cp "$WORK/custom-pki/web-leaf.key" "$WORK/custom-pki/web-leaf.key.real"
+cp "$WORK/custom-pki/unrelated.key" "$WORK/custom-pki/web-leaf.key"
+if _detectExternalCertManagement >/dev/null; then
+    bad "N: fired on a cert and key that are not a pair"
+else
+    ok "N: a mismatched cert/key pair is not adopted"
+fi
+cp "$WORK/custom-pki/web-leaf.key.real" "$WORK/custom-pki/web-leaf.key"
+
+# O. An empty custom directory must not change the answer for a normal install.
+reset_env
+PKI_custom_dir="$WORK/custom-pki-empty"
+mkdir -p "$PKI_custom_dir"
+if _detectExternalCertManagement >/dev/null; then
+    bad "O: fired on a genuine FOG install with an empty PKI_custom_dir"
+else
+    ok "O: an empty PKI_custom_dir leaves a FOG-issued leaf alone"
 fi
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"

--- a/tests/install-settings-resolution.test.sh
+++ b/tests/install-settings-resolution.test.sh
@@ -318,6 +318,7 @@ modelKeys="
     FOG_packages FOG_program_dir FOG_send_reports FOG_update_channel
     NET_fog_server_ip NET_hostname NET_interface NET_subnet_mask
     PKI_allowed_domain_names PKI_client_cert_dir PKI_client_encrypt_cert PKI_client_encrypt_key
+    PKI_custom_dir
     PKI_internal_subnets PKI_root_ca_cert PKI_root_ca_key PKI_root_dir
     PKI_san_dns_names
     PKI_san_ip_addresses PKI_sb_ca_cert PKI_sb_codesign_cert PKI_sb_codesign_key


### PR DESCRIPTION
ADR 0024 settled *how* to use a certificate FOG did not issue: the `PKI_` key names a canonical path, and the admin either makes that path resolve to their file or records their own path in it. What was missing was a *where*. "Outside the web zone" is anywhere at all, so every document explaining this invented its own example directory — `/etc/pki/fog`, `/etc/letsencrypt/live`, `~/.acme.sh` — and a reader had no way to tell whether the location mattered.

It does. [fog-docs#178](https://github.com/FOGProject/fog-docs/pull/178) shipped a Cloudflare recipe installing into `/etc/fog/pki/web/leaf/`, which is **inside** the web zone, so `_externallyManagedLeaf()` reads the leaf as FOG's own and the next run regenerates over it. The mechanism was fine; there was nowhere obvious to point it at.

## What this adds

`/etc/fog/customizations/pki`, recorded as `PKI_custom_dir`.

It is a **sibling** of `$(_pkiRootDir)`, never a directory inside it — that is the whole mechanism rather than tidiness. `_externallyManagedLeaf()` compares against the web zone directory, so a sibling answers "the admin's" with no flag to set, nothing that can go stale, and **no change to the detection itself**.

Drop `web-leaf.pem` and `web-leaf.key` there and re-run the installer, and that is the entire procedure. They are signal 0 of `_detectExternalCertManagement()`, and `createSSLCA()`'s existing detect-then-`_linkCanonical()` step points the canonical paths at them.

Adoption requires **both** files and requires them to be a genuine pair. `_certKeyPairMatches()` compares the subject public key rather than an RSA modulus, so an EC pair is judged correctly (GH-1393). A missing or mismatched key is **not** adopted — FOG's own leaf still serves, whereas adopting one would point the vhost at a certificate the web server cannot start with.

Two documented names, not a glob: a glob has to choose between candidates on its own, and the run where it chooses wrong repoints the vhost without saying so.

## Two details worth a reviewer's attention

**The default is derived, not hardcoded.** `$(dirname "$(_pkiRootDir)")/customizations`. Hardcoding `/etc/fog` would have every shell test that reached `_ensureCustomizationsTree()` `mkdir` that directory on whatever machine the suite ran on; the tests already relocate `PKI_root_dir`, and this follows it for free.

**It is not `$fogprogramdir/customizations`, and conflating them would be a bug.** The `/opt` one is FOG's *output* — copies it makes of the admin's files before a run rebuilds the tree they lived in, restored afterwards. The `/etc` one is an *input* FOG only reads. A `readme.txt` in each says which is which and why there are two: keys and certificates are small, secret and irreplaceable so they belong where a backup policy already looks, and the FHS does not put binaries under `/etc`, which is what keeps kernels and iPXE backgrounds on the `/opt` side. Neither readme is overwritten once present. Both directories get `restorecon`, which also removes the label footgun `PKI_ZONES.md` warns about — a directory FOG creates carries the right label instead of whatever an arbitrary location happened to have.

## Also corrects a wrong statement in `.fogsettings`

The "Derived -- do not edit" header said the installer "recomputes these every run, so editing a path here moves nothing". True of most canonical keys, **false of the three that matter**: `_resolveWebLeafPaths()` resets `PKI_web_vhost_cert` only while it holds one of four known-FOG defaults, and `createWebIntermediateCA()` treats `PKI_web_trust_chain` the same way. `PKI_ZONES.md` has documented the sed-the-path route for as long as the header has denied it works, so an admin who believed the header had no way to discover it.

## Deliberately not in this PR

`writeUpdateFile()` hard-reassigns `PKI_client_encrypt_key`/`_cert` to the zone paths, so an admin path from `--client-cert`/`--client-key` is lost on the next run — contradicting `_clientLeafTarget()`'s documented contract. And `PKI_web_external_root_cert` persists the admin's *source* path, routinely a temp file. Both are pre-existing defects found while investigating; filed separately rather than folded in here.

## Verification

`tests/external-cert-detection.test.sh` gains five cases (adoption, the returned pair, a leaf with no key, a mismatched pair, an empty directory), and `reset_env` now pins `PKI_custom_dir` into the scratch tree — without that, signal 0 would read the host filesystem and every existing case would answer out of it. `PKI_custom_dir` is added to the `managedKeys` assertion.

Honest note on local runs: this was developed on Windows, where Git Bash rewrites `openssl -subj "/CN=..."` into a Windows path, so the suite's openssl fixtures do not build and several cases — including the two new ones that need a real keypair — fail there. `external-cert-detection`, `pki-tree-relocation`, `pki-idempotence` and `trust-anchor` fail *identically before and after* this change on that box, so it introduces no regression, but **CI is the first place the new cases run for real.** The logic was verified separately against genuine fixtures built with the MSYS escape: all sixteen assertions pass, covering the pair test in both directions, signal 0 firing and not firing, `_externallyManagedLeaf()` agreeing that the sibling directory is external while a leaf inside the zone is not, relocation staying inside the scratch root, and the readme not being clobbered on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNj39e7pDke6Rr6Whxin9U
