### PR TITLE
Decide GH-1685: the leaf is not the CA, and the chain has to arrive too

### DIFF
--- a/docs/PKI_ZONES.md
+++ b/docs/PKI_ZONES.md
@@ -546,7 +546,7 @@ The installer creates it, and `restorecon`s it — which is also the fix for the
 SELinux footgun above, since a directory FOG creates carries the right label
 instead of whatever an arbitrary location happened to have.
 
-**Drop a pair in and re-run the installer.** Two names:
+**Drop a pair in and re-run the installer.** Two names, both required (a third, optional one for the chain is below):
 
 ```
 /etc/fog/customizations/pki/web-leaf.pem
@@ -572,6 +572,44 @@ side for the reason the PKI tree itself moved there; kernels and boot images sta
 under `/opt` because the FHS does not put binaries in `/etc`. See
 [ADR 0040](adr/0040-certificates-you-bring-live-in-a-customizations-tree.md).
 
+### If your CA is not one this server already trusts
+
+A leaf is not servable on its own. Two separate things have to be true, and
+neither is implied by the other:
+
+1. **The intermediates have to reach the vhost**, or clients get an incomplete
+   chain. Add a third, optional file beside the pair:
+
+   ```
+   /etc/fog/customizations/pki/web-leaf-chain.pem
+   ```
+
+   Or make `web-leaf.pem` a fullchain — leaf first, then intermediates, the
+   shape every ACME client emits. FOG splits it and keeps **only the leaf** at
+   the canonical leaf path, because a bundle stored there grows by one copy of
+   the intermediate on every run and iPXE stops booting long before a browser
+   complains (GH-863). The order of the file does not matter: certificates are
+   classified by whether they are self-signed and by whether the public key
+   matches the key, never by position.
+
+2. **The root has to be anchored**, or every HTTPS call this server makes to
+   itself fails to verify — which is most of what the installer does after it
+   writes the vhost. Import it from the Certificates page, or pass
+   `--web-ca-root`. A self-signed root left in the chain file is **not** taken
+   as consent to trust it; FOG reports which issuer is missing and waits for the
+   import.
+
+The two go together. FOG refuses to adopt a leaf when no path builds — a
+refusal, not a warning, because adopting one trades a server that works for one
+that does not, and the failure shows up as unrelated HTTPS errors much later.
+The refusal names the issuer it could not find.
+
+If your deployment is genuinely one where no path can build on this host —
+split-horizon DNS, an internal CA reachable only elsewhere, clients that pin —
+set the canonical paths by hand as described under **Certificate paths** above
+and re-run the installer. That route does not consult the chain, and it is
+deliberately not a checkbox on the Certificates page: it is the one case where
+you are telling FOG you know better than its verification.
 ## Let's Encrypt and ACME
 
 **FOG does not run an ACME client and will not.** Use `certbot`, `acme.sh`, or

--- a/docs/adr/0036-the-web-tier-changes-pki-through-a-fixed-verb-set.md
+++ b/docs/adr/0036-the-web-tier-changes-pki-through-a-fixed-verb-set.md
@@ -5,6 +5,188 @@
 accepted, and implemented on `working-1.6` as `packages/pki/fog-pki-admin` plus
 `_installPkiAdminHelper()`.
 
+## Amended 2026-09-02 — the leaf is not the CA
+
+Settles FOGProject/fogproject#1685, and reverses one of the alternatives
+rejected below. GH-1681 changed the ground: `/etc/fog/customizations/pki` is now
+a documented place to put a certificate you brought, and a `web-leaf.pem` /
+`web-leaf.key` pair dropped there is signal 0 of
+`_detectExternalCertManagement()`. The page already *reports* the derived
+`externally_managed_leaf` state; nothing could act on it.
+
+**What this ADR never decided.** The decision below is about a root CA, and it
+says so throughout — `import-root`, the anchor, "what this server trusts". A
+leaf appears once, in the Consequences, only to say `acmeLeaf` is retired and
+the state is derived. Leaf *import* was not considered and not rejected. Read as
+a blanket rule, "PHP is the threat model" forecloses it; that reading is wider
+than what was argued for, and this amendment narrows the rule to what the
+argument actually supports.
+
+**The narrowing.** No **CA** private key transits PHP. A vhost leaf key may. The
+two are not the same asset:
+
+| material | blast radius if the web tier is compromised |
+|---|---|
+| root CA key | the certificate every `fog-client` **pins** — impersonate the imaging server to the whole estate, push arbitrary images and snapins as SYSTEM |
+| vhost leaf key | TLS for the console, on a box whose web tier the attacker already owns |
+
+The qualifier that keeps this honest is **wildcards**. A `*.example.com` key is
+the common case an administrator already holds, and it covers hosts that are not
+this one — so its theft is the one outcome that escalates past "the attacker
+already owns this web tier". That is a reason to say so at the point of upload
+and to prefer the two routes that never send a key, not a reason to refuse the
+channel: every enrollment protocol that avoids it is CSR-based (PKCS#10, ACME,
+EST, CMP), PKCS#12 exists precisely to transport a key with its certificate, and
+the appliances that do accept one — pfSense, UniFi, iDRAC, Proxmox, IIS, cPanel
+— are all cases where the management UI is already the privileged process.
+
+**What does not change.** The web tier still names a verb and an allowlisted
+token, and still never names a path. `import-leaf` is a sixth verb, not a
+reversal of the rule: the helper decides every destination, exactly as
+`import-root` does. In particular the PKCS#12 **passphrase is not an argument**.
+`_pkiRun()` builds a command line and `exec()`s it, so an argument is readable
+in `/proc` by every local user for the life of the call; the passphrase is
+staged as a second file under the same `reqid`, read with `openssl -passin
+file:`, and unlinked with it.
+
+**Three routes, because they suit different policies.** In the order the page
+offers them:
+
+| route | verbs | does a key transit PHP? |
+|---|---|---|
+| adopt what is in `PKI_custom_dir` | `adopt-custom-leaf` | no |
+| CSR out, certificate in | `make-leaf-csr`, `install-leaf-cert <reqid>` | no — the helper generates the key at `0400 root:root` |
+| upload a leaf bundle | `import-leaf <reqid>` | yes, for one request |
+
+`adopt-custom-leaf` takes **no argument at all**: the directory comes from the
+helper's own `0600 root:root` config. A free-text "use the certificate at this
+path" field was the obvious alternative and is refused on the grounds already
+recorded below — the sibling directory GH-1681 blessed is what makes a
+fixed-location action possible instead. `make-leaf-csr` follows
+`packages/web/service/nodecert.php`, which has signed storage-node CSRs without
+moving a key since before this page existed.
+
+**Accept the artifacts administrators actually hold.** A fullchain PEM — leaf,
+intermediates, sometimes the root — or a bare leaf with a separate
+`web-leaf-chain.pem`, or a PKCS#12 container. All are split by the helper and
+classified by property, never by position: the certificate whose public key
+matches the private key is the leaf, and the remaining non-self-signed ones are
+the chain. Position cannot be trusted, and `_writeWebChainFiles()` and
+`_rootFromChain()` already say why — FOG's own writers disagree, with
+`createWebIntermediateCA()` writing issuer-first and `validateExternalCA()`
+writing the root first.
+
+**The leaf slot receives exactly one certificate.** A fullchain input is split
+before anything is written, never stored whole. GH-863 is what this rule is made
+of: once `PKI_web_vhost_cert` named the assembled bundle, every run appended one
+more copy of the intermediate — fourteen certificates on a live server — and
+iPXE validates pairwise from the trusted root upwards, so copy 2 was checked
+against copy 1 as its issuer and every HTTPS netboot died at `boot.php` with
+nothing server-side saying why. Browsers tolerated it. This is the highest-risk
+regression in the feature, and it is pinned by test.
+
+**New checked properties**, the analogue of `import-root` keeping only
+self-signed certificates:
+
+- The leaf must **not** be a CA. Refusing `CA:TRUE` is what makes "no CA private
+  key reaches this channel" a checked property rather than a promise.
+- The certificate and key must be a genuine pair, by `_certKeyPairMatches()`'s
+  subject-public-key comparison — not an RSA modulus, which cannot read an EC
+  key at all (GH-1393).
+- The leaf must be in date, and a path must **build**: `openssl verify -trusted
+  <anchor set> -untrusted <supplied chain>`. Adopting a leaf whose chain does
+  not build trades a working server for a broken one, because FOG's own HTTPS
+  self-calls stop verifying — which is what `tests/selfcall-verification.test.sh`
+  exists to catch. The refusal names the issuer that is missing.
+  `docs/PKI_ZONES.md` documents the one escape hatch, for split-horizon and
+  pinned deployments; it is not a checkbox on the page.
+
+**A root inside an uploaded bundle is reported, never anchored.** The page says
+which issuer the leaf chains to and that this server does not trust it yet, and
+offers a separate import that runs the existing `import-root` path. Anchoring
+changes what the whole host accepts, so it stays a decision somebody makes
+knowingly — the reasoning that already keeps `import-root` self-signed-only.
+
+This obliges the new verbs to **strip self-signed certificates out of whatever
+they write to `PKI_web_trust_chain`**, and the reason is not tidiness.
+`_resolveTrustAnchor()` anchors `_rootFromChain("${PKI_web_trust_chain}")`, so a
+root left in the chain file is anchored on the next rebuild and the explicit
+import becomes theatre. Note the asymmetry, before anyone simplifies the strip
+away: the *served* chain is already safe, because `_writeWebChainFiles()` filters
+self-signed out when it assembles — "a self-signed certificate in here is the
+root, and it is the one thing that must not be sent". It is the anchor path that
+needs the strip.
+
+**Certificate material takes effect at once; flags still wait for the
+installer.** This narrows the Consequence below that says the preferences "take
+effect on the next installer run and not before". That reasoning is right for a
+flag the installer reads back and wrong for a certificate: a button labeled
+"use this certificate" that does not change what the server serves is a button
+that does not work. So the certificate verbs relink `PKI_web_vhost_cert` and
+`PKI_web_vhost_key` and reload the web server. The vhost needs no rewrite — it
+already names the canonical paths — so relink plus reload is the whole of it.
+The preferences are unchanged.
+
+**`set-preference`'s allowlist becomes per-key, and this reverses a rejected
+alternative.** The value pattern was one `^(yes|no)$` for all three keys.
+`BOOT_url_proto` is `http` or `https`, so the domain becomes per-key —
+`^(http|https)$` for that one. Still a value drawn from a fixed set, so the rule
+holds; it is the implementation that generalizes.
+
+The reversal is the substantive part, and is stated plainly rather than left to
+be discovered. "`BOOT_url_proto_forced` in the allowlist" is rejected below,
+because "forcing netboot to HTTPS with neither steering key set … breaks PXE for
+machines that cannot fix themselves. Not a thing a misclick should reach."
+Adding `BOOT_url_proto` achieves what that entry would have, and this ADR should
+not pretend otherwise: `_resolveInstallMode()` sets `BOOT_url_proto_forced=yes`
+whenever an explicit value is supplied, so writing the protocol **is** forcing
+it.
+
+What answers the original objection is the two conditions it named, both now
+met. The switch is never offered alone — `BOOT_url_proto`,
+`BOOT_rebuild_ipxe_with_my_ca` and `PKI_web_cert_publicly_trusted` are presented
+as **one decision**, because "can iPXE validate what this server serves" is one
+question and three keys are how it is answered. And it is not a misclick: the
+page states that a leaf iPXE cannot verify means every netboot dies at
+`boot.php`; that under `BOOT_url_proto=https` ADR 0018 makes `FOG_WEB_HOST` a
+record rather than a control, rewritten on every run; and that the install
+**stops** if the served certificate carries no usable name, since
+`--extra-server-name` feeds only FOG's own SAN list and cannot rescue a leaf
+issued outside FOG. The gate is still `system.pki`, deny by default.
+
+**The redirect and netboot transport are two settings, and the page must stop
+implying otherwise.** `WEB_https_redirect` already excludes netboot, and does it
+conditionally: when `BOOT_url_proto != https` the vhost skips the redirect for
+`service/ipxe/`, `service/secureboot/` and `service/uboot/` — the three paths a
+bootloader fetches for itself, the last being U-Boot's HTTP-only `wget`, which
+cannot follow a redirect at all. `management/other/ca.cert.der` is exempt
+**unconditionally**, whatever the netboot transport, because redirecting it would
+make fetching the CA require already trusting the CA. Everything else FOS
+fetches uses `curl -Lks` and so survives a redirect, which is load-bearing and
+recorded nowhere else: a FOS fetch that ever drops `-k` has to be added to the
+exclusion too.
+
+Two obligations follow. The behavior is **pinned by test against the generated
+config for both engines**, because `docs/PKI_ZONES.md` lists the nginx branch of
+this exclusion among the things that have never executed. And the page states
+that the redirect is **not fully reversible**: it also emits
+`Strict-Transport-Security max-age=15768000`, which is the redirect's semantics
+with a memory — a browser that has seen it refuses plain HTTP to this host for
+six months out of its own cache, so turning the switch off does nothing for
+anyone who has already visited.
+
+**The helper still duplicates rather than shares.** `_certKeyPairMatches()`,
+`_customPkiPair()`, `_splitPemBundle()`, `_rootFromChain()` and `_linkCanonical()`
+are ported into `fog-pki-admin`, not called. An installed server has `bin/` but
+no `lib/`, so there is nothing to share — the same reason the helper already
+carries its own copy of `_splitPemBundle()` and the anchor rebuild, and the same
+obligation: the tests pin both copies against one behavior.
+`_detectExternalCertManagement()` is **not** ported. Signal 0 is as portable as
+`_customPkiPair()`, but signals 1 through 3 need `$etcconf` — the live,
+OS-specific vhost path — along with `$fogprogramdir` and `$PKI_client_cert_dir`,
+and a helper that reconstructed those would be answering a question it cannot
+see the inputs to.
+
 ## Context
 
 `FOGConfigurationPage::certificates()` was read-only. Everything an
@@ -151,5 +333,8 @@ machines that cannot fix themselves. Not a thing a misclick should reach.
   `acmeLeaf` is derived rather than stored
 - [ADR 0015](0015-install-settings-are-independent-keys.md) — the three
   preferences are independent keys
+- Issue: FOGProject/fogproject#1685 — the 2026-09-02 amendment; FOGProject/fogproject#1681 blessed the directory it adopts from
+- [ADR 0040](0040-certificates-you-bring-live-in-a-customizations-tree.md) — the customizations tree the leaf is adopted out of
+- [ADR 0018](0018-netboot-addresses-this-server-by-its-certificate-name.md) — why `BOOT_url_proto=https` makes `FOG_WEB_HOST` a record
 - `docs/PKI_ZONES.md` — the zones the slots name
 - `docs/FOGSETTINGS.md` — the reader table this helper is now the second entry in

--- a/docs/adr/0040-certificates-you-bring-live-in-a-customizations-tree.md
+++ b/docs/adr/0040-certificates-you-bring-live-in-a-customizations-tree.md
@@ -7,6 +7,28 @@ accepted, and implemented on `working-1.6` as `_customPkiDir()` /
 with `PKI_custom_dir` recorded in `.fogsettings` and signal 0 of
 `_detectExternalCertManagement()`.
 
+## Amended 2026-09-02 — a third name, for the chain
+
+`web-leaf-chain.pem` joins `web-leaf.pem` and `web-leaf.key` as a documented
+name in this directory, optional where the other two are required. It settles a
+gap FOGProject/fogproject#1685 found: a leaf issued by an external CA is not
+servable on its own. The chain has to reach the vhost, and the pair test here
+deliberately excludes `PKI_web_trust_chain`, so a leaf whose intermediates are
+nowhere could be adopted and then fail to build a path.
+
+Three names rather than two does not weaken "two names, not a glob" — the
+reasoning was never about the count. It was that FOG must not choose between
+candidates on its own, and an explicitly documented third name chooses nothing.
+A fullchain `web-leaf.pem` is also accepted, and is split rather than stored
+whole: the leaf slot takes exactly one certificate, for the GH-863 reason
+recorded in [ADR 0036](0036-the-web-tier-changes-pki-through-a-fixed-verb-set.md)'s
+2026-09-02 amendment.
+
+Adoption otherwise behaves as decided below. A chain that does not let the leaf
+verify is a refusal, not a warning, and a self-signed root found in the supplied
+material is reported for an explicit import rather than anchored — the amendment
+to ADR 0036 carries both rules and the reason the second one is not optional.
+
 ## Context
 
 [ADR 0024](0024-fogsettings-unified-key-model.md) settled how FOG uses a


### PR DESCRIPTION
Records the decision #1685 was filed to force. Docs only — no code — because the analysis is the expensive part and the implementation should not have to re-derive it.

#1685 is labelled `ready-for-human` for a reason: its second question is a security judgement. This settles it, in the place the next reader will actually look.

## The narrowing

**No *CA* private key transits PHP. A vhost leaf key may.**

ADR 0036 is argued about a root CA from beginning to end — `import-root`, the anchor, "what this server trusts" — and mentions a leaf exactly once, in its Consequences, only to say `acmeLeaf` is retired and the state is derived. **Leaf import was never considered and never rejected.** Read as a blanket rule, "PHP is the threat model" forecloses it; that reading is wider than what was argued for. So this fills a silence rather than overturning a finding.

| material | blast radius if the web tier is compromised |
|---|---|
| root CA key | the certificate every `fog-client` **pins** — impersonate the imaging server to the whole estate |
| vhost leaf key | TLS for the console, on a box whose web tier the attacker already owns |

The qualifier that keeps that honest is **wildcards**: `*.example.com` is the common case an admin already holds, and it covers hosts that are not this one. That is a reason to say so at the point of upload and to prefer the routes that never send a key — not to refuse the channel, given that PKCS#12 exists to transport exactly this and every appliance that accepts one is a case where the management UI is already privileged.

## Three routes

| route | verbs | key through PHP? |
|---|---|---|
| adopt what is in `PKI_custom_dir` | `adopt-custom-leaf` | no |
| CSR out, certificate in | `make-leaf-csr`, `install-leaf-cert <reqid>` | no |
| upload a leaf bundle | `import-leaf <reqid>` | yes, for one request |

`adopt-custom-leaf` takes **no argument at all** — stricter than ADR 0036 requires. The free-text path field #1685 floated is refused on the ADR's own recorded grounds; #1681's sibling directory is what makes a fixed-location action possible instead. `make-leaf-csr` follows `service/nodecert.php`, which has signed storage-node CSRs without moving a key since before this page existed. The PKCS#12 passphrase is explicitly **not** an argument, because `_pkiRun()` builds a command line and an argument is readable in `/proc` for the life of the call.

## Two things #1685 did not account for

**An external CA has to be *trusted*, not just served.** No verb can write `PKI_web_trust_chain` today, and `_customPkiPair()` deliberately excludes it from the pair test — so **FOG will currently adopt a leaf it cannot build a path for.** Fullchain PEM, a separate `web-leaf-chain.pem`, and PKCS#12 are all accepted, split by property and never by position. A path must build or the adoption is refused, naming the missing issuer.

A self-signed root in the supplied material is *reported* for an explicit import, never anchored — which obliges the verbs to **strip self-signed certificates out of what they write to the chain file.** Not tidiness: `_resolveTrustAnchor()` anchors `_rootFromChain("${PKI_web_trust_chain}")`, so a root left there is anchored on the next rebuild and the explicit import becomes theatre. Note the asymmetry before anyone simplifies the strip away — the *served* chain is already safe, because `_writeWebChainFiles()` filters self-signed out when it assembles.

**The leaf slot takes exactly one certificate.** GH-863 is what that rule is made of: once the leaf path named the assembled bundle, every run appended another copy of the intermediate — fourteen on a live server — and iPXE validates pairwise, so every HTTPS netboot died at `boot.php` while browsers shrugged. Highest-risk regression in the feature, and it is pinned by test.

## Also settled: the redirect and netboot switches

Not raised in #1685, but the same page and the same boundary.

`WEB_https_redirect` already excludes netboot correctly — `service/ipxe/`, `service/secureboot/` and `service/uboot/` when `BOOT_url_proto != https`, and `ca.cert.der` **unconditionally**, since redirecting it would make fetching the CA require already trusting the CA. What is missing is proof: `PKI_ZONES.md`'s own "Still unverified" list names the nginx branch of this exclusion as never executed, so it gets pinned against the generated config for **both** engines before the page leans on it. The switch is also **not fully reversible** — it emits HSTS, which is the redirect's semantics with a memory — and the page has to say so.

And `BOOT_url_proto` joins the `set-preference` allowlist, with the value domain becoming per-key (`^(http|https)$` beside `^(yes|no)$`).

**This reverses a rejected alternative, and the amendment says so plainly rather than leaving it to be discovered.** "`BOOT_url_proto_forced` in the allowlist" is rejected in ADR 0036 because forcing netboot to HTTPS "breaks PXE for machines that cannot fix themselves. Not a thing a misclick should reach." Adding `BOOT_url_proto` achieves what that entry would have — `_resolveInstallMode()` sets the forced flag whenever an explicit value is supplied, so writing the protocol *is* forcing it. What answers the objection is its own two conditions, both now met: the switch is never offered alone (it is one decision with `BOOT_rebuild_ipxe_with_my_ca` and `PKI_web_cert_publicly_trusted`), and it is not a misclick (iPXE validation, ADR 0018's `FOG_WEB_HOST`-as-record, and the install that *stops* on an unusable name are all stated at the point of change, behind deny-by-default `system.pki`).

## One correction to #1685's premise

The issue says both actions "should call the existing machinery rather than reimplement it". They cannot: `lib/common/functions.sh` is not shipped to an installed server. `fog-pki-admin` already duplicates `_externallyManagedLeaf()` inline and says why — "an installed server has `bin/` but no `lib/`, so there is nothing to share." So the helper ports `_certKeyPairMatches()`, `_customPkiPair()`, `_splitPemBundle()`, `_rootFromChain()` and `_linkCanonical()`, all of which are pure. `_detectExternalCertManagement()` is **not** ported: signal 0 is as portable as `_customPkiPair()`, but signals 1–3 need `$etcconf`, the live OS-specific vhost path.

## Form

An `## Amended` section on ADR 0036 rather than a new ADR, following ADR 0013's precedent — placed immediately after `## Status`, newest-first, as 0013 does, and the original Decision text is left untouched. The verb-and-token rule survives intact, so a supersession would overstate the change. ADR 0040 gains a third documented name for the chain; three names is not a weaker rule than two, because the reasoning was never the count — it was that FOG must not choose between candidates on its own.

