### PR TITLE
Add a Local files tab to the kernel and initrd update pages

### DIFF
--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -5223,6 +5223,72 @@ function reinitialize() {
       });
   };
 
+  /**
+   * The Local files tab's row actions on Kernel Update / Initrd Update.
+   *
+   * node=about is sent explicitly. The download endpoints are requested with
+   * no node at all, which is why they needed entries in
+   * GLOBAL_SUB_OVERRIDES to be permission-checked properly -- these resolve
+   * against the page's own node instead, so their permissions are declared
+   * where the rest of that page's are.
+   *
+   * Delegated and namespaced: the pane arrives with the page, by AJAX.
+   */
+  var setupBootFileActions = function() {
+    var post = function(sub, data, confirmText) {
+      if (confirmText && !window.confirm(confirmText)) {
+        return;
+      }
+      $.apiCall(
+          'post',
+          '?node=about&sub=' + sub,
+          data,
+          function(err) {
+            if (!err) {
+              // Re-read rather than patch the row in place: the server
+              // decides what is now in use as what, and which rows may
+              // still offer a Delete button. Guessing that here would be a
+              // second copy of those rules.
+              //
+              // location.reload(), the same way the certificates pane on
+              // this page refreshes after a write. The API token pane calls
+              // table.ajax.reload() instead, but that is a DataTable and
+              // this pane deliberately is not.
+              location.reload();
+            }
+          }
+      );
+    };
+
+    $(document)
+      .off('click.fogBootFileAct')
+      .on('click.fogBootFileAct', '.fog-bootfile-keep', function(e) {
+        e.preventDefault();
+        var $b = $(this);
+        post('bootfilekeep', {
+          name: $b.data('name'),
+          keep: $b.data('keep')
+        });
+      })
+      .on('click.fogBootFileAct', '.fog-bootfile-default', function(e) {
+        e.preventDefault();
+        var $a = $(this);
+        post('bootfiledefault', {
+          name: $a.data('name'),
+          key: $a.data('key')
+        });
+      })
+      .on('click.fogBootFileAct', '.fog-bootfile-delete', function(e) {
+        e.preventDefault();
+        var name = $(this).data('name');
+        post(
+            'bootfiledelete',
+            {name: name},
+            'Delete ' + name + ' from the boot directory?'
+        );
+      });
+  };
+
   $.debugLog("=== DEBUG LOGGING ENABLED ===");
   setupIntegrations();
   if ($.fn.inputmask) {
@@ -5244,6 +5310,7 @@ function reinitialize() {
     });
   });
   setupBootFilePickers();
+  setupBootFileActions();
   disableFormDefaults();
   wireImportForm();
   setupPasswordReveal();

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -191,8 +191,20 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "wurde abgebrochen"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "Gelöscht"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -207,8 +219,20 @@ msgid "%s images"
 msgstr "Images"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr "läuft nicht mehr"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -224,6 +248,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -252,6 +280,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1263,6 +1295,10 @@ msgstr "Standard Logout-Zeit (in Minuten)"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "Keine Datei wurde hochgeladen"
+
 msgid "BIOS Date"
 msgstr "BIOS-Datum"
 
@@ -1307,6 +1343,18 @@ msgstr "Passwort binden"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "Löschen der Datei fehlgeschlagen"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "Boot-Optionen:"
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "Site aktualisiert!"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1683,6 +1731,9 @@ msgstr "Gehäuse-Version"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2349,8 +2400,31 @@ msgid "Default Width"
 msgstr "Standardbreite"
 
 #, fuzzy
+msgid "Default init, ARM64"
+msgstr "Standardbreite"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "Standardbreite"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "Standardbreite"
+
+#, fuzzy
 msgid "Default is disabled"
 msgstr "Standard ist deaktiviert"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "Standard-Bildwiederholrate"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "Standarddrucker aktualisieren"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4476,6 +4550,9 @@ msgstr "In "
 msgid "In FOG"
 msgstr "zu booten."
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4855,6 +4932,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5260,6 +5343,10 @@ msgstr "Laden fehlgeschlagen: %s"
 msgid "Loading data to field"
 msgstr "Laden von Daten zum Feld %s"
 
+#, fuzzy
+msgid "Local files"
+msgstr "Standorte"
+
 msgid "Location"
 msgstr "Ort"
 
@@ -5548,6 +5635,9 @@ msgstr "Speicher"
 msgid "Memory limit cannot be less than 128"
 msgstr "Menüpunkt oder Titel darf nicht leer sein."
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "Beschreibung"
@@ -5628,6 +5718,9 @@ msgstr "Modell"
 #, fuzzy
 msgid "Models"
 msgstr "Modell"
+
+msgid "Modified"
+msgstr ""
 
 #, fuzzy
 msgid "Module"
@@ -5969,6 +6062,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "Keine Datei wurde hochgeladen"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "Erstellen eines Snapin-Jobs fehlgeschlagen"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -6129,6 +6226,9 @@ msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "Die zugewiesene Image Speichergruppe ist nicht gültig."
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 msgid "No such filter"
 msgstr ""
@@ -8022,6 +8122,10 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr "Name der Speichergruppe"
 
 #, fuzzy
+msgid "Set as"
+msgstr "Service-Update fehlgeschlagen"
+
+#, fuzzy
 msgid "Set failed"
 msgstr "Service-Update fehlgeschlagen"
 
@@ -8537,6 +8641,9 @@ msgstr "Drucker-Update fehlgeschlagen!"
 
 msgid "Status"
 msgstr "Status"
+
+msgid "Stop keeping"
+msgstr ""
 
 msgid "Storage"
 msgstr "Speicher"
@@ -9282,6 +9389,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr " | Datei oder Pfad ist nicht erreichbar"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9477,6 +9588,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "Temporäre Datei konnte nicht gelesen werden."
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -10075,6 +10190,10 @@ msgstr "Nicht verfügbar"
 
 msgid "Uncategorized"
 msgstr ""
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "zugeordneter Host"
 
 msgid "Unicast"
 msgstr "Unicast"
@@ -10747,6 +10866,10 @@ msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
+msgstr "Keine Verbindung zur Datenbank"
 
 msgid "You do not have permission to change provider group associations."
 msgstr ""
@@ -11516,6 +11639,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 #, fuzzy
 msgid "second"
 msgstr "Sekunde"
@@ -12086,10 +12212,6 @@ msgstr ""
 #~ msgstr "Aktualisieren/Erstellen des Image-Logs fehlgeschlagen"
 
 #, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "Löschen der Datei fehlgeschlagen"
-
-#, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "Ich bin nicht der FOG-Web-Server"
 
@@ -12213,10 +12335,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "Host Aktualisierung erfolgreich!"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "Site aktualisiert!"
 
 #, fuzzy
 #~ msgid "Host Snapins"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -196,8 +196,20 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "has been successfully updated"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "Deleted"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -212,8 +224,20 @@ msgid "%s images"
 msgstr "Images"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr " no longer exists"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -229,6 +253,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -257,6 +285,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1267,6 +1299,10 @@ msgstr "Default log out time (in minutes)"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "No file was uploaded"
+
 msgid "BIOS Date"
 msgstr "BIOS Date"
 
@@ -1311,6 +1347,18 @@ msgstr "Domain Password"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "Failed to delete file"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "Boot Options:"
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "Service Updated!"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1686,6 +1734,9 @@ msgstr "Chassis Version"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2352,8 +2403,31 @@ msgid "Default Width"
 msgstr "Default Width"
 
 #, fuzzy
+msgid "Default init, ARM64"
+msgstr "Default Width"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "Default Width"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "Default Width"
+
+#, fuzzy
 msgid "Default is disabled"
 msgstr "Donations are disabled"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "Default Refresh Rate"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "Update Printer"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4478,6 +4552,9 @@ msgstr "In "
 msgid "In FOG"
 msgstr "In "
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4857,6 +4934,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5272,6 +5355,10 @@ msgstr "Load failed: %s"
 msgid "Loading data to field"
 msgstr "Loading data to field %s"
 
+#, fuzzy
+msgid "Local files"
+msgstr "Locations"
+
 msgid "Location"
 msgstr "Location"
 
@@ -5560,6 +5647,9 @@ msgstr "Memory"
 msgid "Memory limit cannot be less than 128"
 msgstr "Menu Item or title cannot be blank"
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "Description"
@@ -5640,6 +5730,9 @@ msgstr "Model"
 #, fuzzy
 msgid "Models"
 msgstr "Model"
+
+msgid "Modified"
+msgstr ""
 
 #, fuzzy
 msgid "Module"
@@ -5981,6 +6074,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "No file was uploaded"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "Failed to create Snapin Job"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -6141,6 +6238,9 @@ msgstr "An image already exists with this name!"
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "The image storage group assigned is not valid"
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 msgid "No such filter"
 msgstr ""
@@ -8033,6 +8133,10 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr "Storage Group Name"
 
 #, fuzzy
+msgid "Set as"
+msgstr "Service update failed"
+
+#, fuzzy
 msgid "Set failed"
 msgstr "Service update failed"
 
@@ -8548,6 +8652,9 @@ msgstr "Printer update failed!"
 
 msgid "Status"
 msgstr "Status"
+
+msgid "Stop keeping"
+msgstr ""
 
 msgid "Storage"
 msgstr "Storage"
@@ -9291,6 +9398,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr " | File or path cannot be reached"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9486,6 +9597,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "Could not read temp file"
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -10084,6 +10199,10 @@ msgstr "Not Available"
 
 msgid "Uncategorized"
 msgstr ""
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "No node associated"
 
 msgid "Unicast"
 msgstr "Unicast"
@@ -10755,6 +10874,10 @@ msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
+msgstr "No connection to the database"
 
 msgid "You do not have permission to change provider group associations."
 msgstr ""
@@ -11520,6 +11643,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 #, fuzzy
 msgid "second"
 msgstr "Icon"
@@ -12080,10 +12206,6 @@ msgstr ""
 #~ msgstr "Failed to update/create image log"
 
 #, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "Failed to delete file"
-
-#, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "I am not the fog web server"
 
@@ -12204,10 +12326,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "Install / Update Successful!"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "Service Updated!"
 
 #, fuzzy
 #~ msgid "Host Snapins"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -194,8 +194,20 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "se ha actualizado correctamente"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "Borrar"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -210,8 +222,20 @@ msgid "%s images"
 msgstr "Imagen"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr "Impresora ya existe"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -227,6 +251,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, fuzzy, php-format
@@ -255,6 +283,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1281,6 +1313,10 @@ msgstr "Por defecto cerrar sesión en el tiempo (en minutos)"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "Ningún archivo fue subido"
+
 msgid "BIOS Date"
 msgstr "Fecha del BIOS"
 
