### PR TITLE
Decide a boot file's role by reading it, not by naming it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -618,4 +618,7 @@ Canonical labels: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-hu
 
 ### Domain docs
 
-Single-context: `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+Single-context: `CONTEXT.md` and `docs/adr/` at the repo root.
+`CONTEXT.md` is the glossary and nothing else -- no implementation detail, no
+decisions. A decision that is hard to reverse, surprising without context, and
+the result of a real trade-off gets an ADR instead.

--- a/docs/adr/0041-a-boot-file-is-what-its-bytes-say-not-what-its-name-says.md
+++ b/docs/adr/0041-a-boot-file-is-what-its-bytes-say-not-what-its-name-says.md
@@ -112,7 +112,7 @@ field name and is what posts, and the select has no name at all and only writes
 into it. With no JavaScript the field degrades to the free-text box it was
 before the dropdowns landed, rather than to nothing.
 
-A stored value that names no recognised file is shown in that box with a note
+A stored value that names no recognized file is shown in that box with a note
 saying so, and saved as typed. It is not refused — the admin holding a
 known-good kernel for awkward hardware knows something the classifier does not.
 

--- a/docs/adr/0041-a-boot-file-is-what-its-bytes-say-not-what-its-name-says.md
+++ b/docs/adr/0041-a-boot-file-is-what-its-bytes-say-not-what-its-name-says.md
@@ -1,0 +1,134 @@
+# A boot file is what its bytes say, not what its name says
+
+## Status
+
+accepted
+
+## Context
+
+The Host and Group Kernel and Init fields became dropdowns built from the boot
+directory listing, because the installer now leaves the outgoing kernel behind
+as `bzImage.<release>` on every update — so that directory is exactly the set
+of "current, or any version still on this server, or anything I put here
+myself", and picking from it beats typing a filename from memory.
+
+What that listing could not do was say what any of those files were FOR. The
+rule it shipped with had no positive test for a kernel at all:
+
+```php
+$isInit = (bool)preg_match('/(^|\/)(init|arm_init)|\.(xz|cpio\.gz)/i', $file);
+if ($type === 'init' ? $isInit : !$isInit) {
+```
+
+An init was a name that looked like one; a kernel was **everything else** that
+survived a blacklist of extensions. Two failures came out of that, and they
+fail in opposite directions.
+
+The first is a naming collision, not an oversight. `memdisk`, `memtest.bin` and
+`grub.exe` were kept in the kernel list deliberately, because the *same* list
+feeds `FOG_MEMTEST_KERNEL`, which legitimately points at them. There was one
+list and two meanings, so narrowing it for the host field would have emptied
+the memtest field. The setting's own name is where the collision is written
+down: it says kernel and means payload.
+
+The second is that a blacklist cannot be finished. `.efi` covered `refind.efi`;
+a server carrying `refind.efi.new` from an old backup script offered it as a
+bootable host kernel. Every future file dropped in that directory defaults to
+"kernel" under a rule of that shape, and the directory is one an admin is
+explicitly invited to put their own files in.
+
+Tightening the pattern would have traded one of those for the other. A stricter
+allowlist — `bzImage*`, `arm_Image*` — throws away the hand-compiled kernel
+under a name FOG does not ship, which is half the reason the dropdown exists.
+
+## Decision
+
+### 1. The role is read out of the file
+
+Four roles, decided by `FOGPage::bootFileRole()` from the file's own contents:
+
+| Role | Test |
+|---|---|
+| FOS Kernel | `HdrS` at 0x202 (x86 setup header magic) or `ARMd` at 0x38 (arm64 Image header magic) |
+| FOS Init | an initramfs archive or compression magic at offset 0 |
+| Boot Payload | neither of the above, and not one of FOG's own web assets |
+| Unclassified | FOG's web assets sharing the directory, and `.unsigned` signing working files |
+
+Each field then asks for the role it means. The host and group fields ask for a
+FOS Kernel or a FOS Init; `FOG_MEMTEST_KERNEL` asks for a Boot Payload. One
+list serving two meanings is what put memdisk in a kernel menu, so there is no
+longer one list.
+
+`grub.exe` and `memdisk` are PE binaries, so a PE/`MZ` check could not have
+separated them from an EFI-stub kernel. The two header magics can, and an
+arm64 kernel is *also* a PE image when built with the EFI stub, which is why
+its magic is checked in its own right rather than inferred.
+
+### 2. Name-based exclusion survives for exactly two things
+
+FOG's own web assets (`boot.php`, `bg.png`, `refind.conf`) and the `.unsigned`
+working files `_resignKernels()` leaves behind. Both are files FOG itself put
+there under names FOG chose, so a name is the right thing to know them by —
+and `bzImage.unsigned` holds genuine kernel bytes, so content alone would
+offer a half-signed working file as bootable.
+
+Everything else that is neither kernel nor init is a **payload**, not
+unclassified. `memtest.bin` and `memdisk` are raw images with no magic to match
+on, and `FOG_MEMTEST_KERNEL` has always pointed at them; classifying by what we
+can prove would have quietly dropped them out of the one field that needs them.
+
+### 3. It is read in PHP, not by shelling out
+
+No `file(1)`, no `attr`, no `shell_exec`. The obvious implementation was to
+shell out — `utils/reporting/report.sh` already runs `file(1)` over this very
+directory — but the web tier cannot rely on that. `SELinux/fog.te` carries no
+rule permitting `httpd_t` to execute `bin_t`, which is why the Kernel Versions
+panel reports `Unknown` on RHEL-family servers: its `attr` calls return empty
+and the reason is discarded on stderr. Building the dropdown on the same
+mechanism would inherit that failure and hide it the same way.
+
+Reading bytes needs no binary, no extended attribute support, and no exec
+permission.
+
+### 4. One 4KiB read, at fixed offsets
+
+Both magics live at fixed offsets, so the test is exact and costs one 4KiB read
+per file rather than a scan of a 50MB image. The x86 setup header also records
+where its own version banner lives — a 16-bit offset at 0x20e, relative to
+0x200 — so `bootFileKernelVersion()` reads the version without searching
+either.
+
+arm64's header has no equivalent field, so that answers `''`. A caller must say
+the version is unavailable rather than inventing one: reporting a wrong version
+is worse than reporting none, and this directory already has a way of reporting
+wrong versions — an in-place overwrite leaves FOG's old `tag_name` xattr on the
+admin's kernel, so it reports as original.
+
+### 5. The typed name survives as a failsafe
+
+A classifier can be wrong, and an admin can be about to copy in a file that is
+not there yet. So every field keeps a manual entry: the text input carries the
+field name and is what posts, and the select has no name at all and only writes
+into it. With no JavaScript the field degrades to the free-text box it was
+before the dropdowns landed, rather than to nothing.
+
+A stored value that names no recognised file is shown in that box with a note
+saying so, and saved as typed. It is not refused — the admin holding a
+known-good kernel for awkward hardware knows something the classifier does not.
+
+## Consequences
+
+- An arm64 kernel not named `arm*` now classifies correctly for the dropdown
+  but is still judged by its prefix at boot time by
+  `IpxeBootMenu::_fileFitsArch()`, which remains name-based. That is the one
+  case nothing can police, and it is noted in that method's docblock.
+- A file whose first 4KiB cannot be read at all is Unclassified, so an
+  unreadable file disappears from the dropdowns rather than being offered and
+  failing at boot.
+- The listing now reads every file in the directory instead of only its names.
+  The cost is bounded (4KiB each, a directory of tens of files) but it is no
+  longer free, which is the argument for caching the answer once there is
+  somewhere to cache it.
+- `FOG_MEMTEST_KERNEL` keeps a name that describes the wrong thing. Renaming it
+  is a settings migration and not worth it on its own; the glossary in
+  `CONTEXT.md` records that it names a Boot Payload.

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -5217,7 +5217,7 @@ function reinitialize() {
         } else {
           $value.addClass('d-none').val(picked);
         }
-        // The server's "not a recognised file" note described the value the
+        // The server's "not a recognized file" note described the value the
         // form loaded with. Once you change the control it is stale.
         $picker.closest('.fog-bootfile').find('.fog-bootfile-note').remove();
       });

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -5189,6 +5189,40 @@ function reinitialize() {
     $(':input:not(textarea)', this).off('keypress');
   };
 
+  /**
+   * The boot-file pickers on the host, group, mass edit and settings forms.
+   *
+   * The text input carries the field name and is the thing that posts; the
+   * select has no name at all and only writes into it. That is what makes
+   * these fields degrade to a plain text box if this never runs, rather than
+   * posting nothing -- and it is why the picker can offer "type it myself"
+   * without the server needing a second field to read.
+   *
+   * Delegated and namespaced, because pages arrive by AJAX and doPageLoad()
+   * runs this again on every one of them.
+   */
+  var setupBootFilePickers = function() {
+    var MANUAL = '__fog_manual__'; // FOGPage::BOOT_MANUAL_VALUE
+    $(document)
+      .off('change.fogBootFile')
+      .on('change.fogBootFile', '.fog-bootfile-picker', function() {
+        var $picker = $(this),
+          $value = $('#' + $picker.data('target')),
+          picked = $picker.val();
+        if (!$value.length) {
+          return;
+        }
+        if (picked === MANUAL) {
+          $value.removeClass('d-none').val('').trigger('focus');
+        } else {
+          $value.addClass('d-none').val(picked);
+        }
+        // The server's "not a recognised file" note described the value the
+        // form loaded with. Once you change the control it is stale.
+        $picker.closest('.fog-bootfile').find('.fog-bootfile-note').remove();
+      });
+  };
+
   $.debugLog("=== DEBUG LOGGING ENABLED ===");
   setupIntegrations();
   if ($.fn.inputmask) {
@@ -5209,6 +5243,7 @@ function reinitialize() {
       dropdownParent: $modal.length ? $modal : $(document.body)
     });
   });
+  setupBootFilePickers();
   disableFormDefaults();
   wireImportForm();
   setupPasswordReveal();

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -9749,7 +9749,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Bereits registriert als"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -2680,6 +2680,9 @@ msgstr ""
 msgid "Enrollment kit"
 msgstr ""
 
+msgid "Enter a name manually"
+msgstr ""
+
 #, fuzzy, php-format
 msgid "Enter a valid %s name"
 msgstr "Bitte geben Sie einen gültigen Hostnamen ein"
@@ -9746,6 +9749,9 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Bereits registriert als"
 
+msgid "This name is not a recognised file in the boot directory."
+msgstr ""
+
 #, fuzzy
 msgid "This node could not be found"
 msgstr "Temporäre Datei konnte nicht gelesen werden."
@@ -11398,10 +11404,6 @@ msgid "not built yet"
 msgstr ""
 
 #, fuzzy
-msgid "not found on disk"
-msgstr "auf diesem Knoten nicht gefunden"
-
-#, fuzzy
 msgid "not found on this node"
 msgstr "auf diesem Knoten nicht gefunden"
 
@@ -12658,6 +12660,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "no database to"
 #~ msgstr "Keine Datenbank zum"
+
+#, fuzzy
+#~ msgid "not found on disk"
+#~ msgstr "auf diesem Knoten nicht gefunden"
 
 #, fuzzy
 #~ msgid "to clear the field on every host in this group."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -2682,6 +2682,9 @@ msgstr ""
 msgid "Enrollment kit"
 msgstr ""
 
+msgid "Enter a name manually"
+msgstr ""
+
 #, fuzzy, php-format
 msgid "Enter a valid %s name"
 msgstr "Please enter a valid hostname"
@@ -9754,6 +9757,9 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Already registered as"
 
+msgid "This name is not a recognised file in the boot directory."
+msgstr ""
+
 #, fuzzy
 msgid "This node could not be found"
 msgstr "Could not read temp file"
@@ -11403,10 +11409,6 @@ msgid "not built yet"
 msgstr ""
 
 #, fuzzy
-msgid "not found on disk"
-msgstr "Image not found on node"
-
-#, fuzzy
 msgid "not found on this node"
 msgstr "Image not found on node"
 
@@ -12615,6 +12617,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "no database to"
 #~ msgstr "No database to work off"
+
+#, fuzzy
+#~ msgid "not found on disk"
+#~ msgstr "Image not found on node"
 
 #, fuzzy
 #~ msgid "to clear the field on every host in this group."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -9757,7 +9757,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Already registered as"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2715,6 +2715,9 @@ msgstr ""
 msgid "Enrollment kit"
 msgstr ""
 
+msgid "Enter a name manually"
+msgstr ""
+
 #, fuzzy, php-format
 msgid "Enter a valid %s name"
 msgstr "Por favor introduce un nombre de sesión"
@@ -9917,6 +9920,9 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Impresora ya existe"
 
+msgid "This name is not a recognised file in the boot directory."
+msgstr ""
+
 #, fuzzy
 msgid "This node could not be found"
 msgstr "No se pudo leer el archivo temporal"
@@ -11568,10 +11574,6 @@ msgid "not built yet"
 msgstr ""
 
 #, fuzzy
-msgid "not found on disk"
-msgstr "No se encontró Clase FOGPage para este nodo"
-
-#, fuzzy
 msgid "not found on this node"
 msgstr "No se encontró Clase FOGPage para este nodo"
 
@@ -12760,6 +12762,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "multicast tasks!"
 #~ msgstr "MulticastTask"
+
+#, fuzzy
+#~ msgid "not found on disk"
+#~ msgstr "No se encontró Clase FOGPage para este nodo"
 
 #, fuzzy
 #~ msgid "username"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -9920,7 +9920,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Impresora ya existe"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -9750,7 +9750,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Bereits registriert als"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2680,6 +2680,9 @@ msgstr ""
 msgid "Enrollment kit"
 msgstr ""
 
+msgid "Enter a name manually"
+msgstr ""
+
 #, fuzzy, php-format
 msgid "Enter a valid %s name"
 msgstr "Bitte geben Sie einen gültigen Hostnamen ein"
@@ -9747,6 +9750,9 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Bereits registriert als"
 
+msgid "This name is not a recognised file in the boot directory."
+msgstr ""
+
 #, fuzzy
 msgid "This node could not be found"
 msgstr "Temporäre Datei konnte nicht gelesen werden."
@@ -11399,10 +11405,6 @@ msgid "not built yet"
 msgstr ""
 
 #, fuzzy
-msgid "not found on disk"
-msgstr "auf diesem Knoten nicht gefunden"
-
-#, fuzzy
 msgid "not found on this node"
 msgstr "auf diesem Knoten nicht gefunden"
 
@@ -12659,6 +12661,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "no database to"
 #~ msgstr "Keine Datenbank zum"
+
+#, fuzzy
+#~ msgid "not found on disk"
+#~ msgstr "auf diesem Knoten nicht gefunden"
 
 #, fuzzy
 #~ msgid "to clear the field on every host in this group."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2683,6 +2683,9 @@ msgstr ""
 msgid "Enrollment kit"
 msgstr ""
 
+msgid "Enter a name manually"
+msgstr ""
+
 #, fuzzy, php-format
 msgid "Enter a valid %s name"
 msgstr "S'il vous plaît entrer un nom d'hôte valide"
@@ -9739,6 +9742,9 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Déjà inscrit comme"
 
+msgid "This name is not a recognised file in the boot directory."
+msgstr ""
+
 #, fuzzy
 msgid "This node could not be found"
 msgstr "Impossible de lire le fichier temporaire"
@@ -11389,10 +11395,6 @@ msgid "not built yet"
 msgstr ""
 
 #, fuzzy
-msgid "not found on disk"
-msgstr "Image not found sur le noeud"
-
-#, fuzzy
 msgid "not found on this node"
 msgstr "Image not found sur le noeud"
 
@@ -12605,6 +12607,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "no database to"
 #~ msgstr "Aucune base de données de travailler hors"
+
+#, fuzzy
+#~ msgid "not found on disk"
+#~ msgstr "Image not found sur le noeud"
 
 #, fuzzy
 #~ msgid "to clear the field on every host in this group."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -9742,7 +9742,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Déjà inscrit comme"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -9457,7 +9457,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Già registrato come"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -2616,6 +2616,9 @@ msgstr ""
 msgid "Enrollment kit"
 msgstr ""
 
+msgid "Enter a name manually"
+msgstr ""
+
 #, fuzzy, php-format
 msgid "Enter a valid %s name"
 msgstr "Si prega di inserire un nome host valido"
@@ -9454,6 +9457,9 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Già registrato come"
 
+msgid "This name is not a recognised file in the boot directory."
+msgstr ""
+
 #, fuzzy
 msgid "This node could not be found"
 msgstr "Impossibile leggere il file temporaneo"
@@ -11042,10 +11048,6 @@ msgstr "nodi che contengono questa immagine"
 msgid "not built yet"
 msgstr ""
 
-#, fuzzy
-msgid "not found on disk"
-msgstr "Non trovato su questo nodo"
-
 msgid "not found on this node"
 msgstr "Non trovato su questo nodo"
 
@@ -12258,6 +12260,10 @@ msgstr ""
 
 #~ msgid "no database to"
 #~ msgstr "Nessun database a"
+
+#, fuzzy
+#~ msgid "not found on disk"
+#~ msgstr "Non trovato su questo nodo"
 
 #, fuzzy
 #~ msgid "to clear the field on every host in this group."

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -9402,7 +9402,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "既に次の名前で登録されています:"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -2602,6 +2602,9 @@ msgstr ""
 msgid "Enrollment kit"
 msgstr ""
 
+msgid "Enter a name manually"
+msgstr ""
+
 #, fuzzy, php-format
 msgid "Enter a valid %s name"
 msgstr "有効なホスト名を入力してください"
@@ -9399,6 +9402,9 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "既に次の名前で登録されています:"
 
+msgid "This name is not a recognised file in the boot directory."
+msgstr ""
+
 #, fuzzy
 msgid "This node could not be found"
 msgstr "強制終了できませんでした"
@@ -10988,10 +10994,6 @@ msgstr "このイメージを含むノード"
 
 msgid "not built yet"
 msgstr ""
-
-#, fuzzy
-msgid "not found on disk"
-msgstr "このノード上に見つかりません"
 
 msgid "not found on this node"
 msgstr "このノード上に見つかりません"
@@ -13802,6 +13804,10 @@ msgstr ""
 
 #~ msgid "no login will appear"
 #~ msgstr "ログイン画面は表示されません"
+
+#, fuzzy
+#~ msgid "not found on disk"
+#~ msgstr "このノード上に見つかりません"
 
 #~ msgid "of"
 #~ msgstr "の"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -2310,6 +2310,9 @@ msgstr ""
 msgid "Enrollment kit"
 msgstr ""
 
+msgid "Enter a name manually"
+msgstr ""
+
 #, php-format
 msgid "Enter a valid %s name"
 msgstr ""
@@ -8353,6 +8356,9 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr ""
 
+msgid "This name is not a recognised file in the boot directory."
+msgstr ""
+
 msgid "This node could not be found"
 msgstr ""
 
@@ -9794,9 +9800,6 @@ msgid "nodes containing this image"
 msgstr ""
 
 msgid "not built yet"
-msgstr ""
-
-msgid "not found on disk"
 msgstr ""
 
 msgid "not found on this node"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -8356,7 +8356,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr ""
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 msgid "This node could not be found"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -2682,6 +2682,9 @@ msgstr ""
 msgid "Enrollment kit"
 msgstr ""
 
+msgid "Enter a name manually"
+msgstr ""
+
 #, fuzzy, php-format
 msgid "Enter a valid %s name"
 msgstr "Por favor insira um nome de host válido"
@@ -9741,6 +9744,9 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Já está registado como"
 
+msgid "This name is not a recognised file in the boot directory."
+msgstr ""
+
 #, fuzzy
 msgid "This node could not be found"
 msgstr "Não foi possível ler arquivo temporário"
@@ -11391,10 +11397,6 @@ msgid "not built yet"
 msgstr ""
 
 #, fuzzy
-msgid "not found on disk"
-msgstr "Imagem não encontrada no nó"
-
-#, fuzzy
 msgid "not found on this node"
 msgstr "Imagem não encontrada no nó"
 
@@ -12607,6 +12609,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "no database to"
 #~ msgstr "Nenhum banco de dados para trabalhar fora"
+
+#, fuzzy
+#~ msgid "not found on disk"
+#~ msgstr "Imagem não encontrada no nó"
 
 #, fuzzy
 #~ msgid "to clear the field on every host in this group."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -9744,7 +9744,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Já está registado como"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -2682,6 +2682,9 @@ msgstr ""
 msgid "Enrollment kit"
 msgstr ""
 
+msgid "Enter a name manually"
+msgstr ""
+
 #, fuzzy, php-format
 msgid "Enter a valid %s name"
 msgstr "请输入一个有效的主机名"
@@ -9741,6 +9744,9 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "已注册为"
 
+msgid "This name is not a recognised file in the boot directory."
+msgstr ""
+
 #, fuzzy
 msgid "This node could not be found"
 msgstr "无法读取临时文件"
@@ -11391,10 +11397,6 @@ msgid "not built yet"
 msgstr ""
 
 #, fuzzy
-msgid "not found on disk"
-msgstr "图片没有节点发现"
-
-#, fuzzy
 msgid "not found on this node"
 msgstr "图片没有节点发现"
 
@@ -12607,6 +12609,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "no database to"
 #~ msgstr "没有数据库工作关闭"
+
+#, fuzzy
+#~ msgid "not found on disk"
+#~ msgstr "图片没有节点发现"
 
 #, fuzzy
 #~ msgid "to clear the field on every host in this group."

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -9744,7 +9744,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "已注册为"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -5986,7 +5986,7 @@ abstract class FOGPage extends FOGBase
         }
         /**
          * A stored value naming a file that is not on disk -- or one the
-         * classifier does not recognise as this role -- must still appear and
+         * classifier does not recognize as this role -- must still appear and
          * must still be what the form posts. Dropping it would silently
          * rewrite the host's kernel to the default the moment anyone opened
          * the form. It is shown in the manual box below, with a note, rather
@@ -6019,7 +6019,7 @@ abstract class FOGPage extends FOGBase
         }
         /**
          * The typed failsafe. A dropdown can only offer what the classifier
-         * recognised, and an admin running a kernel it does not recognise --
+         * recognized, and an admin running a kernel it does not recognize --
          * or about to copy one in -- still has to be able to name it. This is
          * also the escape hatch if the classifier is ever wrong.
          *
@@ -6060,7 +6060,7 @@ abstract class FOGPage extends FOGBase
             . (
                 $manualValue ?
                 '<small class="form-text text-warning fog-bootfile-note">'
-                . _('This name is not a recognised file in the boot directory.')
+                . _('This name is not a recognized file in the boot directory.')
                 . '</small>' :
                 ''
             )

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -5696,8 +5696,176 @@ abstract class FOGPage extends FOGBase
             . '</label>';
     }
     /**
-     * Lists the kernel or init files actually present in the FOS boot
-     * directory, newest first.
+     * What a file in the FOS boot directory is FOR.
+     *
+     * A FOS Kernel boots the imaging environment; a FOS Init is the initramfs
+     * it boots with; a Boot Payload is something the boot menu can chain but
+     * which does not boot FOS (memdisk, memtest.bin, grub.exe, refind*.efi);
+     * anything else sharing that directory is Unclassified.
+     */
+    const BOOT_ROLE_KERNEL = 'kernel';
+    const BOOT_ROLE_INIT = 'init';
+    const BOOT_ROLE_PAYLOAD = 'payload';
+    const BOOT_ROLE_OTHER = 'unclassified';
+    /**
+     * Picker value meaning "I will type the name myself".
+     *
+     * Not a filename any filesystem would produce, and matched literally by
+     * fog.common.js -- change it in both places or in neither.
+     */
+    const BOOT_MANUAL_VALUE = '__fog_manual__';
+    /**
+     * Decides what a boot directory file is, by reading it.
+     *
+     * Deciding by NAME is what put memdisk, memtest.bin and grub.exe in the
+     * Host Kernel dropdown: there was no positive test for a kernel, only
+     * "an init looks like this, so everything else is a kernel". A blacklist
+     * of extensions cannot be completed either -- an old backup script
+     * leaving refind.efi.new behind defeats it -- and a hand-compiled kernel
+     * under any name has to keep working.
+     *
+     * So read the file instead. The tests are exact and cost one 4KiB read
+     * rather than a scan of a 50MB image:
+     *
+     * - x86/x86_64: 'HdrS', the Linux setup header's own magic, at 0x202.
+     * - arm64: 'ARMd', the Image header's magic, at 0x38.
+     *
+     * grub.exe and memdisk are PE binaries too, so a PE check alone could not
+     * separate them from an EFI-stub kernel; these two can.
+     *
+     * Note what is deliberately NOT excluded by name: only FOG's own web
+     * assets that share this directory, and the .unsigned working files
+     * _resignKernels() leaves behind. Everything else that is neither kernel
+     * nor init is a payload, because memtest.bin and memdisk are raw images
+     * with no magic to match on and FOG_MEMTEST_KERNEL legitimately points at
+     * them.
+     *
+     * @param string $path full path to the file
+     *
+     * @return string one of the BOOT_ROLE_* constants
+     */
+    public static function bootFileRole($path)
+    {
+        if (!is_file($path) || !is_readable($path)) {
+            return self::BOOT_ROLE_OTHER;
+        }
+        $name = basename($path);
+        if (preg_match('/\.(unsigned|php|png|jpe?g|gif|svg|css|js|conf)$/i', $name)) {
+            return self::BOOT_ROLE_OTHER;
+        }
+        $head = self::readMagic($path, 4096);
+        if ($head === '') {
+            return self::BOOT_ROLE_OTHER;
+        }
+        if (self::_looksLikeInit($head)) {
+            return self::BOOT_ROLE_INIT;
+        }
+        if (self::_looksLikeKernel($head)) {
+            return self::BOOT_ROLE_KERNEL;
+        }
+        return self::BOOT_ROLE_PAYLOAD;
+    }
+    /**
+     * True when $head carries a Linux kernel image's own header magic.
+     *
+     * @param string $head leading bytes of the file
+     *
+     * @return bool
+     */
+    private static function _looksLikeKernel($head)
+    {
+        // x86/x86_64 bzImage: setup header magic, four bytes at 0x202.
+        if (substr($head, 0x202, 4) === 'HdrS') {
+            return true;
+        }
+        /**
+         * arm64 Image: header magic 0x644d5241 at 0x38, which is the bytes
+         * 'ARMd'. An arm64 kernel is also a PE image when built with EFI stub
+         * support, so this has to be checked in its own right rather than
+         * inferred from MZ.
+         */
+        if (substr($head, 0x38, 4) === 'ARMd') {
+            return true;
+        }
+        return false;
+    }
+    /**
+     * True when $head carries an initramfs archive or compression magic.
+     *
+     * FOS ships init.xz and arm_init.cpio.gz, but a hand-built initramfs may
+     * use any compressor the kernel can unpack, so accept those too rather
+     * than pinning the two names FOG happens to download.
+     *
+     * @param string $head leading bytes of the file
+     *
+     * @return bool
+     */
+    private static function _looksLikeInit($head)
+    {
+        $magics = [
+            "\xfd" . '7zXZ' . "\x00",
+            "\x1f\x8b",
+            "\x28\xb5\x2f\xfd",
+            "\x04\x22\x4d\x18",
+            'BZh',
+            "\x5d\x00\x00",
+            "\x89" . 'LZO',
+            '070701',
+            '070702',
+            '070707',
+            "\xc7\x71",
+        ];
+        foreach ($magics as $magic) {
+            if (0 === strpos($head, $magic)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    /**
+     * Reads a kernel image's own version banner, or '' when it has none.
+     *
+     * The x86 setup header records where its version string lives: a 16-bit
+     * offset at 0x20e, relative to 0x200. That is exact, so there is no
+     * scanning and no guessing.
+     *
+     * arm64 Image has no equivalent field, so this answers '' there. A caller
+     * displaying this must say the version is unavailable rather than
+     * inventing one; reporting a wrong version is worse than reporting none.
+     *
+     * @param string $path full path to the file
+     *
+     * @return string e.g. '6.6.30 (fos@buildroot) #1 SMP', or ''
+     */
+    public static function bootFileKernelVersion($path)
+    {
+        $head = self::readMagic($path, 4096);
+        if (substr($head, 0x202, 4) !== 'HdrS') {
+            return '';
+        }
+        $at = @unpack('v', substr($head, 0x20e, 2));
+        if (!is_array($at) || empty($at[1])) {
+            return '';
+        }
+        $at = $at[1] + 0x200;
+        $bytes = self::readMagic($path, $at + 512);
+        if (strlen($bytes) <= $at) {
+            return '';
+        }
+        $parts = explode("\x00", substr($bytes, $at, 512), 2);
+        $ver = trim($parts[0]);
+        /**
+         * Refuse anything not plainly printable. A bad offset lands in the
+         * middle of the compressed image, and rendering that as a version
+         * would be worse than saying nothing.
+         */
+        if ($ver === '' || preg_match('/[^\x20-\x7e]/', $ver)) {
+            return '';
+        }
+        return $ver;
+    }
+    /**
+     * Lists the boot directory files holding the role $type, newest first.
      *
      * Kernels and inits are files on disk, not database records, so there is
      * nothing for buildSelectBox() to enumerate. Reading the directory is the
@@ -5706,13 +5874,29 @@ abstract class FOGPage extends FOGBase
      * on every update, that directory is exactly the list of "current, or any
      * version still on this server, or anything I put here myself".
      *
-     * @param string $type 'kernel' or 'init'
+     * The role is decided by bootFileRole(), so a field asking for a kernel
+     * is offered kernels only. One list serving both the Host Kernel field
+     * and FOG_MEMTEST_KERNEL is what put memdisk in the kernel dropdown.
+     *
+     * @param string $type 'kernel', 'init' or 'payload'
      *
      * @return array filenames
      */
     public static function kernelFileList($type = 'kernel')
     {
-        $dir = trim((string)self::getSetting('FOG_TFTP_PXE_KERNEL_DIR'));
+        /**
+         * An empty list is a legitimate answer, and kernelFileSelect() turns
+         * it into a plain text input -- so a server whose boot directory has
+         * moved stays editable. A settings read that cannot answer at all is
+         * the same situation from the caller's point of view, and one field
+         * out of the thirty on a mass edit form must not take the form down
+         * with it.
+         */
+        try {
+            $dir = trim((string)self::getSetting('FOG_TFTP_PXE_KERNEL_DIR'));
+        } catch (\Throwable $e) {
+            return [];
+        }
         if (empty($dir) || !is_dir($dir) || !is_readable($dir)) {
             return [];
         }
@@ -5720,32 +5904,27 @@ abstract class FOGPage extends FOGBase
         if ($files === false) {
             return [];
         }
+        switch ($type) {
+            case 'init':
+                $want = self::BOOT_ROLE_INIT;
+                break;
+            case 'payload':
+                $want = self::BOOT_ROLE_PAYLOAD;
+                break;
+            default:
+                $want = self::BOOT_ROLE_KERNEL;
+                break;
+        }
         $out = [];
         foreach ($files as $file) {
             if ($file === '.' || $file === '..') {
                 continue;
             }
-            if (!is_file($dir . DIRECTORY_SEPARATOR . $file)) {
+            $path = $dir . DIRECTORY_SEPARATOR . $file;
+            if (!is_file($path)) {
                 continue;
             }
-            /**
-             * Split by shape rather than by a fixed list of names, so a
-             * custom kernel and the per-release siblings both appear.
-             *
-             * .unsigned copies are excluded -- they are _resignKernels()
-             * working files, not something to boot.
-             *
-             * The web assets and config that share this directory
-             * (boot.php/advanced.php/index.php, the bg images, refind.conf)
-             * are excluded too. "Anything that is not an init" swept all of
-             * them into the kernel list, which is not a menu anybody wants to
-             * pick a kernel out of.
-             */
-            if (preg_match('/\.(unsigned|php|png|jpe?g|gif|svg|conf|efi)$/i', $file)) {
-                continue;
-            }
-            $isInit = (bool)preg_match('/(^|\/)(init|arm_init)|\.(xz|cpio\.gz)/i', $file);
-            if ($type === 'init' ? $isInit : !$isInit) {
+            if (self::bootFileRole($path) === $want) {
                 $out[] = $file;
             }
         }
@@ -5806,14 +5985,14 @@ abstract class FOGPage extends FOGBase
             );
         }
         /**
-         * A stored value naming a file that is no longer on disk must still
-         * appear, and still be selected. Dropping it would silently rewrite
-         * the host's kernel to the default the moment anyone opened the form.
+         * A stored value naming a file that is not on disk -- or one the
+         * classifier does not recognise as this role -- must still appear and
+         * must still be what the form posts. Dropping it would silently
+         * rewrite the host's kernel to the default the moment anyone opened
+         * the form. It is shown in the manual box below, with a note, rather
+         * than as an option that pretends the file is there.
          */
-        $missing = ($current !== '' && !in_array($current, $files, true));
-        if ($missing) {
-            array_unshift($files, $current);
-        }
+        $manualValue = ($current !== '' && !in_array($current, $files, true));
         /**
          * The blank option is load-bearing, not filler. On a host or group an
          * empty kernel/init means "inherit the global default", so it must be
@@ -5836,23 +6015,56 @@ abstract class FOGPage extends FOGBase
                 . ($file === $current ? ' selected' : '')
                 . '>'
                 . \Initiator::e($file)
-                . (
-                    $missing && $file === $current ?
-                    ' (' . _('not found on disk') . ')' :
-                    ''
-                )
                 . '</option>';
         }
+        /**
+         * The typed failsafe. A dropdown can only offer what the classifier
+         * recognised, and an admin running a kernel it does not recognise --
+         * or about to copy one in -- still has to be able to name it. This is
+         * also the escape hatch if the classifier is ever wrong.
+         *
+         * The TEXT INPUT carries the field name and is what posts, always;
+         * the select has no name and is a picker that writes into it. So with
+         * no JavaScript the field degrades to the free-text box it was before
+         * the dropdowns landed, rather than to nothing.
+         */
+        $opts .= '<option value="' . self::BOOT_MANUAL_VALUE . '"'
+            . ($manualValue ? ' selected' : '')
+            . '>- '
+            . _('Enter a name manually')
+            . ' -</option>';
 
-        return '<select class="'
+        return '<div class="fog-bootfile">'
+            . '<select class="'
             . $class
-            . ' fog-select2" name="'
-            . $name
+            . ' fog-select2 fog-bootfile-picker" data-target="'
+            . \Initiator::e($id)
             . '" id="'
-            . $id
-            . '" autocomplete="off">'
+            . \Initiator::e($id)
+            . '-picker" autocomplete="off">'
             . $opts
-            . '</select>';
+            . '</select>'
+            . '<input type="text" class="'
+            . $class
+            . ' fog-bootfile-value mt-1'
+            . ($manualValue ? '' : ' d-none')
+            . '" name="'
+            . \Initiator::e($name)
+            . '" id="'
+            . \Initiator::e($id)
+            . '" value="'
+            . \Initiator::e($current)
+            . '" placeholder="'
+            . ($type === 'init' ? 'customInit.xz' : 'bzImage_Custom')
+            . '" autocomplete="off">'
+            . (
+                $manualValue ?
+                '<small class="form-text text-warning fog-bootfile-note">'
+                . _('This name is not a recognised file in the boot directory.')
+                . '</small>' :
+                ''
+            )
+            . '</div>';
     }
     /**
      * Makes an input element.

--- a/packages/web/src/Boot/IpxeBootMenu.php
+++ b/packages/web/src/Boot/IpxeBootMenu.php
@@ -386,8 +386,13 @@ class IpxeBootMenu extends BootMenuBase
      * so an override across that line can only ever fail to boot.
      *
      * The test is the `arm` filename prefix -- the convention every kernel
-     * and init FOG ships follows (arm_Image, arm_init.cpio.gz), and the same
-     * one FOGPage::kernelFileList() already keys off.
+     * and init FOG ships follows (arm_Image, arm_init.cpio.gz). Note this is
+     * now the ONLY name-based rule about these files:
+     * FOGPage::kernelFileList() used to key off names too, and no longer
+     * does -- it reads each file's own header magic. A custom-named arm64
+     * kernel is therefore classified correctly for the dropdown and still
+     * judged by its prefix here, so an arm kernel not called arm* is the one
+     * case this cannot police.
      *
      * @param string $file the stored override
      *

--- a/packages/web/src/Pages/FOGConfigurationPage.php
+++ b/packages/web/src/Pages/FOGConfigurationPage.php
@@ -1885,26 +1885,6 @@ class FOGConfigurationPage extends FOGPage
                                 $row['settingKey']
                             );
                             break;
-                            /**
-                             * The default kernels are filenames in the FOS boot
-                             * directory, so offer what is actually there --
-                             * including the per-release siblings the installer
-                             * leaves behind on every update, which is what makes
-                             * "put the default back on the previous kernel" a
-                             * selection rather than a typed guess.
-                             */
-                        case 'FOG_TFTP_PXE_KERNEL':
-                        case 'FOG_TFTP_PXE_KERNEL_32':
-                        case 'FOG_TFTP_PXE_KERNEL_ARM':
-                        case 'FOG_MEMTEST_KERNEL':
-                            $input = self::kernelFileSelect(
-                                $row['settingID'],
-                                $row['settingValue'],
-                                'kernel',
-                                'form-control',
-                                $row['settingKey']
-                            );
-                            break;
                         case (isset($needstobecheckbox[$row['settingKey']])):
                             $input = self::makeInput(
                                 '',
@@ -3157,6 +3137,55 @@ class FOGConfigurationPage extends FOGPage
         array $needstobecheckbox
     ) {
         switch ($row['settingKey']) {
+            /**
+             * The default kernels, inits and the memtest payload are all
+             * filenames in the FOS boot directory, so offer what is actually
+             * there -- the per-release siblings the installer leaves behind
+             * included, which is what makes "put the default back on the
+             * previous kernel" a selection rather than a typed guess.
+             *
+             * These cases used to live in getIpxeList(), whose $ServicesToSee
+             * allow-list does not contain any of these keys -- so the switch
+             * arm never ran and this page rendered the default kernel as a
+             * plain text box. This is the renderer the settings page actually
+             * uses.
+             *
+             * The role differs per key and that is the point:
+             * FOG_MEMTEST_KERNEL is NAMED for a kernel but points at a boot
+             * payload (memtest.bin, memdisk, grub.exe). One list serving both
+             * meanings is what offered those three as a boot kernel.
+             */
+            case 'FOG_TFTP_PXE_KERNEL':
+            case 'FOG_TFTP_PXE_KERNEL_32':
+            case 'FOG_TFTP_PXE_KERNEL_ARM':
+                $input = self::kernelFileSelect(
+                    $row['settingID'],
+                    $row['settingValue'],
+                    'kernel',
+                    'form-control',
+                    $row['settingKey']
+                );
+                break;
+            case 'FOG_PXE_BOOT_IMAGE':
+            case 'FOG_PXE_BOOT_IMAGE_32':
+            case 'FOG_PXE_BOOT_IMAGE_ARM':
+                $input = self::kernelFileSelect(
+                    $row['settingID'],
+                    $row['settingValue'],
+                    'init',
+                    'form-control',
+                    $row['settingKey']
+                );
+                break;
+            case 'FOG_MEMTEST_KERNEL':
+                $input = self::kernelFileSelect(
+                    $row['settingID'],
+                    $row['settingValue'],
+                    'payload',
+                    'form-control',
+                    $row['settingKey']
+                );
+                break;
             case 'FOG_VIEW_DEFAULT_SCREEN':
                 $vals = [
                     _('10') => 10,

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -4188,7 +4188,7 @@ class HostManagement extends FOGPage
                 'field' => 'kernel',
                 'empty' => '',
                 'label' => _('Host Kernel'),
-                'kind' => 'text',
+                'kind' => 'kernel',
                 'tab' => 'general'
             ],
             'kernelArgs' => [
@@ -4209,7 +4209,7 @@ class HostManagement extends FOGPage
                 'field' => 'init',
                 'empty' => '',
                 'label' => _('Host Init'),
-                'kind' => 'text',
+                'kind' => 'init',
                 'tab' => 'general'
             ],
             'biosexit' => [
@@ -4609,6 +4609,34 @@ class HostManagement extends FOGPage
             case 'image':
                 return self::getClass('ImageManager')
                     ->buildSelectBox('', $name, 'name', '', false, 'id', $id);
+            /**
+             * The same picker the single-host form uses. Mass edit was left on
+             * a free-text box when the dropdowns landed, so the one place a
+             * typo reaches four hundred hosts at once was the one place
+             * offering no list to choose from.
+             *
+             * Blank is a legitimate mass-edit value here -- it means "clear
+             * the override and inherit the global default" -- which is why
+             * the spec's 'empty' is '' rather than null.
+             */
+            case 'kernel':
+                return self::kernelFileSelect(
+                    $name,
+                    '',
+                    'kernel',
+                    'form-control',
+                    $id,
+                    _('Use the default kernel')
+                );
+            case 'init':
+                return self::kernelFileSelect(
+                    $name,
+                    '',
+                    'init',
+                    'form-control',
+                    $id,
+                    _('Use the default init')
+                );
             case 'biosexit':
             case 'efiexit':
                 return Setting::buildExitSelector($name, '', true, $id);

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -4609,16 +4609,16 @@ class HostManagement extends FOGPage
             case 'image':
                 return self::getClass('ImageManager')
                     ->buildSelectBox('', $name, 'name', '', false, 'id', $id);
-            /**
-             * The same picker the single-host form uses. Mass edit was left on
-             * a free-text box when the dropdowns landed, so the one place a
-             * typo reaches four hundred hosts at once was the one place
-             * offering no list to choose from.
-             *
-             * Blank is a legitimate mass-edit value here -- it means "clear
-             * the override and inherit the global default" -- which is why
-             * the spec's 'empty' is '' rather than null.
-             */
+                /**
+                 * The same picker the single-host form uses. Mass edit was left on
+                 * a free-text box when the dropdowns landed, so the one place a
+                 * typo reaches four hundred hosts at once was the one place
+                 * offering no list to choose from.
+                 *
+                 * Blank is a legitimate mass-edit value here -- it means "clear
+                 * the override and inherit the global default" -- which is why
+                 * the spec's 'empty' is '' rather than null.
+                 */
             case 'kernel':
                 return self::kernelFileSelect(
                     $name,

--- a/tests/boot-file-roles.test.php
+++ b/tests/boot-file-roles.test.php
@@ -1,0 +1,312 @@
+<?php
+/**
+ * A boot directory file's role is decided by reading it, not by its name.
+ *
+ * The Host Kernel dropdown offered memdisk, memtest.bin and grub.exe because
+ * FOGPage::kernelFileList() had no positive test for a kernel -- it knew what
+ * an init looked like and called everything else a kernel, behind a blacklist
+ * of extensions. Two consequences, both reported:
+ *
+ *   - memdisk/memtest.bin/grub.exe are boot payloads. They were kept in the
+ *     kernel list on purpose, because the SAME list feeds FOG_MEMTEST_KERNEL,
+ *     which legitimately points at them. One list, two meanings.
+ *   - a blacklist cannot be completed. `.efi` covered refind.efi; an old
+ *     backup script leaving refind.efi.new behind walked straight through it.
+ *
+ * So the fixtures below are built to the real on-disk shapes and the role is
+ * asserted for each. The two that matter most are the pair a name-based rule
+ * gets wrong in OPPOSITE directions: bzImage_MyHardware is a hand-compiled
+ * kernel under a name FOG never ships and must be offered, while
+ * bzImage.unsigned holds genuine kernel bytes and must NOT be -- it is a
+ * _resignKernels() working file, not something to boot.
+ *
+ * The previous round of this bug was caught by rendering the helper against a
+ * real service/ipxe rather than reasoning about what lives there. This is that
+ * directory, as a fixture.
+ *
+ * DB-free: the fake DB answers the one globalSettings read for the directory.
+ *
+ * Usage: php tests/boot-file-roles.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('boot-file-roles');
+$db = FogTestHarness::fakeDb();
+
+$t = new FogChecks();
+
+/**
+ * An x86/x86_64 bzImage: PE for the EFI stub, plus the setup header magic at
+ * 0x202 and, when a version is wanted, the 16-bit offset at 0x20e that says
+ * where the version banner lives (relative to 0x200).
+ *
+ * @param string $version banner to embed, or '' for none
+ *
+ * @return string
+ */
+function fixtureX86Kernel($version = '')
+{
+    $buf = str_repeat("\x00", 4096);
+    $buf = substr_replace($buf, 'MZ', 0, 2);
+    $buf = substr_replace($buf, 'HdrS', 0x202, 4);
+    if ($version !== '') {
+        // 0x300 in the file is 0x100 past the 0x200 the field is relative to.
+        $buf = substr_replace($buf, pack('v', 0x100), 0x20e, 2);
+        $buf = substr_replace(
+            $buf,
+            $version . "\x00",
+            0x300,
+            strlen($version) + 1
+        );
+    }
+
+    return $buf;
+}
+
+/**
+ * An arm64 Image: header magic 'ARMd' at 0x38, and PE as well because the
+ * EFI stub is built in. No version field exists in this header.
+ *
+ * @return string
+ */
+function fixtureArmKernel()
+{
+    $buf = str_repeat("\x00", 4096);
+    $buf = substr_replace($buf, 'MZ', 0, 2);
+    $buf = substr_replace($buf, 'ARMd', 0x38, 4);
+
+    return $buf;
+}
+
+/**
+ * A PE executable that is NOT a kernel: grub.exe, refind*.efi, and the .new
+ * copy an old backup script left behind. This is the shape a PE-only check
+ * would wrongly call a kernel.
+ *
+ * @return string
+ */
+function fixturePeBinary()
+{
+    return 'MZ' . str_repeat('X', 4094);
+}
+
+$dir = dirname(FOG_CACHE_DIR) . '/service/ipxe';
+mkdir($dir, 0755, true);
+// The TFTP uploader's backup directory. A directory, so nothing may list it.
+mkdir($dir . '/backup', 0755, true);
+file_put_contents($dir . '/backup/bzImage_20260806_111046', 'old');
+
+$kernelVersion = '6.6.30 (fos@buildroot) #1 SMP Wed Aug 6 11:10:46 UTC 2026';
+
+$fixtures = [
+    // name => [bytes, expected role]
+    'bzImage' => [fixtureX86Kernel($kernelVersion), 'kernel'],
+    'bzImage32' => [fixtureX86Kernel('6.6.30 (fos@buildroot) #1 SMP'), 'kernel'],
+    'bzImage.20260701-093344' => [fixtureX86Kernel('6.6.12'), 'kernel'],
+    'bzImage_MyHardware' => [fixtureX86Kernel('6.1.99-custom'), 'kernel'],
+    'arm_Image' => [fixtureArmKernel(), 'kernel'],
+    'init.xz' => ["\xfd" . '7zXZ' . "\x00" . str_repeat('z', 512), 'init'],
+    'init_32.xz' => ["\xfd" . '7zXZ' . "\x00" . str_repeat('z', 512), 'init'],
+    'init.xz.20260701-093344' => [
+        "\xfd" . '7zXZ' . "\x00" . str_repeat('z', 512),
+        'init'
+    ],
+    'arm_init.cpio.gz' => ["\x1f\x8b" . str_repeat('g', 512), 'init'],
+    'customInit.lz4' => ["\x04\x22\x4d\x18" . str_repeat('l', 512), 'init'],
+    'memdisk' => [str_repeat('D', 4096), 'payload'],
+    'memtest.bin' => [str_repeat('T', 4096), 'payload'],
+    'grub.exe' => [fixturePeBinary(), 'payload'],
+    'refind.efi' => [fixturePeBinary(), 'payload'],
+    'refind_x64.efi' => [fixturePeBinary(), 'payload'],
+    'refind.efi.new' => [fixturePeBinary(), 'payload'],
+    'bzImage.unsigned' => [fixtureX86Kernel('6.6.30'), 'unclassified'],
+    'refind.conf' => ["timeout 20\n", 'unclassified'],
+    'boot.php' => ['<?php // boot', 'unclassified'],
+    'advanced.php' => ['<?php // advanced', 'unclassified'],
+    'index.php' => ['<?php // index', 'unclassified'],
+    'bg.png' => ["\x89PNG\r\n\x1a\n" . str_repeat('p', 64), 'unclassified'],
+];
+
+foreach ($fixtures as $name => $spec) {
+    file_put_contents($dir . '/' . $name, $spec[0]);
+}
+
+$db->responder = function ($sql, $params) use ($dir) {
+    if (false !== stripos($sql, 'FROM `globalSettings`')) {
+        return [
+            [
+                'settingKey' => 'FOG_TFTP_PXE_KERNEL_DIR',
+                'settingValue' => $dir . '/'
+            ]
+        ];
+    }
+
+    return null;
+};
+
+$page = 'FOG\Base\FOGPage';
+
+// --- the role of every file in the directory ------------------------------
+
+foreach ($fixtures as $name => $spec) {
+    $got = $page::bootFileRole($dir . '/' . $name);
+    $t->check(
+        sprintf('%s is a %s (got %s)', $name, $spec[1], $got),
+        $spec[1] === $got
+    );
+}
+
+$t->check(
+    'a directory is not a boot file',
+    'unclassified' === $page::bootFileRole($dir . '/backup')
+);
+$t->check(
+    'a file that does not exist is not a boot file',
+    'unclassified' === $page::bootFileRole($dir . '/nope')
+);
+
+// --- what each dropdown is actually offered ------------------------------
+
+$kernels = $page::kernelFileList('kernel');
+$inits = $page::kernelFileList('init');
+$payloads = $page::kernelFileList('payload');
+
+/**
+ * The reported bug, stated as an assertion. These four were offered as host
+ * kernels; three of them deliberately, because one list served both the boot
+ * kernel fields and FOG_MEMTEST_KERNEL.
+ */
+foreach (['memdisk', 'memtest.bin', 'grub.exe', 'refind.efi.new'] as $notK) {
+    $t->check(
+        $notK . ' is not offered as a kernel',
+        !in_array($notK, $kernels, true)
+    );
+}
+$t->check(
+    'refind.efi and its arch siblings are not offered as kernels',
+    !in_array('refind.efi', $kernels, true)
+    && !in_array('refind_x64.efi', $kernels, true)
+);
+$t->check(
+    'a resign working file is not offered as a kernel',
+    !in_array('bzImage.unsigned', $kernels, true)
+);
+$t->check(
+    'the web assets sharing the directory are not offered as kernels',
+    !in_array('boot.php', $kernels, true)
+    && !in_array('index.php', $kernels, true)
+    && !in_array('bg.png', $kernels, true)
+    && !in_array('refind.conf', $kernels, true)
+);
+$t->check(
+    'the TFTP backup directory is not offered as a kernel',
+    !in_array('backup', $kernels, true)
+);
+
+$gotKernels = $kernels;
+sort($gotKernels);
+$wantKernels = [
+    'arm_Image',
+    'bzImage',
+    'bzImage.20260701-093344',
+    'bzImage32',
+    'bzImage_MyHardware'
+];
+sort($wantKernels);
+$t->check(
+    'the kernels are offered, custom names and per-release siblings included',
+    $gotKernels === $wantKernels
+);
+
+$t->check(
+    'no init is offered as a kernel',
+    !in_array('init.xz', $kernels, true)
+    && !in_array('arm_init.cpio.gz', $kernels, true)
+);
+
+$t->check(
+    'the inits are offered, including a versioned sibling and lz4',
+    5 === count($inits)
+    && in_array('init.xz', $inits, true)
+    && in_array('init_32.xz', $inits, true)
+    && in_array('init.xz.20260701-093344', $inits, true)
+    && in_array('arm_init.cpio.gz', $inits, true)
+    && in_array('customInit.lz4', $inits, true)
+);
+$t->check(
+    'no kernel is offered as an init',
+    !in_array('bzImage', $inits, true)
+    && !in_array('arm_Image', $inits, true)
+);
+
+/**
+ * FOG_MEMTEST_KERNEL points at these, so narrowing the kernel list must not
+ * cost the payload field its options -- that would trade one bug for another.
+ */
+$t->check(
+    'the payload field still offers memdisk, memtest.bin and grub.exe',
+    in_array('memdisk', $payloads, true)
+    && in_array('memtest.bin', $payloads, true)
+    && in_array('grub.exe', $payloads, true)
+);
+$t->check(
+    'refind.efi.new is a payload, not hidden -- it can still be chained',
+    in_array('refind.efi.new', $payloads, true)
+    && in_array('refind.efi', $payloads, true)
+);
+$t->check(
+    'no kernel or init is offered as a payload',
+    !in_array('bzImage', $payloads, true)
+    && !in_array('init.xz', $payloads, true)
+);
+
+// --- ordering -------------------------------------------------------------
+
+$t->check(
+    'a plain name sorts above its per-release sibling',
+    array_search('bzImage', $kernels, true)
+    < array_search('bzImage.20260701-093344', $kernels, true)
+);
+
+// --- the version banner --------------------------------------------------
+
+$t->check(
+    'an x86 kernel reports the version recorded in its own setup header',
+    $kernelVersion === $page::bootFileKernelVersion($dir . '/bzImage')
+);
+$t->check(
+    'an arm64 kernel reports no version rather than inventing one',
+    '' === $page::bootFileKernelVersion($dir . '/arm_Image')
+);
+$t->check(
+    'a payload reports no version',
+    '' === $page::bootFileKernelVersion($dir . '/grub.exe')
+);
+$t->check(
+    'a kernel with no version field reports none',
+    '' === $page::bootFileKernelVersion($dir . '/memdisk')
+);
+
+// --- an unreadable directory still leaves the field editable -------------
+
+$db->responder = function ($sql, $params) {
+    if (false !== stripos($sql, 'FROM `globalSettings`')) {
+        return [
+            [
+                'settingKey' => 'FOG_TFTP_PXE_KERNEL_DIR',
+                'settingValue' => '/nonexistent/service/ipxe/'
+            ]
+        ];
+    }
+
+    return null;
+};
+FogTestHarness::setStatic('FOGBase', '_settingsCache', []);
+$t->check(
+    'a missing directory answers an empty list, not an error',
+    [] === $page::kernelFileList('kernel')
+);
+
+$t->finish();

--- a/tests/mass-edit-form.test.php
+++ b/tests/mass-edit-form.test.php
@@ -159,14 +159,38 @@ $check(
 
 // --- Value controls -------------------------------------------------------
 
-$text = $call('massEditValueControl', ['kernel', $core['kernel']]);
+/**
+ * kernelArgs, not kernel: the kernel and init fields are boot-file pickers
+ * now, and a picker reads FOG_TFTP_PXE_KERNEL_DIR to know what to offer,
+ * which this DB-free bootstrap cannot answer. Their kinds are pinned below
+ * instead, at the spec level where no render is needed.
+ */
+$text = $call('massEditValueControl', ['kernelArgs', $core['kernelArgs']]);
 $check(
     'a text value posts as value[<key>]',
-    false !== strpos($text, 'name="value[kernel]"')
+    false !== strpos($text, 'name="value[kernelArgs]"')
 );
 $check(
     'a text value renders empty -- there is no read path',
     false !== strpos($text, 'value=""')
+);
+
+/**
+ * Mass edit was left on a free-text box when the host form gained the
+ * dropdowns, so the one place a typo reaches every selected host at once was
+ * the only place offering no list to pick from.
+ */
+$check(
+    'the kernel field is a boot-file picker, not free text',
+    'kernel' === ($core['kernel']['kind'] ?? '')
+);
+$check(
+    'the init field is a boot-file picker, not free text',
+    'init' === ($core['init']['kind'] ?? '')
+);
+$check(
+    'kernel arguments stay free text -- they are not a filename',
+    'text' === ($core['kernelArgs']['kind'] ?? '')
 );
 
 $pass = $call('massEditValueControl', ['ADPass', $core['ADPass']]);


### PR DESCRIPTION
Fixes the reported bug: memdisk, memtest.bin, grub.exe and `refind.efi.new` were offered in the Host Kernel dropdown.

## Why they were there

`kernelFileList()` had **no positive test for a kernel**. An init was a name that looked like one, and a kernel was everything else that survived a blacklist of extensions:

```php
$isInit = (bool)preg_match('/(^|\/)(init|arm_init)|\.(xz|cpio\.gz)/i', $file);
if ($type === 'init' ? $isInit : !$isInit) {
```

That fails in both directions:

- **memdisk/memtest.bin/grub.exe were kept on purpose.** The same list feeds `FOG_MEMTEST_KERNEL`, which legitimately points at exactly those. One list, two meanings — so tightening it for the host field would have emptied the memtest field. The collision is written into the setting's own name: it says kernel and means payload.
- **A blacklist cannot be finished.** `.efi` covered `refind.efi`; `refind.efi.new`, left behind by an old backup script, walked straight through. Every future file dropped in that directory defaults to "kernel" under a rule of that shape — and that directory is one admins are explicitly invited to put their own files in.

Tightening the pattern to `bzImage*` would just trade one failure for the other: it throws away the hand-compiled kernel under a name FOG doesn't ship, which is half the reason the dropdown exists.

## What this does

`FOGPage::bootFileRole()` reads the file. Four roles, decided by header magic at fixed offsets:

| Role | Test |
|---|---|
| FOS Kernel | `HdrS` at 0x202 (x86 setup header) or `ARMd` at 0x38 (arm64 Image header) |
| FOS Init | initramfs archive/compression magic at offset 0 |
| Boot Payload | neither, and not one of FOG's own web assets |
| Unclassified | FOG's web assets, and `.unsigned` signing working files |

Each field asks for the role it means — host/group ask for kernels and inits, `FOG_MEMTEST_KERNEL` asks for a payload. `grub.exe` and `memdisk` are PE binaries too, so an `MZ` check alone could not have separated them; an arm64 kernel is *also* PE when built with the EFI stub, which is why its magic is checked in its own right.

`refind.efi.new` becomes a **payload** rather than being hidden — it can still be chained, so it belongs in the payload field, just never in a kernel menu.

**Pure PHP, no `file(1)` and no `attr`.** The obvious implementation was to shell out (`utils/reporting/report.sh` already runs `file(1)` over this directory), but `SELinux/fog.te` has no rule letting `httpd_t` exec `bin_t` — which is already why the Kernel Versions panel reports `Unknown` on RHEL-family servers. Building the dropdown on that mechanism would inherit the same failure and hide it the same way. One 4KiB read per file; the x86 setup header records where its own version banner lives, so `bootFileKernelVersion()` reads it without scanning a 50MB image.

Reasoning, alternatives and consequences: `docs/adr/0041-a-boot-file-is-what-its-bytes-say-not-what-its-name-says.md`.

## Also fixed — the same defect, the picker applied inconsistently

- **Mass edit** was still a free-text box (`'kind' => 'text'`). The one place a typo reaches every selected host at once was the only place offering no list.
- **The default kernel settings rendered as plain text boxes.** Their `kernelFileSelect()` case lived in `getIpxeList()`, whose `$ServicesToSee` allow-list contains none of those keys, so the switch arm never ran. Moved to `_renderSettingInput()` — what the settings page actually calls — and extended to the three init defaults (`FOG_PXE_BOOT_IMAGE`, `_32`, `_ARM`), which never had a picker at all.

## The typed failsafe

Every field keeps manual entry. The **text input carries the field name and is what posts**; the select has no name and only writes into it. So with no JavaScript the field degrades to the free-text box it was before the dropdowns landed, rather than to nothing. A stored value naming no recognised file is shown in that box with a note and saved as typed — not refused. An admin holding a known-good kernel for awkward hardware knows something the classifier does not.

## Verification

- `tests/boot-file-roles.test.php` — new, 45 checks. Builds the real on-disk shapes as a fixture directory, including the two a name-based rule gets wrong in **opposite** directions: `bzImage_MyHardware` (a hand-compiled kernel under a name FOG never ships — must be offered) and `bzImage.unsigned` (genuine kernel bytes, must **not** be). Asserts the role of every file, what each of the three dropdowns is offered, the sort order, and the version banner.
- Full `tests/*.test.php` sweep, before and after on the same box: **29 failures both times, identical set** — all traced to this Windows box having no gettext extension (`Call to undefined function _()`), not to this change. Pass count goes 218 → 219 with the new test.
- `tests/mass-edit-form.test.php` gained 3 checks and its "text field" example moved from `kernel` to `kernelArgs`, since `kernel` is a picker now. Its `massEditTabbedFields()` render made the settings read reachable in a DB-free harness, so `kernelFileList()` now answers `[]` when the setting cannot be read at all — the same degradation `kernelFileSelect()` already documents for an unreadable directory, and one field must not take a thirty-field form down with it.
- `php -l` clean on all touched files; `node --check` clean on `fog.common.js`.
- **The two `phpstan` passes were not run:** no `composer` and no `vendor/` on this box. CI is the first place they run.

## Not in this PR

- **A save-time warning.** The plan called for one; the load-time notice in the manual box covers the same ground for host, group, mass edit and settings at once, whereas a save-time warning needs threading a message out of each post handler's save closure separately. Worth doing, but as its own change rather than buried here.
- **`CONTEXT.md`.** Written locally, then found that `.gitignore` lists `CONTEXT.md` and `CONTEXT-MAP.md` deliberately — so the glossary is agent-local by repo policy and is not committed. The role definitions live in the ADR instead. If a tracked glossary is wanted, fog-docs is the place per the workspace convention. The stale `docs/agents/domain.md` pointer in `CLAUDE.md` is repointed; the two neighbouring pointers to that same non-existent directory (`issue-tracker.md`, `triage-labels.md`) are left alone as a separate concern.

## One consequence worth a reviewer's eye

The listing now reads every file in the directory rather than only its names. The cost is bounded — 4KiB each, a directory of tens of files — but it is no longer free, and it happens on every render of a host form, a group form, the mass edit modal and the settings page. Caching the answer wants somewhere to cache it, which is the next piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYw9JCZGPeHuse6RTyNPgs