## Verification

- Docs only. `git diff --stat` is three files under `docs/`; no test reads any of them (only a comment in `pki-tree-relocation.test.sh` mentions `PKI_ZONES.md`).
- US-spelling: `tests/us-spelling.test.php` cannot enumerate files on this box, so the added prose was checked against the test's own 113-word list directly — four hits found and fixed (`enrolment`, `artefacts`, `labelled`, `behaviour`), plus `generalises`, which the list does not carry.
- Every ADR cross-link added resolves to a file that exists.
- The suite was run for a baseline. Failures on this box are the documented Windows fixture problem, not this change: Git Bash rewrites `openssl -subj "/CN=..."` into `C:/Program Files/Git/CN=...`, so no openssl fixture builds here. Confirmed directly rather than assumed. CI is the first place those run for real, and this change touches no code they cover.

## Follow-ups this unblocks

- The implementation of the verbs and the page. The test cases the decision needs are named in the amendment so they are not rediscovered.
- A separate issue for the redirect/netboot half, so the vhost-emission tests are not gated behind the import verbs.
- `PKI_ZONES.md`'s "Still unverified" nginx line is deliberately **left in place** — the tests are what earn its removal, and only once that branch has actually run.

Closes nothing on its own; #1685 stays open for the implementation, re-scoped to this decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
