### PR TITLE
Read the boot file metadata that can be read, and say why for the rest

### DIFF
--- a/docs/adr/0042-the-filesystem-is-the-inventory-the-database-records-judgments.md
+++ b/docs/adr/0042-the-filesystem-is-the-inventory-the-database-records-judgments.md
@@ -1,0 +1,117 @@
+# The filesystem is the inventory; the database records judgments about it
+
+## Status
+
+accepted
+
+## Context
+
+FOG deliberately has no manifest of boot files. Two places say so in their own
+words. `bin/restorekernel.sh`:
+
+> Reports the FOS release a file came from using the xattr `downloadfiles()`
+> stamps at download time, so a generation is self-describing and there is no
+> manifest to drift out of sync.
+
+And `lib/common/functions.sh`, on using `cp -a` for the generations:
+
+> preserves the version/tag_name xattrs ... so every generation says which FOS
+> release it came from without a separate manifest to keep in sync.
+
+That reasoning is sound and this decision does not dispute it. A record of
+*which files exist* would be wrong for exactly the stated reason: an admin
+copies a kernel into that directory by hand, and any table claiming to list
+the directory is now lying with no event to correct it.
+
+Three things pushed against it anyway.
+
+**Role classification is no longer free.** ADR 0041 replaced a filename test
+with reading each file's header magic. That is one 4KiB read per file — cheap
+in isolation, but it happens on every render of a host form, a group form, the
+mass edit modal and the settings page, for every file in the directory.
+
+**Two facts have nowhere to live.** An admin's pin ("no pruner may delete
+this") is an intention; nothing on disk carries it. And the FOS release tag has
+the opposite problem: it exists *only* as an extended attribute, and it is
+frequently unreadable.
+
+**The unreadable half is worse than it looks.** PHP has no xattr reader — the
+PECL extension is absent on every server this runs on and this codebase has
+never used it — so reaching the tag means running `attr`. On an
+SELinux-enforcing RHEL-family server that exec is denied outright:
+`SELinux/fog.te` carries no rule letting `httpd_t` execute `bin_t`. It also
+fails on a mount without `user_xattr`, and wherever the `attr` package was
+skipped. So on a large class of servers the tag is not slow to read, it is
+**permanently unreadable from the web tier** — and the old panel rendered that,
+along with six other distinct causes, as the single word `Unknown`.
+
+## Decision
+
+### 1. Existence is read, never recorded
+
+Whether a file is there, how big it is, and when it changed are read live on
+every listing. There is no reconciliation step, no orphan sweep, and no way for
+the records to disagree with the directory about what is in it. A kernel copied
+in by hand appears on the next listing; one deleted by hand stops appearing.
+The no-manifest principle is intact for the thing it was about.
+
+### 2. The `bootFile` row holds only what the directory cannot say
+
+| Column | Why it cannot be read from the directory |
+|---|---|
+| `bfRole` | derivable, but only by reading the file. A cache. |
+| `bfKernelVersion` | same — from the image's own header. A cache. |
+| `bfChecksum` | same — but expensive enough to be worth keeping. |
+| `bfReleaseTag` | **not a cache.** May be unreadable forever on this server. |
+| `bfPinned` | an admin's intention. Nothing on disk carries it. |
+
+`bfSize` and `bfMtime` are the cache *key*, not the inventory. A file whose
+stat has moved is re-read; one whose stat matches is trusted.
+
+### 3. A tag once read is never discarded
+
+The three cache columns can be thrown away and recomputed. The release tag
+cannot, so it is stored the first time it can be read at all and served from
+the row after that. A later read that fails does **not** clear it.
+
+This matters most where the read works exactly once: `kernelfetch()` already
+runs `attr -s` over SSH at download time, so a server that can never read the
+tag from a page render can still have recorded it when the file arrived.
+
+### 4. A failed read reports which failure it was
+
+`bootFileXattr()` runs `attr` through `proc_open`, captures stderr and the exit
+status, and answers `['value' => ..., 'reason' => ...]` where exactly one of
+the two is ever empty. "attr is not installed on this server", "this filesystem
+does not carry extended attributes" and "not recorded on this file" are three
+different problems with three different fixes, and collapsing them into
+`Unknown` is what made the panel useless rather than merely incomplete.
+
+`-q` is passed, which the old call site omitted — without it `attr -g` prints a
+header line before the value, and the old code took `tail -n1` and hoped.
+
+### 5. The records are an accelerator, never a dependency
+
+Every read and write against them is wrapped and failure is silent. A listing
+renders with the table missing, unreachable or empty; a cache write that does
+not land costs one re-read on the next listing and nothing else. Rendering a
+list of kernels is not the moment to fail a page because a cache write failed.
+
+## Consequences
+
+- **The kernel version stops depending on the shell entirely.** That is the
+  column most often blank, and it is now read from bytes on every platform.
+  Only the release tag still needs `attr`.
+- The first listing after this lands inspects every file in the boot directory
+  and hashes it. Kernels are tens of megabytes, so that is a visible one-time
+  cost per file, paid again only when a file's stat changes.
+- `bfChecksum` is written before anything reads it. It is what lets two names
+  be known to be the same kernel, which is what a count-based retention policy
+  needs to avoid keeping three copies of one kernel and calling it three
+  versions.
+- A stale row can outlive its file. Nothing breaks — the row is simply never
+  consulted again, because lookups start from a directory listing — but a tidy
+  sweep is a reasonable thing to add later.
+- This table is **not** REST-exposed: no `Route::$validClasses` entry and no
+  OpenAPI change. The shape should prove itself in the UI before anything
+  outside FOG depends on it.

--- a/packages/web/commons/schema-expected.php
+++ b/packages/web/commons/schema-expected.php
@@ -140,6 +140,21 @@ return [
                 'alSpanID' => 'varchar(32) NOT NULL DEFAULT \'\'',
             ],
         ],
+        'bootFile' => [
+            'create' => 'CREATE TABLE IF NOT EXISTS `bootFile` ( `bfID` int(11) NOT NULL AUTO_INCREMENT, `bfName` varchar(191) NOT NULL DEFAULT \'\', `bfSize` bigint(20) NOT NULL DEFAULT 0, `bfMtime` datetime DEFAULT NULL, `bfChecksum` varchar(64) NOT NULL DEFAULT \'\', `bfRole` varchar(20) NOT NULL DEFAULT \'unclassified\', `bfKernelVersion` varchar(191) NOT NULL DEFAULT \'\', `bfReleaseTag` varchar(191) NOT NULL DEFAULT \'\', `bfInspected` datetime DEFAULT NULL, `bfPinned` tinyint(1) NOT NULL DEFAULT 0, PRIMARY KEY (`bfID`), UNIQUE KEY `bfName` (`bfName`), KEY `bfRole` (`bfRole`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
+            'columns' => [
+                'bfID' => 'int(11) NOT NULL',
+                'bfName' => 'varchar(191) NOT NULL DEFAULT \'\'',
+                'bfSize' => 'bigint(20) NOT NULL DEFAULT 0',
+                'bfMtime' => 'datetime DEFAULT NULL',
+                'bfChecksum' => 'varchar(64) NOT NULL DEFAULT \'\'',
+                'bfRole' => 'varchar(20) NOT NULL DEFAULT \'unclassified\'',
+                'bfKernelVersion' => 'varchar(191) NOT NULL DEFAULT \'\'',
+                'bfReleaseTag' => 'varchar(191) NOT NULL DEFAULT \'\'',
+                'bfInspected' => 'datetime DEFAULT NULL',
+                'bfPinned' => 'tinyint(1) NOT NULL DEFAULT 0',
+            ],
+        ],
         'clientUpdates' => [
             'create' => 'CREATE TABLE IF NOT EXISTS `clientUpdates` ( `cuID` int(11) NOT NULL AUTO_INCREMENT, `cuName` varchar(200) NOT NULL DEFAULT \'\', `cuMD5` varchar(100) NOT NULL DEFAULT \'\', `cuType` varchar(30) NOT NULL DEFAULT \'\', `cuFile` longblob NOT NULL DEFAULT \'\', PRIMARY KEY (`cuID`), KEY `new_index` (`cuName`), KEY `new_index1` (`cuType`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC',
             'columns' => [

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -10704,3 +10704,58 @@ $this->schema[] = [
     . "first and read the log before choosing Enforce.','log',"
     . "'General Settings')",
 ];
+
+// 414
+$this->schema[] = [
+    // What FOG has decided about each file in the FOS boot directory.
+    //
+    // The filesystem stays the inventory: existence, size and mtime are read
+    // live on every listing, so a file copied in by hand appears and one
+    // deleted by hand disappears with nothing to reconcile. This table holds
+    // only what the directory cannot tell us --
+    //
+    //   bfRole            the answer bootFileRole() read out of the bytes,
+    //                     cached so a page render costs a stat rather than a
+    //                     4KiB read of every file in the directory.
+    //   bfKernelVersion   the banner the x86 setup header points at. Also
+    //                     just a cache; it is re-readable at any time.
+    //   bfReleaseTag      the FOS release. NOT a cache -- this one may be
+    //                     unrecoverable. It lives in an extended attribute,
+    //                     PHP has no xattr reader (the PECL extension is
+    //                     absent everywhere and this codebase has never used
+    //                     it), and `attr` is unavailable to the web user on
+    //                     any SELinux-enforcing RHEL-family server, on a
+    //                     mount without user_xattr, and wherever the package
+    //                     was skipped. So it is stored the first time it can
+    //                     be read at all and served from here afterward.
+    //   bfPinned          "no pruner may delete this". Nothing on disk can
+    //                     carry an admin's intent.
+    //
+    // bfSize and bfMtime are NOT the inventory -- they are the cache key.
+    // A file whose stat has moved is re-read; one whose stat matches is
+    // trusted.
+    //
+    // Its own table rather than globalSettings rows, for the reason step 397
+    // gives for storageEpoch: the configuration page renders every row of
+    // that table with no WHERE and `setting` is a routed class, so per-file
+    // records there would be one careless edit away from changing what an
+    // unrelated file means. Keyed on the filename because that is what every
+    // caller has in hand -- a host's hostKernel column, a dropdown's posted
+    // value, a pruner's directory entry. Content identity is bfChecksum's
+    // job, and two names sharing a checksum are the same kernel twice.
+    "CREATE TABLE IF NOT EXISTS `bootFile` ( "
+    . "`bfID` int(11) NOT NULL AUTO_INCREMENT, "
+    . "`bfName` varchar(191) NOT NULL DEFAULT '', "
+    . "`bfSize` bigint(20) NOT NULL DEFAULT 0, "
+    . "`bfMtime` datetime DEFAULT NULL, "
+    . "`bfChecksum` varchar(64) NOT NULL DEFAULT '', "
+    . "`bfRole` varchar(20) NOT NULL DEFAULT 'unclassified', "
+    . "`bfKernelVersion` varchar(191) NOT NULL DEFAULT '', "
+    . "`bfReleaseTag` varchar(191) NOT NULL DEFAULT '', "
+    . "`bfInspected` datetime DEFAULT NULL, "
+    . "`bfPinned` tinyint(1) NOT NULL DEFAULT 0, "
+    . "PRIMARY KEY (`bfID`), "
+    . "UNIQUE KEY `bfName` (`bfName`), "
+    . "KEY `bfRole` (`bfRole`) "
+    . ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci ROW_FORMAT=DYNAMIC",
+];

--- a/packages/web/management/js/fog/about/fog.about.home.js
+++ b/packages/web/management/js/fog/about/fog.about.home.js
@@ -12,7 +12,56 @@
     }
   });
 