@@ -1326,6 +1362,18 @@ msgstr "Contraseña de dominio"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "No se pudo crear el usuario"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "Opciones de arranque:"
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "Servicio de Actualización!"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1703,6 +1751,9 @@ msgstr "Versión chasis"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2377,8 +2428,31 @@ msgid "Default Width"
 msgstr "Ancho por defecto"
 
 #, fuzzy
+msgid "Default init, ARM64"
+msgstr "Ancho por defecto"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "Ancho por defecto"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "Ancho por defecto"
+
+#, fuzzy
 msgid "Default is disabled"
 msgstr "Ancho por defecto"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "Frecuencia de actualización predeterminado"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "Actualizar impresora"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4555,6 +4629,9 @@ msgstr "En "
 msgid "In FOG"
 msgstr "En "
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4945,6 +5022,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5359,6 +5442,10 @@ msgid "Loading data to field"
 msgstr "La carga de datos de campo de %s"
 
 #, fuzzy
+msgid "Local files"
+msgstr "Acción"
+
+#, fuzzy
 msgid "Location"
 msgstr "Acción"
 
@@ -5661,6 +5748,9 @@ msgstr "Memoria"
 msgid "Memory limit cannot be less than 128"
 msgstr "Elementos de menú o el título no puede estar en blanco"
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "Descripción:"
@@ -5741,6 +5831,9 @@ msgstr "Modelo"
 #, fuzzy
 msgid "Models"
 msgstr "Modelo"
+
+msgid "Modified"
+msgstr ""
 
 msgid "Module"
 msgstr "Módulo"
@@ -6089,6 +6182,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "Ningún archivo fue subido"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "No se pudo crear Complemento de empleo"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -6250,6 +6347,9 @@ msgstr "Una imagen ya existe con este nombre!"
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "Marque aquí para ver los grupos no asignado esta imagen"
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 msgid "No such filter"
 msgstr ""
@@ -8164,6 +8264,10 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr "Nombre del grupo de almacenamiento"
 
 #, fuzzy
+msgid "Set as"
+msgstr "actualización de servicio no pudo"
+
+#, fuzzy
 msgid "Set failed"
 msgstr "actualización de servicio no pudo"
 
@@ -8688,6 +8792,9 @@ msgstr "actualización de la impresora ha fallado!"
 
 msgid "Status"
 msgstr "Estado"
+
+msgid "Stop keeping"
+msgstr ""
 
 #, fuzzy
 msgid "Storage"
@@ -9453,6 +9560,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr "No se pudo leer el archivo temporal"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9650,6 +9761,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "No se pudo leer el archivo temporal"
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -10243,6 +10358,10 @@ msgstr "No se dispone de hash"
 
 msgid "Uncategorized"
 msgstr ""
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "No nodo asociado"
 
 #, fuzzy
 msgid "Unicast"
@@ -10920,6 +11039,10 @@ msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
+msgstr "Haga clic en el botón para exportar la base de datos."
 
 msgid "You do not have permission to change provider group associations."
 msgstr ""
@@ -11686,6 +11809,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 msgid "second"
 msgstr ""
 
@@ -12248,10 +12374,6 @@ msgstr ""
 #~ msgstr "No se pudo crear Complemento de empleo"
 
 #, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "No se pudo crear el usuario"
-
-#, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Reiniciar"
 
@@ -12369,10 +12491,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "actualización Valoración falló"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "Servicio de Actualización!"
 
 #, fuzzy
 #~ msgid "Host Snapins"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -191,8 +191,20 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "wurde abgebrochen"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "Gelöscht"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -207,8 +219,20 @@ msgid "%s images"
 msgstr "Images"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr "läuft nicht mehr"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -224,6 +248,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -252,6 +280,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1263,6 +1295,10 @@ msgstr "Standard Logout-Zeit (in Minuten)"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "Keine Datei wurde hochgeladen"
+
 msgid "BIOS Date"
 msgstr "BIOS-Datum"
 
@@ -1307,6 +1343,18 @@ msgstr "Passwort binden"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "Löschen der Datei fehlgeschlagen"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "Boot-Optionen:"
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "Site aktualisiert!"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1683,6 +1731,9 @@ msgstr "Gehäuse-Version"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2349,8 +2400,31 @@ msgid "Default Width"
 msgstr "Standardbreite"
 
 #, fuzzy
+msgid "Default init, ARM64"
+msgstr "Standardbreite"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "Standardbreite"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "Standardbreite"
+
+#, fuzzy
 msgid "Default is disabled"
 msgstr "Standard ist deaktiviert"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "Standard-Bildwiederholrate"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "Standarddrucker aktualisieren"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4476,6 +4550,9 @@ msgstr "In "
 msgid "In FOG"
 msgstr "zu booten."
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4856,6 +4933,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5261,6 +5344,10 @@ msgstr "Laden fehlgeschlagen: %s"
 msgid "Loading data to field"
 msgstr "Laden von Daten zum Feld %s"
 
+#, fuzzy
+msgid "Local files"
+msgstr "Standorte"
+
 msgid "Location"
 msgstr "Ort"
 
@@ -5549,6 +5636,9 @@ msgstr "Speicher"
 msgid "Memory limit cannot be less than 128"
 msgstr "Menüpunkt oder Titel darf nicht leer sein."
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "Beschreibung"
@@ -5629,6 +5719,9 @@ msgstr "Modell"
 #, fuzzy
 msgid "Models"
 msgstr "Modell"
+
+msgid "Modified"
+msgstr ""
 
 #, fuzzy
 msgid "Module"
@@ -5970,6 +6063,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "Keine Datei wurde hochgeladen"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "Erstellen eines Snapin-Jobs fehlgeschlagen"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -6130,6 +6227,9 @@ msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "Die zugewiesene Image Speichergruppe ist nicht gültig."
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 msgid "No such filter"
 msgstr ""
@@ -8023,6 +8123,10 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr "Name der Speichergruppe"
 
 #, fuzzy
+msgid "Set as"
+msgstr "Service-Update fehlgeschlagen"
+
+#, fuzzy
 msgid "Set failed"
 msgstr "Service-Update fehlgeschlagen"
 
@@ -8538,6 +8642,9 @@ msgstr "Drucker-Update fehlgeschlagen!"
 
 msgid "Status"
 msgstr "Status"
+
+msgid "Stop keeping"
+msgstr ""
 
 msgid "Storage"
 msgstr "Speicher"
@@ -9283,6 +9390,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr " | Datei oder Pfad ist nicht erreichbar"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9478,6 +9589,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "Temporäre Datei konnte nicht gelesen werden."
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -10076,6 +10191,10 @@ msgstr "Nicht verfügbar"
 
 msgid "Uncategorized"
 msgstr ""
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "zugeordneter Host"
 
 msgid "Unicast"
 msgstr "Unicast"
@@ -10748,6 +10867,10 @@ msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
+msgstr "Keine Verbindung zur Datenbank"
 
 msgid "You do not have permission to change provider group associations."
 msgstr ""
@@ -11517,6 +11640,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 #, fuzzy
 msgid "second"
 msgstr "Sekunde"
@@ -12087,10 +12213,6 @@ msgstr ""
 #~ msgstr "Aktualisieren/Erstellen des Image-Logs fehlgeschlagen"
 
 #, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "Löschen der Datei fehlgeschlagen"
-
-#, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "Ich bin nicht der FOG-Web-Server"
 
@@ -12214,10 +12336,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "Host Aktualisierung erfolgreich!"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "Site aktualisiert!"
 
 #, fuzzy
 #~ msgid "Host Snapins"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -197,8 +197,20 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "a été mis à jour avec succès"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "supprimé"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -213,8 +225,20 @@ msgid "%s images"
 msgstr "Images"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr " n'existe plus"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -230,6 +254,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -258,6 +286,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1268,6 +1300,10 @@ msgstr "Par défaut déconnecter le temps (en minutes)"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "Aucun fichier a été téléchargé"
+
 msgid "BIOS Date"
 msgstr "BIOS date"
 
@@ -1312,6 +1348,18 @@ msgstr "domaine Mot de passe"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "Impossible de supprimer le fichier"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "Options de démarrage:"
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "Service de mise à jour!"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1687,6 +1735,9 @@ msgstr "Châssis Version"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2353,8 +2404,31 @@ msgid "Default Width"
 msgstr "Par défaut Largeur"
 
 #, fuzzy
+msgid "Default init, ARM64"
+msgstr "Par défaut Largeur"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "Par défaut Largeur"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "Par défaut Largeur"
+
+#, fuzzy
 msgid "Default is disabled"
 msgstr "Les dons sont désactivés"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "Par défaut Taux de rafraîchissement"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "Mise à jour de l'imprimante"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4479,6 +4553,9 @@ msgstr "Dans "
 msgid "In FOG"
 msgstr "Dans "
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4858,6 +4935,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5260,6 +5343,10 @@ msgstr "Échec du chargement: %s"
 msgid "Loading data to field"
 msgstr "Chargement des données à champ %s"
 
+#, fuzzy
+msgid "Local files"
+msgstr "Emplacements"
+
 msgid "Location"
 msgstr "Emplacement"
 
@@ -5548,6 +5635,9 @@ msgstr "Mémoire"
 msgid "Memory limit cannot be less than 128"
 msgstr "Élément de menu ou le titre ne peut pas être vide"
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "La description"
@@ -5628,6 +5718,9 @@ msgstr "Modèle"
 #, fuzzy
 msgid "Models"
 msgstr "Modèle"
+
+msgid "Modified"
+msgstr ""
 
 msgid "Module"
 msgstr "Module"
@@ -5968,6 +6061,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "Aucun fichier a été téléchargé"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "Échec de la création d'emploi Snapin"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -6128,6 +6225,9 @@ msgstr "Une image existe déjà avec ce nom!"
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "Le groupe de stockage d'images attribuée est non valable"
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 msgid "No such filter"
 msgstr ""
@@ -8019,6 +8119,10 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr "Nom du groupe de stockage"
 
 #, fuzzy
+msgid "Set as"
+msgstr "mise à jour du service n'a pas"
+
+#, fuzzy
 msgid "Set failed"
 msgstr "mise à jour du service n'a pas"
 
@@ -8533,6 +8637,9 @@ msgstr "mise à jour de l'imprimante a échoué!"
 
 msgid "Status"
 msgstr "statut"
+
+msgid "Stop keeping"
+msgstr ""
 
 msgid "Storage"
 msgstr "Stockage"
@@ -9276,6 +9383,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr " | Fichier ou chemin ne peut pas être atteint"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9471,6 +9582,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "Impossible de lire le fichier temporaire"
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -10069,6 +10184,10 @@ msgstr "Indisponible"
 
 msgid "Uncategorized"
 msgstr ""
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "Aucun noeud associé"
 
 msgid "Unicast"
 msgstr "Unicast"
