### PR TITLE
Quote the xattr values written over SSH, and report a failed stamp

### DIFF
--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -9550,6 +9550,9 @@ msgstr "Die hochgeladene Datei überschreitet die Upload_max_filesize"
 msgid "The uploaded file was only partially uploaded"
 msgstr "Die hochgeladene Datei wurde nur teilweise hochgeladen"
 
+msgid "The version and release could not be recorded on the file, so it will report as unknown. See the PHP error log."
+msgstr ""
+
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -9559,6 +9559,9 @@ msgstr "The uploaded file exceeds the upload_max_filesize directive in php.ini"
 msgid "The uploaded file was only partially uploaded"
 msgstr "The uploaded file was only partially uploaded"
 
+msgid "The version and release could not be recorded on the file, so it will report as unknown. See the PHP error log."
+msgstr ""
+
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -9722,6 +9722,9 @@ msgstr "El archivo subido excede la directiva upload_max_filesize en php.ini"
 msgid "The uploaded file was only partially uploaded"
 msgstr "El archivo subido se ha subido sólo parcialmente"
 
+msgid "The version and release could not be recorded on the file, so it will report as unknown. See the PHP error log."
+msgstr ""
+
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -9551,6 +9551,9 @@ msgstr "Die hochgeladene Datei überschreitet die Upload_max_filesize"
 msgid "The uploaded file was only partially uploaded"
 msgstr "Die hochgeladene Datei wurde nur teilweise hochgeladen"
 
+msgid "The version and release could not be recorded on the file, so it will report as unknown. See the PHP error log."
+msgstr ""
+
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -9544,6 +9544,9 @@ msgstr "Le fichier téléchargé excède la directive upload_max_filesize dans p
 msgid "The uploaded file was only partially uploaded"
 msgstr "Le fichier n'a été que partiellement téléchargé"
 
+msgid "The version and release could not be recorded on the file, so it will report as unknown. See the PHP error log."
+msgstr ""
+
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -9262,6 +9262,9 @@ msgstr "Il file caricato supera upload_max_filesize"
 msgid "The uploaded file was only partially uploaded"
 msgstr "Il file caricato è stato solo parzialmente caricato"
 
+msgid "The version and release could not be recorded on the file, so it will report as unknown. See the PHP error log."
+msgstr ""
+
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -9208,6 +9208,9 @@ msgstr "アップロードしたファイルが upload_max_filesize を超えて
 msgid "The uploaded file was only partially uploaded"
 msgstr "アップロードしたファイルは一部しかアップロードされませんでした"
 
+msgid "The version and release could not be recorded on the file, so it will report as unknown. See the PHP error log."
+msgstr ""
+
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -8168,6 +8168,9 @@ msgstr ""
 msgid "The uploaded file was only partially uploaded"
 msgstr ""
 
+msgid "The version and release could not be recorded on the file, so it will report as unknown. See the PHP error log."
+msgstr ""
+
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -9546,6 +9546,9 @@ msgstr "O arquivo enviado excede a directiva upload_max_filesize em php.ini"
 msgid "The uploaded file was only partially uploaded"
 msgstr "O arquivo enviado foi apenas parcialmente carregado"
 
+msgid "The version and release could not be recorded on the file, so it will report as unknown. See the PHP error log."
+msgstr ""
+
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -9546,6 +9546,9 @@ msgstr "上传的文件超过php.ini中定义的upload_max_filesize指令"
 msgid "The uploaded file was only partially uploaded"
 msgstr "上传的文件只有部分被上传"
 
+msgid "The version and release could not be recorded on the file, so it will report as unknown. See the PHP error log."
+msgstr ""
+
 msgid "The web application can read the following private keys. It should not be able to read any of them, and anything able to run code in this web application can copy them."
 msgstr ""
 

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -2816,8 +2816,23 @@ abstract class FOGPage extends FOGBase
                     }
                     self::$FOGSSH->put($tmpfile, $orig);
                     self::$FOGSSH->sftp_chmod($orig, 0644);
-                    $br_cmd = "attr -s version -V $br_ver $orig";
-                    $tg_cmd = "attr -s tag_name -V $tg_ver $orig";
+                    /**
+                     * Quoted, because $br_ver and $tg_ver come from the POST
+                     * body and this string is run as a command on the storage
+                     * node. Unquoted, a value carrying a space or a shell
+                     * metacharacter is read as further commands.
+                     */
+                    $stampFailed = false;
+                    $br_cmd = sprintf(
+                        'attr -s version -V %s %s',
+                        escapeshellarg((string)$br_ver),
+                        escapeshellarg($orig)
+                    );
+                    $tg_cmd = sprintf(
+                        'attr -s tag_name -V %s %s',
+                        escapeshellarg((string)$tg_ver),
+                        escapeshellarg($orig)
+                    );
                     $output_br = self::$FOGSSH->exec($br_cmd);
                     $output_tg = self::$FOGSSH->exec($tg_cmd);
                     $error_br = self::$FOGSSH->fetch_stream($output_br, SSH2_STREAM_STDERR);
@@ -2829,10 +2844,12 @@ abstract class FOGPage extends FOGBase
                     $error_br_t = stream_get_contents($error_br);
                     $error_tg_t = stream_get_contents($error_tg);
                     if ($error_br_t) {
+                        $stampFailed = true;
                         error_log(_('Error on ssh command setting version'). ' ' . $br_cmd);
                         error_log(_('Error'). ': ' . $error_br_t);
                     }
                     if ($error_tg_t) {
+                        $stampFailed = true;
                         error_log(_('Error on ssh command setting tag_name'). ' ' . $tg_cmd);
                         error_log(_('Error'). ': ' . $error_tg_t);
                     }