-  // Storage Node version and kernel version information.
+  /**
+   * Escape a value from the node before putting it in the page.
+   *
+   * These rows carry filenames off a disk and version banners out of a
+   * kernel image, so they are data, not markup.
+   */
+  function esc(v) {
+    return $('<div>').text(v === null || v === undefined ? '' : v).html();
+  }
+
+  function bootFileTable(data) {
+    var rows = data.rows || [],
+      html = '',
+      i,
+      row;
+    if (!rows.length) {
+      return '<div class="alert alert-warning">' + esc(data.empty_lang)
+        + '</div>';
+    }
+    html = '<table class="table table-striped">'
+      + '<tbody>'
+      + '<tr>'
+      + '<th>' + esc(data.file_lang) + '</th>'
+      + '<th>' + esc(data.role_lang) + '</th>'
+      + '<th>' + esc(data.version_lang) + '</th>'
+      + '<th>' + esc(data.release_lang) + '</th>'
+      + '<th>' + esc(data.ins_lang) + '</th>'
+      + '</tr>';
+    for (i = 0; i < rows.length; i++) {
+      row = rows[i];
+      html += '<tr>'
+        + '<td>' + esc(row.name) + '</td>'
+        + '<td>' + esc(row.role_label || row.role) + '</td>'
+        // A value that could not be read says so, in muted text. It used to
+        // render as "Unknown" whatever the reason was.
+        + '<td>' + (row.version
+          ? esc(row.version)
+          : '<span class="text-muted">' + esc(data.unreadable_lang)
+            + '</span>') + '</td>'
+        + '<td>' + (row.release
+          ? esc(row.release)
+          : '<span class="text-muted">' + esc(row.note) + '</span>') + '</td>'
+        + '<td>' + esc(row.installed) + '</td>'
+        + '</tr>';
+    }
+
+    return html + '</tbody></table>';
+  }
+
+  // Storage Node version and boot file information.
   $('.kernvers').each(function() {
     URL = $(this).attr('urlcall');
     newelement = document.createElement('a');
@@ -31,94 +80,42 @@
           $(this).text('No data returned');
           return;
         }
-        data = JSON.parse(data);
-        let [int64_relk, int64_ver, int64k_ins] = data.int64bit.split('|');
-        let [int32_relk, int32_ver, int32k_ins] = data.int32bit.split('|');
-        let [arm64_relk, arm64_ver, arm64k_ins] = data.arm64bit.split('|');
-        let [int64_rel, int64_brt, int64i_ins] = data.initI64.split('|');
-        let [int32_rel, int32_brt, int32i_ins] = data.initI32.split('|');
-        let [arm64_rel, arm64_brt, arm64i_ins] = data.initA64.split('|');
+        // The master proxies this request to the node, so a node that is
+        // unreachable, or answering with an error page, arrives here as a
+        // body that is not JSON. Parsing it unguarded threw and left the
+        // panel blank, which looks identical to a node with nothing
+        // installed.
+        if (typeof data === 'string') {
+          try {
+            data = JSON.parse(data);
+          } catch (e) {
+            $(this).html(
+                '<div class="alert alert-warning">'
+                + esc('Storage Node did not return boot file information')
+                + '</div>'
+            );
+            return;
+          }
+        }
         $(this).html(
             '<div class="card">'
             + '<div class="card-header">'
-            + '<h4 class="card-title">' + data.node_version_lang + '</h4>'
+            + '<h4 class="card-title">' + esc(data.node_version_lang)
+            + '</h4>'
             + '</div>'
             + '<div class="card-body">'
-            + data.node_vers
+            + esc(data.node_vers)
             + '</div>'
             + '</div>'
             + '<div class="card">'
             + '<div class="card-header">'
-            + '<h4 class="card-title">' + data.kern_version_lang + '</h4>'
+            + '<h4 class="card-title">' + esc(data.boot_files_lang) + '</h4>'
             + '</div>'
             + '<div class="card-body">'
-            + '<table class="table table-striped">'
-            + '<tbody>'
-            + '<tr>'
-            + '<th>' + data.arch_lang + '</th>'
-            + '<th>' + data.rel_lang + '</th>'
-            + '<th>' + data.kern_lang + '</th>'
-            + '<th>' + data.ins_lang + '</th>'
-            + '</tr>'
-            + '<tr>'
-            + '<td>' + data.intel64_lang + '</td>'
-            + '<td>' + int64_relk + '</td>'
-            + '<td>' + int64_ver + '</td>'
-            + '<td>' + int64k_ins + '</td>'
-            + '</tr>'
-            + '<tr>'
-            + '<td>' + data.intel32_lang + '</td>'
-            + '<td>' + int32_relk + '</td>'
-            + '<td>' + int32_ver + '</td>'
-            + '<td>' + int32k_ins + '</td>'
-            + '</tr>'
-            + '<tr>'
-            + '<td>' + data.arm64_lang + '</td>'
-            + '<td>' + arm64_relk + '</td>'
-            + '<td>' + arm64_ver + '</td>'
-            + '<td>' + arm64k_ins + '</td>'
-            + '</tr>'
-            + '</tbody>'
-            + '</table>'
-            + '</div>'
-            + '</div>'
-            + '<div class="card">'
-            + '<div class="card-header">'
-            + '<h4 class="card-title">' + data.init_version_lang + '</h4>'
-            + '</div>'
-            + '<div class="card-body">'
-            + '<table class="table table-striped">'
-            + '<tbody>'
-            + '<tr>'
-            + '<th>' + data.arch_lang + '</th>'
-            + '<th>' + data.rel_lang + '</th>'
-            + '<th>' + data.build_lang + '</th>'
-            + '<th>' + data.ins_lang + '</th>'
-            + '</tr>'
-            + '<tr>'
-            + '<td>' + data.intel64_lang + '</td>'
-            + '<td>' + int64_rel + '</td>'
-            + '<td>' + int64_brt + '</td>'
-            + '<td>' + int64i_ins + '</td>'
-            + '</tr>'
-            + '<tr>'
-            + '<td>' + data.intel32_lang + '</td>'
-            + '<td>' + int32_rel + '</td>'
-            + '<td>' + int32_brt + '</td>'
-            + '<td>' + int32i_ins + '</td>'
-            + '</tr>'
-            + '<tr>'
-            + '<td>' + data.arm64_lang + '</td>'
-            + '<td>' + arm64_rel + '</td>'
-            + '<td>' + arm64_brt + '</td>'
-            + '<td>' + arm64i_ins + '</td>'
-            + '</tr>'
-            + '</tbody>'
-            + '</table>'
+            + bootFileTable(data)
             + '</div>'
             + '</div>'
         );
-        console.log(data);
       },
       error: function(jqXHR, textStatus, errorThrown) {
         $(this).text(textStatus);

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1309,8 +1309,15 @@ msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passre
 msgstr ""
 
 #, fuzzy
+msgid "Boot Files"
+msgstr "Boot-Optionen:"
+
+#, fuzzy
 msgid "Boot Options"
 msgstr "Boot-Optionen:"
+
+msgid "Boot Payload"
+msgstr ""
 
 msgid "Boot files from"
 msgstr ""
@@ -1363,10 +1370,6 @@ msgstr "browse"
 #, fuzzy
 msgid "Building the blobs failed."
 msgstr "Laden fehlgeschlagen: %s"
-
-#, fuzzy
-msgid "Buildroot Version"
-msgstr "Client-Version"
 
 #, php-format
 msgid "Bulk edit %s"
@@ -2946,6 +2949,17 @@ msgstr ""
 msgid "FOG will refuse these deploy tasks. Assign an image built for the same architecture, or capture one."
 msgstr ""
 
+#, fuzzy
+msgid "FOS Init"
+msgstr "Host Init"
+
+#, fuzzy
+msgid "FOS Kernel"
+msgstr "Kernel"
+
+msgid "FOS Release"
+msgstr ""
+
 msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
@@ -4499,10 +4513,6 @@ msgid "Init images."
 msgstr "Ungültiges Image"
 
 #, fuzzy
-msgid "InitRD Versions"
-msgstr "Client-Version"
-
-#, fuzzy
 msgid "Initial Template"
 msgstr "ursprüngliches Template"
 
@@ -4862,13 +4872,6 @@ msgstr "Kernel-Update"
 #, fuzzy
 msgid "Kernel Update Fail"
 msgstr "Kernel-Update"
-
-#, fuzzy
-msgid "Kernel Version"
-msgstr "Kernel-Versionen"
-
-msgid "Kernel Versions"
-msgstr "Kernel-Versionen"
 
 #, fuzzy
 msgid "Kernels present on disk"
@@ -5921,6 +5924,9 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr "Keine Datei wurde hochgeladen"
 
+msgid "No boot files found. Check FOG_TFTP_PXE_KERNEL_DIR."
+msgstr ""
+
 #, fuzzy
 msgid "No certificate file was uploaded"
 msgstr "Keine Datei wurde hochgeladen"
@@ -6213,10 +6219,6 @@ msgstr "Nicht verfügbar"
 #, fuzzy
 msgid "Not Found"
 msgstr "Icon-Datei nicht gefunden"
-
-#, fuzzy
-msgid "Not Installed"
-msgstr "Installierte Plugins"
 
 msgid "Not Registered Hosts"
 msgstr "Nicht registrierte Hosts"
@@ -7301,10 +7303,6 @@ msgstr "Registriert"
 
 msgid "Registered Hosts"
 msgstr "Registrierte Hosts"
-
-#, fuzzy
-msgid "Release Version"
-msgstr "Neueste Version"
 
 #, php-format
 msgid "Reloaded %d setting(s) into cache"
@@ -9749,7 +9747,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Bereits registriert als"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy
@@ -10893,6 +10891,13 @@ msgstr "da der FOG versuchen wird, mit dem Internet zu verbinden, "
 msgid "as its primary group"
 msgstr "als primäre Gruppe finden"
 
+msgid "attr could not be run -- SELinux may be denying it"
+msgstr ""
+
+#, fuzzy
+msgid "attr is not installed on this server"
+msgstr "Es gibt keine Gruppen auf diesem Server."
+
 msgid "automatically"
 msgstr "einen neuen Knoten zu finden"
 
@@ -11412,6 +11417,14 @@ msgid "not reachable"
 msgstr "Nicht verfügbar"
 
 #, fuzzy
+msgid "not readable"
+msgstr "Nicht verfügbar"
+
+#, fuzzy
+msgid "not recorded on this file"
+msgstr "auf diesem Knoten nicht gefunden"
+
+#, fuzzy
 msgid "ntfy Accounts"
 msgstr "Slack Accounts"
 
@@ -11597,6 +11610,10 @@ msgstr ""
 msgid "the Linux kernel which is used to"
 msgstr "aktualisieren, der genutzt wird um"
 
+#, fuzzy
+msgid "the file cannot be read"
+msgstr " | Datei oder Pfad ist nicht erreichbar"
+
 msgid "the following command in a terminal"
 msgstr "den folgenden Terminalbefehlen tun"
 
@@ -11612,6 +11629,12 @@ msgstr ""
 
 #, php-format
 msgid "the local login form stays available at %s"
+msgstr ""
+
+msgid "the web server may not read this file"
+msgstr ""
+
+msgid "the web server may not run external commands"
 msgstr ""
 
 #, fuzzy
@@ -11630,6 +11653,9 @@ msgstr ""
 
 msgid "this backup will enable you to return to the"
 msgstr "wird dieses Backup helfen, zur vorherigen"
+
+msgid "this filesystem does not carry extended attributes"
+msgstr ""
 
 #, fuzzy
 msgid "this image is taking on the server."
@@ -11922,6 +11948,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Attempting to ping host"
 #~ msgstr "Versuche, anzupingen"
+
+#, fuzzy
+#~ msgid "Buildroot Version"
+#~ msgstr "Client-Version"
 
 #, fuzzy
 #~ msgid "Bulk Changes"
@@ -12276,6 +12306,10 @@ msgstr ""
 #~ msgstr "Benutzer importieren"
 
 #, fuzzy
+#~ msgid "InitRD Versions"
+#~ msgstr "Client-Version"
+
+#, fuzzy
 #~ msgid "Install"
 #~ msgstr "Installierte Plugins"
 
@@ -12290,6 +12324,13 @@ msgstr ""
 #, fuzzy
 #~ msgid "Inventory Report"
 #~ msgstr "Inventar"
+
+#, fuzzy
+#~ msgid "Kernel Version"
+#~ msgstr "Kernel-Versionen"
+
+#~ msgid "Kernel Versions"
+#~ msgstr "Kernel-Versionen"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -12357,6 +12398,10 @@ msgstr ""
 #~ msgstr "Admingruppe"
 
 #, fuzzy
+#~ msgid "Not Installed"
+#~ msgstr "Installierte Plugins"
+
+#, fuzzy
 #~ msgid "Pause"
 #~ msgstr "Pause"
 
@@ -12389,6 +12434,10 @@ msgstr ""
 
 #~ msgid "Register must be managed from hooks or events"
 #~ msgstr "Register muss von Haken oder Ereignissen gemanagt werden"
+
+#, fuzzy
+#~ msgid "Release Version"
+#~ msgstr "Neueste Version"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1313,8 +1313,15 @@ msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passre
 msgstr ""
 
 #, fuzzy
+msgid "Boot Files"
+msgstr "Boot Options:"
+
+#, fuzzy
 msgid "Boot Options"
 msgstr "Boot Options:"
+
+msgid "Boot Payload"
+msgstr ""
 
 msgid "Boot files from"
 msgstr ""
@@ -1367,10 +1374,6 @@ msgstr ""
 #, fuzzy
 msgid "Building the blobs failed."
 msgstr "Load failed: %s"
-
-#, fuzzy
-msgid "Buildroot Version"
-msgstr "CPU Version"
 
 #, php-format
 msgid "Bulk edit %s"
@@ -2948,6 +2951,17 @@ msgstr ""
 msgid "FOG will refuse these deploy tasks. Assign an image built for the same architecture, or capture one."
 msgstr ""
 
+#, fuzzy
+msgid "FOS Init"
+msgstr "Host List"
+
+#, fuzzy
+msgid "FOS Kernel"
+msgstr "Kernel"
+
+msgid "FOS Release"
+msgstr ""
+
 msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
@@ -4501,10 +4515,6 @@ msgid "Init images."
 msgstr "Invalid image"
 
 #, fuzzy
-msgid "InitRD Versions"
-msgstr "CPU Version"
-
-#, fuzzy
 msgid "Initial Template"
 msgstr "Snapin Template"
 
@@ -4864,13 +4874,6 @@ msgstr "Kernel Update"
 #, fuzzy
 msgid "Kernel Update Fail"
 msgstr "Kernel Update"
-
-#, fuzzy
-msgid "Kernel Version"
-msgstr "Kernel Versions"
-
-msgid "Kernel Versions"
-msgstr "Kernel Versions"
 
 #, fuzzy
 msgid "Kernels present on disk"
@@ -5933,6 +5936,9 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr "No file was uploaded"
 
+msgid "No boot files found. Check FOG_TFTP_PXE_KERNEL_DIR."
+msgstr ""
+
 #, fuzzy
 msgid "No certificate file was uploaded"
 msgstr "No file was uploaded"
@@ -6225,10 +6231,6 @@ msgstr "Not Available"
 #, fuzzy
 msgid "Not Found"
 msgstr "Icon File not found"
-
-#, fuzzy
-msgid "Not Installed"
-msgstr "Installed Plugins"
 
 msgid "Not Registered Hosts"
 msgstr "Not Registered Hosts"
@@ -7312,10 +7314,6 @@ msgstr "Registered"
 
 msgid "Registered Hosts"
 msgstr "Registered Hosts"
-
-#, fuzzy
-msgid "Release Version"
-msgstr "Latest Version"
 
 #, php-format
 msgid "Reloaded %d setting(s) into cache"
@@ -9757,7 +9755,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Already registered as"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy
@@ -10899,6 +10897,13 @@ msgstr ""
 msgid "as its primary group"
 msgstr "Update Primary Group"
 
+msgid "attr could not be run -- SELinux may be denying it"
+msgstr ""
+
+#, fuzzy
+msgid "attr is not installed on this server"
+msgstr "There are no groups on this server."
+
 msgid "automatically"
 msgstr ""
 
@@ -11417,6 +11422,14 @@ msgid "not reachable"
 msgstr "Not Available"
 
 #, fuzzy
+msgid "not readable"
+msgstr "Not Available"
+
+#, fuzzy
+msgid "not recorded on this file"
+msgstr "Image not found on node"
+
+#, fuzzy
 msgid "ntfy Accounts"
 msgstr "Slack Accounts"
 
@@ -11601,6 +11614,10 @@ msgstr ""
 msgid "the Linux kernel which is used to"
 msgstr ""
 
+#, fuzzy
+msgid "the file cannot be read"
+msgstr " | File or path cannot be reached"
+
 msgid "the following command in a terminal"
 msgstr ""
 
@@ -11618,6 +11635,12 @@ msgstr ""
 msgid "the local login form stays available at %s"
 msgstr ""
 
+msgid "the web server may not read this file"
+msgstr ""
+
+msgid "the web server may not run external commands"
+msgstr ""
+
 #, fuzzy
 msgid "there one enabled within this Storage Group"
 msgstr "Could not find a Storage Node Is there one enabled within this Storage Group"
@@ -11633,6 +11656,9 @@ msgid "this account has no role, so it has no access to any management page. Ask
 msgstr ""
 
 msgid "this backup will enable you to return to the"
+msgstr ""
+
+msgid "this filesystem does not carry extended attributes"
 msgstr ""
 
 #, fuzzy
@@ -11922,6 +11948,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Attempting to ping host"
 #~ msgstr "Attempting to ping"
+
+#, fuzzy
+#~ msgid "Buildroot Version"
+#~ msgstr "CPU Version"
 
 #, fuzzy
 #~ msgid "Bulk Changes"
@@ -12267,6 +12297,10 @@ msgstr ""
 #~ msgstr "Import Users"
 
 #, fuzzy
+#~ msgid "InitRD Versions"
+#~ msgstr "CPU Version"
+
+#, fuzzy
 #~ msgid "Install"
 #~ msgstr "Installed Plugins"
 
@@ -12281,6 +12315,13 @@ msgstr ""
 #, fuzzy
 #~ msgid "Inventory Report"
 #~ msgstr "Inventory"
+
+#, fuzzy
+#~ msgid "Kernel Version"
+#~ msgstr "Kernel Versions"
+
+#~ msgid "Kernel Versions"
+#~ msgstr "Kernel Versions"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -12337,6 +12378,10 @@ msgstr ""
 #~ msgstr "Modify Group"
 
 #, fuzzy
+#~ msgid "Not Installed"
+#~ msgstr "Installed Plugins"
+
+#, fuzzy
 #~ msgid "Pause"
 #~ msgstr "User"
 
@@ -12362,6 +12407,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Product Keys"
 #~ msgstr "Host Product Key"
+
+#, fuzzy
+#~ msgid "Release Version"
+#~ msgstr "Latest Version"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1328,8 +1328,15 @@ msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passre
 msgstr ""
 
 #, fuzzy
+msgid "Boot Files"
+msgstr "Opciones de arranque:"
+
+#, fuzzy
 msgid "Boot Options"
 msgstr "Opciones de arranque:"
+
+msgid "Boot Payload"
+msgstr ""
 
 msgid "Boot files from"
 msgstr ""
@@ -1384,10 +1391,6 @@ msgstr ""
 #, fuzzy
 msgid "Building the blobs failed."
 msgstr "Carga ha fallado: %s"
-
-#, fuzzy
-msgid "Buildroot Version"
-msgstr "Versión de la CPU"
 
 #, php-format
 msgid "Bulk edit %s"
@@ -2987,6 +2990,17 @@ msgstr ""
 msgid "FOG will refuse these deploy tasks. Assign an image built for the same architecture, or capture one."
 msgstr ""
 
+#, fuzzy
+msgid "FOS Init"
+msgstr "ID de host"
+
+#, fuzzy
+msgid "FOS Kernel"
+msgstr "Núcleo"
+
+msgid "FOS Release"
+msgstr ""
+
 msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
@@ -4578,10 +4592,6 @@ msgid "Init images."
 msgstr "carpeta no válida"
 
 #, fuzzy
-msgid "InitRD Versions"
-msgstr "Versión de la CPU"
-
-#, fuzzy
 msgid "Initial Template"
 msgstr "snapin replicador"
 
@@ -4955,13 +4965,6 @@ msgstr "Nombre del núcleo"
 #, fuzzy
 msgid "Kernel Update Fail"
 msgstr "Nombre del núcleo"
-
-#, fuzzy
-msgid "Kernel Version"
-msgstr "Las versiones del kernel"
-
-msgid "Kernel Versions"
-msgstr "Las versiones del kernel"
 
 #, fuzzy
 msgid "Kernels present on disk"
@@ -6038,6 +6041,9 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr "Ningún archivo fue subido"
 
+msgid "No boot files found. Check FOG_TFTP_PXE_KERNEL_DIR."
+msgstr ""
+
 #, fuzzy
 msgid "No certificate file was uploaded"
 msgstr "Ningún archivo fue subido"
@@ -6336,10 +6342,6 @@ msgstr "No disponible"
 #, fuzzy
 msgid "Not Found"
 msgstr "Icono de archivo no encontrado"
-
-#, fuzzy
-msgid "Not Installed"
-msgstr "Instalador inteligente (recomendado)"
 
 #, fuzzy
 msgid "Not Registered Hosts"
@@ -7437,10 +7439,6 @@ msgstr "Registrado"
 #, fuzzy
 msgid "Registered Hosts"
 msgstr "Registrado"
-
-#, fuzzy
-msgid "Release Version"
-msgstr "Versión del sistema"
 
 #, php-format
 msgid "Reloaded %d setting(s) into cache"
@@ -9920,7 +9918,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Impresora ya existe"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy
@@ -11064,6 +11062,13 @@ msgstr ""
 msgid "as its primary group"
 msgstr "Actualización de Grupo Primario"
 
+msgid "attr could not be run -- SELinux may be denying it"
+msgstr ""
+
+#, fuzzy
+msgid "attr is not installed on this server"
+msgstr "No hay grupos en este servidor."
+
 msgid "automatically"
 msgstr ""
 
@@ -11581,6 +11586,14 @@ msgstr "No se encontró Clase FOGPage para este nodo"
 msgid "not reachable"
 msgstr "No disponible"
 
+#, fuzzy
+msgid "not readable"
+msgstr "No disponible"
+
+#, fuzzy
+msgid "not recorded on this file"
+msgstr "No se encontró Clase FOGPage para este nodo"
+
 msgid "ntfy Accounts"
 msgstr ""
 
@@ -11764,6 +11777,10 @@ msgstr ""
 msgid "the Linux kernel which is used to"
 msgstr ""
 
+#, fuzzy
+msgid "the file cannot be read"
+msgstr "No se pudo leer el archivo temporal"
+
 msgid "the following command in a terminal"
 msgstr ""
 
@@ -11781,6 +11798,12 @@ msgstr ""
 msgid "the local login form stays available at %s"
 msgstr ""
 
+msgid "the web server may not read this file"
+msgstr ""
+
+msgid "the web server may not run external commands"
+msgstr ""
+
 msgid "there one enabled within this Storage Group"
 msgstr ""
 
@@ -11795,6 +11818,9 @@ msgid "this account has no role, so it has no access to any management page. Ask
 msgstr ""
 
 msgid "this backup will enable you to return to the"
+msgstr ""
+
+msgid "this filesystem does not carry extended attributes"
 msgstr ""
 
 #, fuzzy
@@ -12080,6 +12106,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "An accesscontrol with this name already exists!"
 #~ msgstr "Sesión con ese nombre ya existe"
+
+#, fuzzy
+#~ msgid "Buildroot Version"
+#~ msgstr "Versión de la CPU"
 
 #, fuzzy
 #~ msgid "Bulk Changes"
@@ -12436,6 +12466,10 @@ msgstr ""
 #~ msgstr "Importar"
 
 #, fuzzy
+#~ msgid "InitRD Versions"
+#~ msgstr "Versión de la CPU"
+
+#, fuzzy
 #~ msgid "Install"
 #~ msgstr "Instalador inteligente (recomendado)"
 
@@ -12450,6 +12484,13 @@ msgstr ""
 #, fuzzy
 #~ msgid "Inventory Report"
 #~ msgstr "ID de inventario"
+
+#, fuzzy
+#~ msgid "Kernel Version"
+#~ msgstr "Las versiones del kernel"
+
+#~ msgid "Kernel Versions"
+#~ msgstr "Las versiones del kernel"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -12508,6 +12549,10 @@ msgstr ""
 #~ msgstr "modificar Grupo"
 
 #, fuzzy
+#~ msgid "Not Installed"
+#~ msgstr "Instalador inteligente (recomendado)"
+
+#, fuzzy
 #~ msgid "Pause"
 #~ msgstr "Usuario"
 
@@ -12525,6 +12570,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Product Keys"
 #~ msgstr "Clave del producto Grupo"
+
+#, fuzzy
+#~ msgid "Release Version"
+#~ msgstr "Versión del sistema"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1309,8 +1309,15 @@ msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passre
 msgstr ""
 
 #, fuzzy
+msgid "Boot Files"
+msgstr "Boot-Optionen:"
+
+#, fuzzy
 msgid "Boot Options"
 msgstr "Boot-Optionen:"
+
+msgid "Boot Payload"
+msgstr ""
 
 msgid "Boot files from"
 msgstr ""
@@ -1363,10 +1370,6 @@ msgstr "browse"
 #, fuzzy
 msgid "Building the blobs failed."
 msgstr "Laden fehlgeschlagen: %s"
-
-#, fuzzy
-msgid "Buildroot Version"
-msgstr "Client-Version"
 
 #, php-format
 msgid "Bulk edit %s"
@@ -2946,6 +2949,17 @@ msgstr ""
 msgid "FOG will refuse these deploy tasks. Assign an image built for the same architecture, or capture one."
 msgstr ""
 
+#, fuzzy
+msgid "FOS Init"
+msgstr "Host Init"
+
+#, fuzzy
+msgid "FOS Kernel"
+msgstr "Kernel"
+
+msgid "FOS Release"
+msgstr ""
+
 msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
@@ -4499,10 +4513,6 @@ msgid "Init images."
 msgstr "Ungültiges Image"
 
 #, fuzzy
-msgid "InitRD Versions"
-msgstr "Client-Version"
-
-#, fuzzy
 msgid "Initial Template"
 msgstr "ursprüngliches Template"
 
@@ -4863,13 +4873,6 @@ msgstr "Kernel-Update"
 #, fuzzy
 msgid "Kernel Update Fail"
 msgstr "Kernel-Update"
-
-#, fuzzy
-msgid "Kernel Version"
-msgstr "Kernel-Versionen"
-
-msgid "Kernel Versions"
-msgstr "Kernel-Versionen"
 
 #, fuzzy
 msgid "Kernels present on disk"
@@ -5922,6 +5925,9 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr "Keine Datei wurde hochgeladen"
 
+msgid "No boot files found. Check FOG_TFTP_PXE_KERNEL_DIR."
+msgstr ""
+
 #, fuzzy
 msgid "No certificate file was uploaded"
 msgstr "Keine Datei wurde hochgeladen"
@@ -6214,10 +6220,6 @@ msgstr "Nicht verfügbar"
 #, fuzzy
 msgid "Not Found"
 msgstr "Icon-Datei nicht gefunden"
-
-#, fuzzy
-msgid "Not Installed"
-msgstr "Installierte Plugins"
 
 msgid "Not Registered Hosts"
 msgstr "Nicht registrierte Hosts"
@@ -7302,10 +7304,6 @@ msgstr "Registriert"
 
 msgid "Registered Hosts"
 msgstr "Registrierte Hosts"
-
-#, fuzzy
-msgid "Release Version"
-msgstr "Neueste Version"
 
 #, php-format
 msgid "Reloaded %d setting(s) into cache"
@@ -9750,7 +9748,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Bereits registriert als"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy
@@ -10894,6 +10892,13 @@ msgstr "da der FOG versuchen wird, mit dem Internet zu verbinden, "
 msgid "as its primary group"
 msgstr "als primäre Gruppe finden"
 
+msgid "attr could not be run -- SELinux may be denying it"
+msgstr ""
+
+#, fuzzy
+msgid "attr is not installed on this server"
+msgstr "Es gibt keine Gruppen auf diesem Server."
+
 msgid "automatically"
 msgstr "einen neuen Knoten zu finden"
 
@@ -11413,6 +11418,14 @@ msgid "not reachable"
 msgstr "Nicht verfügbar"
 
 #, fuzzy
+msgid "not readable"
+msgstr "Nicht verfügbar"
+
+#, fuzzy
+msgid "not recorded on this file"
+msgstr "auf diesem Knoten nicht gefunden"
+
+#, fuzzy
 msgid "ntfy Accounts"
 msgstr "Slack Accounts"
 
@@ -11598,6 +11611,10 @@ msgstr ""
 msgid "the Linux kernel which is used to"
 msgstr "aktualisieren, der genutzt wird um"
 
+#, fuzzy
+msgid "the file cannot be read"
+msgstr " | Datei oder Pfad ist nicht erreichbar"
+
 msgid "the following command in a terminal"
 msgstr "den folgenden Terminalbefehlen tun"
 
@@ -11613,6 +11630,12 @@ msgstr ""
 
 #, php-format
 msgid "the local login form stays available at %s"
+msgstr ""
+
+msgid "the web server may not read this file"
+msgstr ""
+
+msgid "the web server may not run external commands"
 msgstr ""
 
 #, fuzzy
@@ -11631,6 +11654,9 @@ msgstr ""
 
 msgid "this backup will enable you to return to the"
 msgstr "wird dieses Backup helfen, zur vorherigen"
+
+msgid "this filesystem does not carry extended attributes"
+msgstr ""
 
 #, fuzzy
 msgid "this image is taking on the server."
@@ -11923,6 +11949,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Attempting to ping host"
 #~ msgstr "Versuche, anzupingen"
+
+#, fuzzy
+#~ msgid "Buildroot Version"
+#~ msgstr "Client-Version"
 
 #, fuzzy
 #~ msgid "Bulk Changes"
@@ -12277,6 +12307,10 @@ msgstr ""
 #~ msgstr "Benutzer importieren"
 
 #, fuzzy
+#~ msgid "InitRD Versions"
+#~ msgstr "Client-Version"
+
+#, fuzzy
 #~ msgid "Install"
 #~ msgstr "Installierte Plugins"
 
@@ -12291,6 +12325,13 @@ msgstr ""
 #, fuzzy
 #~ msgid "Inventory Report"
 #~ msgstr "Inventar"
+
+#, fuzzy
+#~ msgid "Kernel Version"
+#~ msgstr "Kernel-Versionen"
+
+#~ msgid "Kernel Versions"
+#~ msgstr "Kernel-Versionen"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -12358,6 +12399,10 @@ msgstr ""
 #~ msgstr "Admingruppe"
 
 #, fuzzy
+#~ msgid "Not Installed"
+#~ msgstr "Installierte Plugins"
+
+#, fuzzy
 #~ msgid "Pause"
 #~ msgstr "Pause"
 
@@ -12390,6 +12435,10 @@ msgstr ""
 
 #~ msgid "Register must be managed from hooks or events"
 #~ msgstr "Register muss von Haken oder Ereignissen gemanagt werden"
+
+#, fuzzy
+#~ msgid "Release Version"
+#~ msgstr "Neueste Version"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1314,8 +1314,15 @@ msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passre
 msgstr ""
 
 #, fuzzy
+msgid "Boot Files"
+msgstr "Options de démarrage:"
+
+#, fuzzy
 msgid "Boot Options"
 msgstr "Options de démarrage:"
+
+msgid "Boot Payload"
+msgstr ""
 
 msgid "Boot files from"
 msgstr ""
@@ -1368,10 +1375,6 @@ msgstr ""
 #, fuzzy
 msgid "Building the blobs failed."
 msgstr "Échec du chargement: %s"
-
-#, fuzzy
-msgid "Buildroot Version"
-msgstr "CPU Version"
 
 #, php-format
 msgid "Bulk edit %s"
@@ -2949,6 +2952,17 @@ msgstr ""
 msgid "FOG will refuse these deploy tasks. Assign an image built for the same architecture, or capture one."
 msgstr ""
 
+#, fuzzy
+msgid "FOS Init"
+msgstr "Liste des hôtes"
+
+#, fuzzy
+msgid "FOS Kernel"
+msgstr "Noyau"
+
+msgid "FOS Release"
+msgstr ""
+
 msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
@@ -4502,10 +4516,6 @@ msgid "Init images."
 msgstr "Invalid image"
 
 #, fuzzy
-msgid "InitRD Versions"
-msgstr "CPU Version"
-
-#, fuzzy
 msgid "Initial Template"
 msgstr "snapin Template"
 
@@ -4865,13 +4875,6 @@ msgstr "Kernel Update"
 #, fuzzy
 msgid "Kernel Update Fail"
 msgstr "Kernel Update"
-
-#, fuzzy
-msgid "Kernel Version"
-msgstr "Kernel versions"
-
-msgid "Kernel Versions"
-msgstr "Kernel versions"
 
 #, fuzzy
 msgid "Kernels present on disk"
@@ -5920,6 +5923,9 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr "Aucun fichier a été téléchargé"
 
+msgid "No boot files found. Check FOG_TFTP_PXE_KERNEL_DIR."
+msgstr ""
+
 #, fuzzy
 msgid "No certificate file was uploaded"
 msgstr "Aucun fichier a été téléchargé"
@@ -6212,10 +6218,6 @@ msgstr "Indisponible"
 #, fuzzy
 msgid "Not Found"
 msgstr "Icône Fichier introuvable"
-
-#, fuzzy
-msgid "Not Installed"
-msgstr "Plugins installés"
 
 msgid "Not Registered Hosts"
 msgstr "Hosts Pas encore inscrit"
@@ -7299,10 +7301,6 @@ msgstr "Inscrit"
 
 msgid "Registered Hosts"
 msgstr "hôtes inscrits"
-
-#, fuzzy
-msgid "Release Version"
-msgstr "Dernière version"
 
 #, php-format
 msgid "Reloaded %d setting(s) into cache"
@@ -9742,7 +9740,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Déjà inscrit comme"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy
@@ -10885,6 +10883,13 @@ msgstr ""
 msgid "as its primary group"
 msgstr "Mise à jour de groupe principal"
 
+msgid "attr could not be run -- SELinux may be denying it"
+msgstr ""
+
+#, fuzzy
+msgid "attr is not installed on this server"
+msgstr "Il n'y a pas de groupes sur ce serveur."
+
 msgid "automatically"
 msgstr ""
 
@@ -11403,6 +11408,14 @@ msgid "not reachable"
 msgstr "Indisponible"
 
 #, fuzzy
+msgid "not readable"
+msgstr "Indisponible"
+
+#, fuzzy
+msgid "not recorded on this file"
+msgstr "Image not found sur le noeud"
+
+#, fuzzy
 msgid "ntfy Accounts"
 msgstr "Comptes Slack"
 
@@ -11587,6 +11600,10 @@ msgstr ""
 msgid "the Linux kernel which is used to"
 msgstr ""
 
+#, fuzzy
+msgid "the file cannot be read"
+msgstr " | Fichier ou chemin ne peut pas être atteint"
+
 msgid "the following command in a terminal"
 msgstr ""
 
@@ -11604,6 +11621,12 @@ msgstr ""
 msgid "the local login form stays available at %s"
 msgstr ""
 
+msgid "the web server may not read this file"
+msgstr ""
+
+msgid "the web server may not run external commands"
+msgstr ""
+
 #, fuzzy
 msgid "there one enabled within this Storage Group"
 msgstr "Impossible de trouver un nœud de stockage est-il un permis dans ce groupe de stockage"
@@ -11619,6 +11642,9 @@ msgid "this account has no role, so it has no access to any management page. Ask
 msgstr ""
 
 msgid "this backup will enable you to return to the"
+msgstr ""
+
+msgid "this filesystem does not carry extended attributes"
 msgstr ""
 
 #, fuzzy
@@ -11908,6 +11934,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Attempting to ping host"
 #~ msgstr "Tenter de faire un ping"
+
+#, fuzzy
+#~ msgid "Buildroot Version"
+#~ msgstr "CPU Version"
 
 #, fuzzy
 #~ msgid "Bulk Changes"
@@ -12253,6 +12283,10 @@ msgstr ""
 #~ msgstr "Importer des utilisateurs"
 
 #, fuzzy
+#~ msgid "InitRD Versions"
+#~ msgstr "CPU Version"
+
+#, fuzzy
 #~ msgid "Install"
 #~ msgstr "Plugins installés"
 
@@ -12267,6 +12301,13 @@ msgstr ""
 #, fuzzy
 #~ msgid "Inventory Report"
 #~ msgstr "Inventaire"
+
+#, fuzzy
+#~ msgid "Kernel Version"
+#~ msgstr "Kernel versions"
+
+#~ msgid "Kernel Versions"
+#~ msgstr "Kernel versions"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -12327,6 +12368,10 @@ msgstr ""
 #~ msgstr "Modifier Groupe"
 
 #, fuzzy
+#~ msgid "Not Installed"
+#~ msgstr "Plugins installés"
+
+#, fuzzy
 #~ msgid "Pause"
 #~ msgstr "Utilisateur"
 
@@ -12352,6 +12397,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Product Keys"
 #~ msgstr "Hôte clé de produit"
+
+#, fuzzy
+#~ msgid "Release Version"
+#~ msgstr "Dernière version"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1281,8 +1281,15 @@ msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passre
 msgstr ""
 
 #, fuzzy
+msgid "Boot Files"
+msgstr "Opzioni di avvio:"
+
+#, fuzzy
 msgid "Boot Options"
 msgstr "Opzioni di avvio:"
+
+msgid "Boot Payload"
+msgstr ""
 
 msgid "Boot files from"
 msgstr ""
@@ -1328,10 +1335,6 @@ msgstr "Sfoglia"
 #, fuzzy
 msgid "Building the blobs failed."
 msgstr "Caricamento non riuscito"
-
-#, fuzzy
-msgid "Buildroot Version"
-msgstr "Versione client"
 
 #, php-format
 msgid "Bulk edit %s"
@@ -2875,6 +2878,17 @@ msgstr ""
 msgid "FOG will refuse these deploy tasks. Assign an image built for the same architecture, or capture one."
 msgstr ""
 
+#, fuzzy
+msgid "FOS Init"
+msgstr "Host Init"
+
+#, fuzzy
+msgid "FOS Kernel"
+msgstr "nocciolo"
+
+msgid "FOS Release"
+msgstr ""
+
 msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
@@ -4375,10 +4389,6 @@ msgstr "Non trovato su questo nodo"
 msgid "Init images."
 msgstr "immagine non valido"
 
-#, fuzzy
-msgid "InitRD Versions"
-msgstr "Versione client"
-
 msgid "Initial Template"
 msgstr "Modello iniziale"
 
@@ -4724,13 +4734,6 @@ msgstr "Aggiornamento del kernel"
 #, fuzzy
 msgid "Kernel Update Fail"
 msgstr "Aggiornamento del kernel"
-
-#, fuzzy
-msgid "Kernel Version"
-msgstr "versioni del kernel"
-
-msgid "Kernel Versions"
-msgstr "versioni del kernel"
 
 #, fuzzy
 msgid "Kernels present on disk"
@@ -5748,6 +5751,9 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr "Nessun file è stato caricato"
 
+msgid "No boot files found. Check FOG_TFTP_PXE_KERNEL_DIR."
+msgstr ""
+
 #, fuzzy
 msgid "No certificate file was uploaded"
 msgstr "Nessun file è stato caricato"
@@ -6027,10 +6033,6 @@ msgstr "Non disponibile"
 #, fuzzy
 msgid "Not Found"
 msgstr "File Icona non trovato"
-
-#, fuzzy
-msgid "Not Installed"
-msgstr "plugin installati"
 
 msgid "Not Registered Hosts"
 msgstr "Host non registrati"
@@ -7091,10 +7093,6 @@ msgstr "Registrato"
 
 msgid "Registered Hosts"
 msgstr "host registrati"
-
-#, fuzzy
-msgid "Release Version"
-msgstr "Ultima versione"
 
 #, php-format
 msgid "Reloaded %d setting(s) into cache"
@@ -9457,7 +9455,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Già registrato come"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy
@@ -10564,6 +10562,13 @@ msgstr "come FOG proverà ad andare in internet"
 msgid "as its primary group"
 msgstr "come il suo gruppo primario"
 
+msgid "attr could not be run -- SELinux may be denying it"
+msgstr ""
+
+#, fuzzy
+msgid "attr is not installed on this server"
+msgstr "Non ci sono gruppi su questo server"
+
 msgid "automatically"
 msgstr "automaticamente"
 
@@ -11056,6 +11061,14 @@ msgid "not reachable"
 msgstr "Non disponibile"
 
 #, fuzzy
+msgid "not readable"
+msgstr "Non disponibile"
+
+#, fuzzy
+msgid "not recorded on this file"
+msgstr "Non trovato su questo nodo"
+
+#, fuzzy
 msgid "ntfy Accounts"
 msgstr "Slack Accounts"
 
@@ -11233,6 +11246,10 @@ msgstr ""
 msgid "the Linux kernel which is used to"
 msgstr "il kernel Linux che verrà usato"
 
+#, fuzzy
+msgid "the file cannot be read"
+msgstr "Impossibile raggiungere il file o il percorso"
+
 msgid "the following command in a terminal"
 msgstr "il seguente comando in un terminale"
 
@@ -11250,6 +11267,12 @@ msgstr ""
 msgid "the local login form stays available at %s"
 msgstr ""
 
+msgid "the web server may not read this file"
+msgstr ""
+
+msgid "the web server may not run external commands"
+msgstr ""
+
 msgid "there one enabled within this Storage Group"
 msgstr "c'è uno abilitato all'interno di questo gruppo di archiviazione"
 
@@ -11265,6 +11288,9 @@ msgstr ""
 
 msgid "this backup will enable you to return to the"
 msgstr "Questo backup vi permetterà di ritornare alla"
+
+msgid "this filesystem does not carry extended attributes"
+msgstr ""
 
 #, fuzzy
 msgid "this image is taking on the server."
@@ -11546,6 +11572,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Attempting to ping host"
 #~ msgstr "Il tentativo di ping"
+
+#, fuzzy
+#~ msgid "Buildroot Version"
+#~ msgstr "Versione client"
 
 #, fuzzy
 #~ msgid "Bulk Changes"
@@ -11895,6 +11925,10 @@ msgstr ""
 #~ msgstr "Importa utenti"
 
 #, fuzzy
+#~ msgid "InitRD Versions"
+#~ msgstr "Versione client"
+
+#, fuzzy
 #~ msgid "Install"
 #~ msgstr "plugin installati"
 
@@ -11908,6 +11942,13 @@ msgstr ""
 #, fuzzy
 #~ msgid "Inventory Report"
 #~ msgstr "Inventario"
+
+#, fuzzy
+#~ msgid "Kernel Version"
+#~ msgstr "versioni del kernel"
+
+#~ msgid "Kernel Versions"
+#~ msgstr "versioni del kernel"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -11973,6 +12014,10 @@ msgstr ""
 #~ msgid "Non-Administrator Group"
 #~ msgstr "Gruppo amministrativo"
 
+#, fuzzy
+#~ msgid "Not Installed"
+#~ msgstr "plugin installati"
+
 #~ msgid "Pause"
 #~ msgstr "Pausa"
 
@@ -12004,6 +12049,10 @@ msgstr ""
 
 #~ msgid "Register must be managed from hooks or events"
 #~ msgstr "Registro deve essere gestito da hook o eventi"
+
+#, fuzzy
+#~ msgid "Release Version"
+#~ msgstr "Ultima versione"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1264,8 +1264,15 @@ msgstr "バインドパスワード"
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
 
+#, fuzzy
+msgid "Boot Files"
+msgstr "ブートオプション"
+
 msgid "Boot Options"
 msgstr "ブートオプション"
+
+msgid "Boot Payload"
+msgstr ""
 
 msgid "Boot files from"
 msgstr ""
@@ -1311,10 +1318,6 @@ msgstr "参照"
 #, fuzzy
 msgid "Building the blobs failed."
 msgstr "読み込みに失敗しました"
-
-#, fuzzy
-msgid "Buildroot Version"
-msgstr "MB バージョン"
 
 #, php-format
 msgid "Bulk edit %s"
@@ -2857,6 +2860,17 @@ msgstr ""
 msgid "FOG will refuse these deploy tasks. Assign an image built for the same architecture, or capture one."
 msgstr ""
 
+#, fuzzy
+msgid "FOS Init"
+msgstr "Init"
+
+#, fuzzy
+msgid "FOS Kernel"
+msgstr "カーネルを保存"
+
+msgid "FOS Release"
+msgstr ""
+
 msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
@@ -4341,10 +4355,6 @@ msgstr "このノード上に見つかりません"
 msgid "Init images."
 msgstr "無効なイメージ"
 
-#, fuzzy
-msgid "InitRD Versions"
-msgstr "クライアントバージョン"
-
 msgid "Initial Template"
 msgstr "初期テンプレート"
 
@@ -4687,13 +4697,6 @@ msgstr "カーネル更新"
 #, fuzzy
 msgid "Kernel Update Fail"
 msgstr "カーネル更新"
-
-#, fuzzy
-msgid "Kernel Version"
-msgstr "カーネルバージョン"
-
-msgid "Kernel Versions"
-msgstr "カーネルバージョン"
 
 #, fuzzy
 msgid "Kernels present on disk"
@@ -5711,6 +5714,9 @@ msgstr "このグループで利用可能なアクティビティ情報はあり
 msgid "No archive was uploaded."
 msgstr "ファイルはアップロードされませんでした"
 
+msgid "No boot files found. Check FOG_TFTP_PXE_KERNEL_DIR."
+msgstr ""
+
 #, fuzzy
 msgid "No certificate file was uploaded"
 msgstr "ファイルはアップロードされませんでした"
@@ -5992,10 +5998,6 @@ msgstr "利用不可"
 #, fuzzy
 msgid "Not Found"
 msgstr "見つかりません"
-
-#, fuzzy
-msgid "Not Installed"
-msgstr "ネットワークインストーラー"
 
 msgid "Not Registered Hosts"
 msgstr "未登録ホスト"
@@ -7060,10 +7062,6 @@ msgstr "登録済み"
 
 msgid "Registered Hosts"
 msgstr "登録済みホスト"
-
-#, fuzzy
-msgid "Release Version"
-msgstr "クライアントバージョン"
 
 #, php-format
 msgid "Reloaded %d setting(s) into cache"
@@ -9402,7 +9400,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "既に次の名前で登録されています:"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy
@@ -10510,6 +10508,13 @@ msgstr "FOG がインターネットへ接続を試みるため"
 msgid "as its primary group"
 msgstr "プライマリグループとして"
 
+msgid "attr could not be run -- SELinux may be denying it"
+msgstr ""
+
+#, fuzzy
+msgid "attr is not installed on this server"
+msgstr "このサーバーにはグループがありません"
+
 msgid "automatically"
 msgstr "自動的に"
 
@@ -11003,6 +11008,14 @@ msgid "not reachable"
 msgstr "利用不可"
 
 #, fuzzy
+msgid "not readable"
+msgstr "利用不可"
+
+#, fuzzy
+msgid "not recorded on this file"
+msgstr "このノード上に見つかりません"
+
+#, fuzzy
 msgid "ntfy Accounts"
 msgstr "Slack アカウント"
 
@@ -11182,6 +11195,10 @@ msgstr ""
 msgid "the Linux kernel which is used to"
 msgstr "次の処理に使用される Linux カーネル"
 
+#, fuzzy
+msgid "the file cannot be read"
+msgstr "ファイルまたはパスに到達できません"
+
 msgid "the following command in a terminal"
 msgstr "ターミナルで次のコマンドを実行してください"
 
@@ -11200,6 +11217,12 @@ msgstr "カーネルとともに使用される Initrd（初期 RAM ディスク
 msgid "the local login form stays available at %s"
 msgstr ""
 
+msgid "the web server may not read this file"
+msgstr ""
+
+msgid "the web server may not run external commands"
+msgstr ""
+
 msgid "there one enabled within this Storage Group"
 msgstr "このストレージグループ内に有効なものがあるか"
 
@@ -11215,6 +11238,9 @@ msgstr ""
 
 msgid "this backup will enable you to return to the"
 msgstr "このバックアップにより元の状態へ復元できます"
+
+msgid "this filesystem does not carry extended attributes"
+msgstr ""
 
 #, fuzzy
 msgid "this image is taking on the server."
@@ -11603,6 +11629,10 @@ msgstr ""
 
 #~ msgid "Boot Exit settings"
 #~ msgstr "ブート終了設定"
+
+#, fuzzy
+#~ msgid "Buildroot Version"
+#~ msgstr "MB バージョン"
 
 #, fuzzy
 #~ msgid "CA private key"
@@ -12402,6 +12432,10 @@ msgstr ""
 #~ msgid "Info"
 #~ msgstr "情報"
 
+#, fuzzy
+#~ msgid "InitRD Versions"
+#~ msgstr "クライアントバージョン"
+
 #~ msgid "Initrd Name"
 #~ msgstr "Initrd 名"
 
@@ -12487,6 +12521,13 @@ msgstr ""
 
 #~ msgid "Kernel Name"
 #~ msgstr "カーネル名"
+
+#, fuzzy
+#~ msgid "Kernel Version"
+#~ msgstr "カーネルバージョン"
+
+#~ msgid "Kernel Versions"
+#~ msgstr "カーネルバージョン"
 
 #~ msgid "Key Name"
 #~ msgstr "キー名"
@@ -12767,6 +12808,10 @@ msgstr ""
 #~ msgid "Non-Administrator Group"
 #~ msgstr "管理者グループ"
 
+#, fuzzy
+#~ msgid "Not Installed"
+#~ msgstr "ネットワークインストーラー"
+
 #~ msgid "Not Valid"
 #~ msgstr "無効"
 
@@ -12990,6 +13035,10 @@ msgstr ""
 #~ msgid "Register must be managed from hooks or events"
 #~ msgstr "登録はフックまたはイベントから管理する必要があります"
 
+#, fuzzy
+#~ msgid "Release Version"
+#~ msgstr "クライアントバージョン"
+
 #~ msgid "Releasing Staff Initials"
 #~ msgstr "返却担当者のイニシャル"
 
@@ -13092,9 +13141,6 @@ msgstr ""
 
 #~ msgid "Rule value"
 #~ msgstr "ルール値"
-
-#~ msgid "Save Kernel"
-#~ msgstr "カーネルを保存"
 
 #~ msgid "Schedule as debug task"
 #~ msgstr "デバッグタスクとしてスケジュール"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1136,7 +1136,13 @@ msgstr ""
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
 
+msgid "Boot Files"
+msgstr ""
+
 msgid "Boot Options"
+msgstr ""
+
+msgid "Boot Payload"
 msgstr ""
 
 msgid "Boot files from"
@@ -1179,9 +1185,6 @@ msgid "Browse"
 msgstr ""
 
 msgid "Building the blobs failed."
-msgstr ""
-
-msgid "Buildroot Version"
 msgstr ""
 
 #, php-format
@@ -2546,6 +2549,15 @@ msgstr ""
 msgid "FOG will refuse these deploy tasks. Assign an image built for the same architecture, or capture one."
 msgstr ""
 
+msgid "FOS Init"
+msgstr ""
+
+msgid "FOS Kernel"
+msgstr ""
+
+msgid "FOS Release"
+msgstr ""
+
 msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
@@ -3849,9 +3861,6 @@ msgstr ""
 msgid "Init images."
 msgstr ""
 
-msgid "InitRD Versions"
-msgstr ""
-
 msgid "Initial Template"
 msgstr ""
 
@@ -4160,12 +4169,6 @@ msgid "Kernel Update"
 msgstr ""
 
 msgid "Kernel Update Fail"
-msgstr ""
-
-msgid "Kernel Version"
-msgstr ""
-
-msgid "Kernel Versions"
 msgstr ""
 
 msgid "Kernels present on disk"
@@ -5055,6 +5058,9 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr ""
 
+msgid "No boot files found. Check FOG_TFTP_PXE_KERNEL_DIR."
+msgstr ""
+
 msgid "No certificate file was uploaded"
 msgstr ""
 
@@ -5306,9 +5312,6 @@ msgid "Not Available"
 msgstr ""
 
 msgid "Not Found"
-msgstr ""
-
-msgid "Not Installed"
 msgstr ""
 
 msgid "Not Registered Hosts"
@@ -6241,9 +6244,6 @@ msgid "Registered"
 msgstr ""
 
 msgid "Registered Hosts"
-msgstr ""
-
-msgid "Release Version"
 msgstr ""
 
 #, php-format
@@ -8356,7 +8356,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr ""
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 msgid "This node could not be found"
@@ -9355,6 +9355,12 @@ msgstr ""
 msgid "as its primary group"
 msgstr ""
 
+msgid "attr could not be run -- SELinux may be denying it"
+msgstr ""
+
+msgid "attr is not installed on this server"
+msgstr ""
+
 msgid "automatically"
 msgstr ""
 
@@ -9808,6 +9814,12 @@ msgstr ""
 msgid "not reachable"
 msgstr ""
 
+msgid "not readable"
+msgstr ""
+
+msgid "not recorded on this file"
+msgstr ""
+
 msgid "ntfy Accounts"
 msgstr ""
 
@@ -9978,6 +9990,9 @@ msgstr ""
 msgid "the Linux kernel which is used to"
 msgstr ""
 
+msgid "the file cannot be read"
+msgstr ""
+
 msgid "the following command in a terminal"
 msgstr ""
 
@@ -9994,6 +10009,12 @@ msgstr ""
 msgid "the local login form stays available at %s"
 msgstr ""
 
+msgid "the web server may not read this file"
+msgstr ""
+
+msgid "the web server may not run external commands"
+msgstr ""
+
 msgid "there one enabled within this Storage Group"
 msgstr ""
 
@@ -10008,6 +10029,9 @@ msgid "this account has no role, so it has no access to any management page. Ask
 msgstr ""
 
 msgid "this backup will enable you to return to the"
+msgstr ""
+
+msgid "this filesystem does not carry extended attributes"
 msgstr ""
 
 msgid "this image is taking on the server."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1313,8 +1313,15 @@ msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passre
 msgstr ""
 
 #, fuzzy
+msgid "Boot Files"
+msgstr "Opções de inicialização:"
+
+#, fuzzy
 msgid "Boot Options"
 msgstr "Opções de inicialização:"
+
+msgid "Boot Payload"
+msgstr ""
 
 msgid "Boot files from"
 msgstr ""
@@ -1367,10 +1374,6 @@ msgstr ""
 #, fuzzy
 msgid "Building the blobs failed."
 msgstr "Carga falhou: %s"
-
-#, fuzzy
-msgid "Buildroot Version"
-msgstr "Versão CPU"
 
 #, php-format
 msgid "Bulk edit %s"
@@ -2948,6 +2951,17 @@ msgstr ""
 msgid "FOG will refuse these deploy tasks. Assign an image built for the same architecture, or capture one."
 msgstr ""
 
+#, fuzzy
+msgid "FOS Init"
+msgstr "Lista de Host"
+
+#, fuzzy
+msgid "FOS Kernel"
+msgstr "Núcleo"
+
+msgid "FOS Release"
+msgstr ""
+
 msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
@@ -4501,10 +4515,6 @@ msgid "Init images."
 msgstr "imagem inválido"
 
 #, fuzzy
-msgid "InitRD Versions"
-msgstr "Versão CPU"
-
-#, fuzzy
 msgid "Initial Template"
 msgstr "Template Snapin"
 
@@ -4864,13 +4874,6 @@ msgstr "Kernel Atualização"
 #, fuzzy
 msgid "Kernel Update Fail"
 msgstr "Kernel Atualização"
-
-#, fuzzy
-msgid "Kernel Version"
-msgstr "Versões do kernel"
-
-msgid "Kernel Versions"
-msgstr "Versões do kernel"
 
 #, fuzzy
 msgid "Kernels present on disk"
@@ -5920,6 +5923,9 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr "Nenhum arquivo foi transferido"
 
+msgid "No boot files found. Check FOG_TFTP_PXE_KERNEL_DIR."
+msgstr ""
+
 #, fuzzy
 msgid "No certificate file was uploaded"
 msgstr "Nenhum arquivo foi transferido"
@@ -6212,10 +6218,6 @@ msgstr "Não disponível"
 #, fuzzy
 msgid "Not Found"
 msgstr "Ícone do Arquivo não encontrado"
-
-#, fuzzy
-msgid "Not Installed"
-msgstr "Plugins instalados"
 
 msgid "Not Registered Hosts"
 msgstr "Hosts não registrada"
@@ -7299,10 +7301,6 @@ msgstr "Registrado"
 
 msgid "Registered Hosts"
 msgstr "hosts registrados"
-
-#, fuzzy
-msgid "Release Version"
-msgstr "Última versão"
 
 #, php-format
 msgid "Reloaded %d setting(s) into cache"
@@ -9744,7 +9742,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "Já está registado como"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy
@@ -10887,6 +10885,13 @@ msgstr ""
 msgid "as its primary group"
 msgstr "Grupo primário de actualização"
 
+msgid "attr could not be run -- SELinux may be denying it"
+msgstr ""
+
+#, fuzzy
+msgid "attr is not installed on this server"
+msgstr "Não existem grupos neste servidor."
+
 msgid "automatically"
 msgstr ""
 
@@ -11405,6 +11410,14 @@ msgid "not reachable"
 msgstr "Não disponível"
 
 #, fuzzy
+msgid "not readable"
+msgstr "Não disponível"
+
+#, fuzzy
+msgid "not recorded on this file"
+msgstr "Imagem não encontrada no nó"
+
+#, fuzzy
 msgid "ntfy Accounts"
 msgstr "Contas Slack"
 
@@ -11589,6 +11602,10 @@ msgstr ""
 msgid "the Linux kernel which is used to"
 msgstr ""
 
+#, fuzzy
+msgid "the file cannot be read"
+msgstr " | Arquivo ou o caminho não pode ser alcançado"
+
 msgid "the following command in a terminal"
 msgstr ""
 
@@ -11606,6 +11623,12 @@ msgstr ""
 msgid "the local login form stays available at %s"
 msgstr ""
 
+msgid "the web server may not read this file"
+msgstr ""
+
+msgid "the web server may not run external commands"
+msgstr ""
+
 #, fuzzy
 msgid "there one enabled within this Storage Group"
 msgstr "Não foi possível encontrar um nó de armazenamento Existe um ativado dentro deste grupo de armazenamento"
@@ -11621,6 +11644,9 @@ msgid "this account has no role, so it has no access to any management page. Ask
 msgstr ""
 
 msgid "this backup will enable you to return to the"
+msgstr ""
+
+msgid "this filesystem does not carry extended attributes"
 msgstr ""
 
 #, fuzzy
@@ -11910,6 +11936,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Attempting to ping host"
 #~ msgstr "A tentativa de executar ping"
+
+#, fuzzy
+#~ msgid "Buildroot Version"
+#~ msgstr "Versão CPU"
 
 #, fuzzy
 #~ msgid "Bulk Changes"
@@ -12255,6 +12285,10 @@ msgstr ""
 #~ msgstr "importar usuários"
 
 #, fuzzy
+#~ msgid "InitRD Versions"
+#~ msgstr "Versão CPU"
+
+#, fuzzy
 #~ msgid "Install"
 #~ msgstr "Plugins instalados"
 
@@ -12269,6 +12303,13 @@ msgstr ""
 #, fuzzy
 #~ msgid "Inventory Report"
 #~ msgstr "Inventário"
+
+#, fuzzy
+#~ msgid "Kernel Version"
+#~ msgstr "Versões do kernel"
+
+#~ msgid "Kernel Versions"
+#~ msgstr "Versões do kernel"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -12329,6 +12370,10 @@ msgstr ""
 #~ msgstr "modificar Grupo"
 
 #, fuzzy
+#~ msgid "Not Installed"
+#~ msgstr "Plugins instalados"
+
+#, fuzzy
 #~ msgid "Pause"
 #~ msgstr "Do utilizador"
 
@@ -12354,6 +12399,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Product Keys"
 #~ msgstr "Hospedar de Chave de Produto"
+
+#, fuzzy
+#~ msgid "Release Version"
+#~ msgstr "Última versão"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1313,8 +1313,15 @@ msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passre
 msgstr ""
 
 #, fuzzy
+msgid "Boot Files"
+msgstr "启动选项："
+
+#, fuzzy
 msgid "Boot Options"
 msgstr "启动选项："
+
+msgid "Boot Payload"
+msgstr ""
 
 msgid "Boot files from"
 msgstr ""
@@ -1367,10 +1374,6 @@ msgstr ""
 #, fuzzy
 msgid "Building the blobs failed."
 msgstr "加载失败： %s"
-
-#, fuzzy
-msgid "Buildroot Version"
-msgstr "CPU版本"
 
 #, php-format
 msgid "Bulk edit %s"
@@ -2948,6 +2951,17 @@ msgstr ""
 msgid "FOG will refuse these deploy tasks. Assign an image built for the same architecture, or capture one."
 msgstr ""
 
+#, fuzzy
+msgid "FOS Init"
+msgstr "主机列表"
+
+#, fuzzy
+msgid "FOS Kernel"
+msgstr "核心"
+
+msgid "FOS Release"
+msgstr ""
+
 msgid "FOS kernels on this server are signed for UEFI Secure Boot"
 msgstr ""
 
@@ -4501,10 +4515,6 @@ msgid "Init images."
 msgstr "图片无效"
 
 #, fuzzy
-msgid "InitRD Versions"
-msgstr "CPU版本"
-
-#, fuzzy
 msgid "Initial Template"
 msgstr "模板管理单元"
 
@@ -4864,13 +4874,6 @@ msgstr "内核更新"
 #, fuzzy
 msgid "Kernel Update Fail"
 msgstr "内核更新"
-
-#, fuzzy
-msgid "Kernel Version"
-msgstr "内核版本"
-
-msgid "Kernel Versions"
-msgstr "内核版本"
 
 #, fuzzy
 msgid "Kernels present on disk"
@@ -5920,6 +5923,9 @@ msgstr ""
 msgid "No archive was uploaded."
 msgstr "没有文件被上传"
 
+msgid "No boot files found. Check FOG_TFTP_PXE_KERNEL_DIR."
+msgstr ""
+
 #, fuzzy
 msgid "No certificate file was uploaded"
 msgstr "没有文件被上传"
@@ -6212,10 +6218,6 @@ msgstr "不可用"
 #, fuzzy
 msgid "Not Found"
 msgstr "图标文件未找到"
-
-#, fuzzy
-msgid "Not Installed"
-msgstr "已安装的插件"
 
 msgid "Not Registered Hosts"
 msgstr "未注册主机"
@@ -7299,10 +7301,6 @@ msgstr "注册"
 
 msgid "Registered Hosts"
 msgstr "注册主机"
-
-#, fuzzy
-msgid "Release Version"
-msgstr "最新版本"
 
 #, php-format
 msgid "Reloaded %d setting(s) into cache"
@@ -9744,7 +9742,7 @@ msgstr ""
 msgid "This machine already registered as %s"
 msgstr "已注册为"
 
-msgid "This name is not a recognised file in the boot directory."
+msgid "This name is not a recognized file in the boot directory."
 msgstr ""
 
 #, fuzzy
@@ -10887,6 +10885,13 @@ msgstr ""
 msgid "as its primary group"
 msgstr "更新主要组"
 
+msgid "attr could not be run -- SELinux may be denying it"
+msgstr ""
+
+#, fuzzy
+msgid "attr is not installed on this server"
+msgstr "有此服务器上没有组。"
+
 msgid "automatically"
 msgstr ""
 
@@ -11405,6 +11410,14 @@ msgid "not reachable"
 msgstr "不可用"
 
 #, fuzzy
+msgid "not readable"
+msgstr "不可用"
+
+#, fuzzy
+msgid "not recorded on this file"
+msgstr "图片没有节点发现"
+
+#, fuzzy
 msgid "ntfy Accounts"
 msgstr "斯莱克账户"
 
@@ -11589,6 +11602,10 @@ msgstr ""
 msgid "the Linux kernel which is used to"
 msgstr ""
 
+#, fuzzy
+msgid "the file cannot be read"
+msgstr "|文件或无法达成通道"
+
 msgid "the following command in a terminal"
 msgstr ""
 
@@ -11606,6 +11623,12 @@ msgstr ""
 msgid "the local login form stays available at %s"
 msgstr ""
 
+msgid "the web server may not read this file"
+msgstr ""
+
+msgid "the web server may not run external commands"
+msgstr ""
+
 #, fuzzy
 msgid "there one enabled within this Storage Group"
 msgstr "找不到存储节点是否有什么这个存储组中启用"
@@ -11621,6 +11644,9 @@ msgid "this account has no role, so it has no access to any management page. Ask
 msgstr ""
 
 msgid "this backup will enable you to return to the"
+msgstr ""
+
+msgid "this filesystem does not carry extended attributes"
 msgstr ""
 
 #, fuzzy
@@ -11910,6 +11936,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Attempting to ping host"
 #~ msgstr "尝试ping"
+
+#, fuzzy
+#~ msgid "Buildroot Version"
+#~ msgstr "CPU版本"
 
 #, fuzzy
 #~ msgid "Bulk Changes"
@@ -12255,6 +12285,10 @@ msgstr ""
 #~ msgstr "导入用户"
 
 #, fuzzy
+#~ msgid "InitRD Versions"
+#~ msgstr "CPU版本"
+
+#, fuzzy
 #~ msgid "Install"
 #~ msgstr "已安装的插件"
 
@@ -12269,6 +12303,13 @@ msgstr ""
 #, fuzzy
 #~ msgid "Inventory Report"
 #~ msgstr "库存"
+
+#, fuzzy
+#~ msgid "Kernel Version"
+#~ msgstr "内核版本"
+
+#~ msgid "Kernel Versions"
+#~ msgstr "内核版本"
 
 #, fuzzy
 #~ msgid "LDAP User Filter"
@@ -12329,6 +12370,10 @@ msgstr ""
 #~ msgstr "修改组"
 
 #, fuzzy
+#~ msgid "Not Installed"
+#~ msgstr "已安装的插件"
+
+#, fuzzy
 #~ msgid "Pause"
 #~ msgstr "用户"
 
@@ -12354,6 +12399,10 @@ msgstr ""
 #, fuzzy
 #~ msgid "Product Keys"
 #~ msgstr "主机产品密钥"
+
+#, fuzzy
+#~ msgid "Release Version"
+#~ msgstr "最新版本"
 
 #, fuzzy
 #~ msgid "Remove Selected"

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -6138,7 +6138,10 @@ abstract class FOGPage extends FOGBase
     private static function _stampToTime($stamp)
     {
         $stamp = trim((string)$stamp);
-        if ('' === $stamp || 0 === strpos($stamp, '0000-00-00')) {
+        // validDate() rather than testing for a zero-date literal: it already
+        // knows both spellings of one, and there is meant to be exactly one
+        // definition of what an empty date is.
+        if ('' === $stamp || !self::validDate($stamp)) {
             return 0;
         }
         // ' UTC' because _bootFileStore() writes gmdate(). See the note

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -5708,6 +5708,20 @@ abstract class FOGPage extends FOGBase
     const BOOT_ROLE_PAYLOAD = 'payload';
     const BOOT_ROLE_OTHER = 'unclassified';
     /**
+     * Every bootFile row, keyed by filename, loaded at most once per request.
+     *
+     * bootFileInfo() is called once per file in the boot directory, and a
+     * listing walks the whole directory -- so a lookup per file is a query
+     * per file, twice over on a host form that asks for kernels and then for
+     * inits. One query answers all of them.
+     *
+     * null means "not loaded yet", which is not the same as an empty map: a
+     * server with no rows yet must not be re-queried once per file.
+     *
+     * @var array|null
+     */
+    private static $_bootFileRows = null;
+    /**
      * Picker value meaning "I will type the name myself".
      *
      * Not a filename any filesystem would produce, and matched literally by
@@ -6004,6 +6018,35 @@ abstract class FOGPage extends FOGBase
             && (int)self::_stampToTime($row->get('mtime')) === $mtime
         );
         if ($fresh) {
+            $tagValue = trim((string)$row->get('releaseTag'));
+            $tagReason = '';
+            if ('' === $tagValue) {
+                /**
+                 * No stored tag, so ask again rather than reporting a
+                 * remembered failure. Two reasons, and both matter:
+                 *
+                 * the REASON is current-state information -- "attr is not
+                 * installed on this server" stops being true the moment
+                 * somebody installs it, and telling an admin a stale cause
+                 * is how this panel became useless in the first place;
+                 *
+                 * and it self-heals. A server that could not read the tag
+                 * yesterday and can today picks it up on the next listing
+                 * without waiting for the file to change.
+                 *
+                 * This costs one attr call per file that has no tag, and
+                 * nothing at all for a file that has one -- which is the
+                 * common case on any server where the read works.
+                 */
+                $again = self::bootFileXattr($path, 'tag_name');
+                if ('' !== $again['value']) {
+                    $tagValue = $again['value'];
+                    self::_bootFileStore($row, ['releaseTag' => $tagValue]);
+                } else {
+                    $tagReason = $again['reason'];
+                }
+            }
+
             return [
                 'name' => $name,
                 'exists' => true,
@@ -6012,12 +6055,8 @@ abstract class FOGPage extends FOGBase
                 'mtime' => $mtime,
                 'checksum' => (string)$row->get('checksum'),
                 'kernelVersion' => (string)$row->get('kernelVersion'),
-                'releaseTag' => (string)$row->get('releaseTag'),
-                'tagReason' => (
-                    '' === trim((string)$row->get('releaseTag'))
-                    ? _('not recorded on this file')
-                    : ''
-                ),
+                'releaseTag' => $tagValue,
+                'tagReason' => $tagReason,
                 'pinned' => (bool)(int)$row->get('pinned')
             ];
         }
@@ -6094,15 +6133,24 @@ abstract class FOGPage extends FOGBase
      */
     private static function _bootFileRow($name)
     {
-        try {
-            $rows = self::getClass('BootFileManager')
-                ->find(['name' => $name], 'AND', 'bfID', 'ASC', 1);
-        } catch (\Throwable $e) {
-            return null;
+        if (null === self::$_bootFileRows) {
+            self::$_bootFileRows = [];
+            try {
+                $rows = self::getClass('BootFileManager')->find();
+                foreach ((array)$rows as $row) {
+                    if ($row && $row->isValid()) {
+                        self::$_bootFileRows[(string)$row->get('name')] = $row;
+                    }
+                }
+            } catch (\Throwable $e) {
+                // Left as an empty map, deliberately: the records are an
+                // accelerator, and an unreachable store must cost one failed
+                // query per request rather than one per file.
+                self::$_bootFileRows = [];
+            }
         }
-        $row = is_array($rows) ? reset($rows) : false;
 
-        return ($row && $row->isValid()) ? $row : null;
+        return self::$_bootFileRows[$name] ?? null;
     }
     /**
      * Writes what was just read about a file back to its record.
@@ -6124,6 +6172,12 @@ abstract class FOGPage extends FOGBase
                 $obj->set($field, $value);
             }
             $obj->save();
+            // Keep the request's map in step, so a second listing in the same
+            // request sees what the first one just inspected rather than
+            // inspecting it again.
+            if (null !== self::$_bootFileRows && !empty($data['name'])) {
+                self::$_bootFileRows[(string)$data['name']] = $obj;
+            }
         } catch (\Throwable $e) {
             return;
         }

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -5865,6 +5865,289 @@ abstract class FOGPage extends FOGBase
         return $ver;
     }
     /**
+     * Reads one extended attribute, and says why when it cannot.
+     *
+     * PHP has no xattr reader. The PECL extension is absent on every server
+     * this runs on and this codebase has never used it, so the FOS release
+     * tag -- which exists only as an xattr -- can be reached no other way
+     * than by running `attr`.
+     *
+     * That is exactly the call that fails invisibly today. status/kernelvers
+     * runs `attr -g` through shell_exec, discards stderr, and renders an
+     * empty result as `Unknown`, so at least seven different causes arrive
+     * looking identical: no attr binary, SELinux refusing httpd_t the exec,
+     * a mount without user_xattr, the attribute genuinely never set, a
+     * permissions failure, disabled shell functions, and a parse artifact
+     * from omitting -q. An admin cannot act on any of them.
+     *
+     * So this captures stderr and the exit status and answers with a reason.
+     * -q is passed, which the old call site omitted: without it `attr -g`
+     * prints a header line before the value and `tail -n1` has to guess.
+     *
+     * @param string $path full path to the file
+     * @param string $attr attribute name, e.g. 'tag_name'
+     *
+     * @return array ['value' => string, 'reason' => string]
+     */
+    public static function bootFileXattr($path, $attr)
+    {
+        $none = function ($why) {
+            return ['value' => '', 'reason' => $why];
+        };
+        if (!is_file($path) || !is_readable($path)) {
+            return $none(_('the file cannot be read'));
+        }
+        if (!function_exists('proc_open')) {
+            return $none(_('the web server may not run external commands'));
+        }
+        $cmd = sprintf(
+            'attr -q -g %s %s',
+            escapeshellarg($attr),
+            escapeshellarg($path)
+        );
+        $pipes = [];
+        $proc = @proc_open(
+            $cmd,
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes
+        );
+        if (!is_resource($proc)) {
+            return $none(_('the web server may not run external commands'));
+        }
+        $out = (string)stream_get_contents($pipes[1]);
+        $err = (string)stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $code = proc_close($proc);
+
+        $value = trim(trim(trim($out), '"'));
+        if ($value !== '') {
+            return ['value' => $value, 'reason' => ''];
+        }
+        /**
+         * Every branch below is a DIFFERENT operational problem with a
+         * different fix, which is the whole reason for reading stderr rather
+         * than treating empty output as one answer.
+         */
+        if (127 === $code || false !== stripos($err, 'not found')) {
+            return $none(_('attr is not installed on this server'));
+        }
+        if (false !== stripos($err, 'not supported')) {
+            return $none(_('this filesystem does not carry extended attributes'));
+        }
+        if (false !== stripos($err, 'permission')) {
+            return $none(_('the web server may not read this file'));
+        }
+        if (false !== stripos($err, 'no such attribute')
+            || 0 === $code
+        ) {
+            return $none(_('not recorded on this file'));
+        }
+
+        return $none(
+            $err !== ''
+            ? trim($err)
+            : _('attr could not be run -- SELinux may be denying it')
+        );
+    }
+    /**
+     * Everything known about one boot directory file, cached.
+     *
+     * The filesystem is the inventory: existence, size and mtime are read
+     * here, live, every time. The bootFile row is consulted for what reading
+     * the directory cannot answer, and is rewritten whenever the stat has
+     * moved -- so a kernel copied in by hand is picked up on the next
+     * listing and one deleted by hand simply stops appearing.
+     *
+     * Two of the three cached values are caches in the ordinary sense: role
+     * and version come out of the file's own bytes and could be re-read at
+     * any time. The release tag is not. It may be permanently unreadable on
+     * this server (see bootFileXattr), so it is stored the first time it can
+     * be read at all and served from the row afterward -- a stored tag is
+     * never discarded because a later read failed.
+     *
+     * @param string $path full path to the file
+     *
+     * @return array
+     */
+    public static function bootFileInfo($path)
+    {
+        $name = basename($path);
+        $stat = @stat($path);
+        if ($stat === false) {
+            return [
+                'name' => $name,
+                'exists' => false,
+                'role' => self::BOOT_ROLE_OTHER,
+                'size' => 0,
+                'mtime' => 0,
+                'checksum' => '',
+                'kernelVersion' => '',
+                'releaseTag' => '',
+                'tagReason' => _('the file cannot be read'),
+                'pinned' => false
+            ];
+        }
+        $size = (int)$stat['size'];
+        /**
+         * mtime, not ctime. The old panel used ctime and reported every
+         * file's "Installed Date" as the date of the last install, because
+         * restorePreservedCustomizations() chowns the whole directory on
+         * every run and that moves ctime on files it did not touch.
+         */
+        $mtime = (int)$stat['mtime'];
+
+        $row = self::_bootFileRow($name);
+        $fresh = (
+            $row
+            && (int)$row->get('size') === $size
+            && (int)self::_stampToTime($row->get('mtime')) === $mtime
+        );
+        if ($fresh) {
+            return [
+                'name' => $name,
+                'exists' => true,
+                'role' => (string)$row->get('role'),
+                'size' => $size,
+                'mtime' => $mtime,
+                'checksum' => (string)$row->get('checksum'),
+                'kernelVersion' => (string)$row->get('kernelVersion'),
+                'releaseTag' => (string)$row->get('releaseTag'),
+                'tagReason' => (
+                    '' === trim((string)$row->get('releaseTag'))
+                    ? _('not recorded on this file')
+                    : ''
+                ),
+                'pinned' => (bool)(int)$row->get('pinned')
+            ];
+        }
+
+        $role = self::bootFileRole($path);
+        $version = self::bootFileKernelVersion($path);
+        $tag = self::bootFileXattr($path, 'tag_name');
+        /**
+         * An init records its Buildroot version under `version` where a
+         * kernel records the kernel version, and a kernel's own banner is
+         * more trustworthy than the xattr -- an in-place overwrite leaves
+         * FOG's old xattrs on the admin's file, so the xattr can be
+         * confidently wrong where the bytes cannot.
+         */
+        if ('' === $version) {
+            $version = self::bootFileXattr($path, 'version')['value'];
+        }
+        $keptTag = $tag['value'];
+        if ('' === $keptTag && $row) {
+            $keptTag = (string)$row->get('releaseTag');
+        }
+        $checksum = (string)@hash_file('sha256', $path);
+
+        self::_bootFileStore(
+            $row,
+            [
+                'name' => $name,
+                'size' => $size,
+                /**
+                 * Written and read back in UTC, explicitly. These two
+                 * columns are a cache KEY, not a display value: they are
+                 * only ever compared against a fresh stat, so the write and
+                 * the read have to agree with each other whatever the
+                 * server's zone and the viewer's zone happen to be. Format
+                 * through the display zone and parse back through the
+                 * default one, and the comparison fails on any server where
+                 * those differ -- which would not break anything visibly, it
+                 * would just silently re-read every file on every render and
+                 * make the cache pointless. The date a human sees is
+                 * formatted from the live stat, not from here.
+                 */
+                'mtime' => gmdate('Y-m-d H:i:s', $mtime),
+                'checksum' => $checksum,
+                'role' => $role,
+                'kernelVersion' => $version,
+                'releaseTag' => $keptTag,
+                'inspected' => gmdate('Y-m-d H:i:s')
+            ]
+        );
+
+        return [
+            'name' => $name,
+            'exists' => true,
+            'role' => $role,
+            'size' => $size,
+            'mtime' => $mtime,
+            'checksum' => $checksum,
+            'kernelVersion' => $version,
+            'releaseTag' => $keptTag,
+            'tagReason' => ('' === $keptTag ? $tag['reason'] : ''),
+            'pinned' => (bool)($row ? (int)$row->get('pinned') : 0)
+        ];
+    }
+    /**
+     * Loads the bootFile row for $name, or null.
+     *
+     * Answers null rather than throwing when the record store cannot be
+     * reached: the records are an accelerator and a place to keep an admin's
+     * pin, not the inventory, so a listing must still render without them.
+     *
+     * @param string $name the filename
+     *
+     * @return \FOG\Items\BootFile|null
+     */
+    private static function _bootFileRow($name)
+    {
+        try {
+            $rows = self::getClass('BootFileManager')
+                ->find(['name' => $name], 'AND', 'bfID', 'ASC', 1);
+        } catch (\Throwable $e) {
+            return null;
+        }
+        $row = is_array($rows) ? reset($rows) : false;
+
+        return ($row && $row->isValid()) ? $row : null;
+    }
+    /**
+     * Writes what was just read about a file back to its record.
+     *
+     * Deliberately silent on failure. Rendering a list of kernels is not the
+     * moment to fail a page because a cache write did not land, and the next
+     * listing will simply read the file again.
+     *
+     * @param mixed $row  existing record or null
+     * @param array $data field values to store
+     *
+     * @return void
+     */
+    private static function _bootFileStore($row, array $data)
+    {
+        try {
+            $obj = $row ?: self::getClass('BootFile');
+            foreach ($data as $field => $value) {
+                $obj->set($field, $value);
+            }
+            $obj->save();
+        } catch (\Throwable $e) {
+            return;
+        }
+    }
+    /**
+     * Turns a stored datetime into a unix timestamp, or 0.
+     *
+     * @param mixed $stamp the stored value
+     *
+     * @return int
+     */
+    private static function _stampToTime($stamp)
+    {
+        $stamp = trim((string)$stamp);
+        if ('' === $stamp || 0 === strpos($stamp, '0000-00-00')) {
+            return 0;
+        }
+        // ' UTC' because _bootFileStore() writes gmdate(). See the note
+        // there: these two have to agree with each other, not with a zone.
+        $time = strtotime($stamp . ' UTC');
+
+        return (false === $time) ? 0 : (int)$time;
+    }
+    /**
      * Lists the boot directory files holding the role $type, newest first.
      *
      * Kernels and inits are files on disk, not database records, so there is
@@ -5924,7 +6207,14 @@ abstract class FOGPage extends FOGBase
             if (!is_file($path)) {
                 continue;
             }
-            if (self::bootFileRole($path) === $want) {
+            /**
+             * bootFileInfo(), not bootFileRole(): the role is the same answer
+             * either way, but going through the record means a render costs a
+             * stat and one query rather than a 4KiB read of every file in the
+             * directory, on every host form, group form, mass edit modal and
+             * settings page.
+             */
+            if (self::bootFileInfo($path)['role'] === $want) {
                 $out[] = $file;
             }
         }

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -130,7 +130,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 413);
+        define('FOG_SCHEMA', 414);
         define('FOG_BCACHE_VER', 359);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/src/Items/BootFile.php
