### PR TITLE
Document where a certificate you bring goes, in the docs that answer that

### DIFF
--- a/docs/EXTERNAL_CA_AND_LETSENCRYPT.md
+++ b/docs/EXTERNAL_CA_AND_LETSENCRYPT.md
@@ -39,6 +39,7 @@ without any FOG-side change — see below.
 ## Table of contents
 
 - [How FOG uses certificates](#how-fog-uses-certificates)
+- [Where to put a certificate you brought](#where-to-put-a-certificate-you-brought)
 - [How iPXE validates HTTPS](#how-ipxe-validates-https)
 - [What `--external-ca` does](#what---external-ca-does)
 - [Recommended: internal ACME CA (step-ca)](#recommended-internal-acme-ca-step-ca)
@@ -85,6 +86,41 @@ The same swap does not have this problem for iPXE — see next section.
 > this document is about. This split is recent — Secure Boot support was added
 > to FOG well after the SSL CA already existed, so older FOG installs (or
 > memories of them) may reasonably recall a single CA doing everything.
+
+---
+
+## Where to put a certificate you brought
+
+`/etc/fog/customizations/pki/`, recorded as `PKI_custom_dir`. Drop the pair in
+under these two names and re-run the installer:
+
+```
+/etc/fog/customizations/pki/web-leaf.pem
+/etc/fog/customizations/pki/web-leaf.key
+```
+
+FOG detects the pair, points `PKI_web_vhost_cert`/`PKI_web_vhost_key` at it, and
+stops re-issuing that leaf. Nothing in `.fogsettings` to edit, and no symlink to
+make. Both files are required and must be a genuine pair; a missing or
+mismatched key is not adopted, and FOG carries on with its own certificate
+rather than leaving a web server that cannot start.
+
+It is a **sibling** of `$(_pkiRootDir)`, never a directory inside it — FOG
+decides whether a leaf is its own by asking whether the canonical path resolves
+inside the web zone, so a certificate written into `/etc/fog/pki/web/leaf/`
+(equivalently `/opt/fog/pki/web/leaf/`, which is the same directory through a
+symlink) is read as FOG's and regenerated over.
+
+The alternatives — symlinking the canonical path at your file, or recording your
+real path in `.fogsettings` — both still work and are described in
+[PKI_ZONES.md](PKI_ZONES.md). See
+[ADR 0040](adr/0040-certificates-you-bring-live-in-a-customizations-tree.md) for
+why the directory is where it is, and why it is not
+`$fogprogramdir/customizations`.
+
+**None of this changes the fog-client problem above.** Adopting a publicly
+issued leaf makes the browser and iPXE happy; `ca.cert.der` is still FOG's own
+root, which is what fog-client pins. Read the caveats before rolling one out.
 
 ---
 

--- a/docs/FOGSETTINGS.md
+++ b/docs/FOGSETTINGS.md
@@ -63,7 +63,8 @@ in this area:
 | Kind | Meaning | Examples |
 |---|---|---|
 | **Preference** | The admin's decision. Persisted so it survives an upgrade, and *nothing* may silently reverse it | `PKI_sb_enabled`, `SVC_firewall_control`, `FOG_update_channel`, `FOG_install_mode`, `PKI_internal_subnets`, `BOOT_kernel_backups_kept`, `WEB_url_primary` |
-| **Record** | Written so it can be read back for reference. The installer recomputes the real value every run and ignores what is stored | `FOG_program_dir`, `FOG_git_path`, `FOG_packages`, `WEB_php_version`, `BOOT_url_proto`, every canonical `PKI_*` path |
+| **Record** | Written so it can be read back for reference. The installer recomputes the real value every run and ignores what is stored | `FOG_program_dir`, `FOG_git_path`, `FOG_packages`, `WEB_php_version`, `BOOT_url_proto`, most canonical `PKI_*` paths |
+| **Honored record** | Recomputed only while it still holds one of the installer's own defaults; any other value is left alone on every run, so the admin may point it at their own file | `PKI_web_vhost_cert`, `PKI_web_vhost_key`, `PKI_web_trust_chain` |
 | **Hand-set** | Nothing in the installer writes it; it survives only because the merge preserves unknown lines | `inetConnectTimeout`, `inetMaxTime`, `storageLocationCapture`, `ftppasvmin`/`ftppasvmax`, `mcastportmin`/`mcastportmax` |
 | **Inferred preference** | A preference the installer may write *once* from what it observed, and then treats as the admin's | `WEB_https_redirect`, `BOOT_url_proto_forced` |
 
@@ -262,10 +263,11 @@ NET_interface='eth0'
 ...
 
 ## Derived -- do not edit
-## Canonical certificate paths. The installer recomputes these every
-## run, so editing a path here moves nothing. To use a certificate FOG
-## did not issue, leave the path alone and make it resolve to your file
-## (a symlink is enough) -- FOG then reads the target and leaves it be.
+## Canonical certificate paths. The installer recomputes most of these
+## every run, so editing one here moves nothing.
+##
+## The exceptions are PKI_web_vhost_cert, PKI_web_vhost_key and
+## PKI_web_trust_chain ...
 PKI_root_ca_cert='...'
 ...
 ## End of FOG Settings

--- a/docs/SUPPORTED_CUSTOMIZATIONS.md
+++ b/docs/SUPPORTED_CUSTOMIZATIONS.md
@@ -53,6 +53,11 @@ fog-docs at `docs/1.6/management/server/supported-customizations.md`.
   managed block.
 - **Yours to place**: files under names FOG does not ship. Nothing removes
   them.
+- **Adopted**: a `web-leaf.pem`/`web-leaf.key` pair in
+  `/etc/fog/customizations/pki` is picked up on the next run and served, with
+  nothing to configure. That directory is the `/etc` counterpart of
+  `$fogprogramdir/customizations` and runs the other way round -- FOG writes the
+  `/opt` one, and only reads the `/etc` one. There is a `readme.txt` in each.
 - **Not preserved**: edits *inside* the managed block, direct edits to
   `default.ipxe`, and anything under the web root that FOG does not ship — the
   tree is rebuilt wholesale on every run.


### PR DESCRIPTION
Follow-up to #1681, which landed the code with `PKI_ZONES.md` and ADR 0040 updated and nothing else. Three code-repo documents an admin actually reaches for still described the old world. This commit was pushed to #1681 shortly after it merged, so it needs its own PR.

**`EXTERNAL_CA_AND_LETSENCRYPT.md`** gets a "Where to put a certificate you brought" section. `PKI_ZONES.md` points at it as the full walkthrough and it had no mention of the tree at all. It also repeats the one thing easy to lose here: adopting a publicly issued leaf does not change what `fog-client` pins.

**`SUPPORTED_CUSTOMIZATIONS.md`** gains **Adopted** alongside preserved / yours to place / not preserved. It is only a pointer file, but its short version is what gets read on an isolated imaging network with no route to the docs site — and it now says there are two customizations directories running in opposite directions.

**`FOGSETTINGS.md`** carried the same wrong claim the `.fogsettings` header did. Its key-kind table listed "every canonical `PKI_*` path" as a **Record** — recomputed every run and ignored. Three of them are not: `PKI_web_vhost_cert`, `PKI_web_vhost_key` and `PKI_web_trust_chain` are honored whenever they hold anything but an installer default, which is what makes the recorded-path route work at all. That now has its own row, because the preference-versus-record distinction is described on that page as load-bearing, and a key that is neither was invisible.

Docs only — no code, no test changes.

The fog-docs counterparts are in FOGProject/fog-docs#179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNj39e7pDke6Rr6Whxin9U