@@ -2846,12 +2863,23 @@ abstract class FOGPage extends FOGBase
                         unlink($tmpfile);
                     }
                     $code = HTTPResponseCodes::HTTP_SUCCESS;
+                    /**
+                     * A failed stamp used to be logged and nothing else, so
+                     * the file simply reported an unknown version later with
+                     * no record of why. Say it here, where the admin is.
+                     */
+                    $msgText = $resigned
+                        ? _('File uploaded to storage node and '
+                            . 're-signed for Secure Boot!')
+                        : _('File uploaded to storage node!');
+                    if ($stampFailed) {
+                        $msgText .= ' ' . _('The version and release could '
+                            . 'not be recorded on the file, so it will '
+                            . 'report as unknown. See the PHP error log.');
+                    }
                     $this->jsonSend($code, json_encode(
                         [
-                            'msg' => $resigned
-                                ? _('File uploaded to storage node and '
-                                    . 're-signed for Secure Boot!')
-                                : _('File uploaded to storage node!'),
+                            'msg' => $msgText,
                             'title' => _('Update Kernel Success')
                         ]
                     ));
@@ -3164,8 +3192,23 @@ abstract class FOGPage extends FOGBase
                     }
                     self::$FOGSSH->put($tmpfile, $orig);
                     self::$FOGSSH->sftp_chmod($orig, 0644);
-                    $br_cmd = "attr -s version -V $br_ver $orig";
-                    $tg_cmd = "attr -s tag_name -V $tg_ver $orig";
+                    /**
+                     * Quoted, because $br_ver and $tg_ver come from the POST
+                     * body and this string is run as a command on the storage
+                     * node. Unquoted, a value carrying a space or a shell
+                     * metacharacter is read as further commands.
+                     */
+                    $stampFailed = false;
+                    $br_cmd = sprintf(
+                        'attr -s version -V %s %s',
+                        escapeshellarg((string)$br_ver),
+                        escapeshellarg($orig)
+                    );
+                    $tg_cmd = sprintf(
+                        'attr -s tag_name -V %s %s',
+                        escapeshellarg((string)$tg_ver),
+                        escapeshellarg($orig)
+                    );
                     $output_br = self::$FOGSSH->exec($br_cmd);
                     $output_tg = self::$FOGSSH->exec($tg_cmd);
                     $error_br = self::$FOGSSH->fetch_stream($output_br, SSH2_STREAM_STDERR);
@@ -3177,10 +3220,12 @@ abstract class FOGPage extends FOGBase
                     $error_br_t = stream_get_contents($error_br);
                     $error_tg_t = stream_get_contents($error_tg);
                     if ($error_br_t) {
+                        $stampFailed = true;
                         error_log(_('Error on ssh command setting version'). ' ' . $br_cmd);
                         error_log(_('Error'). ': ' . $error_br_t);
                     }
                     if ($error_tg_t) {
+                        $stampFailed = true;
                         error_log(_('Error on ssh command setting tag_name'). ' ' . $tg_cmd);
                         error_log(_('Error'). ': ' . $error_tg_t);
                     }
@@ -3194,9 +3239,15 @@ abstract class FOGPage extends FOGBase
                         unlink($tmpfile);
                     }
                     $code = HTTPResponseCodes::HTTP_SUCCESS;
+                    $msgText = _('File uploaded to storage node!');
+                    if ($stampFailed) {
+                        $msgText .= ' ' . _('The version and release could '
+                            . 'not be recorded on the file, so it will '
+                            . 'report as unknown. See the PHP error log.');
+                    }
                     $this->jsonSend($code, json_encode(
                         [
-                            'msg' => _('File uploaded to storage node!'),
+                            'msg' => $msgText,
                             'title' => _('Update Initrd Success')
                         ]
                     ));


### PR DESCRIPTION
`kernelfetch()` and `initrdfetch()` finish a kernel/init download by recording the file's version and FOS release tag as extended attributes, running `attr -s` on the storage node over SSH. Both built the command by interpolation:

```php
$br_cmd = "attr -s version -V $br_ver $orig";
```

`$br_ver` and `$tg_ver` are `filter_input(INPUT_POST, ...)` reads. Unquoted, a value carrying a space or a shell metacharacter is read as further commands rather than as the value. In practice the values come from FOG's own parse of the GitHub release list, so nothing is injecting anything today — but the code trusts the request instead of checking it, and any admin-authenticated request can put what it likes in those fields.

`escapeshellarg()` on both values and on the path. The web tier only ever runs on Linux, so that produces the POSIX single-quoting the remote shell expects. `status/kernelvers.php` already quotes the same way for its local `shell_exec`.

## Also: a failed stamp is no longer silent

When one of those commands failed, the error went to `error_log()` and nowhere else. That is the most likely reason a kernel later reports an unknown version — and the Kernel Versions panel on FOG Configuration → Home cannot tell "never stamped" apart from a missing `attr` binary, a mount without `user_xattr`, SELinux denying the exec, or a parse artifact. All of them render as the same `Unknown`.

The upload still succeeds (the file is on the node and correct; only the labelling failed), so this is appended to the success message rather than raised as an error:

> File uploaded to storage node! The version and release could not be recorded on the file, so it will report as unknown. See the PHP error log.

## Verification

`php -l` clean on the touched file. The two `phpstan` passes were **not** run locally — this box has no `composer` and no `vendor/`, so CI is the first place they run. No behavioural change to the download or upload path itself: same commands, same order, same success and failure responses apart from the appended note.

Worth a reviewer's eye on whether the appended sentence should instead be a separate `warning` key in the JSON — that would need a matching change in `fog.about.kernel.js` / `fog.about.initrd.js`, which felt like more than this fix should carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYw9JCZGPeHuse6RTyNPgs