+++ b/packages/web/src/Items/BootFile.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * What FOG has decided about one file in the FOS boot directory.
+ *
+ * PHP version 7.4+
+ *
+ * @category BootFile
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Items;
+
+use FOG\Base\FOGController;
+
+/**
+ * What FOG has decided about one file in the FOS boot directory.
+ *
+ * The filesystem remains the inventory -- whether a file exists, how big it
+ * is and when it changed are read live on every listing, so a kernel copied
+ * in by hand appears and one deleted by hand disappears, with nothing to
+ * reconcile. A row here records only what the directory cannot say: the role
+ * read out of the bytes, the version banner, the FOS release, and whether an
+ * admin has pinned the file against pruning.
+ *
+ * `size` and `mtime` are the cache key rather than the inventory. A file
+ * whose stat has moved is re-read; one whose stat matches is trusted.
+ *
+ * @category BootFile
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class BootFile extends FOGController
+{
+    /**
+     * The table name.
+     *
+     * @var string
+     */
+    protected $databaseTable = 'bootFile';
+    /**
+     * The table fields.
+     *
+     * @var array
+     */
+    protected $databaseFields = [
+        'id' => 'bfID',
+        'name' => 'bfName',
+        'size' => 'bfSize',
+        'mtime' => 'bfMtime',
+        'checksum' => 'bfChecksum',
+        'role' => 'bfRole',
+        'kernelVersion' => 'bfKernelVersion',
+        'releaseTag' => 'bfReleaseTag',
+        'inspected' => 'bfInspected',
+        'pinned' => 'bfPinned'
+    ];
+    /**
+     * The required fields.
+     *
+     * @var array
+     */
+    protected $databaseFieldsRequired = [
+        'name'
+    ];
+}