@@ -10741,6 +10860,10 @@ msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
+msgstr "Pas de connexion à la base de données"
 
 msgid "You do not have permission to change provider group associations."
 msgstr ""
@@ -11506,6 +11629,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 #, fuzzy
 msgid "second"
 msgstr "Icône"
@@ -12066,10 +12192,6 @@ msgstr ""
 #~ msgstr "Impossible de mettre à jour / créer une image journal"
 
 #, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "Impossible de supprimer le fichier"
-
-#, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "Je ne suis pas le serveur web de brouillard"
 
@@ -12190,10 +12312,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "Installation / Mise à jour réussie!"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "Service de mise à jour!"
 
 #, fuzzy
 #~ msgid "Host Snapins"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -196,8 +196,20 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "è stato cancellato"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "eliminata"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -212,8 +224,20 @@ msgid "%s images"
 msgstr "immagini"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr "non è più in esecuzione"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -229,6 +253,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -257,6 +285,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1236,6 +1268,10 @@ msgstr "Predefinito disconnettersi tempo (in minuti)"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "Nessun file è stato caricato"
+
 msgid "BIOS Date"
 msgstr "BIOS Data"
 
@@ -1279,6 +1315,18 @@ msgstr "Bind Password"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "Impossibile eliminare il file"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "Opzioni di avvio:"
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "Sito aggiornato!"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1643,6 +1691,9 @@ msgstr "Telaio Version"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2290,8 +2341,31 @@ msgstr "Predefinito: frequenza aggiornamento"
 msgid "Default Width"
 msgstr "Larghezza predefinita"
 
+#, fuzzy
+msgid "Default init, ARM64"
+msgstr "Larghezza predefinita"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "Larghezza predefinita"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "Larghezza predefinita"
+
 msgid "Default is disabled"
 msgstr "Il valore predefinito è disabilitato"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "Predefinito: frequenza aggiornamento"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "Aggiorna la stampante predefinita"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4353,6 +4427,9 @@ msgstr "In"
 msgid "In FOG"
 msgstr "In FOG"
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4717,6 +4794,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5101,6 +5184,10 @@ msgstr "Caricamento non riuscito"
 msgid "Loading data to field"
 msgstr "Caricamento dei dati campo"
 
+#, fuzzy
+msgid "Local files"
+msgstr "sedi"
+
 msgid "Location"
 msgstr "Luogo"
 
@@ -5380,6 +5467,9 @@ msgstr "Memoria"
 msgid "Memory limit cannot be less than 128"
 msgstr "Voce di menu o il titolo non può essere vuoto"
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "Descrizione"
@@ -5459,6 +5549,9 @@ msgstr "Modello"
 #, fuzzy
 msgid "Models"
 msgstr "Modello"
+
+msgid "Modified"
+msgstr ""
 
 #, fuzzy
 msgid "Module"
@@ -5795,6 +5888,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "Nessun file è stato caricato"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "Impossibile creare Snapin lavoro"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -5948,6 +6045,9 @@ msgstr "Un host già esiste con questo nome!"
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "Il gruppo di archiviazione immagine assegnato non è valido"
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 msgid "No such filter"
 msgstr ""
@@ -7794,6 +7894,10 @@ msgstr "Nome gruppo di archiviazione"
 msgid "Set Storage Group as Primary for Snapins"
 msgstr "Nome gruppo di archiviazione"
 
+#, fuzzy
+msgid "Set as"
+msgstr "Fallita impostazione"
+
 msgid "Set failed"
 msgstr "Fallita impostazione"
 
@@ -8282,6 +8386,9 @@ msgstr "Aggiornamento della stampante non è riuscito!"
 
 msgid "Status"
 msgstr "Stato"
+
+msgid "Stop keeping"
+msgstr ""
 
 msgid "Storage"
 msgstr "Conservazione"
@@ -8997,6 +9104,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr "Impossibile raggiungere il file o il percorso"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9191,6 +9302,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "Impossibile leggere il file temporaneo"
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -9774,6 +9889,10 @@ msgstr "Non disponibile"
 
 msgid "Uncategorized"
 msgstr ""
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "Host associato"
 
 msgid "Unicast"
 msgstr "Unicast"
@@ -10424,6 +10543,10 @@ msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
+msgstr "Nessuna connessione al database"
 
 msgid "You do not have permission to change provider group associations."
 msgstr ""
@@ -11158,6 +11281,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 msgid "second"
 msgstr "secondo"
 
@@ -11708,10 +11834,6 @@ msgstr ""
 #~ msgstr "Impossibile aggiornare / creare log immagine"
 
 #, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "Impossibile eliminare il file"
-
-#, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "Io non sono il server web fog"
 
@@ -11834,10 +11956,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "Aggiornamento host completato!"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "Sito aggiornato!"
 
 #, fuzzy
 #~ msgid "Host Snapins"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -186,9 +186,21 @@ msgstr ""
 msgid "%s can only be run on one host at a time"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "%s cannot be used as %s."
+msgstr "Windows で使用できます"
+
 #, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "キャンセルできませんでした"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "削除済み"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -203,8 +215,20 @@ msgid "%s images"
 msgstr "イメージ"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr "選択したプリンターを追加"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -220,6 +244,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -248,6 +276,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1220,6 +1252,10 @@ msgstr "ホスト自動ログアウト"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "利用可能なスナップイン"
+
 msgid "BIOS Date"
 msgstr "BIOS 日付"
 
@@ -1263,6 +1299,18 @@ msgstr "バインドパスワード"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "削除"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "ブートオプション"
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "サイトを更新しました！"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1626,6 +1674,9 @@ msgstr "シャーシバージョン"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2276,8 +2327,31 @@ msgstr "既定の更新レート"
 msgid "Default Width"
 msgstr "既定の幅"
 
+#, fuzzy
+msgid "Default init, ARM64"
+msgstr "既定の幅"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "既定の幅"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "既定の幅"
+
 msgid "Default is disabled"
 msgstr "既定では無効です"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "既定の更新レート"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "既定で有効"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4320,6 +4394,10 @@ msgid "In FOG"
 msgstr "FOG 内"
 
 #, fuzzy
+msgid "In use as"
+msgstr "次を使用する必要があります"
+
+#, fuzzy
 msgid "Include"
 msgstr "含まれる項目"
 
@@ -4680,6 +4758,12 @@ msgid "Join Domain after image task"
 msgstr "展開後にドメイン参加"
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5067,6 +5151,10 @@ msgstr "読み込みに失敗しました"
 msgid "Loading data to field"
 msgstr "フィールドにデータを読み込んでいます"
 
+#, fuzzy
+msgid "Local files"
+msgstr "ロケーション"
+
 msgid "Location"
 msgstr "ロケーション"
 
@@ -5343,6 +5431,9 @@ msgstr "メモリ"
 msgid "Memory limit cannot be less than 128"
 msgstr "メニュー項目またはタイトルは空にできません"
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "説明"
@@ -5424,6 +5515,9 @@ msgstr "モデル"
 #, fuzzy
 msgid "Models"
 msgstr "モデル"
+
+msgid "Modified"
+msgstr ""
 
 #, fuzzy
 msgid "Module"
@@ -5758,6 +5852,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "ファイルはアップロードされませんでした"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "スナップインジョブの作成に失敗しました"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -5913,6 +6011,9 @@ msgstr "このイメージを削除できる有効なマスターノードがあ
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "割り当てられたイメージのストレージグループが無効です"
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 #, fuzzy
 msgid "No such filter"
@@ -7753,6 +7854,10 @@ msgstr ""
 msgid "Set Storage Group as Primary for Snapins"
 msgstr "ストレージグループの説明"
 
+#, fuzzy
+msgid "Set as"
+msgstr "設定に失敗しました"
+
 msgid "Set failed"
 msgstr "設定に失敗しました"
 
@@ -8236,6 +8341,9 @@ msgstr "サイトの更新に失敗しました！"
 
 msgid "Status"
 msgstr "状態"
+
+msgid "Stop keeping"
+msgstr ""
 
 msgid "Storage"
 msgstr "ストレージ"
@@ -8941,6 +9049,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr "ファイルまたはパスに到達できません"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9136,6 +9248,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "強制終了できませんでした"
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -9718,6 +9834,10 @@ msgstr "利用できません"
 #, fuzzy
 msgid "Uncategorized"
 msgstr "権限がありません"
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "関連付けられたホスト"
 
 #, fuzzy
 msgid "Unicast"
@@ -10363,6 +10483,10 @@ msgstr "少なくとも 1 つのグループを関連付ける必要がありま
 
 #, fuzzy
 msgid "You do not have permission to change LDAP group associations."
+msgstr "少なくとも 1 つのグループを関連付ける必要があります"
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
 msgstr "少なくとも 1 つのグループを関連付ける必要があります"
 
 #, fuzzy
@@ -11105,6 +11229,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 msgid "second"
 msgstr "秒"
 
@@ -11618,9 +11745,6 @@ msgstr ""
 #~ msgid "Attempting to ping host"
 #~ msgstr "ping を試行しています"
 
-#~ msgid "Available Snapins"
-#~ msgstr "利用可能なスナップイン"
-
 #~ msgid "Barcode Numbers"
 #~ msgstr "バーコード番号"
 
@@ -12054,10 +12178,6 @@ msgstr ""
 #~ msgid "Failed to upload \"%s\" to Master Node"
 #~ msgstr "\"%s\" のマスターノードへのアップロードに失敗しました"
 
-#, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "削除"
-
 #~ msgid "File Integrity Management"
 #~ msgstr "ファイル整合性管理"
 
@@ -12279,10 +12399,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "サイトを更新しました"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "サイトを更新しました！"
 
 #~ msgid "Host Snapins"
 #~ msgstr "ホスト スナップイン"
@@ -12507,9 +12623,6 @@ msgstr ""
 #~ msgid "Is restricted"
 #~ msgstr "制限付き"
 
-#~ msgid "It can be used on Windows"
-#~ msgstr "Windows で使用できます"
-
 #~ msgid "It is primarily geared for the smart installer methodology now"
 #~ msgstr "現在は主にスマートインストーラー方式向けに設計されています"
 
@@ -12673,9 +12786,6 @@ msgstr ""
 
 #~ msgid "Must have an image associated"
 #~ msgstr "イメージが関連付けられている必要があります"
-
-#~ msgid "Must use an"
-#~ msgstr "次を使用する必要があります"
 
 #~ msgid "NAME"
 #~ msgstr "名前"
