### PR TITLE
Fix two PKI records that do not survive the next installer run

### DIFF
--- a/docs/FOGSETTINGS.md
+++ b/docs/FOGSETTINGS.md
@@ -64,7 +64,7 @@ in this area:
 |---|---|---|
 | **Preference** | The admin's decision. Persisted so it survives an upgrade, and *nothing* may silently reverse it | `PKI_sb_enabled`, `SVC_firewall_control`, `FOG_update_channel`, `FOG_install_mode`, `PKI_internal_subnets`, `BOOT_kernel_backups_kept`, `WEB_url_primary` |
 | **Record** | Written so it can be read back for reference. The installer recomputes the real value every run and ignores what is stored | `FOG_program_dir`, `FOG_git_path`, `FOG_packages`, `WEB_php_version`, `BOOT_url_proto`, most canonical `PKI_*` paths |
-| **Honored record** | Recomputed only while it still holds one of the installer's own defaults; any other value is left alone on every run, so the admin may point it at their own file | `PKI_web_vhost_cert`, `PKI_web_vhost_key`, `PKI_web_trust_chain` |
+| **Honored record** | Recomputed only while it still holds one of the installer's own defaults; any other value is left alone on every run, so the admin may point it at their own file | `PKI_web_vhost_cert`, `PKI_web_vhost_key`, `PKI_web_trust_chain`, `PKI_client_encrypt_cert`, `PKI_client_encrypt_key` |
 | **Hand-set** | Nothing in the installer writes it; it survives only because the merge preserves unknown lines | `inetConnectTimeout`, `inetMaxTime`, `storageLocationCapture`, `ftppasvmin`/`ftppasvmax`, `mcastportmin`/`mcastportmax` |
 | **Inferred preference** | A preference the installer may write *once* from what it observed, and then treats as the admin's | `WEB_https_redirect`, `BOOT_url_proto_forced` |
 
@@ -208,8 +208,14 @@ the same treatment via `resolvedfoggitpath`.
 `FOG_program_dir` is therefore a **record** of where the install is, written from
 the live variable. `settingLine()` resolves values by indirect expansion
 (`${!key}`), so that record needs its own explicit assignment in
-`writeUpdateFile()` or the emitted line would simply be empty. The same applies
-to `PKI_client_encrypt_cert`/`_key`.
+`writeUpdateFile()` or the emitted line would simply be empty.
+
+`PKI_client_encrypt_cert`/`_key` need an assignment there for the same reason,
+but they are **honored records**, not plain ones: the assignment goes through
+`_clientLeafTarget()`, which answers the client zone path for an unset or
+FOG-owned value and leaves an admin's own path -- from `--client-cert` /
+`--client-key` -- untouched. Assigning the zone path directly recorded FOG's
+file over the admin's, so the relocation was silently gone by the next run.
 
 Renaming the `fog.conf` variable is a separate change: every existing server
 already carries the old spelling in that file.

--- a/docs/PKI_ZONES.md
+++ b/docs/PKI_ZONES.md
@@ -458,12 +458,27 @@ installs, not storage nodes — see
 [MULTI_SERVER_CA.md](MULTI_SERVER_CA.md), which covers this flag set applied
 across a fleet and the alternatives to it.
 