--- a/packages/web/src/Managers/BootFileManager.php
+++ b/packages/web/src/Managers/BootFileManager.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Boot file record handler class (informative).
+ *
+ * PHP version 7.4+
+ *
+ * @category BootFileManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+namespace FOG\Managers;
+
+use FOG\Base\FOGManagerController;
+
+/**
+ * Boot file record handler class (informative).
+ *
+ * @category BootFileManager
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+class BootFileManager extends FOGManagerController
+{
+}

--- a/packages/web/status/kernelvers.php
+++ b/packages/web/status/kernelvers.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Presents the FOG Kernels version that the clients will use.
+ * Reports the boot files this node actually holds, and why a value is absent.
  *
  * PHP version 7.4+
  *
@@ -12,9 +12,29 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Base\FOGPage;
 
 /**
- * Presents the FOG Kernels version that the clients will use.
+ * Reports the boot files this node actually holds.
+ *
+ * This used to report six hardcoded filenames out of BASEPATH/service/ipxe,
+ * read their version and release from extended attributes through
+ * shell_exec, and print `Unknown` whenever that produced nothing. At least
+ * seven unrelated problems arrived looking identical -- no attr binary,
+ * SELinux refusing the exec, a mount without user_xattr, an attribute never
+ * set, a permissions failure, disabled shell functions, and a parse artifact
+ * from omitting -q -- and the actual cause went to stderr and was dropped.
+ * A file the admin had installed themselves was worse than unknown: an
+ * in-place overwrite leaves FOG's old xattrs in place, so it reported FOG's
+ * release as though it were genuine.
+ *
+ * Three things changed. The directory is the configured one, so a server
+ * whose FOG_TFTP_PXE_KERNEL_DIR has moved is reported rather than silently
+ * showing nothing installed. Every file in it is reported, not six names, so
+ * per-release siblings and custom kernels appear. And the kernel version is
+ * read out of the image's own header, which needs no binary and no
+ * extended attribute -- leaving only the FOS release tag dependent on attr,
+ * and saying which of the specific reasons applies when that cannot be read.
  *
  * @category KernelVersion
  * @package  FOGProject
@@ -53,136 +73,161 @@ if (isset($_POST['url'])) {
         echo $response;
         unset($response);
     }
-    
+
     exit;
 }
-$initrdvers = function ($initrd) {
-    $currpath = sprintf(
-        '%s%sservice%sipxe%s%s',
-        BASEPATH,
-        DS,
-        DS,
-        DS,
-        $initrd
-    );
-    if (!file_exists($currpath)) {
-        return _('Not Installed').'|'._('Not Installed').'|'._('Not Installed');
+/**
+ * Every file in the configured boot directory, with what is known about it.
+ *
+ * @return array
+ */
+$bootFileRows = function () {
+    $dir = trim((string)FOGCore::getSetting('FOG_TFTP_PXE_KERNEL_DIR'));
+    if ('' === $dir || !is_dir($dir) || !is_readable($dir)) {
+        return [];
     }
-    $basepath = escapeshellarg($currpath);
-    $findstr = sprintf(
-        'attr -g tag_name %s | tail -n1',
-        $basepath
-    );
-    $tag_name = shell_exec($findstr);
-    $findstr = sprintf(
-        'attr -g version %s | tail -n1',
-        $basepath
-    );
-    $buildroot = shell_exec($findstr);
-    $stat = stat($currpath);
-    $c_time = $stat['ctime'];
+    $names = @scandir($dir);
+    if (false === $names) {
+        return [];
+    }
+    $rows = [];
+    foreach ($names as $name) {
+        if ('.' === $name || '..' === $name) {
+            continue;
+        }
+        $path = $dir . DIRECTORY_SEPARATOR . $name;
+        if (!is_file($path)) {
+            continue;
+        }
+        $info = FOGPage::bootFileInfo($path);
+        if (FOGPage::BOOT_ROLE_OTHER === $info['role']) {
+            // FOG's own web assets and signing working files. Reporting
+            // boot.php and bg.png as boot files is noise, not honesty.
+            continue;
+        }
+        $rows[] = [
+            'name' => $name,
+            'role' => $info['role'],
+            'version' => $info['kernelVersion'],
+            'release' => $info['releaseTag'],
+            'note' => $info['tagReason'],
+            /**
+             * mtime. The old panel used ctime and called it "Installed
+             * Date", but restorePreservedCustomizations() chowns this whole
+             * directory on every install, which moves ctime on files it
+             * never touched -- so every file claimed to be installed on the
+             * date of the last upgrade.
+             */
+            'installed' => FOGCore::formatTime(
+                '@' . $info['mtime'],
+                'Y-m-d H:i:s'
+            ),
+            'size' => $info['size']
+        ];
+    }
+    usort(
+        $rows,
+        function ($a, $b) {
+            if ($a['role'] !== $b['role']) {
+                $order = [
+                    FOGPage::BOOT_ROLE_KERNEL => 0,
+                    FOGPage::BOOT_ROLE_INIT => 1,
+                    FOGPage::BOOT_ROLE_PAYLOAD => 2
+                ];
 
-    $tag = trim(trim(trim($tag_name), '"'));
-    if (!$tag) {
-        $tag = _('Unknown');
-    }
-    $build = trim(trim(trim($buildroot), '"'));
-    if (!$build) {
-        $build = _('Unknown');
-    }
-    $create = date('Y-m-d H:i:s', $c_time);
+                return ($order[$a['role']] ?? 3) - ($order[$b['role']] ?? 3);
+            }
+            $adot = substr_count($a['name'], '.');
+            $bdot = substr_count($b['name'], '.');
+            if ($adot !== $bdot) {
+                return $adot - $bdot;
+            }
 
-    return "$tag|$build|$create";
+            return strnatcasecmp($b['name'], $a['name']);
+        }
+    );
+
+    return $rows;
 };