@@ -13739,9 +13849,6 @@ msgstr ""
 
 #~ msgid "defined reports that may not be a part of"
 #~ msgstr "一部ではない可能性がある定義済みレポート"
-
-#~ msgid "deleted"
-#~ msgstr "削除済み"
 
 #, fuzzy
 #~ msgid "disabled (all)"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -172,7 +172,19 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
+msgstr ""
+
+#, php-format
+msgid "%s could not be removed."
+msgstr ""
+
+#, php-format
+msgid "%s deleted."
 msgstr ""
 
 #, php-format
@@ -188,7 +200,19 @@ msgid "%s images"
 msgstr ""
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
+msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, php-format
+msgid "%s is no longer kept."
 msgstr ""
 
 #, php-format
@@ -205,6 +229,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -233,6 +261,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1094,6 +1126,9 @@ msgstr ""
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+msgid "Available downloads"
+msgstr ""
+
 msgid "BIOS Date"
 msgstr ""
 
@@ -1134,6 +1169,15 @@ msgid "Bind Password"
 msgstr ""
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
+msgstr ""
+
+msgid "Boot File Deleted"
+msgstr ""
+
+msgid "Boot File Failed"
+msgstr ""
+
+msgid "Boot File Updated"
 msgstr ""
 
 msgid "Boot Files"
@@ -1452,6 +1496,9 @@ msgstr ""
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2025,7 +2072,25 @@ msgstr ""
 msgid "Default Width"
 msgstr ""
 
+msgid "Default init, ARM64"
+msgstr ""
+
+msgid "Default init, i386"
+msgstr ""
+
+msgid "Default init, x86_64"
+msgstr ""
+
 msgid "Default is disabled"
+msgstr ""
+
+msgid "Default kernel, ARM64"
+msgstr ""
+
+msgid "Default kernel, i386"
+msgstr ""
+
+msgid "Default kernel, x86_64"
 msgstr ""
 
 msgid "Default nested group depth"
@@ -3829,6 +3894,9 @@ msgstr ""
 msgid "In FOG"
 msgstr ""
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4154,6 +4222,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -4494,6 +4568,9 @@ msgstr ""
 msgid "Loading data to field"
 msgstr ""
 
+msgid "Local files"
+msgstr ""
+
 msgid "Location"
 msgstr ""
 
@@ -4737,6 +4814,9 @@ msgstr ""
 msgid "Memory limit cannot be less than 128"
 msgstr ""
 
+msgid "Memtest payload"
+msgstr ""
+
 msgid "Menu Description"
 msgstr ""
 
@@ -4804,6 +4884,9 @@ msgid "Model"
 msgstr ""
 
 msgid "Models"
+msgstr ""
+
+msgid "Modified"
 msgstr ""
 
 msgid "Module"
@@ -5100,6 +5183,9 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr ""
 
+msgid "No files in the boot directory."
+msgstr ""
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -5234,6 +5320,9 @@ msgid "No storagegroups assigned to this image"
 msgstr ""
 
 msgid "No storagegroups assigned to this snapin"
+msgstr ""
+
+msgid "No such file in the boot directory."
 msgstr ""
 
 msgid "No such filter"
@@ -6867,6 +6956,9 @@ msgstr ""
 msgid "Set Storage Group as Primary for Snapins"
 msgstr ""
 
+msgid "Set as"
+msgstr ""
+
 msgid "Set failed"
 msgstr ""
 
@@ -7298,6 +7390,9 @@ msgid "State filter"
 msgstr ""
 
 msgid "Status"
+msgstr ""
+
+msgid "Stop keeping"
 msgstr ""
 
 msgid "Storage"
@@ -7921,6 +8016,9 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+msgid "The boot directory cannot be read."
+msgstr ""
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -8101,6 +8199,9 @@ msgid "The provider returned a configuration for a different issuer"
 msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
+msgstr ""
+
+msgid "The record could not be written."
 msgstr ""
 
 msgid "The resource is not in a cancellable state."
@@ -8643,6 +8744,9 @@ msgid "Unavailable"
 msgstr ""
 
 msgid "Uncategorized"
+msgstr ""
+
+msgid "Unclassified"
 msgstr ""
 
 msgid "Unicast"
@@ -9224,6 +9328,9 @@ msgid "You do not have permission to change API tokens."
 msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
+msgstr ""
+
+msgid "You do not have permission to change boot files."
 msgstr ""
 
 msgid "You do not have permission to change provider group associations."
@@ -9904,6 +10011,9 @@ msgid "row(s)"
 msgstr ""
 
 msgid "row(s) converted from 0 to NULL"
+msgstr ""
+
+msgid "same contents as"
 msgstr ""
 
 msgid "second"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -196,8 +196,20 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "foi atualizado com sucesso"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "excluídos"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -212,8 +224,20 @@ msgid "%s images"
 msgstr "imagens"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr " não existe mais"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -229,6 +253,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -257,6 +285,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1267,6 +1299,10 @@ msgstr "Padrão log out tempo (em minutos)"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "Nenhum arquivo foi transferido"
+
 msgid "BIOS Date"
 msgstr "data do BIOS"
 
@@ -1311,6 +1347,18 @@ msgstr "senha de domínio"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "Falha ao excluir arquivo"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "Opções de inicialização:"
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "Serviço Atualizado!"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1686,6 +1734,9 @@ msgstr "chassis Versão"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2352,8 +2403,31 @@ msgid "Default Width"
 msgstr "Largura padrão"
 
 #, fuzzy
+msgid "Default init, ARM64"
+msgstr "Largura padrão"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "Largura padrão"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "Largura padrão"
+
+#, fuzzy
 msgid "Default is disabled"
 msgstr "As doações são deficientes"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "Padrão Refresh Rate"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "Atualizar impressora"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4478,6 +4552,9 @@ msgstr "Dentro "
 msgid "In FOG"
 msgstr "Dentro "
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4857,6 +4934,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5259,6 +5342,10 @@ msgstr "Carga falhou: %s"
 msgid "Loading data to field"
 msgstr "Carregamento de dados para o campo %s"
 
+#, fuzzy
+msgid "Local files"
+msgstr "localizações"
+
 msgid "Location"
 msgstr "Localização"
 
@@ -5547,6 +5634,9 @@ msgstr "Memória"
 msgid "Memory limit cannot be less than 128"
 msgstr "Artigo ou título de menu não pode ficar em branco"
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "Descrição"
@@ -5627,6 +5717,9 @@ msgstr "Modelo"
 #, fuzzy
 msgid "Models"
 msgstr "Modelo"
+
+msgid "Modified"
+msgstr ""
 
 #, fuzzy
 msgid "Module"
@@ -5968,6 +6061,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "Nenhum arquivo foi transferido"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "Falha ao criar Snapin Job"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -6128,6 +6225,9 @@ msgstr "Uma imagem já existe com este nome!"
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "O grupo de armazenamento de imagens atribuído não é válido"
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 msgid "No such filter"
 msgstr ""
@@ -8020,6 +8120,10 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr "Nome do grupo de armazenamento"
 
 #, fuzzy
+msgid "Set as"
+msgstr "atualização do Service falhou"
+
+#, fuzzy
 msgid "Set failed"
 msgstr "atualização do Service falhou"
 
@@ -8535,6 +8639,9 @@ msgstr "atualização da impressora falhou!"
 
 msgid "Status"
 msgstr "estado"
+
+msgid "Stop keeping"
+msgstr ""
 
 msgid "Storage"
 msgstr "Armazenamento"
@@ -9278,6 +9385,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr " | Arquivo ou o caminho não pode ser alcançado"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9473,6 +9584,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "Não foi possível ler arquivo temporário"
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -10071,6 +10186,10 @@ msgstr "Não disponível"
 
 msgid "Uncategorized"
 msgstr ""
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "No nó associado"
 
 msgid "Unicast"
 msgstr "unicast"
@@ -10743,6 +10862,10 @@ msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
+msgstr "Sem conexão com o banco de dados"
 
 msgid "You do not have permission to change provider group associations."
 msgstr ""
@@ -11508,6 +11631,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 #, fuzzy
 msgid "second"
 msgstr "Ícone"
@@ -12068,10 +12194,6 @@ msgstr ""
 #~ msgstr "Falha ao atualizar / criar o registo de imagem"
 
 #, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "Falha ao excluir arquivo"
-
-#, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "Eu não sou o servidor web nevoeiro"
 
@@ -12192,10 +12314,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "Instalar / Atualizar sucesso!"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "Serviço Atualizado!"
 
 #, fuzzy
 #~ msgid "Host Snapins"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -196,8 +196,20 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "已成功更新"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "已删除"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -212,8 +224,20 @@ msgid "%s images"
 msgstr "图片"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr "不复存在"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -229,6 +253,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -257,6 +285,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1267,6 +1299,10 @@ msgstr "默认注销时间（分钟）"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "没有文件被上传"
+
 msgid "BIOS Date"
 msgstr "BIOS日期"
 
@@ -1311,6 +1347,18 @@ msgstr "域密码"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "无法删除文件"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "启动选项："
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "服务更新！"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1686,6 +1734,9 @@ msgstr "机箱版本"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2352,8 +2403,31 @@ msgid "Default Width"
 msgstr "默认宽度"
 
 #, fuzzy
+msgid "Default init, ARM64"
+msgstr "默认宽度"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "默认宽度"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "默认宽度"
+
+#, fuzzy
 msgid "Default is disabled"
 msgstr "捐款将被禁用"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "默认刷新频率"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "更新打印机"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4478,6 +4552,9 @@ msgstr "在"
 msgid "In FOG"
 msgstr "在"
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4857,6 +4934,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5259,6 +5342,10 @@ msgstr "加载失败： %s"
 msgid "Loading data to field"
 msgstr "加载数据到现场%s"
 
+#, fuzzy
+msgid "Local files"
+msgstr "位置"
+
 msgid "Location"
 msgstr "位置"
 
@@ -5547,6 +5634,9 @@ msgstr "记忆"
 msgid "Memory limit cannot be less than 128"
 msgstr "菜单项或标题不能为空"
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "描述"
@@ -5627,6 +5717,9 @@ msgstr "模型"
 #, fuzzy
 msgid "Models"
 msgstr "模型"
+
+msgid "Modified"
+msgstr ""
 
 #, fuzzy
 msgid "Module"
@@ -5968,6 +6061,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "没有文件被上传"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "无法创建管理单元工作"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -6128,6 +6225,9 @@ msgstr "图像已经存在具有此名称！"
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "分配图像存储组无效"
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 msgid "No such filter"
 msgstr ""
@@ -8020,6 +8120,10 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr "存储组名称"
 
 #, fuzzy
+msgid "Set as"
+msgstr "服务更新失败"
+
+#, fuzzy
 msgid "Set failed"
 msgstr "服务更新失败"
 