-**The Client Communication zone is not replaceable this way, deliberately.**
-It is anchored at the certificate every fog-client has pinned, so replacing it
-means re-deploying trust to every registered machine. That is possible — push
-the new `ca.cert.der` by GPO or by reinstalling fog-client — but there is no
-built-in path for it, because there is no way to do it without touching every
-endpoint.
+**The Client Communication zone's CA is not replaceable this way, deliberately.**
+The zone is anchored at the certificate every fog-client has pinned, so
+replacing that *authority* means re-deploying trust to every registered
+machine. That is possible — push the new `ca.cert.der` by GPO or by
+reinstalling fog-client — but there is no built-in path for it, because there is
+no way to do it without touching every endpoint.
+
+Relocating the zone's **leaf** is a different thing, and is supported:
+`--client-cert` and `--client-key` name your own communication keypair, and FOG
+points its canonical names at it rather than issuing its own. The two keys are
+recorded as `PKI_client_encrypt_cert` and `PKI_client_encrypt_key`, and survive
+every later run.
+
+Two things to know before using them. If the material differs from what the
+server issued before, that **is** a re-pin event for every registered client —
+the installer compares fingerprints and says so, but it will not stop you. And
+the private key must stay readable by the web server, because
+`FOGBase::certDecrypt()` opens it on every client `authorize()`; the installer
+sets `0640 root:<apache user>` on the file itself and warns if the web user
+still cannot read it, which is what an untraversable parent directory looks
+like.
 
 **If your CA carries `pathlen:0`** — an ordinary thing for an enterprise to
 issue — it cannot anchor an intermediate. The installer detects this, says so,

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -6710,11 +6710,45 @@ _hardenPkiPermissions() {
     # going through the compat link would work by accident -- but it silently
     # does nothing at all on the run before the link exists, and names the wrong
     # thing in the error log when it fails.
+    #
+    # This now retargets an admin's own file when --client-cert/--client-key
+    # relocated the keypair, and that is deliberate rather than incidental.
+    # certDecrypt() opens this key on every fog-client authorize(), so it HAS to
+    # be readable by the web user; the web leaf's key is exempted from hardening
+    # because an ACME client owns and rewrites it, and nothing owns this one.
     if [[ -f ${PKI_client_encrypt_key} ]]; then
         chown root:${apacheuser} "${PKI_client_encrypt_key}" >>$error_log 2>&1
         chmod 0640 "${PKI_client_encrypt_key}" >>$error_log 2>&1
     fi
     errorStat $?
+    # A chown on the file cannot fix an unreadable PARENT, so a relocated key
+    # under, say, /root/ still leaves every client failing to authenticate with
+    # "Private key not readable" as the only clue -- per client, and naming
+    # nothing. Ask the question the web tier will ask, as the user it will ask
+    # it as, and say so here where somebody is watching.
+    #
+    # runuser then su, the same fallback _keaValidate() uses, and NOT sudo: sudo
+    # needs a sudoers rule for root -> ${apacheuser} that a hardened box may not
+    # have, and a warning that fires because the TEST could not run is worse
+    # than no warning at all. When neither tool is present the check is skipped
+    # rather than guessed.
+    if [[ -f ${PKI_client_encrypt_key} ]]; then
+        commReadable=""
+        if command -v runuser >/dev/null 2>&1; then
+            runuser -u "${apacheuser}" -- test -r "${PKI_client_encrypt_key}" \
+                >>$error_log 2>&1 && commReadable=yes || commReadable=no
+        elif command -v su >/dev/null 2>&1; then
+            su -s /bin/sh -c "test -r '${PKI_client_encrypt_key}'" "${apacheuser}" \
+                >>$error_log 2>&1 && commReadable=yes || commReadable=no
+        fi
+        if [[ $commReadable == no ]]; then
+            echo " * The web server cannot read the client communication key:"
+            echo "     ${PKI_client_encrypt_key}"
+            echo "   Every fog-client will fail to authenticate until it can."
+            echo "   Check that ${apacheuser} can traverse each parent directory."
+        fi
+        unset commReadable
+    fi
     # configureSnapins now prunes ${PKI_client_cert_dir}, so its recursive relabel no longer
     # reaches here either. Re-assert it, or SELinux denies the web tier the
     # read the mode above just granted.
@@ -7125,8 +7159,26 @@ writeUpdateFile() {
         # overwriting it: _customPkiDir() echoes $PKI_custom_dir when that is
         # already set, and only falls back to the default when it is not.
         PKI_custom_dir="$(_customPkiDir)"
-        PKI_client_encrypt_key="$(_pkiZoneDir client)/leaf/.srvprivate.key"
-        PKI_client_encrypt_cert="$(_pkiZoneDir client)/leaf/.srvpublic.crt"
+        # Through _clientLeafTarget(), NOT straight to the zone path, for the
+        # same reason as the two above: --client-cert/--client-key name the
+        # admin's own comm keypair, and assigning the zone path here recorded
+        # FOG's file over theirs. The next run sourced that, and the relocation
+        # was gone with nothing reported -- while installfog.sh's own flag
+        # gating already assumes these keys persist across runs, which is the
+        # promise this restores rather than a new one.
+        #
+        # Safe to call from here: _clientLeafTarget is pure -- readlink -f and
+        # nothing else, no mkdir and no writes -- and it already answers the
+        # zone path for an unset record, for the zone path itself, for the
+        # historic canonical name, and for a recorded path that no longer
+        # exists. Same three arguments _resolveClientLeafPaths passes, so the
+        # two cannot disagree about what counts as FOG's own file.
+        PKI_client_encrypt_key="$(_clientLeafTarget "${PKI_client_encrypt_key}" \
+            "$(_pkiZoneDir client)/leaf/.srvprivate.key" \
+            "${PKI_client_cert_dir}/.srvprivate.key")"
+        PKI_client_encrypt_cert="$(_clientLeafTarget "${PKI_client_encrypt_cert}" \
+            "$(_pkiZoneDir client)/leaf/.srvpublic.crt" \
+            "${PKI_client_cert_dir}/.srvpublic.crt")"
     fi
 
     # Managed keys, in the canonical order a freshly written file uses. This one
@@ -7497,12 +7549,19 @@ writeUpdateFile() {
                 printf '## Canonical certificate paths. The installer recomputes most of these\n'
                 printf '## every run, so editing one here moves nothing.\n'
                 printf '##\n'
-                printf '## The exceptions are PKI_web_vhost_cert, PKI_web_vhost_key and\n'
-                printf '## PKI_web_trust_chain. To serve a certificate FOG did not issue you may\n'
-                printf '## either leave those alone and make each path resolve to your file (a\n'
-                printf '## symlink is enough), or set them to where your files really are -- the\n'
-                printf '## installer only resets one of them while it still holds a default of\n'
-                printf '## its own. Either way FOG stops re-issuing that leaf.\n'
+                printf '## The exceptions are PKI_web_vhost_cert, PKI_web_vhost_key,\n'
+                printf '## PKI_web_trust_chain, PKI_client_encrypt_cert and\n'
+                printf '## PKI_client_encrypt_key. To serve or use a certificate FOG did not\n'
+                printf '## issue you may either leave those alone and make each path resolve to\n'
+                printf '## your file (a symlink is enough), or set them to where your files\n'
+                printf '## really are -- the installer only resets one of them while it still\n'
+                printf '## holds a default of its own. Either way FOG stops re-issuing it.\n'
+                printf '##\n'
+                printf '## The two client_encrypt keys are the fog-client communication keypair,\n'
+                printf '## normally set with --client-cert/--client-key. Relocating them is a\n'
+                printf '## re-pin event if the material differs: the installer says so, and the\n'
+                printf '## key must stay readable by the web server or no client can\n'
+                printf '## authenticate.\n'
                 printf '##\n'
                 printf '## Simplest of all: drop web-leaf.pem and web-leaf.key into\n'
                 printf '## PKI_custom_dir above and re-run the installer, which finds the pair\n'
@@ -9429,6 +9488,20 @@ _separateCommKey() {
     # _externallyManagedLeaf asks of the web leaf.
     zonedir=$(readlink -f "$(_pkiZoneDir client)" 2>/dev/null)
     [[ -n $zonedir && $target == "$zonedir"/* ]] && return 0
+    # And FOG's own compat link at the ADMIN's file is equally not something to
+    # separate -- it is what --client-cert/--client-key mean. The zone test
+    # above cannot see that case, because the whole point of a relocated comm
+    # keypair is that it lives outside the zone.
+    #
+    # Without this the relocation unwinds itself on the very next run: the link
+    # is dereferenced, the admin's key is copied back into $snapindir/ssl as a
+    # REAL file, and _resolveClientLeafPaths' migrate loop then moves that file
+    # into the zone -- so FOG quietly takes ownership of key material the admin
+    # asked it only to point at. The record surviving writeUpdateFile is what
+    # makes this test possible; the two halves are one fix.
+    [[ -n ${PKI_client_encrypt_key} \
+        && $target == "$(readlink -f "${PKI_client_encrypt_key}" 2>/dev/null)" ]] \
+        && return 0
     dots "Separating the client communication key from the web key"
     rm -f "$canon" >>$error_log 2>&1
     cp -f "$target" "$canon" >>$error_log 2>&1

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -5785,9 +5785,10 @@ _installPkiAdminHelper() {
         # filesystem could disagree; deriving it in two places from the same
         # test keeps that property.
         echo "PKI_WEB_ZONE_DIR=${webdir}"
-        # The canonical home for a root imported from the page. Not the
-        # admin's own path: --ca-root persists the SOURCE, which is routinely
-        # a temp file that is gone by the next run.
+        # The canonical home for an imported root, whichever route it came
+        # in by -- the page's import-root writes here, and since GH-1683 so
+        # does --ca-root, which used to record its own source path and so
+        # named a temp file that was gone by the next run.
         echo "PKI_EXTERNAL_ROOT=${webdir}/ca/.externalRoot.pem"
         echo "PKI_CLIENT_CERT=${PKI_client_encrypt_cert}"
         if [[ -f $sbca ]]; then
@@ -6105,9 +6106,12 @@ _resolveTrustAnchor() {
     #
     # Additive and idempotent everywhere else: on a full --external-ca install
     # this certificate is already in the chain above, so the fingerprint check
-    # collapses it. The -f guard matters -- validateExternalCA persists the
-    # admin's SOURCE path, which is routinely a temp file that is gone by the
-    # next run.
+    # collapses it. The -f guard is belt and braces now rather than
+    # load-bearing: validateExternalCA used to persist the admin's SOURCE
+    # path, routinely a temp file gone by the next run, so this silently
+    # anchored nothing on most external-CA servers (GH-1683). Both import
+    # routes now record the canonical copy, and the guard stays only for a
+    # file an admin has since deleted by hand.
     if [[ -n ${PKI_web_external_root_cert} && -f ${PKI_web_external_root_cert} ]]; then
         local tmpd extroot
         tmpd=$(mktemp -d 2>>$error_log)
@@ -7866,6 +7870,12 @@ validateExternalCA() {
     cp "$keysrc" "$destdir/$destkey" >>$error_log 2>&1
     cat "$rootsrc" "$certsrc" > "$destdir/$destchain" 2>>$error_log
     chmod 600 "$destdir/$destkey" >>$error_log 2>&1
+    # The root as well, under the name the Certificates page's helper already
+    # publishes as PKI_EXTERNAL_ROOT. Copied here rather than merely referenced
+    # for the same reason as the three above -- and see the persisted slot below
+    # for what recording the source path instead used to cost.
+    cp "$rootsrc" "$destdir/.externalRoot.pem" >>$error_log 2>&1
+    chmod 0644 "$destdir/.externalRoot.pem" >>$error_log 2>&1
     # ${PKI_web_ca_key}/${PKI_web_ca_cert}/${PKI_web_trust_chain} name the CA that signs the vhost leaf --
     # which is what an external CA replaces, and all it replaces. The root that
     # fog-client pins is ${PKI_root_ca_cert} and is not touched here.
@@ -7877,7 +7887,16 @@ validateExternalCA() {
     # and _resolveTrustAnchor() reads it back out from here -- conflating it
     # with the root fog-client pins is exactly the mistake the three-zone split
     # exists to prevent.
-    PKI_web_external_root_cert="$rootsrc"
+    #
+    # The CANONICAL copy, not $rootsrc. --ca-root is routinely handed a temp
+    # file, so recording the source left this key naming something that no
+    # longer existed by the next run: _resolveTrustAnchor()'s -f guard then made
+    # the miss silent, and GH-1121's fix -- reading this key so an import is not
+    # undone by the next installer run -- held only for roots imported through
+    # the Certificates page. fog-pki-admin's setPreferencePath() has always
+    # recorded the canonical path; this is the CLI half catching up, and it puts
+    # both import routes on one file.
+    PKI_web_external_root_cert="$destdir/.externalRoot.pem"
     errorStat $?
     # iPXE's verifier is narrower than openssl's, and THIS certificate is the
     # one it gets: _resolveIpxeTrust() sets ${ipxetrust} to ${PKI_web_ca_cert},

--- a/tests/client-cert-flags.test.sh
+++ b/tests/client-cert-flags.test.sh
@@ -238,6 +238,87 @@ _discardOrphanedCommLeaf
     && ok "a matching pair is left alone" \
     || bad "a matching pair was deleted"
 
+# --- the record has to SURVIVE writeUpdateFile, and the next run ------------
+# The resolver above was already correct; the bug was that writeUpdateFile then
+# assigned the zone path over its answer, so `--client-cert/--client-key` were
+# honored for exactly one run and silently reverted. Nothing tested
+# writeUpdateFile against these keys at all, which is how that survived.
+#
+# Two passes, because one pass cannot see the bug: pass one held the admin's
+# path in the live variable regardless, and only the FILE it wrote was wrong.
+run2work="$WORK/tworun"
+fogprogramdir="$run2work/opt/fog"
+snapindir="$fogprogramdir/snapins"
+PKI_client_cert_dir="$snapindir/ssl"
+# Into the scratch tree, or _pkiRootDir() reaches for the host's own /etc/fog
+# and _pkiZoneDir client resolves outside anything this test created.
+PKI_root_dir="$fogprogramdir/pki"
+mkdir -p "${PKI_client_cert_dir}" "$fogprogramdir/pki/client/leaf"
+apacheuser="${apacheuser:-www-data}"
+version="1.6.0"
+PKI_client_encrypt_cert="$WORK/a.crt"
+PKI_client_encrypt_key="$WORK/a.key"
+
+# writeUpdateFile reads a great deal of the install's state. Give it only what
+# it needs to emit a file; every unset managed key emits an empty line, which is
+# fine here -- the two keys under test are what this asserts.
+writeUpdateFile >/dev/null 2>&1
+
+settings="$fogprogramdir/.fogsettings"
+[[ -f $settings ]] \
+    && ok "writeUpdateFile emitted a settings file" \
+    || bad "writeUpdateFile wrote no settings file"
+
+is "${PKI_client_encrypt_key}" "$WORK/a.key" \
+   "pass 1: the live key still names the admin's file after writeUpdateFile"
+is "${PKI_client_encrypt_cert}" "$WORK/a.crt" \
+   "pass 1: the live cert still names the admin's file after writeUpdateFile"
+is "$(sed -n "s/^PKI_client_encrypt_key='\(.*\)'$/\1/p" "$settings")" "$WORK/a.key" \
+   "pass 1: the RECORDED key is the admin's file, not the zone path"
+is "$(sed -n "s/^PKI_client_encrypt_cert='\(.*\)'$/\1/p" "$settings")" "$WORK/a.crt" \
+   "pass 1: the RECORDED cert is the admin's file, not the zone path"
+
+# Pass two is the run that used to lose it: read the file back the way the
+# installer does, then resolve and record again with no flags passed.
+unset PKI_client_encrypt_key PKI_client_encrypt_cert
+. "$settings" >/dev/null 2>&1
+is "${PKI_client_encrypt_key}" "$WORK/a.key" \
+   "pass 2: sourcing .fogsettings hands back the admin's key"
+
+_resolveClientLeafPaths >/dev/null 2>&1
+is "${PKI_client_encrypt_key}" "$WORK/a.key" \
+   "pass 2: _resolveClientLeafPaths keeps it"
+writeUpdateFile >/dev/null 2>&1
+is "$(sed -n "s/^PKI_client_encrypt_key='\(.*\)'$/\1/p" "$settings")" "$WORK/a.key" \
+   "pass 2: the record survives a second run with no flags"
+
+# And the compat link must still POINT at the admin's file, because that is what
+# FOGBase::certDecrypt() opens -- it hardcodes the .srvprivate.key filename and
+# never reads PKI_client_encrypt_key. A link into the zone here means every
+# fog-client authenticates against the wrong key, or none.
+_linkClientLeafCompat >/dev/null 2>&1
+[[ -L "${PKI_client_cert_dir}/.srvprivate.key" ]] \
+    && ok "the canonical name is a symlink, not a copy of the key" \
+    || bad "the canonical name is not a symlink -- the key was duplicated"
+is "$(readlink -f "${PKI_client_cert_dir}/.srvprivate.key")" "$(readlink -f "$WORK/a.key")" \
+   "the canonical name resolves to the admin's key"
+
+# _separateCommKey runs FIRST in createSSLCA, before the resolver, and used to
+# know only about the client zone. FOG's own compat link at the admin's file
+# resolves outside that zone, so it dereferenced the link and copied the key
+# back into $snapindir/ssl as a real file -- which the resolver's migrate loop
+# then moved into the zone. That unwound the relocation on every run, and left a
+# private key lying in the directory the snapin replicator walks.
+_separateCommKey >/dev/null 2>&1
+[[ -L "${PKI_client_cert_dir}/.srvprivate.key" ]] \
+    && ok "_separateCommKey leaves FOG's own link at the admin's file alone" \
+    || bad "_separateCommKey dereferenced the link and copied the admin's key"
+is "$(readlink -f "${PKI_client_cert_dir}/.srvprivate.key")" "$(readlink -f "$WORK/a.key")" \
+   "and it still resolves to the admin's key"
+[[ ! -f "$fogprogramdir/pki/client/leaf/.srvprivate.key" ]] \
+    && ok "the admin's key was not migrated into FOG's zone" \
+    || bad "the admin's key material was moved into FOG's own zone"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]] || exit 1
 exit 0

--- a/tests/trust-anchor.test.sh
+++ b/tests/trust-anchor.test.sh
@@ -274,9 +274,10 @@ else
     bad "I: _resolveTrustAnchor returned non-zero"
 fi
 
-# Case J -- validateExternalCA persists the admin's SOURCE path, which is
-# routinely a temp file that is gone by the next run. That must be a no-op,
-# not a failure.
+# Case J -- a recorded imported root that is no longer on disk must be a
+# no-op, not a failure. Until GH-1683 this was the COMMON case, because
+# validateExternalCA persisted the admin's source path; both import routes now
+# record a canonical copy, so it is what is left: a file deleted by hand.
 newcase J
 PKI_root_ca_cert="$WORK/fog/root.pem"
 PKI_web_external_root_cert="$WORK/this-file-was-deleted.pem"
@@ -297,6 +298,54 @@ if _resolveTrustAnchor; then
 else
     bad "K: _resolveTrustAnchor returned non-zero with an imported root present"
 fi
+
+# Case L -- the recorded path must OUTLIVE the source (GH-1683).
+#
+# validateExternalCA used to persist $rootsrc, the path the admin passed to
+# --ca-root, which is routinely a temp file. By the next run the key named
+# something that no longer existed, so case J's skip -- correct in itself -- was
+# what actually happened on most external-CA servers, and the imported root
+# quietly stopped being anchored. It now records the canonical copy beside the
+# rest of the imported zone, which is the same file the Certificates page's
+# helper writes.
+#
+# Driving the real validateExternalCA needs the two output helpers stubbed:
+# errorStat exits on a non-zero status, which inside a test reads as a pass.
+newcase L
+# newcase already points $fogprogramdir and PKI_root_dir into the scratch tree.
+dots() { :; }
+errorStat() { :; }
+PKI_root_ca_cert="$WORK/fog/root.pem"
+# A source that is deleted straight after the import, exactly as a temp file is.
+cp "$WORK/ext/root.pem" "$WORK/L-source-root.pem"
+cp "$WORK/ext/int.pem" "$WORK/L-source-int.pem"
+cp "$WORK/ext/int.key" "$WORK/L-source-int.key"
+importWebCACert="$WORK/L-source-int.pem"
+importWebCAKey="$WORK/L-source-int.key"
+importWebCARoot="$WORK/L-source-root.pem"
+
+validateExternalCA web >/dev/null 2>&1
+
+canonroot="$(_pkiZoneDir web)/ca/.externalRoot.pem"
+[[ -f $canonroot ]] \
+    && ok "L: the imported root is copied into the zone" \
+    || bad "L: no canonical copy of the imported root was written"
+check "${PKI_web_external_root_cert}" "$canonroot" \
+    "L: the CANONICAL path is recorded, not the admin's source"
+
+# The whole point: delete the source the way a temp file goes, and the anchor
+# must still pick the imported root up.
+rm -f "$WORK/L-source-root.pem"
+if _resolveTrustAnchor; then
+    check "$(count_certs "$trustAnchorPem")" "2" \
+        "L: the anchor still carries the imported root after the source is gone"
+    has_fp "$trustAnchorPem" "$EXTROOT_FP" \
+        && ok "L: and it is the imported root" \
+        || bad "L: the imported root is not in the anchor"
+else
+    bad "L: _resolveTrustAnchor returned non-zero after the source was removed"
+fi
+unset importWebCACert importWebCAKey importWebCARoot
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
Closes #1682. Closes #1683.

Both were found while investigating certificate customization for #1681 and filed rather than folded in. They are the same class of defect — **a `PKI_*` path the installer records that the next run silently replaces or cannot find** — which is why they share a PR, one commit each.

## #1682 — a relocated client communication keypair

`--client-cert`/`--client-key` were honored for the run they were passed and silently reverted afterwards. **Two code paths did it, and fixing either alone leaves the other.**

`writeUpdateFile()` assigned the client zone path straight over `PKI_client_encrypt_key`/`_cert` before recording them. They are live variables, not record-locals, so the admin's path — honored during the run by `_clientLeafTarget()` — was overwritten in `.fogsettings` and the next run sourced FOG's own file back. They now record through `_clientLeafTarget()`, which is pure (`readlink -f`, no writes) and already answers the zone path for an unset record, the zone path itself, the historic canonical name, and a path that no longer exists. Same shape `PKI_root_dir` and `PKI_custom_dir` two lines above already use; ADR 0040 already named this pair as the defect not to copy.

`_separateCommKey()` was the subtler path. It runs first in `createSSLCA()` and exempted only a symlink resolving *inside* the client zone — but the whole point of a relocated keypair is that it lives outside it. So on the next run it dereferenced FOG's own compat link, copied the admin's key back into `$snapindir/ssl` as a real file, and `_resolveClientLeafPaths`' migrate loop then moved that file into the zone: FOG quietly took ownership of key material it had been asked only to *point at*, leaving a private key in the directory the snapin replicator walks. It now also exempts a link resolving to the recorded `PKI_client_encrypt_key`.

### Client communication is unaffected by design — this was the thing to be sure of

- **fog-client depends on URLs, not server paths.** It fetches `management/other/ssl/srvpublic.crt`, a **copy** made from the record, and pins `ca.cert.der` derived from `PKI_root_ca_cert`, untouched here. Relocating the record changes which file is copied, never the URL.
- **PHP never reads `PKI_client_encrypt_key`.** `FOGBase::certDecrypt()` hardcodes `${sslbase}/.srvprivate.key` — *".srvprivate.key, always"* — so it opens the **canonical name**, and `_linkClientLeafCompat()` connects that name to the real file *from the record*. A correct record is what makes the symlink correct; the reverted record is what made it wrong.
- **Changing the material is a separate, already-handled event** — that is a re-pin, and `_warnClientRepin()` warns on a fingerprint difference. This fix makes that warning *more* accurate, because it no longer compares the wrong file.

`_hardenPkiPermissions` keeps its `chown root:$apacheuser` / `chmod 0640`, and that now retargets the admin's file deliberately: `certDecrypt()` opens this key on every `authorize()`, so it **has** to be web-readable. The web leaf's key is exempt from hardening because an ACME client owns and rewrites it; nothing owns this one. What a chown cannot fix is an unreadable **parent** — a key under `/root/` leaves every client failing with `Private key not readable` as the only clue, per client, naming nothing — so the run now asks the question the web tier will ask, as the user it will ask it as. `runuser` then `su`, the fallback `_keaValidate()` already uses, and deliberately **not** `sudo`: sudo needs a root→apache rule a hardened box may not have, and a warning that fires because the *test* could not run is worse than no warning. Neither tool present means the check is skipped, never guessed.

Fixing the record also fixes the Certificates page for free — `_installPkiAdminHelper()` writes `PKI_CLIENT_KEY`/`PKI_CLIENT_CERT` from these live variables, so the page was inspecting FOG's zone path even on the run that honored the flags.

## #1683 — the imported external root

`validateExternalCA()` persisted `$rootsrc`, the path handed to `--ca-root`, routinely a temp file. The bytes were always safe; the recorded *pointer* died with the file. `_resolveTrustAnchor()` re-reads that key on every run specifically so an imported root is not dropped from the anchor, and guards with `-f`, so it degraded silently — which is why nobody noticed that GH-1121's fix held only for roots imported through the Certificates page.

The root is now copied to `$destdir/.externalRoot.pem` and *that* is recorded. For the web zone `$destdir` is `$(_pkiZoneDir web)/ca`, exactly the `PKI_EXTERNAL_ROOT` the helper already publishes — so **both import routes converge on one file**, with no new key and no new config. Deriving the name from `$destdir` also keeps the currently-unreachable root/flat zone correct by construction. Two comments that documented the bug as a known workaround are corrected.

## Verification

New coverage:

- `tests/client-cert-flags.test.sh` had **no `writeUpdateFile` coverage at all**, which is how #1682 survived the GH-1120 rename. It gains a two-run case — one pass cannot see the bug, since pass one held the right value in the variable and only the file it wrote was wrong. **Fails 11 of 13 assertions with the fix reverted.**
- `tests/trust-anchor.test.sh` gains case L, driving the real `validateExternalCA`. **Fails 2 of 4 with the fix reverted**; the other two pass either way because `PKI_web_trust_chain` carries the root by a second route, which is why the canonical-path assertions are the ones that pin this. Case J's comment is corrected in the same pass — its assertion is still right, but until now the case it calls an exception was the common one.

Adjacent suites checked against `git stash` baselines and **identical before and after**: `client-zone-migration` (33/2), `pki-idempotence` (2/1), `external-cert-detection` (25/4), `node-cert-external-ca` (fixture error). Fully green: `fogsettings-migration` (40/0), `install-settings-resolution` (50/0), `client-repin-warning` (12/0).

**Honest note on local runs.** This was developed on Windows, where Git Bash rewrites `openssl -subj "/CN=..."` into a Windows path and `ln -s` copies instead of linking — so `client-cert-flags` and `trust-anchor` die building their own fixtures and cannot run here at all. Both new cases were therefore verified by standalone probes using the `//CN=` MSYS escape and `MSYS=winsymlinks:nativestrict`, replicating each case assertion for assertion, and re-run with the fixes reverted to confirm they fail. **CI is the first place the new cases run inside their real suites.**

Not covered by any test, and worth a manual pass on a real server:

```bash
./installfog.sh -y --client-cert /etc/pki/comm.crt --client-key /etc/pki/comm.key
grep '^PKI_client_encrypt' /opt/fog/.fogsettings   # must name /etc/pki/*
./installfog.sh -y
grep '^PKI_client_encrypt' /opt/fog/.fogsettings   # must STILL name /etc/pki/*
ls -l /opt/fog/snapins/ssl/.srvprivate.key         # a symlink, not a copy
readlink -f /opt/fog/snapins/ssl/.srvprivate.key   # /etc/pki/comm.key
```

Then load a page that decrypts client traffic and confirm no `Private key not readable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNj39e7pDke6Rr6Whxin9U