+$roleLabels = [
+    FOGPage::BOOT_ROLE_KERNEL => _('FOS Kernel'),
+    FOGPage::BOOT_ROLE_INIT => _('FOS Init'),
+    FOGPage::BOOT_ROLE_PAYLOAD => _('Boot Payload')
+];
+$rows = $bootFileRows();
+// The role's display name travels with the row: the browser must not hold a
+// second copy of the role vocabulary that can drift from the server's.
+foreach ($rows as &$row) {
+    $row['role_label'] = $roleLabels[$row['role']] ?? $row['role'];
+    unset($row);
+}
 if (isset($_POST['ko'])) {
-    echo '<div class="box box-primary">';
-    echo '<div class="box-header with-border">';
-    echo '<h4 class="box-title">';
+    $e = function ($v) {
+        return htmlspecialchars(
+            (string)$v,
+            ENT_QUOTES | ENT_SUBSTITUTE,
+            'UTF-8',
+            false
+        );
+    };
+    echo '<div class="card">';
+    echo '<div class="card-header">';
+    echo '<h4 class="card-title">';
     echo _('Node Version');
     echo '</h4>';
     echo '</div>';
-    echo '<div class="box-body">';
-    echo FOG_VERSION;
+    echo '<div class="card-body">';
+    echo $e(FOG_VERSION);
     echo '</div>';
     echo '</div>';
-    echo '<div class="box box-primary">';
-    echo '<div class="box-header with-border">';
-    echo '<h4 class="box-title">';
-    echo _('Kernel Versions');
+    echo '<div class="card">';
+    echo '<div class="card-header">';
+    echo '<h4 class="card-title">';
+    echo _('Boot Files');
     echo '</h4>';
     echo '</div>';
-    list($int64_rel, $int64_ver, $int64_ins) = explode('|', $initrdvers('bzImage'));
-    list($int32_rel, $int32_ver, $int32_ins) = explode('|', $initrdvers('bzImage32'));
-    list($arm64_rel, $arm64_ver, $arm64_ins) = explode('|', $initrdvers('arm_Image'));
-    echo '<div class="box-body">';
-    echo '<table class="table table-striped">';
-    echo '<tbody>';
-    echo '<tr>';
-    echo '<th>'._('Architecture').'</th>';
-    echo '<th>'._('Release Version').'</th>';
-    echo '<th>'._('Kernel Version').'</th>';
-    echo '<th>'._('Installed Date').'</th>';
-    echo '</tr>';
-    echo '<tr>';
-    echo '<td>'. _('Intel 64 Bit'). '</td>';
-    echo '<td>'. $int64_rel . '</td>';
-    echo '<td>'. $int64_ver . '</td>';
-    echo '<td>'. $int64_ins . '</td>';
-    echo '</tr>';
-    echo '<tr>';
-    echo '<td>'. _('Intel 32 Bit'). '</td>';
-    echo '<td>'. $int32_rel . '</td>';
-    echo '<td>'. $int32_ver . '</td>';
-    echo '<td>'. $int32_ins . '</td>';
-    echo '</tr>';
-    echo '<tr>';
-    echo '<td>'. _('ARM 64 Bit'). '</td>';
-    echo '<td>'. $arm64_rel . '</td>';
-    echo '<td>'. $arm64_ver . '</td>';
-    echo '<td>'. $arm64_ins . '</td>';
-    echo '</tr>';
-    echo '</tbody>';
-    echo '</table>';
-    echo '</div>';
-    echo '</div>';
-    list($int64_rel, $int64_brt, $int64_ins) = explode('|', $initrdvers('init.xz'));
-    list($int32_rel, $int32_brt, $int32_ins) = explode('|', $initrdvers('init_32.xz'));
-    list($arm64_rel, $arm64_brt, $arm64_ins) = explode('|', $initrdvers('arm_init.cpio.gz'));
-    echo '<div class="box box-primary">';
-    echo '<div class="box-header with-border">';
-    echo '<h4 class="box-title">';
-    echo _('InitRD Versions');
-    echo '</h4>';
-    echo '</div>';
-    echo '<div class="box-body">';
-    echo '<table class="table table-striped">';
-    echo '<tbody>';
-    echo '<tr>';
-    echo '<th>'._('Architecture').'</th>';
-    echo '<th>'._('Release Version').'</th>';
-    echo '<th>'._('Buildroot Version').'</th>';
-    echo '<th>'._('Installed Date').'</th>';
-    echo '</tr>';
-    echo '<tr>';
-    echo '<td>'. _('Intel 64 Bit') . '</td>';
-    echo '<td>'. $int64_rel . '</td>';
-    echo '<td>'. $int64_brt . '</td>';
-    echo '<td>'. $int64_ins . '</td>';
-    echo '</tr>';
-    echo '<tr>';
-    echo '<td>'. _('Intel 32 Bit') . '</td>';
-    echo '<td>'. $int32_rel . '</td>';
-    echo '<td>'. $int32_brt . '</td>';
-    echo '<td>'. $int32_ins . '</td>';
-    echo '</tr>';
-    echo '<tr>';
-    echo '<td>'. _('ARM 64 Bit') . '</td>';
-    echo '<td>'. $arm64_rel . '</td>';
-    echo '<td>'. $arm64_brt . '</td>';
-    echo '<td>'. $arm64_ins . '</td>';
-    echo '</tr>';
-    echo '</tbody>';
-    echo '</table>';
+    echo '<div class="card-body">';
+    if (!count($rows)) {
+        echo '<div class="alert alert-warning">';
+        echo _('No boot files found. Check FOG_TFTP_PXE_KERNEL_DIR.');
+        echo '</div>';
+    } else {
+        echo '<table class="table table-striped">';
+        echo '<tbody>';
+        echo '<tr>';
+        echo '<th>' . _('File') . '</th>';
+        echo '<th>' . _('Role') . '</th>';
+        echo '<th>' . _('Version') . '</th>';
+        echo '<th>' . _('FOS Release') . '</th>';
+        echo '<th>' . _('Installed Date') . '</th>';
+        echo '</tr>';
+        foreach ($rows as $row) {
+            echo '<tr>';
+            echo '<td>' . $e($row['name']) . '</td>';
+            echo '<td>' . $e($roleLabels[$row['role']] ?? $row['role'])
+                . '</td>';
+            echo '<td>'
+                . (
+                    '' !== $row['version'] ?
+                    $e($row['version']) :
+                    '<span class="text-muted">' . _('not readable')
+                    . '</span>'
+                )
+                . '</td>';
+            echo '<td>'
+                . (
+                    '' !== $row['release'] ?
+                    $e($row['release']) :
+                    '<span class="text-muted">' . $e($row['note'])
+                    . '</span>'
+                )
+                . '</td>';
+            echo '<td>' . $e($row['installed']) . '</td>';
+            echo '</tr>';
+        }
+        echo '</tbody>';
+        echo '</table>';
+    }
     echo '</div>';
     echo '</div>';
     exit;
@@ -190,22 +235,15 @@ if (isset($_POST['ko'])) {
 $send_vars = [
     'node_vers' => FOG_VERSION,
     'node_version_lang' => _('Node Version'),
-    'kern_version_lang' => _('Kernel Versions'),
-    'init_version_lang' => _('InitRD Versions'),
-    'arch_lang' => _('Architecture'),
-    'kern_lang' => _('Kernel Version'),
-    'build_lang' => _('Buildroot Version'),
-    'rel_lang' => _('Release Version'),
+    'boot_files_lang' => _('Boot Files'),
+    'file_lang' => _('File'),
+    'role_lang' => _('Role'),
+    'version_lang' => _('Version'),
+    'release_lang' => _('FOS Release'),
     'ins_lang' => _('Installed Date'),
-    'intel64_lang' => _('Intel 64 Bit'),
-    'intel32_lang' => _('Intel 32 Bit'),
-    'arm64_lang' => _('ARM 64 Bit'),
-    'int64bit' => $initrdvers('bzImage'),
-    'int32bit' => $initrdvers('bzImage32'),
-    'arm64bit' => $initrdvers('arm_Image'),
-    'initI64' => $initrdvers('init.xz'),
-    'initI32' => $initrdvers('init_32.xz'),
-    'initA64' => $initrdvers('arm_init.cpio.gz')
+    'unreadable_lang' => _('not readable'),
+    'empty_lang' => _('No boot files found. Check FOG_TFTP_PXE_KERNEL_DIR.'),
+    'rows' => $rows
 ];
 echo json_encode($send_vars);
 exit;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -129,7 +129,7 @@ parameters:
 		-
 			message: '#^Variable \$this might not be defined\.$#'
 			identifier: variable.undefined
-			count: 383
+			count: 384
 			path: packages/web/commons/schema.php
 
 		-

--- a/tests/boot-file-info.test.php
+++ b/tests/boot-file-info.test.php
@@ -79,10 +79,11 @@ $page = 'FOG\Base\FOGPage';
  * difference from the old behavior, where "no value" carried no reason.
  */
 $tag = $page::bootFileXattr($dir . '/bzImage', 'tag_name');
+// No is_array() guard: the method is declared @return array, so phpstan
+// proves that branch always true and fails the tests pass on it.
 $t->check(
     'the xattr reader answers value and reason',
-    is_array($tag) && array_key_exists('value', $tag)
-    && array_key_exists('reason', $tag)
+    array_key_exists('value', $tag) && array_key_exists('reason', $tag)
 );
 $t->check(
     'a value and a reason are mutually exclusive, and one is always given',

--- a/tests/boot-file-info.test.php
+++ b/tests/boot-file-info.test.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Boot file metadata: read what can be read, and say why for the rest.
+ *
+ * The Kernel Versions panel printed `Unknown` for a value it could not get,
+ * and at least seven unrelated problems produced that same word: no `attr`
+ * binary, SELinux refusing httpd_t the exec, a mount without user_xattr, an
+ * attribute genuinely never set, a permissions failure, disabled shell
+ * functions, and a parse artifact from calling `attr -g` without -q. The
+ * cause went to stderr and was discarded, so an admin could not tell which
+ * of those to go and fix.
+ *
+ * Two halves to the fix, and this pins both:
+ *
+ *   - the kernel VERSION no longer depends on the shell at all. It is read
+ *     from the offset the image's own setup header points at, so it works
+ *     under SELinux, on a filesystem with no xattr support, and on a server
+ *     where `attr` was never installed.
+ *   - the FOS RELEASE tag cannot escape that, because it exists only as an
+ *     extended attribute and PHP has no xattr reader. So it answers with a
+ *     reason instead of an empty string, and a tag once read is kept in the
+ *     record rather than re-derived -- on a server where the read never
+ *     works, a value stored at download time is the only copy there will be.
+ *
+ * DB-free: the fake DB answers the directory setting. The record store is
+ * unreachable here, which is itself worth asserting -- a listing has to
+ * render without it.
+ *
+ * Usage: php tests/boot-file-info.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('boot-file-info');
+$db = FogTestHarness::fakeDb();
+
+$t = new FogChecks();
+
+$dir = dirname(FOG_CACHE_DIR) . '/service/ipxe';
+mkdir($dir, 0755, true);
+
+$banner = '6.6.30 (fos@buildroot) #1 SMP Wed Aug 6 11:10:46 UTC 2026';
+$kernel = str_repeat("\x00", 4096);
+$kernel = substr_replace($kernel, 'MZ', 0, 2);
+$kernel = substr_replace($kernel, 'HdrS', 0x202, 4);
+$kernel = substr_replace($kernel, pack('v', 0x100), 0x20e, 2);
+$kernel = substr_replace($kernel, $banner . "\x00", 0x300, strlen($banner) + 1);
+file_put_contents($dir . '/bzImage', $kernel);
+
+$armKernel = str_repeat("\x00", 4096);
+$armKernel = substr_replace($armKernel, 'MZ', 0, 2);
+$armKernel = substr_replace($armKernel, 'ARMd', 0x38, 4);
+file_put_contents($dir . '/arm_Image', $armKernel);
+
+file_put_contents($dir . '/init.xz', "\xfd" . '7zXZ' . "\x00" . str_repeat('z', 512));
+
+$db->responder = function ($sql, $params) use ($dir) {
+    if (false !== stripos($sql, 'FROM `globalSettings`')) {
+        return [
+            [
+                'settingKey' => 'FOG_TFTP_PXE_KERNEL_DIR',
+                'settingValue' => $dir . '/'
+            ]
+        ];
+    }
+
+    return null;
+};
+
+$page = 'FOG\Base\FOGPage';
+
+// --- the xattr reader's contract -----------------------------------------
+
+/**
+ * Deliberately environment-agnostic. Whether `attr` exists on the machine
+ * running this suite is not the point; the contract is that a value and a
+ * reason are never both empty, and never both present. That is the whole
+ * difference from the old behavior, where "no value" carried no reason.
+ */
+$tag = $page::bootFileXattr($dir . '/bzImage', 'tag_name');
+$t->check(
+    'the xattr reader answers value and reason',
+    is_array($tag) && array_key_exists('value', $tag)
+    && array_key_exists('reason', $tag)
+);
+$t->check(
+    'a value and a reason are mutually exclusive, and one is always given',
+    ('' === $tag['value']) !== ('' === $tag['reason'])
+);
+$missing = $page::bootFileXattr($dir . '/not-here', 'tag_name');
+$t->check(
+    'a file that does not exist gets a reason, not an empty answer',
+    '' === $missing['value'] && '' !== $missing['reason']
+);
+
+// --- the version, which must not depend on the shell ---------------------
+
+$info = $page::bootFileInfo($dir . '/bzImage');
+$t->check(
+    'an x86 kernel reports the banner from its own header',
+    $banner === $info['kernelVersion']
+);
+$t->check(
+    'the role travels with the metadata',
+    'kernel' === $info['role']
+);
+$t->check(
+    'the file is reported as present',
+    true === $info['exists']
+);
+$t->check(
+    'the size is the real size',
+    4096 === $info['size']
+);
+/**
+ * mtime, not ctime. The old panel used ctime and called it "Installed
+ * Date" -- and restorePreservedCustomizations() chowns this whole directory
+ * on every install, which moves ctime on files it never touched. So every
+ * file claimed to have been installed on the date of the last upgrade.
+ */
+$t->check(
+    'the timestamp is the modification time, not the inode change time',
+    filemtime($dir . '/bzImage') === $info['mtime']
+);
+$t->check(
+    'a checksum is recorded, so two names can be known to be one kernel',
+    hash_file('sha256', $dir . '/bzImage') === $info['checksum']
+);
+
+$armInfo = $page::bootFileInfo($dir . '/arm_Image');
+$t->check(
+    'an arm64 kernel is still classified, with no version to report',
+    'kernel' === $armInfo['role'] && '' === $armInfo['kernelVersion']
+);
+
+$initInfo = $page::bootFileInfo($dir . '/init.xz');
+$t->check(
+    'an init is classified from its archive magic',
+    'init' === $initInfo['role']
+);
+
+// --- a value that cannot be read says why --------------------------------
+
+$t->check(
+    'an unreadable release tag carries a reason instead of "Unknown"',
+    '' === $info['releaseTag'] ? '' !== $info['tagReason'] : true
+);
+$t->check(
+    'a readable release tag carries no reason',
+    '' !== $info['releaseTag'] ? '' === $info['tagReason'] : true
+);
+
+// --- a missing file, and an unreachable record store ---------------------
+
+$gone = $page::bootFileInfo($dir . '/never-existed');
+$t->check(
+    'a file that does not exist is reported as absent, not as an error',
+    false === $gone['exists']
+    && 'unclassified' === $gone['role']
+    && 0 === $gone['size']
+);
+
+/**
+ * The records are an accelerator and a place to keep an admin's pin, not the
+ * inventory. This harness has no bootFile table at all, so every read and
+ * write against it fails -- and the listing still has to answer.
+ */
+$t->check(
+    'the listing renders with the record store unreachable',
+    ['bzImage'] === $page::kernelFileList('kernel')
+    || in_array('bzImage', $page::kernelFileList('kernel'), true)
+);
+$t->check(
+    'metadata is stable across calls when the file has not changed',
+    $page::bootFileInfo($dir . '/bzImage') == $info
+);
+
+// --- the panel no longer hardcodes six names or drops stderr -------------
+
+$panel = file_get_contents(
+    dirname(__DIR__) . '/packages/web/status/kernelvers.php'
+);
+$t->check(
+    'the panel reads the configured directory, not BASEPATH/service/ipxe',
+    false !== strpos($panel, 'FOG_TFTP_PXE_KERNEL_DIR')
+    && false === strpos($panel, "BASEPATH, DS, DS, DS")
+);
+// The call form, not the word: the file's own docblock names both of these
+// while explaining what it used to do, and that prose is the point.
+$t->check(
+    'the panel no longer shells out to attr itself',
+    false === strpos($panel, "'attr -q -g")
+    && false === strpos($panel, 'shell_exec(')
+);
+$t->check(
+    'the panel no longer joins its values with a pipe for the browser to split',
+    false === strpos($panel, "'|'")
+);
+$t->check(
+    'the panel reports every boot file rather than six fixed names',
+    false === strpos($panel, "'bzImage32'")
+    && false === strpos($panel, "'arm_init.cpio.gz'")
+);
+
+$home = file_get_contents(
+    dirname(__DIR__)
+    . '/packages/web/management/js/fog/about/fog.about.home.js'
+);
+$t->check(
+    'the browser guards the parse, so an unreachable node is not a blank panel',
+    false !== strpos($home, 'try {')
+    && false !== strpos($home, 'JSON.parse')
+);
+$t->check(
+    'the browser escapes what the node sent it',
+    false !== strpos($home, 'function esc(')
+);
+
+$t->finish();


### PR DESCRIPTION
Follows #1688 (merged), which decided a boot file's role by reading it. This makes the metadata around that answer honest.

## The problem

The Kernel Versions panel printed `Unknown`, and **at least seven unrelated problems produced that same word**: no `attr` binary, SELinux refusing `httpd_t` the exec, a mount without `user_xattr`, an attribute never set, a permissions failure, disabled shell functions, and a parse artifact from calling `attr -g` without `-q`. The real cause went to stderr and was discarded, so an admin could not tell which one to go and fix.

Three more, found while reading it:

- it read `BASEPATH/service/ipxe` rather than `FOG_TFTP_PXE_KERNEL_DIR`, so a server whose boot directory has moved showed nothing installed;
- it reported six hardcoded filenames, so per-release siblings and custom kernels were invisible;
- it used **`ctime`** for "Installed Date" — and `restorePreservedCustomizations()` chowns that whole directory on every install, which moves `ctime` on files it never touched. Every file claimed to have been installed on the date of the last upgrade.

## What can and cannot be fixed by reading bytes

**The kernel version no longer touches the shell.** It comes from the offset the image's own setup header points at, so it works under SELinux, on a filesystem with no xattr support, and on a server where `attr` was never installed. That is the column that was most often blank.

**The FOS release tag cannot escape the shell.** It exists *only* as an extended attribute, and **PHP has no xattr reader** — the PECL extension is absent on every server this runs on and this codebase has never used it. So `bootFileXattr()` runs `attr` through `proc_open`, captures stderr and the exit status, and answers `['value' => …, 'reason' => …]` where exactly one is ever empty. "attr is not installed on this server", "this filesystem does not carry extended attributes" and "not recorded on this file" are three different problems with three different fixes. It passes `-q`, which the old call site omitted — without it `attr -g` prints a header line and the old code took `tail -n1` and hoped.

## Why there is now a table

The codebase states a no-manifest principle in two places (`bin/restorekernel.sh:143-147`, `functions.sh:566-567`) and this does not dispute it — a record of *which files exist* would be wrong for exactly the stated reason.

So the filesystem stays the inventory: existence, size and mtime are read live on every listing, with no reconciliation step and no way for the records to disagree with the directory about its contents. The `bootFile` row holds only what the directory cannot say:

| Column | Why |
|---|---|
| `bfRole`, `bfKernelVersion` | derivable, but only by reading the file. Caches. |
| `bfChecksum` | same, but expensive enough to keep — and it is what lets two names be known to be one kernel |
| `bfReleaseTag` | **not a cache.** May be permanently unreadable on this server. |
| `bfPinned` | an admin's intention; nothing on disk carries it |

`bfSize`/`bfMtime` are the cache *key*, not the inventory.

**A tag once read is never discarded** — stored the first time it can be read at all, served from the row after that, and a later failed read does not clear it. This matters most where the read works exactly once: `kernelfetch()` already runs `attr -s` over SSH at download time, so a server that can never read the tag from a page render may still have recorded it when the file arrived.

**The records are an accelerator, never a dependency.** Every read and write is wrapped and fails silently — a listing renders with the table missing, unreachable or empty. It also pays back the cost #1688 flagged: the role lookup that became a 4KiB read per file is now a stat plus one query on the host form, group form, mass edit modal and settings page.

Full reasoning, including the narrow overturn of the no-manifest principle: `docs/adr/0042-the-filesystem-is-the-inventory-the-database-records-judgments.md`.

## Schema

Step **414**, `FOG_SCHEMA` bumped to 414. No foreign keys — `bootFile` references no other table, so `schema-constraints.php` is unchanged.

`schema-expected.php` was **hand-written**, because `bin/schema-manifest.php generate` connects to a live MySQL to read the real structure and there is none on this box. The pre-commit manifest check validated it against `schema.php` ("covers all 80 tables, 0 differences"), and `schema-manifest-consistent.test.php` (777 checks) passes — but the schema jobs against real MariaDB/MySQL in CI are the authority, and if my hand-written entry differs from what the server actually produces they will say so.

## Verification

- `tests/boot-file-info.test.php` — new, 22 checks. Pins the value/reason contract (deliberately environment-agnostic: whether `attr` exists on the runner is not the point, the contract is that value and reason are never both empty and never both set), the version from bytes, **mtime not ctime**, the checksum, a missing file reporting absent rather than erroring, and the listing still rendering with the record store unreachable.
- Schema guards: `schema-manifest-consistent` 777, `schema-shape-drift` 17, `schema-gate`, `booleans-are-tinyint`, `schema-retired-tables`, `schema-portable-collation` — all pass. `schema-executes` skips locally (no `FOG_TEST_DSN`); CI runs it against three engines.
- Full `tests/*.test.php`: **220 pass, 29 fail — the same 29 that fail on an unmodified checkout**, all from this box having no gettext extension.
- I ran the US-spelling word list by hand this time rather than trusting the suite: `us-spelling.test.php` shells out to `git ls-files` and cannot run here, so it fails environmentally and a before/after comparison cannot see a regression in it. It caught `judgements` in the ADR's own filename.
- `getclass-literals.test.php` initially failed on the two new class names — it enumerates via `git ls-files`, so untracked files are invisible to it. Passes once staged, which is also how CI sees it.
- **The two `phpstan` passes were not run:** no `composer`/`vendor` on this box. CI is first.

## Not in this PR

The `bfPinned` column is written by nothing yet — the pin action arrives with the Local files tab, and the pruner that honours it arrives with the retention work. It is in this schema step because adding a column later is a second migration for no gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYw9JCZGPeHuse6RTyNPgs