@@ -8535,6 +8639,9 @@ msgstr "打印机更新失败！"
 
 msgid "Status"
 msgstr "状态"
+
+msgid "Stop keeping"
+msgstr ""
 
 msgid "Storage"
 msgstr "存储"
@@ -9278,6 +9385,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr "|文件或无法达成通道"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9473,6 +9584,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "无法读取临时文件"
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -10071,6 +10186,10 @@ msgstr "不可用"
 
 msgid "Uncategorized"
 msgstr ""
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "无关联的节点"
 
 msgid "Unicast"
 msgstr "单播"
@@ -10743,6 +10862,10 @@ msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
+msgstr "没有连接到数据库"
 
 msgid "You do not have permission to change provider group associations."
 msgstr ""
@@ -11508,6 +11631,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 #, fuzzy
 msgid "second"
 msgstr "图标"
@@ -12068,10 +12194,6 @@ msgstr ""
 #~ msgstr "无法更新/创建图像日志"
 
 #, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "无法删除文件"
-
-#, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "我不是雾Web服务器"
 
@@ -12192,10 +12314,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "安装/升级成功！"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "服务更新！"
 
 #, fuzzy
 #~ msgid "Host Snapins"

--- a/packages/web/src/Auth/Authorization.php
+++ b/packages/web/src/Auth/Authorization.php
@@ -209,7 +209,28 @@ class Authorization extends FOGBase
             // on the next installer run. "May change a setting" is not
             // self-evidently "may decide what this server trusts", and SIX
             // page nodes already map onto settings.edit (GH-1121).
-            'certificates' => ['GET' => 'settings.view', 'POST' => 'system.pki']
+            'certificates' => ['GET' => 'settings.view', 'POST' => 'system.pki'],
+            /**
+             * The Local files tab's actions. Viewing the tab is reading
+             * server configuration and stays on settings.view through
+             * _subToAction(); acting on a file is not, so each says so.
+             *
+             * Node-scoped, NOT in GLOBAL_SUB_OVERRIDES. The download subs
+             * are global only because the download JS requests them with no
+             * node at all and they dispatch under the exempt 'home' node --
+             * a shape worth not repeating, so these post with node=about and
+             * resolve here.
+             *
+             * Three subs rather than one endpoint taking an action
+             * parameter, for the reason the API token grid gives: separate
+             * subs CAN each carry their own permission later. Deleting a
+             * bootable kernel and pointing a default at one are not
+             * self-evidently the same power, even though both need
+             * settings.edit today.
+             */
+            'bootfilekeep' => 'settings.edit',
+            'bootfiledefault' => 'settings.edit',
+            'bootfiledelete' => 'settings.edit'
         ],
         'user' => [
             'userapitokenlist' => 'apitoken.view',

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -6205,6 +6205,100 @@ abstract class FOGPage extends FOGBase
         return (false === $time) ? 0 : (int)$time;
     }
     /**
+     * Marks a boot file as one no pruner may remove, or unmarks it.
+     *
+     * The one fact about these files that cannot be read off the disk: it is
+     * an intention, not a property. Stored on the record, and reported by
+     * bootFileInfo() so the listing can show it.
+     *
+     * @param string $name filename in the boot directory
+     * @param bool   $keep true to keep, false to stop keeping
+     *
+     * @return bool whether the record was written
+     */
+    public static function bootFileSetPinned($name, $keep)
+    {
+        $name = basename(trim((string)$name));
+        if ('' === $name) {
+            return false;
+        }
+        try {
+            $row = self::_bootFileRow($name) ?: self::getClass('BootFile');
+            $row->set('name', $name)
+                ->set('pinned', $keep ? 1 : 0);
+            $row->save();
+            if (null !== self::$_bootFileRows) {
+                self::$_bootFileRows[$name] = $row;
+            }
+        } catch (\Throwable $e) {
+            return false;
+        }
+
+        return true;
+    }
+    /**
+     * Removes a boot file, and the record that described it.
+     *
+     * Over the same SSH/SFTP connection kernelfetch() uses to put files
+     * there, not with unlink(). That is where the writes go, FOG_TFTP_HOST
+     * may not be this machine, and using the write path for the delete means
+     * the two cannot disagree about which directory is real. It also means
+     * a server with no SSH credentials configured cannot delete -- which is
+     * the same server that cannot download a kernel either, so it is one
+     * missing configuration rather than a new one.
+     *
+     * The record goes too. Leaving it would strand a row describing a file
+     * that is gone; the listing starts from the directory, so nothing would
+     * ever read it again.
+     *
+     * @param string $name filename in the boot directory
+     *
+     * @throws \Exception when the file cannot be removed
+     *
+     * @return void
+     */
+    public static function bootFileRemove($name)
+    {
+        $name = basename(trim((string)$name));
+        $dir = trim((string)self::getSetting('FOG_TFTP_PXE_KERNEL_DIR'));
+        if ('' === $name || '' === $dir) {
+            throw new \Exception(_('No such file in the boot directory.'));
+        }
+        $target = sprintf('/%s/%s', trim($dir, '/'), $name);
+        $keys = [
+            'FOG_TFTP_FTP_PASSWORD',
+            'FOG_TFTP_FTP_USERNAME',
+            'FOG_TFTP_HOST'
+        ];
+        list($pass, $user, $host) = self::getSetting($keys);
+        self::$FOGSSH->username = $user;
+        self::$FOGSSH->password = $pass;
+        self::$FOGSSH->host = $host;
+        if (!self::$FOGSSH->connect()) {
+            throw new \Exception(_('Unable to connect to ssh'));
+        }
+        $gone = self::$FOGSSH->delete($target);
+        self::$FOGSSH->disconnect();
+        if (!$gone) {
+            throw new \Exception(
+                sprintf(_('%s could not be removed.'), $name)
+            );
+        }
+        try {
+            $row = self::_bootFileRow($name);
+            if ($row) {
+                $row->destroy();
+            }
+            if (null !== self::$_bootFileRows) {
+                unset(self::$_bootFileRows[$name]);
+            }
+        } catch (\Throwable $e) {
+            // The file is gone, which is what was asked. A stranded record
+            // is never read again -- listings start from the directory.
+            return;
+        }
+    }
+    /**
      * Lists the boot directory files holding the role $type, newest first.
      *
      * Kernels and inits are files on disk, not database records, so there is

--- a/packages/web/src/Pages/FOGConfigurationPage.php
+++ b/packages/web/src/Pages/FOGConfigurationPage.php
@@ -13,6 +13,7 @@
 
 namespace FOG\Pages;
 
+use FOG\Audit\Audit;
 use FOG\Audit\Retention;
 use FOG\Auth\Authorization;
 use FOG\Base\FOGBase;
@@ -1577,6 +1578,583 @@ class FOGConfigurationPage extends FOGPage
      *
      * @return void
      */
+    /**
+     * The default-pointer settings a file of this role may be set as.
+     *
+     * The settings stay authoritative for what boots -- IpxeBootMenu reads
+     * them and nothing here changes that. This tab is a second setter for
+     * them, next to the files it is choosing between, because "put the
+     * default back on the kernel that worked" is otherwise a trip to FOG
+     * Settings and a filename typed from memory.
+     *
+     * Keyed by role, because FOG_MEMTEST_KERNEL names a Boot Payload and
+     * offering it a FOS kernel is the bug this whole change set is about.
+     *
+     * @param string $role one of FOGPage::BOOT_ROLE_*
+     *
+     * @return array setting key => label
+     */
+    /**
+     * Dispatch anchor for sub=bootfilekeep. See _postOnly().
+     *
+     * @return void
+     */
+    public function bootfilekeep()
+    {
+        $this->_postOnly();
+    }
+    /**
+     * Dispatch anchor for sub=bootfiledefault. See _postOnly().
+     *
+     * @return void
+     */
+    public function bootfiledefault()
+    {
+        $this->_postOnly();
+    }
+    /**
+     * Dispatch anchor for sub=bootfiledelete. See _postOnly().
+     *
+     * @return void
+     */
+    public function bootfiledelete()
+    {
+        $this->_postOnly();
+    }
+    /**
+     * Resolves a posted filename to a real file in the boot directory.
+     *
+     * basename() and then a membership test against the directory listing,
+     * rather than trusting the name: every one of these endpoints turns a
+     * request parameter into a filesystem path, and "../../etc/passwd" is
+     * the first thing anybody tries. The listing is the allow-list.
+     *
+     * @param string $name posted filename
+     *
+     * @return array|null the bootFileInfo() record, or null
+     */
+    private static function _bootFileNamed($name)
+    {
+        $name = basename(trim((string)$name));
+        if ('' === $name || '.' === $name || '..' === $name) {
+            return null;
+        }
+        $dir = trim((string)self::getSetting('FOG_TFTP_PXE_KERNEL_DIR'));
+        if ('' === $dir || !is_dir($dir)) {
+            return null;
+        }
+        $path = $dir . DIRECTORY_SEPARATOR . $name;
+        if (!is_file($path)) {
+            return null;
+        }
+
+        return self::bootFileInfo($path);
+    }
+    /**
+     * Marks a boot file as one no pruner may remove, or unmarks it.
+     *
+     * Records the intention only. Nothing prunes boot files yet, so there is
+     * nothing for this to protect it from today -- the pruner, and the copy
+     * into the customizations tree that survives a rebuild of the web root,
+     * arrive with the retention work. Writing the flag here means the tab
+     * that shows it is also the thing that sets it.
+     *
+     * @return void
+     */
+    public function bootfilekeepPost()
+    {
+        self::checkAuthAndCSRF();
+        if (!Authorization::can('settings.edit')) {
+            $this->_jsonExit(
+                HTTPResponseCodes::HTTP_FORBIDDEN,
+                [
+                    'error' => _('You do not have permission to change boot '
+                        . 'files.'),
+                    'title' => _('Boot File Failed')
+                ]
+            );
+        }
+        $info = self::_bootFileNamed(filter_input(INPUT_POST, 'name'));
+        if (null === $info) {
+            $this->_jsonExit(
+                HTTPResponseCodes::HTTP_BAD_REQUEST,
+                [
+                    'error' => _('No such file in the boot directory.'),
+                    'title' => _('Boot File Failed')
+                ]
+            );
+        }
+        $keep = (bool)(int)filter_input(INPUT_POST, 'keep');
+        if (!self::bootFileSetPinned($info['name'], $keep)) {
+            $this->_jsonExit(
+                HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR,
+                [
+                    'error' => _('The record could not be written.'),
+                    'title' => _('Boot File Failed')
+                ]
+            );
+        }
+        Audit::record(
+            [
+                'type' => $keep ? 'bootfile.keep' : 'bootfile.unkeep',
+                'subjectType' => 'bootfile',
+                'subjectLabel' => $info['name'],
+                'permission' => 'settings.edit',
+                'renderable' => 1
+            ]
+        );
+        $this->_jsonExit(
+            HTTPResponseCodes::HTTP_SUCCESS,
+            [
+                'msg' => $keep
+                    ? sprintf(_('%s will be kept.'), $info['name'])
+                    : sprintf(_('%s is no longer kept.'), $info['name']),
+                'title' => _('Boot File Updated')
+            ]
+        );
+    }
+    /**
+     * Points one default-pointer setting at this file.
+     *
+     * The setting remains what boots -- this writes the same key FOG
+     * Settings writes, and IpxeBootMenu keeps reading exactly one place.
+     * What it adds is choosing from the files that actually exist, which is
+     * how "put the default back on the kernel that worked" stops being a
+     * filename typed from memory.
+     *
+     * The key is validated against the roles' own list, so a payload cannot
+     * be installed as a boot kernel through a hand-made request.
+     *
+     * @return void
+     */
+    public function bootfiledefaultPost()
+    {
+        self::checkAuthAndCSRF();
+        if (!Authorization::can('settings.edit')) {
+            $this->_jsonExit(
+                HTTPResponseCodes::HTTP_FORBIDDEN,
+                [
+                    'error' => _('You do not have permission to change boot '
+                        . 'files.'),
+                    'title' => _('Boot File Failed')
+                ]
+            );
+        }
+        $info = self::_bootFileNamed(filter_input(INPUT_POST, 'name'));
+        if (null === $info) {
+            $this->_jsonExit(
+                HTTPResponseCodes::HTTP_BAD_REQUEST,
+                [
+                    'error' => _('No such file in the boot directory.'),
+                    'title' => _('Boot File Failed')
+                ]
+            );
+        }
+        $key = trim((string)filter_input(INPUT_POST, 'key'));
+        $allowed = self::_defaultKeysFor($info['role']);
+        if (!isset($allowed[$key])) {
+            $this->_jsonExit(
+                HTTPResponseCodes::HTTP_BAD_REQUEST,
+                [
+                    'error' => sprintf(
+                        _('%s cannot be used as %s.'),
+                        $info['name'],
+                        $key
+                    ),
+                    'title' => _('Boot File Failed')
+                ]
+            );
+        }
+        self::setSetting($key, $info['name']);
+        Audit::record(
+            [
+                'type' => 'bootfile.default',
+                'subjectType' => 'setting',
+                'subjectLabel' => $key,
+                'permission' => 'settings.edit',
+                'text' => $info['name'],
+                'renderable' => 1
+            ]
+        );
+        $this->_jsonExit(
+            HTTPResponseCodes::HTTP_SUCCESS,
+            [
+                'msg' => sprintf(
+                    _('%s is now %s.'),
+                    $info['name'],
+                    $allowed[$key]
+                ),
+                'title' => _('Boot File Updated')
+            ]
+        );
+    }
+    /**
+     * Removes a boot file from the directory.
+     *
+     * Refused for a file a default points at and for one marked kept. The
+     * row buttons already hide in those cases; this refuses it anyway,
+     * because a hidden button is a courtesy and not a rule.
+     *
+     * Deleted over the same SSH/SFTP connection kernelfetch() uses to put
+     * files there, not with unlink(). That is where the writes go, the TFTP
+     * host may not be this machine, and using the write path for the delete
+     * means the two cannot disagree about which directory is real.
+     *
+     * @return void
+     */
+    public function bootfiledeletePost()
+    {
+        self::checkAuthAndCSRF();
+        if (!Authorization::can('settings.edit')) {
+            $this->_jsonExit(
+                HTTPResponseCodes::HTTP_FORBIDDEN,
+                [
+                    'error' => _('You do not have permission to change boot '
+                        . 'files.'),
+                    'title' => _('Boot File Failed')
+                ]
+            );
+        }
+        $info = self::_bootFileNamed(filter_input(INPUT_POST, 'name'));
+        if (null === $info) {
+            $this->_jsonExit(
+                HTTPResponseCodes::HTTP_BAD_REQUEST,
+                [
+                    'error' => _('No such file in the boot directory.'),
+                    'title' => _('Boot File Failed')
+                ]
+            );
+        }
+        if ($info['pinned']) {
+            $this->_jsonExit(
+                HTTPResponseCodes::HTTP_BAD_REQUEST,
+                [
+                    'error' => sprintf(
+                        _('%s is marked to be kept. Stop keeping it first.'),
+                        $info['name']
+                    ),
+                    'title' => _('Boot File Failed')
+                ]
+            );
+        }
+        $pointing = [];
+        foreach (self::_defaultPointers() as $key => $points) {
+            if ($points === $info['name']) {
+                $pointing[] = $key;
+            }
+        }
+        if (count($pointing)) {
+            $this->_jsonExit(
+                HTTPResponseCodes::HTTP_BAD_REQUEST,
+                [
+                    'error' => sprintf(
+                        _('%s is in use as %s. Point that at another file '
+                            . 'first.'),
+                        $info['name'],
+                        implode(', ', $pointing)
+                    ),
+                    'title' => _('Boot File Failed')
+                ]
+            );
+        }
+        try {
+            self::bootFileRemove($info['name']);
+        } catch (\Throwable $e) {
+            $this->_jsonExit(
+                HTTPResponseCodes::HTTP_INTERNAL_SERVER_ERROR,
+                [
+                    'error' => $e->getMessage(),
+                    'title' => _('Boot File Failed')
+                ]
+            );
+        }
+        Audit::record(
+            [
+                'type' => 'bootfile.delete',
+                'subjectType' => 'bootfile',
+                'subjectLabel' => $info['name'],
+                'permission' => 'settings.edit',
+                'renderable' => 1
+            ]
+        );
+        $this->_jsonExit(
+            HTTPResponseCodes::HTTP_SUCCESS,
+            [
+                'msg' => sprintf(_('%s deleted.'), $info['name']),
+                'title' => _('Boot File Deleted')
+            ]
+        );
+    }
+    private static function _defaultKeysFor($role)
+    {
+        switch ($role) {
+            case self::BOOT_ROLE_KERNEL:
+                return [
+                    'FOG_TFTP_PXE_KERNEL' => _('Default kernel, x86_64'),
+                    'FOG_TFTP_PXE_KERNEL_32' => _('Default kernel, i386'),
+                    'FOG_TFTP_PXE_KERNEL_ARM' => _('Default kernel, ARM64')
+                ];
+            case self::BOOT_ROLE_INIT:
+                return [
+                    'FOG_PXE_BOOT_IMAGE' => _('Default init, x86_64'),
+                    'FOG_PXE_BOOT_IMAGE_32' => _('Default init, i386'),
+                    'FOG_PXE_BOOT_IMAGE_ARM' => _('Default init, ARM64')
+                ];
+            case self::BOOT_ROLE_PAYLOAD:
+                return ['FOG_MEMTEST_KERNEL' => _('Memtest payload')];
+        }
+
+        return [];
+    }
+    /**
+     * Every default-pointer setting, with the filename it currently names.
+     *
+     * @return array setting key => filename
+     */
+    private static function _defaultPointers()
+    {
+        $keys = array_merge(
+            array_keys(self::_defaultKeysFor(self::BOOT_ROLE_KERNEL)),
+            array_keys(self::_defaultKeysFor(self::BOOT_ROLE_INIT)),
+            array_keys(self::_defaultKeysFor(self::BOOT_ROLE_PAYLOAD))
+        );
+        $out = [];
+        foreach ($keys as $key) {
+            $out[$key] = trim((string)self::getSetting($key));
+        }
+
+        return $out;
+    }
+    /**
+     * The boot directory, as a table of what is there and what it is for.
+     *
+     * Deliberately the same listing on both the kernel and the initrd page
+     * rather than one filtered per page. The Role column is what makes it
+     * legible, and a file whose role is not what an admin expected is
+     * exactly what they came to look at -- filtering it out of the page they
+     * happened to open would hide the answer.
+     *
+     * A plain server-sorted table, not a DataTable: this pane is not the
+     * active tab on arrival, and DataTables computes column widths wrong
+     * inside a hidden pane. The row count here is tens.
+     *
+     * @return string
+     */
+    private function _bootFileTable()
+    {
+        $dir = trim((string)self::getSetting('FOG_TFTP_PXE_KERNEL_DIR'));
+        if ('' === $dir || !is_dir($dir) || !is_readable($dir)) {
+            return '<div class="alert alert-warning">'
+                . _('The boot directory cannot be read.')
+                . ' '
+                . \Initiator::e($dir)
+                . ' '
+                . _('Check FOG_TFTP_PXE_KERNEL_DIR.')
+                . '</div>';
+        }
+        $names = @scandir($dir);
+        if (false === $names) {
+            $names = [];
+        }
+        $roleLabels = [
+            self::BOOT_ROLE_KERNEL => _('FOS Kernel'),
+            self::BOOT_ROLE_INIT => _('FOS Init'),
+            self::BOOT_ROLE_PAYLOAD => _('Boot Payload'),
+            self::BOOT_ROLE_OTHER => _('Unclassified')
+        ];
+        $roleOrder = [
+            self::BOOT_ROLE_KERNEL => 0,
+            self::BOOT_ROLE_INIT => 1,
+            self::BOOT_ROLE_PAYLOAD => 2,
+            self::BOOT_ROLE_OTHER => 3
+        ];
+        $pointers = self::_defaultPointers();
+        $rows = [];
+        foreach ($names as $name) {
+            if ('.' === $name || '..' === $name) {
+                continue;
+            }
+            $path = $dir . DIRECTORY_SEPARATOR . $name;
+            if (!is_file($path)) {
+                continue;
+            }
+            $rows[] = self::bootFileInfo($path);
+        }
+        usort(
+            $rows,
+            function ($a, $b) use ($roleOrder) {
+                $ao = $roleOrder[$a['role']] ?? 9;
+                $bo = $roleOrder[$b['role']] ?? 9;
+                if ($ao !== $bo) {
+                    return $ao - $bo;
+                }
+                $adot = substr_count($a['name'], '.');
+                $bdot = substr_count($b['name'], '.');
+                if ($adot !== $bdot) {
+                    return $adot - $bdot;
+                }
+
+                return strnatcasecmp($b['name'], $a['name']);
+            }
+        );
+        if (!count($rows)) {
+            return '<div class="alert alert-warning">'
+                . _('No files in the boot directory.')
+                . '</div>';
+        }
+        $mayEdit = Authorization::can('settings.edit');
+        $out = '<div class="table-responsive">';
+        $out .= '<table class="table table-striped fog-bootfile-table">';
+        $out .= '<thead><tr>'
+            . '<th>' . _('File') . '</th>'
+            . '<th>' . _('Role') . '</th>'
+            . '<th>' . _('Version') . '</th>'
+            . '<th>' . _('FOS Release') . '</th>'
+            . '<th>' . _('Size') . '</th>'
+            . '<th>' . _('Modified') . '</th>'
+            . '<th>' . _('In use as') . '</th>'
+            . '<th>' . _('Keep') . '</th>'
+            . ($mayEdit ? '<th>' . _('Actions') . '</th>' : '')
+            . '</tr></thead><tbody>';
+        /**
+         * Two names with the same checksum are the same kernel. Saying so is
+         * what stops "keep three versions" meaning three copies of one --
+         * and an admin looking at bzImage next to bzImage.<release> has no
+         * other way to tell whether an update actually changed anything.
+         */
+        $byChecksum = [];
+        foreach ($rows as $row) {
+            if ('' !== $row['checksum']) {
+                $byChecksum[$row['checksum']][] = $row['name'];
+            }
+        }
+        foreach ($rows as $row) {
+            $name = $row['name'];
+            $inUse = [];
+            foreach ($pointers as $key => $points) {
+                if ($points === $name) {
+                    $inUse[] = $key;
+                }
+            }
+            $same = array_diff(
+                $byChecksum[$row['checksum']] ?? [],
+                [$name]
+            );
+            $out .= '<tr data-bootfile="' . \Initiator::e($name) . '">';
+            $out .= '<td><code>' . \Initiator::e($name) . '</code>'
+                . (
+                    count($same) ?
+                    '<br><small class="text-muted">'
+                    . _('same contents as')
+                    . ' '
+                    . \Initiator::e(implode(', ', $same))
+                    . '</small>' :
+                    ''
+                )
+                . '</td>';
+            $out .= '<td>'
+                . \Initiator::e($roleLabels[$row['role']] ?? $row['role'])
+                . '</td>';
+            $out .= '<td>'
+                . (
+                    '' !== $row['kernelVersion'] ?
+                    \Initiator::e($row['kernelVersion']) :
+                    '<span class="text-muted">' . _('not readable')
+                    . '</span>'
+                )
+                . '</td>';
+            $out .= '<td>'
+                . (
+                    '' !== $row['releaseTag'] ?
+                    \Initiator::e($row['releaseTag']) :
+                    '<span class="text-muted">'
+                    . \Initiator::e($row['tagReason'])
+                    . '</span>'
+                )
+                . '</td>';
+            $out .= '<td>' . \Initiator::e(self::formatByteSize($row['size']))
+                . '</td>';
+            $out .= '<td>'
+                . \Initiator::e(
+                    self::formatTime('@' . $row['mtime'], 'Y-m-d H:i')
+                )
+                . '</td>';
+            $out .= '<td>'
+                . (
+                    count($inUse) ?
+                    '<span class="badge text-bg-primary">'
+                    . \Initiator::e(implode('</span> <span '
+                        . 'class="badge text-bg-primary">', $inUse))
+                    . '</span>' :
+                    '<span class="text-muted">&mdash;</span>'
+                )
+                . '</td>';
+            $out .= '<td>'
+                . (
+                    $row['pinned'] ?
+                    '<span class="badge text-bg-success">' . _('Kept')
+                    . '</span>' :
+                    '<span class="text-muted">&mdash;</span>'
+                )
+                . '</td>';
+            if ($mayEdit) {
+                $out .= '<td>' . $this->_bootFileActions($row, $inUse)
+                    . '</td>';
+            }
+            $out .= '</tr>';
+        }
+        $out .= '</tbody></table></div>';
+
+        return $out;
+    }
+    /**
+     * The per-row controls: keep, set as a default, delete.
+     *
+     * Delete is refused for a file a default points at and for one that is
+     * kept, and the button is simply absent in those cases rather than
+     * present and failing -- the POST handler refuses it too, because a
+     * missing button is a UI courtesy and not a rule.
+     *
+     * @param array $row   one bootFileInfo() record
+     * @param array $inUse setting keys currently naming this file
+     *
+     * @return string
+     */
+    private function _bootFileActions(array $row, array $inUse)
+    {
+        $name = \Initiator::e($row['name']);
+        $keys = self::_defaultKeysFor($row['role']);
+        $out = '<div class="btn-group btn-group-sm" role="group">';
+        $out .= '<button type="button" class="btn btn-secondary '
+            . 'fog-bootfile-keep" data-name="' . $name . '" data-keep="'
+            . ($row['pinned'] ? '0' : '1') . '">'
+            . ($row['pinned'] ? _('Stop keeping') : _('Keep'))
+            . '</button>';
+        if (count($keys)) {
+            $out .= '<button type="button" class="btn btn-primary '
+                . 'dropdown-toggle" data-bs-toggle="dropdown" '
+                . 'aria-expanded="false">'
+                . _('Set as')
+                . '</button><ul class="dropdown-menu">';
+            foreach ($keys as $key => $label) {
+                $out .= '<li><a class="dropdown-item fog-bootfile-default" '
+                    . 'href="#" data-name="' . $name . '" data-key="'
+                    . \Initiator::e($key) . '">'
+                    . \Initiator::e($label)
+                    . '</a></li>';
+            }
+            $out .= '</ul>';
+        }
+        $out .= '</div>';
+        if (!count($inUse) && !$row['pinned']) {
+            $out .= ' <button type="button" class="btn btn-sm btn-danger '
+                . 'fog-bootfile-delete" data-name="' . $name . '">'
+                . _('Delete')
+                . '</button>';
+        }
+
+        return $out;
+    }
     private function _downloadView($type)
     {
         $isKernel = ($type === 'kernel');
@@ -1670,14 +2248,44 @@ class FOGConfigurationPage extends FOGPage
             'info'
         );
 
+        /**
+         * Two tabs in the card that used to hold one table. The releases
+         * available to download were the only thing this page could say, so
+         * "what do I already have, and what is it" had nowhere to be asked.
+         *
+         * The release table stays tab one, and stays the active pane on
+         * arrival: its DataTable initializes at page load and computes
+         * column widths, which it cannot do correctly while hidden.
+         *
+         * false, not the default -1: that would ask getClass() to resolve an
+         * entity for node 'about', and there is none. certificates() in this
+         * file passes false for the same reason.
+         */
+        $tabData = [
+            [
+                'name' => _('Available downloads'),
+                'id' => $type . '-releases',
+                'generator' => function () use ($buttons) {
+                    echo $this->process(
+                        12,
+                        'dataTable',
+                        $buttons,
+                        'display table table-bordered table-striped'
+                    );
+                }
+            ],
+            [
+                'name' => _('Local files'),
+                'id' => $type . '-local',
+                'generator' => function () {
+                    echo $this->_bootFileTable();
+                }
+            ]
+        ];
+
         echo $this->_box(
             $this->title,
-            $this->process(
-                12,
-                'dataTable',
-                $buttons,
-                'display table table-bordered table-striped'
-            ),
+            self::tabFields($tabData, false),
             [
                 'id' => $type . '-update',
                 'help' => $help,

--- a/tests/apitoken-grid-and-scope.test.php
+++ b/tests/apitoken-grid-and-scope.test.php
@@ -329,9 +329,12 @@ $t->check(
         $cfg
     )
 );
+// Counts every POST-only anchor on the page, not only this pane's three, so
+// it moves whenever FOG Configuration gains another one. Eight since the
+// Local files tab added bootfilekeep, bootfiledefault and bootfiledelete.
 $t->check(
     'every mutating anchor refuses the verb instead of doing the work',
-    5 === preg_match_all('/\$this->_postOnly\(\);/', $cfg)
+    8 === preg_match_all('/\$this->_postOnly\(\);/', $cfg)
 );
 $t->check(
     'refusing means 405, not a silent 200',

--- a/tests/boot-file-tab.test.php
+++ b/tests/boot-file-tab.test.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * The Local files tab: what it shows, and what its actions refuse.
+ *
+ * The Kernel Update and Initrd Update pages could only say what was
+ * available to download. "What do I already have, and what is it for" had
+ * nowhere to be asked -- which is also why nothing could offer to point a
+ * default back at the kernel that worked, or to keep one against a future
+ * prune.
+ *
+ * Most of this asserts on the page class's source rather than by rendering,
+ * because rendering the tab needs a boot directory, a settings table and an
+ * authenticated session. What the source can be held to is the wiring that
+ * is easy to get wrong and invisible when wrong:
+ *
+ *   - the release table has to stay tab ONE, because its DataTable computes
+ *     column widths at page load and cannot do that inside a hidden pane;
+ *   - tabFields() must be passed false, not its default -1, or it asks
+ *     getClass() to resolve an entity for node 'about' where there is none;
+ *   - every action endpoint has to check CSRF, check a permission, and
+ *     resolve the posted filename against the directory rather than trusting
+ *     it;
+ *   - and the permissions have to be node-scoped, NOT global.
+ *
+ * The role-to-setting map IS exercised directly, because it is the thing
+ * that stops a boot payload being installed as a boot kernel through a
+ * hand-made request.
+ *
+ * Usage: php tests/boot-file-tab.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('boot-file-tab');
+FogTestHarness::fakeDb();
+
+$t = new FogChecks();
+
+$web = dirname(__DIR__) . '/packages/web';
+$page = file_get_contents($web . '/src/Pages/FOGConfigurationPage.php');
+$auth = file_get_contents($web . '/src/Auth/Authorization.php');
+$js = file_get_contents($web . '/management/js/fog/fog.common.js');
+
+// --- the tabs -------------------------------------------------------------
+
+$t->check(
+    'the download view renders tabs',
+    false !== strpos($page, "'name' => _('Available downloads')")
+    && false !== strpos($page, "'name' => _('Local files')")
+);
+$t->check(
+    'the release table is the first tab, so its DataTable is not built hidden',
+    strpos($page, "_('Available downloads')")
+    < strpos($page, "_('Local files')")
+);
+$t->check(
+    'tabFields is passed false, not the default -1',
+    false !== strpos($page, 'self::tabFields($tabData, false)')
+);
+$t->check(
+    'the local files pane is not a DataTable',
+    false === strpos($page, "fog-bootfile-table' data-datatable")
+    && false !== strpos($page, 'fog-bootfile-table')
+);
+
+// --- the three action endpoints ------------------------------------------
+
+$subs = ['bootfilekeep', 'bootfiledefault', 'bootfiledelete'];
+foreach ($subs as $sub) {
+    $t->check(
+        $sub . ' has a dispatch anchor that refuses a GET',
+        1 === preg_match(
+            '/function ' . $sub . '\(\)\s*\{\s*\$this->_postOnly\(\);/',
+            $page
+        )
+    );
+    $t->check(
+        $sub . ' has a POST handler',
+        false !== strpos($page, 'function ' . $sub . 'Post()')
+    );
+    /**
+     * Node-scoped, not global. The download subs are in
+     * GLOBAL_SUB_OVERRIDES only because their JS posts with no node at all,
+     * so they dispatch under the exempt 'home' node -- a shape worth not
+     * repeating.
+     */
+    $t->check(
+        $sub . ' declares its permission node-scoped, not globally',
+        false !== strpos($auth, "'" . $sub . "' => 'settings.edit'")
+    );
+}
+$globalStart = strpos($auth, 'const GLOBAL_SUB_OVERRIDES');
+$globalBlock = false === $globalStart
+    ? ''
+    : substr($auth, $globalStart, 2000);
+foreach ($subs as $sub) {
+    $t->check(
+        $sub . ' is not in GLOBAL_SUB_OVERRIDES',
+        false === strpos($globalBlock, $sub)
+    );
+}
+
+// Each handler, in its own slice of the file, has to do all three things.
+foreach ($subs as $sub) {
+    $at = strpos($page, 'function ' . $sub . 'Post()');
+    $body = false === $at ? '' : substr($page, $at, 2600);
+    $t->check(
+        $sub . 'Post checks auth and CSRF',
+        false !== strpos($body, 'self::checkAuthAndCSRF();')
+    );
+    $t->check(
+        $sub . 'Post checks a permission explicitly',
+        false !== strpos($body, "Authorization::can('settings.edit')")
+    );
+    $t->check(
+        $sub . 'Post resolves the posted name against the directory',
+        false !== strpos($body, '_bootFileNamed(')
+    );
+    $t->check(
+        $sub . 'Post writes an audit row',
+        false !== strpos($body, 'Audit::record(')
+    );
+}
+
+// --- delete refuses what it must ----------------------------------------
+
+$at = strpos($page, 'function bootfiledeletePost()');
+$deleteBody = false === $at ? '' : substr($page, $at, 3000);
+$t->check(
+    'delete refuses a file that is marked kept',
+    false !== strpos($deleteBody, "\$info['pinned']")
+);
+$t->check(
+    'delete refuses a file a default setting points at',
+    false !== strpos($deleteBody, '_defaultPointers()')
+);
+/**
+ * The row hides those buttons already. The handler refuses anyway, because
+ * a hidden button is a courtesy and a request is not obliged to come from
+ * one.
+ */
+$t->check(
+    'the refusals are server side, not only in the rendered row',
+    false !== strpos($deleteBody, 'HTTP_BAD_REQUEST')
+);
+
+// --- path traversal ------------------------------------------------------
+
+$at = strpos($page, 'function _bootFileNamed(');
+$namedBody = false === $at ? '' : substr($page, $at, 900);
+$t->check(
+    'a posted filename is reduced to a basename',
+    false !== strpos($namedBody, 'basename(')
+);
+$t->check(
+    'and then required to be a real file in the boot directory',
+    false !== strpos($namedBody, 'is_file(')
+    && false !== strpos($namedBody, 'FOG_TFTP_PXE_KERNEL_DIR')
+);
+
+// --- the role to setting map, exercised ---------------------------------
+
+$keysFor = new \ReflectionMethod(
+    'FOG\Pages\FOGConfigurationPage',
+    '_defaultKeysFor'
+);
+$keysFor->setAccessible(true);
+$kernelKeys = array_keys($keysFor->invoke(null, 'kernel'));
+$initKeys = array_keys($keysFor->invoke(null, 'init'));
+$payloadKeys = array_keys($keysFor->invoke(null, 'payload'));
+
+$t->check(
+    'a kernel may be set as any of the three default kernels',
+    [
+        'FOG_TFTP_PXE_KERNEL',
+        'FOG_TFTP_PXE_KERNEL_32',
+        'FOG_TFTP_PXE_KERNEL_ARM'
+    ] === $kernelKeys
+);
+$t->check(
+    'an init may be set as any of the three default inits',
+    [
+        'FOG_PXE_BOOT_IMAGE',
+        'FOG_PXE_BOOT_IMAGE_32',
+        'FOG_PXE_BOOT_IMAGE_ARM'
+    ] === $initKeys
+);
+/**
+ * The collision this whole change set is about: FOG_MEMTEST_KERNEL is named
+ * for a kernel and points at a payload. A payload must be offerable as that
+ * and as nothing else.
+ */
+$t->check(
+    'a payload may be set as the memtest pointer and nothing else',
+    ['FOG_MEMTEST_KERNEL'] === $payloadKeys
+);
+$t->check(
+    'no kernel setting is offered to a payload',
+    !in_array('FOG_TFTP_PXE_KERNEL', $payloadKeys, true)
+);
+$t->check(
+    'no payload setting is offered to a kernel',
+    !in_array('FOG_MEMTEST_KERNEL', $kernelKeys, true)
+);
+$t->check(
+    'an unclassified file may be set as nothing at all',
+    [] === $keysFor->invoke(null, 'unclassified')
+);
+
+// --- the client side -----------------------------------------------------
+
+$t->check(
+    'the actions post with an explicit node, so they resolve node-scoped',
+    false !== strpos($js, "'?node=about&sub=' + sub")
+);
+$t->check(
+    'delete asks first',
+    false !== strpos($js, 'window.confirm(')
+);
+$t->check(
+    'the handlers are delegated and namespaced, so an AJAX page swap is safe',
+    false !== strpos($js, "off('click.fogBootFileAct')")
+);
+$t->check(
+    'a successful action re-reads the page rather than patching the row',
+    false !== strpos($js, 'location.reload();')
+);
+
+$t->finish();


### PR DESCRIPTION
Follows #1687, #1688 and #1690. This is the management surface those three were building toward.

## Why

These pages could only say what was **available to download**. "What do I already have, and what is it for" had nowhere to be asked — which is also why nothing could offer to point a default back at the kernel that worked, or to mark one to be kept against a future prune.

## The tabs

The card that held one table now holds two.

The release table stays **tab one and the pane that is active on arrival**, because its DataTable computes column widths at page load and cannot do that while hidden. The Local files pane is deliberately **not** a DataTable for the same reason — it is the tab that starts hidden — and a plain server-sorted table is enough for a directory of tens of files.

`tabFields($tabData, false)`, not the default `-1`: that would ask `getClass()` to resolve an entity for node `about`, and there is none. `certificates()` in the same file passes `false` for the same reason, and its docblock is where both constraints are written down.

## What the tab reports

Every file in the boot directory, with:

- **Role** — FOS Kernel / FOS Init / Boot Payload / Unclassified
- **Version** — from the image's own header, so it does not depend on `attr`
- **FOS Release** — or the specific reason it cannot be read
- **Size**, **Modified** (mtime, not ctime)
- **In use as** — which default-pointer settings currently name this file
- **Keep** — whether it is marked against pruning
- and a note when two files are **byte-identical**, which is what stops "keep three versions" meaning three copies of one kernel. An admin looking at `bzImage` beside `bzImage.<release>` has no other way to tell whether an update actually changed anything.

The same listing appears on both pages rather than one filtered per page. The Role column is what makes it legible, and a file whose role is not what someone expected is exactly what they came to look at — filtering it out of whichever page they happened to open would hide the answer.

## The actions

Three subs — `bootfilekeep`, `bootfiledefault`, `bootfiledelete` — rather than one endpoint taking an action parameter, for the reason the API token grid gives: separate subs **can** each carry their own permission later. Deleting a bootable kernel and pointing a default at one are not self-evidently the same power, even though both need `settings.edit` today.

**Set as default** writes the same keys FOG Settings writes. The settings stay authoritative for what boots and `IpxeBootMenu` keeps reading exactly one place; what this adds is choosing from the files that actually exist. The key is validated against the role's own list, so a payload cannot be installed as a boot kernel through a hand-made request — `FOG_MEMTEST_KERNEL` is named for a kernel and points at a payload, which is the collision this whole series is about.

**Delete** refuses a file a default points at, and one marked kept. The row hides those buttons already; the handler refuses anyway, because a hidden button is a courtesy and a request is not obliged to come from one. It deletes over the same SSH/SFTP connection `kernelfetch()` writes through — that is where the writes go, `FOG_TFTP_HOST` may not be this machine, and using the write path for the delete means the two cannot disagree about which directory is real.

**Keep** records the intention only. Nothing prunes boot files yet, so there is nothing for it to protect against today — the pruner, and the copy into the customizations tree that survives a rebuild of the web root, arrive with the retention work. Writing the flag here means the tab that shows it is also the thing that sets it.

## Permissions

Node-scoped under `settings`, **not** in `GLOBAL_SUB_OVERRIDES`. The download subs are global only because their JS requests them with no `node=` at all, so they dispatch under the exempt `home` node — a shape worth not repeating. This JS posts `node=about`, so these permissions are declared where the rest of the page's are.

Every handler: `checkAuthAndCSRF()`, an explicit `Authorization::can('settings.edit')`, an `Audit::record()` row, and a posted filename reduced to a `basename()` and then required to be a real file in the boot directory — the directory listing is the allow-list, because every one of these endpoints turns a request parameter into a filesystem path.

## Verification

- `tests/boot-file-tab.test.php` — new, 43 checks. Pins the tab order (the DataTable-in-a-hidden-pane trap), the `false` argument, CSRF + permission + name-resolution + audit on all three handlers, both delete refusals being server-side, and the role→setting map exercised directly: a payload is offerable as `FOG_MEMTEST_KERNEL` and nothing else, a kernel is never offerable as that, and an unclassified file as nothing at all.
- Full `tests/*.test.php`: **221 pass, 29 fail — the same 29 that fail on an unmodified checkout** (this box has no gettext extension).
- `php -l` clean; `node --check` clean.
- US-spelling word list run by hand, since that test cannot run here.
- **The two `phpstan` passes were not run** — no `composer`/`vendor` on this box. CI is first.

## One test changed

`apitoken-grid-and-scope.test.php` asserts `5 === preg_match_all('/\$this->_postOnly\(\);/', $cfg)` — it counts every POST-only anchor on the **whole page**, not only its own three, so three new anchors take it to eight. Bumped with a comment saying so, the same way the phpstan baseline's occurrence counts are bumped rather than regenerated.

## Also corrected

`Common.reloadPage()` does not exist — I had written a guard for it. The house pattern for a non-DataTable pane on this page is plain `location.reload()`, which is what `fog.about.certificates.js` does after a write; the API token pane's `table.ajax.reload()` is a DataTable, which this pane deliberately is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYw9JCZGPeHuse6RTyNPgs
