### PR TITLE
Count distinct kernels, and make "keep this one" survive an upgrade

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -738,6 +738,14 @@ restorePreservedCustomizations() {
     # above excludes them: picking up the new kernel is the point of an
     # update. Keeping bzImage ITSELF is therefore close to meaningless -- keep
     # the sibling or a custom name, which is what the tab steers toward.
+    #
+    # ORDER DEPENDENCY, and it fails silently if broken: the directory is
+    # created by _ensureCustomizationsTree(), which runs inside
+    # configureHttpd() -- installfog.sh calls that BEFORE this function
+    # (backup, then configureHttpd, then restore). Moving either past the
+    # other leaves this reading a directory that does not exist yet, which
+    # the -d guard turns into "nothing was kept" rather than an error, and
+    # the admin's kernel is gone with the record still saying it was kept.
     if [[ -d "${kbdir}/keep" ]]; then
         for f in "${kbdir}/keep"/*; do
             [[ -f $f ]] || continue

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -534,7 +534,7 @@ backupPreservedCustomizations() {
     # So: back up (live directory) minus (what the source tree ships). No
     # guessing, and a fully custom name is covered however it got there.
     [[ -z ${BOOT_kernel_backups_kept} || ! ${BOOT_kernel_backups_kept} =~ ^[0-9]+$ || ${BOOT_kernel_backups_kept} -lt 1 ]] && BOOT_kernel_backups_kept=3
-    local kbdir="${customizationsDir}/kernel-backups" k kf bn n
+    local kbdir="${customizationsDir}/kernel-backups" k kf bn n same
     local shippeddir="${webdirsrc%/}/service/ipxe"
     if [[ -d $ipxedir ]]; then
         mkdir -p "$kbdir" >>$error_log 2>&1 || warn=1
@@ -550,6 +550,40 @@ backupPreservedCustomizations() {
             [[ $n =~ ^[0-9]+$ ]] || continue
             [[ $n -ge ${BOOT_kernel_backups_kept} ]] && rm -rf "$k" >>$error_log 2>&1
         done
+        # Does gen-1 already hold exactly this capture set, byte for byte?
+        #
+        # The rotation used to run on every install unconditionally, and not
+        # every FOG release ships a new FOS kernel -- so three upgrades
+        # carrying one kernel left gen-1, gen-2 and gen-3 holding three
+        # identical copies, and "keep 3" meant one real version. The depth an
+        # admin asked for silently evaporated, and restorekernel.sh --list
+        # offered three snapshots that were the same snapshot.
+        #
+        # Compared by CONTENT and in BOTH directions. A file the admin added
+        # since the last install is a change; so is one they deleted, which a
+        # subset test would call unchanged. Same filters as the copy loop
+        # below, so the two cannot disagree about what a generation holds.
+        same=1
+        if [[ -d "${kbdir}/gen-1" ]]; then
+            for kf in "${ipxedir}"/*; do
+                [[ -f $kf ]] || continue
+                bn=$(basename "$kf")
+                [[ -e "${shippeddir}/${bn}" ]] && continue
+                case $bn in
+                    bzImage.*|bzImage32.*|arm_Image.*|init.xz.*|init_32.xz.*|arm_init.cpio.gz.*) continue ;;
+                esac
+                cmp -s "$kf" "${kbdir}/gen-1/${bn}" || { same=0; break; }
+            done
+            if [[ $same -eq 1 ]]; then
+                for kf in "${kbdir}/gen-1"/*; do
+                    [[ -f $kf ]] || continue
+                    bn=$(basename "$kf")
+                    [[ -f "${ipxedir}/${bn}" ]] || { same=0; break; }
+                done
+            fi
+        else
+            same=0
+        fi
         # GH-1579: rotate on BOOT_kernel_backups_kept, not on the retired
         # pre-GH-1120 spelling kernelBackupGenerations. That name now survives
         # only as a migration source (see migrateDeprecatedKeys) and in the
@@ -559,9 +593,15 @@ backupPreservedCustomizations() {
         # onward were never created, which silently made
         # --kernel-backup-count a no-op and restorekernel.sh --generation N
         # unusable for any N above 1.
-        for ((k = BOOT_kernel_backups_kept - 1; k >= 1; k--)); do
-            [[ -d "${kbdir}/gen-${k}" ]] && mv "${kbdir}/gen-${k}" "${kbdir}/gen-$((k + 1))" >>$error_log 2>&1
-        done
+        #
+        # Skipped entirely when nothing changed: rotating identical content
+        # spends a generation to record that an upgrade happened, and the
+        # generations are for kernels, not for installer runs.
+        if [[ $same -eq 0 ]]; then
+            for ((k = BOOT_kernel_backups_kept - 1; k >= 1; k--)); do
+                [[ -d "${kbdir}/gen-${k}" ]] && mv "${kbdir}/gen-${k}" "${kbdir}/gen-$((k + 1))" >>$error_log 2>&1
+            done
+        fi
         mkdir -p "${kbdir}/gen-1" >>$error_log 2>&1 || warn=1
         # cp -a preserves the version/tag_name xattrs downloadfiles() stamps on
         # each kernel, so every generation says which FOS release it came from
@@ -683,6 +723,27 @@ restorePreservedCustomizations() {
             # this kernel; a sibling would just be a duplicate.
             cmp -s "${kbdir}/gen-1/${bn}" "${ipxedir}/${bn}" && continue
             [[ -e "${ipxedir}/${bn}.${tag}" ]] || cp -a "${kbdir}/gen-1/${bn}" "${ipxedir}/${bn}.${tag}" >>$error_log 2>&1
+        done
+    fi
+    # Files the admin marked to be kept, put back if the fresh tree has none
+    # of that name.
+    #
+    # The web root is deleted and rebuilt on every install, and a per-release
+    # sibling is deliberately NOT part of a generation -- it is already a copy
+    # of a kernel, and snapshotting it would multiply the same bytes by the
+    # generation count. So nothing else brings one back, and "keep this
+    # kernel" would have survived exactly until the next upgrade.
+    #
+    # The six default names are excluded, the same way the generation restore
+    # above excludes them: picking up the new kernel is the point of an
+    # update. Keeping bzImage ITSELF is therefore close to meaningless -- keep
+    # the sibling or a custom name, which is what the tab steers toward.
+    if [[ -d "${kbdir}/keep" ]]; then
+        for f in "${kbdir}/keep"/*; do
+            [[ -f $f ]] || continue
+            bn=$(basename "$f")
+            [[ $defaultnames == *" $bn "* ]] && continue
+            [[ -e "${ipxedir}/${bn}" ]] || cp -a "$f" "${ipxedir}/${bn}" >>$error_log 2>&1 || st=1
         done
     fi
     [[ -d $ipxedir ]] && chown -R ${SVC_user}:${apacheuser} "$ipxedir" >>$error_log 2>&1
@@ -8124,6 +8185,26 @@ _ensureCustomizationsTree() {
     # zone's own leaf/ directory is.
     chmod 0700 "$customdir" >>$error_log 2>&1
     [[ -n $optdir ]] && mkdir -p "$optdir" >>$error_log 2>&1
+    # kernel-backups/keep is the one directory under here the WEB TIER writes.
+    # Marking a boot file to be kept copies it in from service/ipxe, and the
+    # copy is the record: the pruner tests for its existence with no manifest
+    # to read and nothing to drift.
+    #
+    # No sudo helper and no privileged path. The alternative was to follow
+    # packages/secureboot/fog-sign-kernel, but that helper's whole security
+    # property is taking NO arguments -- every path it touches comes from a
+    # root-owned config -- and a helper taking a filename would give that up.
+    # It buys nothing either way: kernelfetch() already writes arbitrary files
+    # into service/ipxe over SSH with the TFTP credentials, so "the web tier
+    # can place a boot file" is a capability it already has.
+    #
+    # 2775 with the group setgid, so a file the web user copies in stays
+    # group-readable to the installer that later restores it.
+    if [[ -n $optdir ]]; then
+        mkdir -p "$optdir/kernel-backups/keep" >>$error_log 2>&1
+        chown "${SVC_user}:${apacheuser}" "$optdir/kernel-backups/keep" >>$error_log 2>&1
+        chmod 2775 "$optdir/kernel-backups/keep" >>$error_log 2>&1
+    fi
     if [[ ! -f "$etcdir/readme.txt" ]]; then
         cat > "$etcdir/readme.txt" <<'ETCREADME'
 This directory is for configuration you supply yourself.

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -191,8 +191,20 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "wurde abgebrochen"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "Gelöscht"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -207,8 +219,20 @@ msgid "%s images"
 msgstr "Images"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr "läuft nicht mehr"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -224,6 +248,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -252,6 +280,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1263,6 +1295,10 @@ msgstr "Standard Logout-Zeit (in Minuten)"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "Keine Datei wurde hochgeladen"
+
 msgid "BIOS Date"
 msgstr "BIOS-Datum"
 
@@ -1307,6 +1343,18 @@ msgstr "Passwort binden"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "Löschen der Datei fehlgeschlagen"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "Boot-Optionen:"
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "Site aktualisiert!"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1683,6 +1731,9 @@ msgstr "Gehäuse-Version"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2349,8 +2400,31 @@ msgid "Default Width"
 msgstr "Standardbreite"
 
 #, fuzzy
+msgid "Default init, ARM64"
+msgstr "Standardbreite"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "Standardbreite"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "Standardbreite"
+
+#, fuzzy
 msgid "Default is disabled"
 msgstr "Standard ist deaktiviert"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "Standard-Bildwiederholrate"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "Standarddrucker aktualisieren"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4476,6 +4550,9 @@ msgstr "In "
 msgid "In FOG"
 msgstr "zu booten."
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4855,6 +4932,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5260,6 +5343,10 @@ msgstr "Laden fehlgeschlagen: %s"
 msgid "Loading data to field"
 msgstr "Laden von Daten zum Feld %s"
 
+#, fuzzy
+msgid "Local files"
+msgstr "Standorte"
+
 msgid "Location"
 msgstr "Ort"
 
@@ -5548,6 +5635,9 @@ msgstr "Speicher"
 msgid "Memory limit cannot be less than 128"
 msgstr "Menüpunkt oder Titel darf nicht leer sein."
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "Beschreibung"
@@ -5628,6 +5718,9 @@ msgstr "Modell"
 #, fuzzy
 msgid "Models"
 msgstr "Modell"
+
+msgid "Modified"
+msgstr ""
 
 #, fuzzy
 msgid "Module"
@@ -5969,6 +6062,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "Keine Datei wurde hochgeladen"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "Erstellen eines Snapin-Jobs fehlgeschlagen"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -6129,6 +6226,9 @@ msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "Die zugewiesene Image Speichergruppe ist nicht gültig."
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 msgid "No such filter"
 msgstr ""
@@ -8022,6 +8122,10 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr "Name der Speichergruppe"
 
 #, fuzzy
+msgid "Set as"
+msgstr "Service-Update fehlgeschlagen"
+
+#, fuzzy
 msgid "Set failed"
 msgstr "Service-Update fehlgeschlagen"
 
@@ -8537,6 +8641,9 @@ msgstr "Drucker-Update fehlgeschlagen!"
 
 msgid "Status"
 msgstr "Status"
+
+msgid "Stop keeping"
+msgstr ""
 
 msgid "Storage"
 msgstr "Speicher"
@@ -9282,6 +9389,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr " | Datei oder Pfad ist nicht erreichbar"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9477,6 +9588,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "Temporäre Datei konnte nicht gelesen werden."
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -10075,6 +10190,10 @@ msgstr "Nicht verfügbar"
 
 msgid "Uncategorized"
 msgstr ""
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "zugeordneter Host"
 
 msgid "Unicast"
 msgstr "Unicast"
@@ -10747,6 +10866,10 @@ msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
+msgstr "Keine Verbindung zur Datenbank"
 
 msgid "You do not have permission to change provider group associations."
 msgstr ""
@@ -11516,6 +11639,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 #, fuzzy
 msgid "second"
 msgstr "Sekunde"
@@ -12086,10 +12212,6 @@ msgstr ""
 #~ msgstr "Aktualisieren/Erstellen des Image-Logs fehlgeschlagen"
 
 #, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "Löschen der Datei fehlgeschlagen"
-
-#, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "Ich bin nicht der FOG-Web-Server"
 
@@ -12213,10 +12335,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "Host Aktualisierung erfolgreich!"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "Site aktualisiert!"
 
 #, fuzzy
 #~ msgid "Host Snapins"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -196,8 +196,20 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "has been successfully updated"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "Deleted"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -212,8 +224,20 @@ msgid "%s images"
 msgstr "Images"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr " no longer exists"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -229,6 +253,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -257,6 +285,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1267,6 +1299,10 @@ msgstr "Default log out time (in minutes)"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "No file was uploaded"
+
 msgid "BIOS Date"
 msgstr "BIOS Date"
 
@@ -1311,6 +1347,18 @@ msgstr "Domain Password"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "Failed to delete file"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "Boot Options:"
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "Service Updated!"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1686,6 +1734,9 @@ msgstr "Chassis Version"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2352,8 +2403,31 @@ msgid "Default Width"
 msgstr "Default Width"
 
 #, fuzzy
+msgid "Default init, ARM64"
+msgstr "Default Width"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "Default Width"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "Default Width"
+
+#, fuzzy
 msgid "Default is disabled"
 msgstr "Donations are disabled"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "Default Refresh Rate"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "Update Printer"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4478,6 +4552,9 @@ msgstr "In "
 msgid "In FOG"
 msgstr "In "
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4857,6 +4934,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5272,6 +5355,10 @@ msgstr "Load failed: %s"
 msgid "Loading data to field"
 msgstr "Loading data to field %s"
 
+#, fuzzy
+msgid "Local files"
+msgstr "Locations"
+
 msgid "Location"
 msgstr "Location"
 
@@ -5560,6 +5647,9 @@ msgstr "Memory"
 msgid "Memory limit cannot be less than 128"
 msgstr "Menu Item or title cannot be blank"
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "Description"
@@ -5640,6 +5730,9 @@ msgstr "Model"
 #, fuzzy
 msgid "Models"
 msgstr "Model"
+
+msgid "Modified"
+msgstr ""
 
 #, fuzzy
 msgid "Module"
@@ -5981,6 +6074,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "No file was uploaded"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "Failed to create Snapin Job"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -6141,6 +6238,9 @@ msgstr "An image already exists with this name!"
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "The image storage group assigned is not valid"
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 msgid "No such filter"
 msgstr ""
@@ -8033,6 +8133,10 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr "Storage Group Name"
 
 #, fuzzy
+msgid "Set as"
+msgstr "Service update failed"
+
+#, fuzzy
 msgid "Set failed"
 msgstr "Service update failed"
 
@@ -8548,6 +8652,9 @@ msgstr "Printer update failed!"
 
 msgid "Status"
 msgstr "Status"
+
+msgid "Stop keeping"
+msgstr ""
 
 msgid "Storage"
 msgstr "Storage"
@@ -9291,6 +9398,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr " | File or path cannot be reached"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9486,6 +9597,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "Could not read temp file"
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -10084,6 +10199,10 @@ msgstr "Not Available"
 
 msgid "Uncategorized"
 msgstr ""
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "No node associated"
 
 msgid "Unicast"
 msgstr "Unicast"
@@ -10755,6 +10874,10 @@ msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
+msgstr "No connection to the database"
 
 msgid "You do not have permission to change provider group associations."
 msgstr ""
@@ -11520,6 +11643,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 #, fuzzy
 msgid "second"
 msgstr "Icon"
@@ -12080,10 +12206,6 @@ msgstr ""
 #~ msgstr "Failed to update/create image log"
 
 #, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "Failed to delete file"
-
-#, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "I am not the fog web server"
 
@@ -12204,10 +12326,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "Install / Update Successful!"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "Service Updated!"
 
 #, fuzzy
 #~ msgid "Host Snapins"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -194,8 +194,20 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "se ha actualizado correctamente"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "Borrar"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -210,8 +222,20 @@ msgid "%s images"
 msgstr "Imagen"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr "Impresora ya existe"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -227,6 +251,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, fuzzy, php-format
@@ -255,6 +283,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1281,6 +1313,10 @@ msgstr "Por defecto cerrar sesión en el tiempo (en minutos)"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "Ningún archivo fue subido"
+
 msgid "BIOS Date"
 msgstr "Fecha del BIOS"
 
@@ -1326,6 +1362,18 @@ msgstr "Contraseña de dominio"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "No se pudo crear el usuario"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "Opciones de arranque:"
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "Servicio de Actualización!"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1703,6 +1751,9 @@ msgstr "Versión chasis"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2377,8 +2428,31 @@ msgid "Default Width"
 msgstr "Ancho por defecto"
 
 #, fuzzy
+msgid "Default init, ARM64"
+msgstr "Ancho por defecto"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "Ancho por defecto"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "Ancho por defecto"
+
+#, fuzzy
 msgid "Default is disabled"
 msgstr "Ancho por defecto"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "Frecuencia de actualización predeterminado"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "Actualizar impresora"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4555,6 +4629,9 @@ msgstr "En "
 msgid "In FOG"
 msgstr "En "
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4945,6 +5022,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5359,6 +5442,10 @@ msgid "Loading data to field"
 msgstr "La carga de datos de campo de %s"
 
 #, fuzzy
+msgid "Local files"
+msgstr "Acción"
+
+#, fuzzy
 msgid "Location"
 msgstr "Acción"
 
@@ -5661,6 +5748,9 @@ msgstr "Memoria"
 msgid "Memory limit cannot be less than 128"
 msgstr "Elementos de menú o el título no puede estar en blanco"
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "Descripción:"
@@ -5741,6 +5831,9 @@ msgstr "Modelo"
 #, fuzzy
 msgid "Models"
 msgstr "Modelo"
+
+msgid "Modified"
+msgstr ""
 
 msgid "Module"
 msgstr "Módulo"
@@ -6089,6 +6182,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "Ningún archivo fue subido"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "No se pudo crear Complemento de empleo"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -6250,6 +6347,9 @@ msgstr "Una imagen ya existe con este nombre!"
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "Marque aquí para ver los grupos no asignado esta imagen"
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 msgid "No such filter"
 msgstr ""
@@ -8164,6 +8264,10 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr "Nombre del grupo de almacenamiento"
 
 #, fuzzy
+msgid "Set as"
+msgstr "actualización de servicio no pudo"
+
+#, fuzzy
 msgid "Set failed"
 msgstr "actualización de servicio no pudo"
 
@@ -8688,6 +8792,9 @@ msgstr "actualización de la impresora ha fallado!"
 
 msgid "Status"
 msgstr "Estado"
+
+msgid "Stop keeping"
+msgstr ""
 
 #, fuzzy
 msgid "Storage"
@@ -9453,6 +9560,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr "No se pudo leer el archivo temporal"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9650,6 +9761,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "No se pudo leer el archivo temporal"
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -10243,6 +10358,10 @@ msgstr "No se dispone de hash"
 
 msgid "Uncategorized"
 msgstr ""
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "No nodo asociado"
 
 #, fuzzy
 msgid "Unicast"
@@ -10920,6 +11039,10 @@ msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
+msgstr "Haga clic en el botón para exportar la base de datos."
 
 msgid "You do not have permission to change provider group associations."
 msgstr ""
@@ -11686,6 +11809,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 msgid "second"
 msgstr ""
 
@@ -12248,10 +12374,6 @@ msgstr ""
 #~ msgstr "No se pudo crear Complemento de empleo"
 
 #, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "No se pudo crear el usuario"
-
-#, fuzzy
 #~ msgid "Force Reboot"
 #~ msgstr "Reiniciar"
 
@@ -12369,10 +12491,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "actualización Valoración falló"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "Servicio de Actualización!"
 
 #, fuzzy
 #~ msgid "Host Snapins"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -191,8 +191,20 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "wurde abgebrochen"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "Gelöscht"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -207,8 +219,20 @@ msgid "%s images"
 msgstr "Images"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr "läuft nicht mehr"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -224,6 +248,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -252,6 +280,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1263,6 +1295,10 @@ msgstr "Standard Logout-Zeit (in Minuten)"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "Keine Datei wurde hochgeladen"
+
 msgid "BIOS Date"
 msgstr "BIOS-Datum"
 
@@ -1307,6 +1343,18 @@ msgstr "Passwort binden"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "Löschen der Datei fehlgeschlagen"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "Boot-Optionen:"
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "Site aktualisiert!"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1683,6 +1731,9 @@ msgstr "Gehäuse-Version"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2349,8 +2400,31 @@ msgid "Default Width"
 msgstr "Standardbreite"
 
 #, fuzzy
+msgid "Default init, ARM64"
+msgstr "Standardbreite"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "Standardbreite"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "Standardbreite"
+
+#, fuzzy
 msgid "Default is disabled"
 msgstr "Standard ist deaktiviert"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "Standard-Bildwiederholrate"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "Standarddrucker aktualisieren"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4476,6 +4550,9 @@ msgstr "In "
 msgid "In FOG"
 msgstr "zu booten."
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4856,6 +4933,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5261,6 +5344,10 @@ msgstr "Laden fehlgeschlagen: %s"
 msgid "Loading data to field"
 msgstr "Laden von Daten zum Feld %s"
 
+#, fuzzy
+msgid "Local files"
+msgstr "Standorte"
+
 msgid "Location"
 msgstr "Ort"
 
@@ -5549,6 +5636,9 @@ msgstr "Speicher"
 msgid "Memory limit cannot be less than 128"
 msgstr "Menüpunkt oder Titel darf nicht leer sein."
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "Beschreibung"
@@ -5629,6 +5719,9 @@ msgstr "Modell"
 #, fuzzy
 msgid "Models"
 msgstr "Modell"
+
+msgid "Modified"
+msgstr ""
 
 #, fuzzy
 msgid "Module"
@@ -5970,6 +6063,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "Keine Datei wurde hochgeladen"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "Erstellen eines Snapin-Jobs fehlgeschlagen"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -6130,6 +6227,9 @@ msgstr "Ein Host mit diesem Namen ist bereits vorhanden!"
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "Die zugewiesene Image Speichergruppe ist nicht gültig."
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 msgid "No such filter"
 msgstr ""
@@ -8023,6 +8123,10 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr "Name der Speichergruppe"
 
 #, fuzzy
+msgid "Set as"
+msgstr "Service-Update fehlgeschlagen"
+
+#, fuzzy
 msgid "Set failed"
 msgstr "Service-Update fehlgeschlagen"
 
@@ -8538,6 +8642,9 @@ msgstr "Drucker-Update fehlgeschlagen!"
 
 msgid "Status"
 msgstr "Status"
+
+msgid "Stop keeping"
+msgstr ""
 
 msgid "Storage"
 msgstr "Speicher"
@@ -9283,6 +9390,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr " | Datei oder Pfad ist nicht erreichbar"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9478,6 +9589,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "Temporäre Datei konnte nicht gelesen werden."
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -10076,6 +10191,10 @@ msgstr "Nicht verfügbar"
 
 msgid "Uncategorized"
 msgstr ""
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "zugeordneter Host"
 
 msgid "Unicast"
 msgstr "Unicast"
@@ -10748,6 +10867,10 @@ msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
+msgstr "Keine Verbindung zur Datenbank"
 
 msgid "You do not have permission to change provider group associations."
 msgstr ""
@@ -11517,6 +11640,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 #, fuzzy
 msgid "second"
 msgstr "Sekunde"
@@ -12087,10 +12213,6 @@ msgstr ""
 #~ msgstr "Aktualisieren/Erstellen des Image-Logs fehlgeschlagen"
 
 #, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "Löschen der Datei fehlgeschlagen"
-
-#, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "Ich bin nicht der FOG-Web-Server"
 
@@ -12214,10 +12336,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "Host Aktualisierung erfolgreich!"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "Site aktualisiert!"
 
 #, fuzzy
 #~ msgid "Host Snapins"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -197,8 +197,20 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "a été mis à jour avec succès"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "supprimé"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -213,8 +225,20 @@ msgid "%s images"
 msgstr "Images"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr " n'existe plus"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -230,6 +254,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -258,6 +286,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1268,6 +1300,10 @@ msgstr "Par défaut déconnecter le temps (en minutes)"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "Aucun fichier a été téléchargé"
+
 msgid "BIOS Date"
 msgstr "BIOS date"
 
@@ -1312,6 +1348,18 @@ msgstr "domaine Mot de passe"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "Impossible de supprimer le fichier"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "Options de démarrage:"
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "Service de mise à jour!"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1687,6 +1735,9 @@ msgstr "Châssis Version"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2353,8 +2404,31 @@ msgid "Default Width"
 msgstr "Par défaut Largeur"
 
 #, fuzzy
+msgid "Default init, ARM64"
+msgstr "Par défaut Largeur"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "Par défaut Largeur"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "Par défaut Largeur"
+
+#, fuzzy
 msgid "Default is disabled"
 msgstr "Les dons sont désactivés"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "Par défaut Taux de rafraîchissement"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "Mise à jour de l'imprimante"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4479,6 +4553,9 @@ msgstr "Dans "
 msgid "In FOG"
 msgstr "Dans "
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4858,6 +4935,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5260,6 +5343,10 @@ msgstr "Échec du chargement: %s"
 msgid "Loading data to field"
 msgstr "Chargement des données à champ %s"
 
+#, fuzzy
+msgid "Local files"
+msgstr "Emplacements"
+
 msgid "Location"
 msgstr "Emplacement"
 
@@ -5548,6 +5635,9 @@ msgstr "Mémoire"
 msgid "Memory limit cannot be less than 128"
 msgstr "Élément de menu ou le titre ne peut pas être vide"
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "La description"
@@ -5628,6 +5718,9 @@ msgstr "Modèle"
 #, fuzzy
 msgid "Models"
 msgstr "Modèle"
+
+msgid "Modified"
+msgstr ""
 
 msgid "Module"
 msgstr "Module"
@@ -5968,6 +6061,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "Aucun fichier a été téléchargé"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "Échec de la création d'emploi Snapin"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -6128,6 +6225,9 @@ msgstr "Une image existe déjà avec ce nom!"
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "Le groupe de stockage d'images attribuée est non valable"
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 msgid "No such filter"
 msgstr ""
@@ -8019,6 +8119,10 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr "Nom du groupe de stockage"
 
 #, fuzzy
+msgid "Set as"
+msgstr "mise à jour du service n'a pas"
+
+#, fuzzy
 msgid "Set failed"
 msgstr "mise à jour du service n'a pas"
 
@@ -8533,6 +8637,9 @@ msgstr "mise à jour de l'imprimante a échoué!"
 
 msgid "Status"
 msgstr "statut"
+
+msgid "Stop keeping"
+msgstr ""
 
 msgid "Storage"
 msgstr "Stockage"
@@ -9276,6 +9383,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr " | Fichier ou chemin ne peut pas être atteint"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9471,6 +9582,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "Impossible de lire le fichier temporaire"
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -10069,6 +10184,10 @@ msgstr "Indisponible"
 
 msgid "Uncategorized"
 msgstr ""
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "Aucun noeud associé"
 
 msgid "Unicast"
 msgstr "Unicast"
@@ -10741,6 +10860,10 @@ msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
+msgstr "Pas de connexion à la base de données"
 
 msgid "You do not have permission to change provider group associations."
 msgstr ""
@@ -11506,6 +11629,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 #, fuzzy
 msgid "second"
 msgstr "Icône"
@@ -12066,10 +12192,6 @@ msgstr ""
 #~ msgstr "Impossible de mettre à jour / créer une image journal"
 
 #, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "Impossible de supprimer le fichier"
-
-#, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "Je ne suis pas le serveur web de brouillard"
 
@@ -12190,10 +12312,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "Installation / Mise à jour réussie!"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "Service de mise à jour!"
 
 #, fuzzy
 #~ msgid "Host Snapins"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -196,8 +196,20 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "è stato cancellato"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "eliminata"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -212,8 +224,20 @@ msgid "%s images"
 msgstr "immagini"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr "non è più in esecuzione"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -229,6 +253,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -257,6 +285,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1236,6 +1268,10 @@ msgstr "Predefinito disconnettersi tempo (in minuti)"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "Nessun file è stato caricato"
+
 msgid "BIOS Date"
 msgstr "BIOS Data"
 
@@ -1279,6 +1315,18 @@ msgstr "Bind Password"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "Impossibile eliminare il file"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "Opzioni di avvio:"
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "Sito aggiornato!"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1643,6 +1691,9 @@ msgstr "Telaio Version"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2290,8 +2341,31 @@ msgstr "Predefinito: frequenza aggiornamento"
 msgid "Default Width"
 msgstr "Larghezza predefinita"
 
+#, fuzzy
+msgid "Default init, ARM64"
+msgstr "Larghezza predefinita"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "Larghezza predefinita"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "Larghezza predefinita"
+
 msgid "Default is disabled"
 msgstr "Il valore predefinito è disabilitato"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "Predefinito: frequenza aggiornamento"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "Aggiorna la stampante predefinita"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4353,6 +4427,9 @@ msgstr "In"
 msgid "In FOG"
 msgstr "In FOG"
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4717,6 +4794,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5101,6 +5184,10 @@ msgstr "Caricamento non riuscito"
 msgid "Loading data to field"
 msgstr "Caricamento dei dati campo"
 
+#, fuzzy
+msgid "Local files"
+msgstr "sedi"
+
 msgid "Location"
 msgstr "Luogo"
 
@@ -5380,6 +5467,9 @@ msgstr "Memoria"
 msgid "Memory limit cannot be less than 128"
 msgstr "Voce di menu o il titolo non può essere vuoto"
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "Descrizione"
@@ -5459,6 +5549,9 @@ msgstr "Modello"
 #, fuzzy
 msgid "Models"
 msgstr "Modello"
+
+msgid "Modified"
+msgstr ""
 
 #, fuzzy
 msgid "Module"
@@ -5795,6 +5888,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "Nessun file è stato caricato"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "Impossibile creare Snapin lavoro"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -5948,6 +6045,9 @@ msgstr "Un host già esiste con questo nome!"
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "Il gruppo di archiviazione immagine assegnato non è valido"
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 msgid "No such filter"
 msgstr ""
@@ -7794,6 +7894,10 @@ msgstr "Nome gruppo di archiviazione"
 msgid "Set Storage Group as Primary for Snapins"
 msgstr "Nome gruppo di archiviazione"
 
+#, fuzzy
+msgid "Set as"
+msgstr "Fallita impostazione"
+
 msgid "Set failed"
 msgstr "Fallita impostazione"
 
@@ -8282,6 +8386,9 @@ msgstr "Aggiornamento della stampante non è riuscito!"
 
 msgid "Status"
 msgstr "Stato"
+
+msgid "Stop keeping"
+msgstr ""
 
 msgid "Storage"
 msgstr "Conservazione"
@@ -8997,6 +9104,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr "Impossibile raggiungere il file o il percorso"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9191,6 +9302,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "Impossibile leggere il file temporaneo"
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -9774,6 +9889,10 @@ msgstr "Non disponibile"
 
 msgid "Uncategorized"
 msgstr ""
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "Host associato"
 
 msgid "Unicast"
 msgstr "Unicast"
@@ -10424,6 +10543,10 @@ msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
+msgstr "Nessuna connessione al database"
 
 msgid "You do not have permission to change provider group associations."
 msgstr ""
@@ -11158,6 +11281,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 msgid "second"
 msgstr "secondo"
 
@@ -11708,10 +11834,6 @@ msgstr ""
 #~ msgstr "Impossibile aggiornare / creare log immagine"
 
 #, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "Impossibile eliminare il file"
-
-#, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "Io non sono il server web fog"
 
@@ -11834,10 +11956,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "Aggiornamento host completato!"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "Sito aggiornato!"
 
 #, fuzzy
 #~ msgid "Host Snapins"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -186,9 +186,21 @@ msgstr ""
 msgid "%s can only be run on one host at a time"
 msgstr ""
 
+#, fuzzy, php-format
+msgid "%s cannot be used as %s."
+msgstr "Windows で使用できます"
+
 #, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "キャンセルできませんでした"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "削除済み"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -203,8 +215,20 @@ msgid "%s images"
 msgstr "イメージ"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr "選択したプリンターを追加"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -220,6 +244,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -248,6 +276,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1220,6 +1252,10 @@ msgstr "ホスト自動ログアウト"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "利用可能なスナップイン"
+
 msgid "BIOS Date"
 msgstr "BIOS 日付"
 
@@ -1263,6 +1299,18 @@ msgstr "バインドパスワード"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "削除"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "ブートオプション"
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "サイトを更新しました！"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1626,6 +1674,9 @@ msgstr "シャーシバージョン"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2276,8 +2327,31 @@ msgstr "既定の更新レート"
 msgid "Default Width"
 msgstr "既定の幅"
 
+#, fuzzy
+msgid "Default init, ARM64"
+msgstr "既定の幅"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "既定の幅"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "既定の幅"
+
 msgid "Default is disabled"
 msgstr "既定では無効です"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "既定の更新レート"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "既定で有効"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4320,6 +4394,10 @@ msgid "In FOG"
 msgstr "FOG 内"
 
 #, fuzzy
+msgid "In use as"
+msgstr "次を使用する必要があります"
+
+#, fuzzy
 msgid "Include"
 msgstr "含まれる項目"
 
@@ -4680,6 +4758,12 @@ msgid "Join Domain after image task"
 msgstr "展開後にドメイン参加"
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5067,6 +5151,10 @@ msgstr "読み込みに失敗しました"
 msgid "Loading data to field"
 msgstr "フィールドにデータを読み込んでいます"
 
+#, fuzzy
+msgid "Local files"
+msgstr "ロケーション"
+
 msgid "Location"
 msgstr "ロケーション"
 
@@ -5343,6 +5431,9 @@ msgstr "メモリ"
 msgid "Memory limit cannot be less than 128"
 msgstr "メニュー項目またはタイトルは空にできません"
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "説明"
@@ -5424,6 +5515,9 @@ msgstr "モデル"
 #, fuzzy
 msgid "Models"
 msgstr "モデル"
+
+msgid "Modified"
+msgstr ""
 
 #, fuzzy
 msgid "Module"
@@ -5758,6 +5852,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "ファイルはアップロードされませんでした"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "スナップインジョブの作成に失敗しました"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -5913,6 +6011,9 @@ msgstr "このイメージを削除できる有効なマスターノードがあ
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "割り当てられたイメージのストレージグループが無効です"
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 #, fuzzy
 msgid "No such filter"
@@ -7753,6 +7854,10 @@ msgstr ""
 msgid "Set Storage Group as Primary for Snapins"
 msgstr "ストレージグループの説明"
 
+#, fuzzy
+msgid "Set as"
+msgstr "設定に失敗しました"
+
 msgid "Set failed"
 msgstr "設定に失敗しました"
 
@@ -8236,6 +8341,9 @@ msgstr "サイトの更新に失敗しました！"
 
 msgid "Status"
 msgstr "状態"
+
+msgid "Stop keeping"
+msgstr ""
 
 msgid "Storage"
 msgstr "ストレージ"
@@ -8941,6 +9049,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr "ファイルまたはパスに到達できません"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9136,6 +9248,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "強制終了できませんでした"
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -9718,6 +9834,10 @@ msgstr "利用できません"
 #, fuzzy
 msgid "Uncategorized"
 msgstr "権限がありません"
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "関連付けられたホスト"
 
 #, fuzzy
 msgid "Unicast"
@@ -10363,6 +10483,10 @@ msgstr "少なくとも 1 つのグループを関連付ける必要がありま
 
 #, fuzzy
 msgid "You do not have permission to change LDAP group associations."
+msgstr "少なくとも 1 つのグループを関連付ける必要があります"
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
 msgstr "少なくとも 1 つのグループを関連付ける必要があります"
 
 #, fuzzy
@@ -11105,6 +11229,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 msgid "second"
 msgstr "秒"
 
@@ -11618,9 +11745,6 @@ msgstr ""
 #~ msgid "Attempting to ping host"
 #~ msgstr "ping を試行しています"
 
-#~ msgid "Available Snapins"
-#~ msgstr "利用可能なスナップイン"
-
 #~ msgid "Barcode Numbers"
 #~ msgstr "バーコード番号"
 
@@ -12054,10 +12178,6 @@ msgstr ""
 #~ msgid "Failed to upload \"%s\" to Master Node"
 #~ msgstr "\"%s\" のマスターノードへのアップロードに失敗しました"
 
-#, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "削除"
-
 #~ msgid "File Integrity Management"
 #~ msgstr "ファイル整合性管理"
 
@@ -12279,10 +12399,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "サイトを更新しました"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "サイトを更新しました！"
 
 #~ msgid "Host Snapins"
 #~ msgstr "ホスト スナップイン"
@@ -12507,9 +12623,6 @@ msgstr ""
 #~ msgid "Is restricted"
 #~ msgstr "制限付き"
 
-#~ msgid "It can be used on Windows"
-#~ msgstr "Windows で使用できます"
-
 #~ msgid "It is primarily geared for the smart installer methodology now"
 #~ msgstr "現在は主にスマートインストーラー方式向けに設計されています"
 
@@ -12673,9 +12786,6 @@ msgstr ""
 
 #~ msgid "Must have an image associated"
 #~ msgstr "イメージが関連付けられている必要があります"
-
-#~ msgid "Must use an"
-#~ msgstr "次を使用する必要があります"
 
 #~ msgid "NAME"
 #~ msgstr "名前"
@@ -13739,9 +13849,6 @@ msgstr ""
 
 #~ msgid "defined reports that may not be a part of"
 #~ msgstr "一部ではない可能性がある定義済みレポート"
-
-#~ msgid "deleted"
-#~ msgstr "削除済み"
 
 #, fuzzy
 #~ msgid "disabled (all)"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -172,7 +172,19 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
+msgstr ""
+
+#, php-format
+msgid "%s could not be removed."
+msgstr ""
+
+#, php-format
+msgid "%s deleted."
 msgstr ""
 
 #, php-format
@@ -188,7 +200,19 @@ msgid "%s images"
 msgstr ""
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
+msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, php-format
+msgid "%s is no longer kept."
 msgstr ""
 
 #, php-format
@@ -205,6 +229,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -233,6 +261,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1094,6 +1126,9 @@ msgstr ""
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+msgid "Available downloads"
+msgstr ""
+
 msgid "BIOS Date"
 msgstr ""
 
@@ -1134,6 +1169,15 @@ msgid "Bind Password"
 msgstr ""
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
+msgstr ""
+
+msgid "Boot File Deleted"
+msgstr ""
+
+msgid "Boot File Failed"
+msgstr ""
+
+msgid "Boot File Updated"
 msgstr ""
 
 msgid "Boot Files"
@@ -1452,6 +1496,9 @@ msgstr ""
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2025,7 +2072,25 @@ msgstr ""
 msgid "Default Width"
 msgstr ""
 
+msgid "Default init, ARM64"
+msgstr ""
+
+msgid "Default init, i386"
+msgstr ""
+
+msgid "Default init, x86_64"
+msgstr ""
+
 msgid "Default is disabled"
+msgstr ""
+
+msgid "Default kernel, ARM64"
+msgstr ""
+
+msgid "Default kernel, i386"
+msgstr ""
+
+msgid "Default kernel, x86_64"
 msgstr ""
 
 msgid "Default nested group depth"
@@ -3829,6 +3894,9 @@ msgstr ""
 msgid "In FOG"
 msgstr ""
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4154,6 +4222,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -4494,6 +4568,9 @@ msgstr ""
 msgid "Loading data to field"
 msgstr ""
 
+msgid "Local files"
+msgstr ""
+
 msgid "Location"
 msgstr ""
 
@@ -4737,6 +4814,9 @@ msgstr ""
 msgid "Memory limit cannot be less than 128"
 msgstr ""
 
+msgid "Memtest payload"
+msgstr ""
+
 msgid "Menu Description"
 msgstr ""
 
@@ -4804,6 +4884,9 @@ msgid "Model"
 msgstr ""
 
 msgid "Models"
+msgstr ""
+
+msgid "Modified"
 msgstr ""
 
 msgid "Module"
@@ -5100,6 +5183,9 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr ""
 
+msgid "No files in the boot directory."
+msgstr ""
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -5234,6 +5320,9 @@ msgid "No storagegroups assigned to this image"
 msgstr ""
 
 msgid "No storagegroups assigned to this snapin"
+msgstr ""
+
+msgid "No such file in the boot directory."
 msgstr ""
 
 msgid "No such filter"
@@ -6867,6 +6956,9 @@ msgstr ""
 msgid "Set Storage Group as Primary for Snapins"
 msgstr ""
 
+msgid "Set as"
+msgstr ""
+
 msgid "Set failed"
 msgstr ""
 
@@ -7298,6 +7390,9 @@ msgid "State filter"
 msgstr ""
 
 msgid "Status"
+msgstr ""
+
+msgid "Stop keeping"
 msgstr ""
 
 msgid "Storage"
@@ -7921,6 +8016,9 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+msgid "The boot directory cannot be read."
+msgstr ""
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -8101,6 +8199,9 @@ msgid "The provider returned a configuration for a different issuer"
 msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
+msgstr ""
+
+msgid "The record could not be written."
 msgstr ""
 
 msgid "The resource is not in a cancellable state."
@@ -8643,6 +8744,9 @@ msgid "Unavailable"
 msgstr ""
 
 msgid "Uncategorized"
+msgstr ""
+
+msgid "Unclassified"
 msgstr ""
 
 msgid "Unicast"
@@ -9224,6 +9328,9 @@ msgid "You do not have permission to change API tokens."
 msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
+msgstr ""
+
+msgid "You do not have permission to change boot files."
 msgstr ""
 
 msgid "You do not have permission to change provider group associations."
@@ -9904,6 +10011,9 @@ msgid "row(s)"
 msgstr ""
 
 msgid "row(s) converted from 0 to NULL"
+msgstr ""
+
+msgid "same contents as"
 msgstr ""
 
 msgid "second"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -196,8 +196,20 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "foi atualizado com sucesso"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "excluídos"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -212,8 +224,20 @@ msgid "%s images"
 msgstr "imagens"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr " não existe mais"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -229,6 +253,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -257,6 +285,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1267,6 +1299,10 @@ msgstr "Padrão log out tempo (em minutos)"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "Nenhum arquivo foi transferido"
+
 msgid "BIOS Date"
 msgstr "data do BIOS"
 
@@ -1311,6 +1347,18 @@ msgstr "senha de domínio"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "Falha ao excluir arquivo"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "Opções de inicialização:"
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "Serviço Atualizado!"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1686,6 +1734,9 @@ msgstr "chassis Versão"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2352,8 +2403,31 @@ msgid "Default Width"
 msgstr "Largura padrão"
 
 #, fuzzy
+msgid "Default init, ARM64"
+msgstr "Largura padrão"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "Largura padrão"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "Largura padrão"
+
+#, fuzzy
 msgid "Default is disabled"
 msgstr "As doações são deficientes"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "Padrão Refresh Rate"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "Atualizar impressora"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4478,6 +4552,9 @@ msgstr "Dentro "
 msgid "In FOG"
 msgstr "Dentro "
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4857,6 +4934,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5259,6 +5342,10 @@ msgstr "Carga falhou: %s"
 msgid "Loading data to field"
 msgstr "Carregamento de dados para o campo %s"
 
+#, fuzzy
+msgid "Local files"
+msgstr "localizações"
+
 msgid "Location"
 msgstr "Localização"
 
@@ -5547,6 +5634,9 @@ msgstr "Memória"
 msgid "Memory limit cannot be less than 128"
 msgstr "Artigo ou título de menu não pode ficar em branco"
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "Descrição"
@@ -5627,6 +5717,9 @@ msgstr "Modelo"
 #, fuzzy
 msgid "Models"
 msgstr "Modelo"
+
+msgid "Modified"
+msgstr ""
 
 #, fuzzy
 msgid "Module"
@@ -5968,6 +6061,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "Nenhum arquivo foi transferido"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "Falha ao criar Snapin Job"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -6128,6 +6225,9 @@ msgstr "Uma imagem já existe com este nome!"
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "O grupo de armazenamento de imagens atribuído não é válido"
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 msgid "No such filter"
 msgstr ""
@@ -8020,6 +8120,10 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr "Nome do grupo de armazenamento"
 
 #, fuzzy
+msgid "Set as"
+msgstr "atualização do Service falhou"
+
+#, fuzzy
 msgid "Set failed"
 msgstr "atualização do Service falhou"
 
@@ -8535,6 +8639,9 @@ msgstr "atualização da impressora falhou!"
 
 msgid "Status"
 msgstr "estado"
+
+msgid "Stop keeping"
+msgstr ""
 
 msgid "Storage"
 msgstr "Armazenamento"
@@ -9278,6 +9385,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr " | Arquivo ou o caminho não pode ser alcançado"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9473,6 +9584,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "Não foi possível ler arquivo temporário"
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -10071,6 +10186,10 @@ msgstr "Não disponível"
 
 msgid "Uncategorized"
 msgstr ""
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "No nó associado"
 
 msgid "Unicast"
 msgstr "unicast"
@@ -10743,6 +10862,10 @@ msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
+msgstr "Sem conexão com o banco de dados"
 
 msgid "You do not have permission to change provider group associations."
 msgstr ""
@@ -11508,6 +11631,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 #, fuzzy
 msgid "second"
 msgstr "Ícone"
@@ -12068,10 +12194,6 @@ msgstr ""
 #~ msgstr "Falha ao atualizar / criar o registo de imagem"
 
 #, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "Falha ao excluir arquivo"
-
-#, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "Eu não sou o servidor web nevoeiro"
 
@@ -12192,10 +12314,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "Instalar / Atualizar sucesso!"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "Serviço Atualizado!"
 
 #, fuzzy
 #~ msgid "Host Snapins"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -196,8 +196,20 @@ msgid "%s can only be run on one host at a time"
 msgstr ""
 
 #, php-format
+msgid "%s cannot be used as %s."
+msgstr ""
+
+#, php-format
 msgid "%s could not be loaded. Check that %s declares a class of that exact name."
 msgstr ""
+
+#, fuzzy, php-format
+msgid "%s could not be removed."
+msgstr "已成功更新"
+
+#, fuzzy, php-format
+msgid "%s deleted."
+msgstr "已删除"
 
 #, php-format
 msgid "%s does not declare schema() migrations, so re-installing it would drop and recreate its tables. Uninstall it first if that is what you want."
@@ -212,8 +224,20 @@ msgid "%s images"
 msgstr "图片"
 
 #, php-format
+msgid "%s is in use as %s. Point that at another file first."
+msgstr ""
+
+#, php-format
 msgid "%s is maintained by the server and cannot be set"
 msgstr ""
+
+#, php-format
+msgid "%s is marked to be kept. Stop keeping it first."
+msgstr ""
+
+#, fuzzy, php-format
+msgid "%s is no longer kept."
+msgstr "不复存在"
 
 #, php-format
 msgid "%s is not a readable .tar.gz archive."
@@ -229,6 +253,10 @@ msgstr ""
 
 #, php-format
 msgid "%s is not writable by the web server. Run \"bin/fog-plugin-uploads.sh enable\" as root."
+msgstr ""
+
+#, php-format
+msgid "%s is now %s."
 msgstr ""
 
 #, php-format
@@ -257,6 +285,10 @@ msgstr ""
 
 #, php-format
 msgid "%s viewed your account on %s."
+msgstr ""
+
+#, php-format
+msgid "%s will be kept."
 msgstr ""
 
 msgid "(all)"
@@ -1267,6 +1299,10 @@ msgstr "默认注销时间（分钟）"
 msgid "Automatic enrollment (Setup/Custom Mode)"
 msgstr ""
 
+#, fuzzy
+msgid "Available downloads"
+msgstr "没有文件被上传"
+
 msgid "BIOS Date"
 msgstr "BIOS日期"
 
@@ -1311,6 +1347,18 @@ msgstr "域密码"
 
 msgid "Body accepts taskTypeID, taskName, shutdown, debug, deploySnapins, passreset, sessionjoin and wol. Wake-on-lan is this route with wol set, not a route of its own."
 msgstr ""
+
+#, fuzzy
+msgid "Boot File Deleted"
+msgstr "无法删除文件"
+
+#, fuzzy
+msgid "Boot File Failed"
+msgstr "启动选项："
+
+#, fuzzy
+msgid "Boot File Updated"
+msgstr "服务更新！"
 
 #, fuzzy
 msgid "Boot Files"
@@ -1686,6 +1734,9 @@ msgstr "机箱版本"
 
 #, php-format
 msgid "Check %s over before installing it."
+msgstr ""
+
+msgid "Check FOG_TFTP_PXE_KERNEL_DIR."
 msgstr ""
 
 msgid "Check the capture folder is owned by and writable to the storage node user"
@@ -2352,8 +2403,31 @@ msgid "Default Width"
 msgstr "默认宽度"
 
 #, fuzzy
+msgid "Default init, ARM64"
+msgstr "默认宽度"
+
+#, fuzzy
+msgid "Default init, i386"
+msgstr "默认宽度"
+
+#, fuzzy
+msgid "Default init, x86_64"
+msgstr "默认宽度"
+
+#, fuzzy
 msgid "Default is disabled"
 msgstr "捐款将被禁用"
+
+#, fuzzy
+msgid "Default kernel, ARM64"
+msgstr "默认刷新频率"
+
+#, fuzzy
+msgid "Default kernel, i386"
+msgstr "更新打印机"
+
+msgid "Default kernel, x86_64"
+msgstr ""
 
 #, fuzzy
 msgid "Default nested group depth"
@@ -4478,6 +4552,9 @@ msgstr "在"
 msgid "In FOG"
 msgstr "在"
 
+msgid "In use as"
+msgstr ""
+
 msgid "Include"
 msgstr ""
 
@@ -4857,6 +4934,12 @@ msgid "Join Domain after image task"
 msgstr ""
 
 msgid "Kbps"
+msgstr ""
+
+msgid "Keep"
+msgstr ""
+
+msgid "Kept"
 msgstr ""
 
 msgid "Kernel"
@@ -5259,6 +5342,10 @@ msgstr "加载失败： %s"
 msgid "Loading data to field"
 msgstr "加载数据到现场%s"
 
+#, fuzzy
+msgid "Local files"
+msgstr "位置"
+
 msgid "Location"
 msgstr "位置"
 
@@ -5547,6 +5634,9 @@ msgstr "记忆"
 msgid "Memory limit cannot be less than 128"
 msgstr "菜单项或标题不能为空"
 
+msgid "Memtest payload"
+msgstr ""
+
 #, fuzzy
 msgid "Menu Description"
 msgstr "描述"
@@ -5627,6 +5717,9 @@ msgstr "模型"
 #, fuzzy
 msgid "Models"
 msgstr "模型"
+
+msgid "Modified"
+msgstr ""
 
 #, fuzzy
 msgid "Module"
@@ -5968,6 +6061,10 @@ msgstr ""
 msgid "No file was uploaded"
 msgstr "没有文件被上传"
 
+#, fuzzy
+msgid "No files in the boot directory."
+msgstr "无法创建管理单元工作"
+
 msgid "No files matched multicast image pattern"
 msgstr ""
 
@@ -6128,6 +6225,9 @@ msgstr "图像已经存在具有此名称！"
 #, fuzzy
 msgid "No storagegroups assigned to this snapin"
 msgstr "分配图像存储组无效"
+
+msgid "No such file in the boot directory."
+msgstr ""
 
 msgid "No such filter"
 msgstr ""
@@ -8020,6 +8120,10 @@ msgid "Set Storage Group as Primary for Snapins"
 msgstr "存储组名称"
 
 #, fuzzy
+msgid "Set as"
+msgstr "服务更新失败"
+
+#, fuzzy
 msgid "Set failed"
 msgstr "服务更新失败"
 
@@ -8535,6 +8639,9 @@ msgstr "打印机更新失败！"
 
 msgid "Status"
 msgstr "状态"
+
+msgid "Stop keeping"
+msgstr ""
 
 msgid "Storage"
 msgstr "存储"
@@ -9278,6 +9385,10 @@ msgstr ""
 msgid "The body is {\"value\": \"...\"}; a form field of the same name is accepted too. An EMPTY value deletes the preference rather than storing emptiness, so a reset leaves no row saying \"no opinion\". Values are capped at 64KB and refused rather than truncated -- a truncated saved state cannot be told from a corrupt one when it is read back."
 msgstr ""
 
+#, fuzzy
+msgid "The boot directory cannot be read."
+msgstr "|文件或无法达成通道"
+
 msgid "The breakdowns cover every inventoried machine. The range selects inventory recorded inside it."
 msgstr ""
 
@@ -9473,6 +9584,10 @@ msgstr ""
 
 msgid "The public half of the keypair fog-client encrypts its check-in to."
 msgstr ""
+
+#, fuzzy
+msgid "The record could not be written."
+msgstr "无法读取临时文件"
 
 msgid "The resource is not in a cancellable state."
 msgstr ""
@@ -10071,6 +10186,10 @@ msgstr "不可用"
 
 msgid "Uncategorized"
 msgstr ""
+
+#, fuzzy
+msgid "Unclassified"
+msgstr "无关联的节点"
 
 msgid "Unicast"
 msgstr "单播"
@@ -10743,6 +10862,10 @@ msgstr ""
 
 msgid "You do not have permission to change LDAP group associations."
 msgstr ""
+
+#, fuzzy
+msgid "You do not have permission to change boot files."
+msgstr "没有连接到数据库"
 
 msgid "You do not have permission to change provider group associations."
 msgstr ""
@@ -11508,6 +11631,9 @@ msgstr ""
 msgid "row(s) converted from 0 to NULL"
 msgstr ""
 
+msgid "same contents as"
+msgstr ""
+
 #, fuzzy
 msgid "second"
 msgstr "图标"
@@ -12068,10 +12194,6 @@ msgstr ""
 #~ msgstr "无法更新/创建图像日志"
 
 #, fuzzy
-#~ msgid "File Deleter"
-#~ msgstr "无法删除文件"
-
-#, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "我不是雾Web服务器"
 
@@ -12192,10 +12314,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Host Site Update Success"
 #~ msgstr "安装/升级成功！"
-
-#, fuzzy
-#~ msgid "Host Site Updated!"
-#~ msgstr "服务更新！"
 
 #, fuzzy
 #~ msgid "Host Snapins"

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -6222,6 +6222,18 @@ abstract class FOGPage extends FOGBase
         if ('' === $name) {
             return false;
         }
+        /**
+         * The copy first, then the flag.
+         *
+         * The copy is what actually protects the file, so a flag written
+         * without one would promise something nothing delivers -- and on the
+         * next upgrade the file would be gone with the record still saying
+         * it was kept. Unpinning goes the same way round for the same
+         * reason: remove the copy, then say it is no longer kept.
+         */
+        if (!self::_bootFileKeepCopy($name, $keep)) {
+            return false;
+        }
         try {
             $row = self::_bootFileRow($name) ?: self::getClass('BootFile');
             $row->set('name', $name)
@@ -6235,6 +6247,87 @@ abstract class FOGPage extends FOGBase
         }
 
         return true;
+    }
+    /**
+     * Puts a copy of a boot file where an upgrade will find it, or removes it.
+     *
+     * `customizations/kernel-backups/keep/` -- and the copy IS the record.
+     * The pruner and the restore are shell functions running while the web
+     * root is being rebuilt, with no database in reach, so the alternative
+     * was a manifest for them to read. A copy needs no parsing and cannot
+     * drift from what it describes, which is the same reasoning
+     * restorekernel.sh gives for using xattrs instead of a manifest.
+     *
+     * It also earns its space: the web root is deleted and rebuilt on every
+     * install, and a per-release sibling is deliberately not part of a
+     * generation, so without this a kept sibling survives exactly until the
+     * next upgrade.
+     *
+     * Known limit, inherited rather than introduced: the source path is the
+     * local one, the same path the listing reads. On a deployment where
+     * FOG_TFTP_HOST is another machine the listing is already reading a
+     * different disk from the one kernelfetch() writes, and this follows the
+     * listing -- what the admin clicked Keep on is what they were shown.
+     *
+     * @param string $name filename in the boot directory
+     * @param bool   $keep true to place the copy, false to remove it
+     *
+     * @return bool
+     */
+    private static function _bootFileKeepCopy($name, $keep)
+    {
+        if (!defined('FOG_BASE_DIR')) {
+            // No installer-written paths file, so there is no customizations
+            // tree to copy into. Nothing to do rather than a failure: a
+            // source checkout has no boot directory to protect either.
+            return true;
+        }
+        $keepDir = FOG_BASE_DIR . DS . 'customizations' . DS
+            . 'kernel-backups' . DS . 'keep';
+        $target = $keepDir . DS . $name;
+        if (!$keep) {
+            if (!is_file($target)) {
+                return true;
+            }
+
+            return @unlink($target);
+        }
+        if (!is_dir($keepDir)) {
+            // Created by the installer, deliberately not here: it is created
+            // once, owned by the service user and group-writable to the web
+            // user, and a directory the web tier makes for itself would own
+            // it instead.
+            return false;
+        }
+        $dir = trim((string)self::getSetting('FOG_TFTP_PXE_KERNEL_DIR'));
+        $source = $dir . DIRECTORY_SEPARATOR . $name;
+        if ('' === $dir || !is_file($source)) {
+            return false;
+        }
+        if (is_file($target) && self::_sameFile($source, $target)) {
+            return true;
+        }
+
+        return @copy($source, $target);
+    }
+    /**
+     * Whether two paths hold the same bytes.
+     *
+     * Size first, because it settles almost every case without reading
+     * either file, and these are kernels.
+     *
+     * @param string $a first path
+     * @param string $b second path
+     *
+     * @return bool
+     */
+    private static function _sameFile($a, $b)
+    {
+        if (filesize($a) !== filesize($b)) {
+            return false;
+        }
+
+        return hash_file('sha256', $a) === hash_file('sha256', $b);
     }
     /**
      * Removes a boot file, and the record that described it.

--- a/tests/boot-file-keep.test.php
+++ b/tests/boot-file-keep.test.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Marking a boot file to be kept places the copy that IS the record.
+ *
+ * The pruner and the restore are shell functions running while the web root
+ * is being rebuilt, with no database in reach. So the alternative to a copy
+ * was a manifest for them to read -- and a copy needs no parsing and cannot
+ * drift from what it describes, which is the same reasoning
+ * bin/restorekernel.sh gives for using xattrs rather than a manifest.
+ *
+ * Two orderings matter and are pinned here:
+ *
+ *   - the copy is placed BEFORE the flag is written. A flag without a copy
+ *     promises protection nothing delivers, and the file would be gone after
+ *     the next upgrade with the record still claiming it was kept.
+ *   - unpinning removes the copy BEFORE clearing the flag, for the mirror
+ *     reason: a cleared flag with the copy still there leaves a file
+ *     protected that the UI says is not.
+ *
+ * Usage: php tests/boot-file-keep.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require __DIR__ . '/lib/fog-test-harness.php';
+
+/**
+ * BEFORE boot(), not after. commons/init.php defines FOG_BASE_DIR only when
+ * nothing else has -- the same relocatability the shell side has for
+ * _resolveCustomizationsDir(), and for the same reason ADR 0040 gives: a
+ * hardcoded path means every test that reaches this code writes into the real
+ * /opt/fog on whatever machine the suite runs on.
+ *
+ * Defining it afterward silently does nothing, which is how this test first
+ * reported a bug that was entirely its own.
+ */
+$base = sys_get_temp_dir() . '/fog-keep-' . getmypid();
+define('FOG_BASE_DIR', $base);
+
+FogTestHarness::boot('boot-file-keep');
+$db = FogTestHarness::fakeDb();
+
+$t = new FogChecks();
+
+$ipxe = $base . '/service/ipxe';
+$keep = $base . '/customizations/kernel-backups/keep';
+mkdir($ipxe, 0755, true);
+register_shutdown_function(
+    function () use ($base) {
+        foreach ([
+            $base . '/customizations/kernel-backups/keep',
+            $base . '/customizations/kernel-backups',
+            $base . '/customizations',
+            $base . '/service/ipxe',
+            $base . '/service'
+        ] as $dir) {
+            foreach ((array)glob($dir . '/*') as $f) {
+                if (is_file($f)) {
+                    @unlink($f);
+                }
+            }
+            @rmdir($dir);
+        }
+    }
+);
+
+file_put_contents($ipxe . '/bzImage.20260701-093344', 'known-good-kernel');
+file_put_contents($ipxe . '/bzImage', 'current-kernel');
+
+$db->responder = function ($sql, $params) use ($ipxe) {
+    if (false !== stripos($sql, 'FROM `globalSettings`')) {
+        return [
+            [
+                'settingKey' => 'FOG_TFTP_PXE_KERNEL_DIR',
+                'settingValue' => $ipxe . '/'
+            ]
+        ];
+    }
+
+    return null;
+};
+
+$copy = new \ReflectionMethod('FOG\Base\FOGPage', '_bootFileKeepCopy');
+$copy->setAccessible(true);
+
+// --- no directory: the installer makes it, not the web tier -------------
+
+/**
+ * Refused rather than created here. The directory is created once by the
+ * installer, owned by the service user and group-writable to the web user;
+ * one the web tier made for itself would be owned by the web user instead.
+ */
+$t->check(
+    'keeping a file refuses when the installer has not made the directory',
+    false === $copy->invoke(null, 'bzImage.20260701-093344', true)
+);
+$t->check(
+    'and no copy is left behind by the attempt',
+    !is_file($keep . '/bzImage.20260701-093344')
+);
+
+mkdir($keep, 0755, true);
+
+// --- the copy ------------------------------------------------------------
+
+$t->check(
+    'keeping a file places the copy',
+    true === $copy->invoke(null, 'bzImage.20260701-093344', true)
+    && is_file($keep . '/bzImage.20260701-093344')
+);
+$t->check(
+    'and the copy holds the same bytes',
+    'known-good-kernel'
+    === file_get_contents($keep . '/bzImage.20260701-093344')
+);
+$t->check(
+    'keeping it again is not an error and does not disturb the copy',
+    true === $copy->invoke(null, 'bzImage.20260701-093344', true)
+    && 'known-good-kernel'
+    === file_get_contents($keep . '/bzImage.20260701-093344')
+);
+
+// --- and the removal ----------------------------------------------------
+
+$t->check(
+    'no longer keeping it removes the copy',
+    true === $copy->invoke(null, 'bzImage.20260701-093344', false)
+    && !is_file($keep . '/bzImage.20260701-093344')
+);
+$t->check(
+    'removing a copy that is not there is not an error',
+    true === $copy->invoke(null, 'bzImage.20260701-093344', false)
+);
+$t->check(
+    'the file itself is untouched by any of this',
+    'known-good-kernel'
+    === file_get_contents($ipxe . '/bzImage.20260701-093344')
+);
+
+// --- a name that is not there -------------------------------------------
+
+$t->check(
+    'keeping a file that does not exist is refused',
+    false === $copy->invoke(null, 'no-such-kernel', true)
+);
+/**
+ * basename() first, then the source has to be a real file in the boot
+ * directory -- these endpoints turn a request parameter into a path.
+ */
+$t->check(
+    'a traversal attempt cannot reach outside the boot directory',
+    false === $copy->invoke(null, '../../../../etc/passwd', true)
+);
+
+// --- the ordering, which is what makes the flag honest ------------------
+
+$src = file_get_contents(
+    dirname(__DIR__) . '/packages/web/src/Base/FOGPage.php'
+);
+$at = strpos($src, 'function bootFileSetPinned(');
+$body = false === $at ? '' : substr($src, $at, 1800);
+$t->check(
+    'the copy is attempted before the record is written',
+    false !== strpos($body, '_bootFileKeepCopy(')
+    && strpos($body, '_bootFileKeepCopy(') < strpos($body, "->save()")
+);
+$t->check(
+    'and a failed copy stops the record being written at all',
+    1 === preg_match(
+        '/if \(!self::_bootFileKeepCopy\(\$name, \$keep\)\) \{\s*'
+        . 'return false;/',
+        $body
+    )
+);
+
+$t->finish();

--- a/tests/kernel-backup-rotation.test.sh
+++ b/tests/kernel-backup-rotation.test.sh
@@ -193,5 +193,122 @@ check "a retention of 1 still holds the newest snapshot" \
 check "the rotation does not read the retired kernelBackupGenerations" \
     "$(! sed 's/#.*//' <<< "$snippet" | grep -q 'kernelBackupGenerations'; echo $?)"
 
+# ---------------------------------------------------------------------------
+# A generation records a KERNEL, not an installer run.
+#
+# The rotation ran unconditionally, and not every FOG release ships a new FOS
+# kernel. Three upgrades carrying one kernel therefore left gen-1, gen-2 and
+# gen-3 holding three identical copies: the depth an admin asked for
+# evaporated silently, and restorekernel.sh --list offered three snapshots
+# that were the same snapshot.
+#
+# These cases need the COPY loop as well as the prune and the rotate -- the
+# comparison is against what gen-1 actually holds -- so they run a second
+# extraction that reaches through it. Same reason as the first: a textual
+# check for cmp would pass on a comparison made in one direction only, and
+# one direction is exactly the bug a subset test would ship (a file the admin
+# DELETED since the last install reads as unchanged).
+# ---------------------------------------------------------------------------
+snippet_full=$(awk '
+    /BOOT_kernel_backups_kept\} -lt 1 \]\] &&/ { grab = 1 }
+    grab { print }
+    grab && /cp -a "\$kf" "\$\{kbdir\}\/gen-1\/\$\{bn\}"/ { seen = 1 }
+    seen && /^        done$/ { exit }
+' "$functions")
+
+if [[ -z $snippet_full ]]; then
+    echo "FAIL: could not find the capture block (prune, rotate and copy) in" >&2
+    echo "  lib/common/functions.sh. If it moved or was rewritten, point this" >&2
+    echo "  test at it -- do not delete the assertion." >&2
+    exit 1
+fi
+
+eval "capture() {
+    local warn=0
+$snippet_full
+    fi
+}"
+
+customizationsDir="$work/dedupe"
+kbdir="$customizationsDir/kernel-backups"
+unset BOOT_kernel_backups_kept kernelBackupGenerations
+rm -rf "$ipxedir"
+mkdir -p "$ipxedir"
+
+printf 'kernel-A' > "$ipxedir/bzImage"
+capture
+
+check "the first capture creates gen-1" \
+    "$([[ -f $kbdir/gen-1/bzImage ]]; echo $?)"
+
+# Same bytes, second install. Nothing changed, so nothing should move.
+capture
+
+check "an install that changed no kernel does not spend a generation" \
+    "$([[ ! -d $kbdir/gen-2 ]]; echo $?)"
+
+check "and gen-1 still holds the kernel" \
+    "$([[ $(cat "$kbdir/gen-1/bzImage") == kernel-A ]]; echo $?)"
+
+# A genuinely new kernel.
+printf 'kernel-B' > "$ipxedir/bzImage"
+capture
+
+check "a new kernel does spend a generation" \
+    "$([[ -d $kbdir/gen-2 ]]; echo $?)"
+
+check "gen-1 holds the new kernel" \
+    "$([[ $(cat "$kbdir/gen-1/bzImage") == kernel-B ]]; echo $?)"
+
+check "gen-2 holds the one it replaced" \
+    "$([[ $(cat "$kbdir/gen-2/bzImage") == kernel-A ]]; echo $?)"
+
+# Three no-change installs in a row must not consume the whole retention,
+# which is the reported redundancy stated as an assertion.
+capture
+capture
+capture
+
+check "three unchanged installs leave the retention untouched" \
+    "$([[ -d $kbdir/gen-1 && -d $kbdir/gen-2 && ! -d $kbdir/gen-3 ]]; echo $?)"
+
+# A file the admin ADDED is a change.
+printf 'mine' > "$ipxedir/bzImage_MyHardware"
+capture
+
+check "a file the admin added counts as a change" \
+    "$([[ -d $kbdir/gen-3 && -f $kbdir/gen-1/bzImage_MyHardware ]]; echo $?)"
+
+# And one they DELETED is a change too -- the case a subset comparison, run
+# in one direction only, would call unchanged.
+customizationsDir="$work/dedupe-del"
+kbdir="$customizationsDir/kernel-backups"
+rm -rf "$ipxedir"
+mkdir -p "$ipxedir"
+printf 'one' > "$ipxedir/bzImage"
+printf 'two' > "$ipxedir/bzImage_Extra"
+capture
+rm -f "$ipxedir/bzImage_Extra"
+capture
+
+check "a file the admin deleted counts as a change" \
+    "$([[ -d $kbdir/gen-2 ]]; echo $?)"
+
+check "and the deleted file is still recoverable from the older generation" \
+    "$([[ -f $kbdir/gen-2/bzImage_Extra && ! -f $kbdir/gen-1/bzImage_Extra ]]; echo $?)"
+
+# The comparison must not be fooled by same size, different content.
+customizationsDir="$work/dedupe-size"
+kbdir="$customizationsDir/kernel-backups"
+rm -rf "$ipxedir"
+mkdir -p "$ipxedir"
+printf 'AAAA' > "$ipxedir/bzImage"
+capture
+printf 'BBBB' > "$ipxedir/bzImage"
+capture
+
+check "content is compared, not size" \
+    "$([[ -d $kbdir/gen-2 ]]; echo $?)"
+
 printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$pass" "$fail"
 [[ $fail -eq 0 ]]

--- a/tests/kernel-keep-survives-upgrade.test.sh
+++ b/tests/kernel-keep-survives-upgrade.test.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+#
+# A boot file marked to be kept survives an upgrade.
+#
+#   tests/kernel-keep-survives-upgrade.test.sh
+#
+# configureHttpd() deletes the whole web root and rebuilds it, so everything
+# in service/ipxe is destroyed on every install. What comes back is whatever
+# restorePreservedCustomizations() puts back -- and the per-release siblings
+# (bzImage.<release>) are deliberately NOT part of a generation, because they
+# are already copies of a kernel and snapshotting them would multiply the same
+# bytes by the generation count.
+#
+# So "keep this kernel" applied to a sibling would have survived exactly until
+# the next upgrade, with nothing reporting that it had gone. The copy in
+# customizations/kernel-backups/keep/ is what makes the promise real, and the
+# copy IS the record: the restore is a shell function running while the web
+# root is being rebuilt, with no database in reach.
+#
+# The restore is EXECUTED against a fixture, not read. The interesting cases
+# are the two exclusions -- a fresh file of the same name must win, and the six
+# default names must never be restored -- and a textual check cannot tell a
+# working exclusion from an inverted one.
+#
+# No root, no network, no FOG install.
+#
+# Usage: bash tests/kernel-keep-survives-upgrade.test.sh
+# Exit status 0 = pass, 1 = fail.
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+functions="$root/lib/common/functions.sh"
+
+pass=0
+fail=0
+
+check() {
+    if [[ $2 -eq 0 ]]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        printf '  FAIL  %s\n' "$1"
+    fi
+}
+
+if [[ ! -r $functions ]]; then
+    echo "FAIL: cannot read $functions" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# The keep-restore block, lifted out of restorePreservedCustomizations().
+# ---------------------------------------------------------------------------
+snippet=$(awk '
+    /if \[\[ -d "\$\{kbdir\}\/keep" \]\]; then/ { grab = 1 }
+    grab { print }
+    grab && /^    fi$/ { exit }
+' "$functions")
+
+if [[ -z $snippet ]]; then
+    echo "FAIL: could not find the keep-restore block in" >&2
+    echo "  lib/common/functions.sh. If it moved or was rewritten, point this" >&2
+    echo "  test at it -- do not delete the assertion." >&2
+    exit 1
+fi
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+error_log="$work/error.log"
+
+eval "restoreKept() {
+    local st=0
+    local defaultnames=\" bzImage bzImage32 arm_Image init.xz init_32.xz arm_init.cpio.gz \"
+    local bn f
+$snippet
+    return \$st
+}"
+
+kbdir="$work/customizations/kernel-backups"
+ipxedir="$work/ipxe"
+mkdir -p "$kbdir/keep" "$ipxedir"
+
+# What an admin marked: a per-release sibling, and a kernel of their own.
+printf 'known-good' > "$kbdir/keep/bzImage.20260701-093344"
+printf 'my-kernel' > "$kbdir/keep/bzImage_MyHardware"
+
+# And a default name, which must NOT come back -- picking up the new kernel is
+# the point of an update, and this is the same exclusion the generation
+# restore makes.
+printf 'old-default' > "$kbdir/keep/bzImage"
+
+# The fresh tree as an install would leave it: the new default kernel, and
+# nothing else.
+printf 'brand-new' > "$ipxedir/bzImage"
+
+restoreKept
+
+check "a kept per-release sibling is restored" \
+    "$([[ -f $ipxedir/bzImage.20260701-093344 ]]; echo $?)"
+
+check "and holds the bytes that were kept" \
+    "$([[ $(cat "$ipxedir/bzImage.20260701-093344") == known-good ]]; echo $?)"
+
+check "a kept custom-named kernel is restored" \
+    "$([[ $(cat "$ipxedir/bzImage_MyHardware" 2>/dev/null) == my-kernel ]]; echo $?)"
+
+# The whole point of the exclusion: an update must not be undone.
+check "a kept file under a DEFAULT name does not overwrite the new kernel" \
+    "$([[ $(cat "$ipxedir/bzImage") == brand-new ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# The default-name exclusion ON ITS OWN.
+#
+# The case above does not test it: bzImage exists in the fresh tree there, so
+# the "leave an existing file alone" guard already prevents the copy and
+# breaking the exclusion changes nothing. Verified by mutation -- disabling
+# the exclusion left that assertion passing.
+#
+# The discriminating fixture is a default name the fresh tree does NOT have.
+# The exclusion must still refuse it: an install that did not land bzImage has
+# a bigger problem than a missing kernel, and quietly reinstating the previous
+# one hides it while pretending the update worked.
+# ---------------------------------------------------------------------------
+kbdir="$work/exclusion/kernel-backups"
+mkdir -p "$kbdir/keep"
+rm -rf "$ipxedir"
+mkdir -p "$ipxedir"
+printf 'old-default' > "$kbdir/keep/bzImage"
+printf 'old-init' > "$kbdir/keep/init.xz"
+printf 'mine' > "$kbdir/keep/bzImage_MyHardware"
+restoreKept
+
+check "a kept DEFAULT name is not restored even when the tree lacks it"     "$([[ ! -e $ipxedir/bzImage ]]; echo $?)"
+
+check "the same for a default init name"     "$([[ ! -e $ipxedir/init.xz ]]; echo $?)"
+
+check "while a custom name in the same directory still is restored"     "$([[ $(cat "$ipxedir/bzImage_MyHardware" 2>/dev/null) == mine ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# A fresh file of the same name always wins, default name or not. The restore
+# fills gaps; it does not reinstate.
+# ---------------------------------------------------------------------------
+kbdir="$work/customizations/kernel-backups"
+rm -rf "$ipxedir"
+mkdir -p "$ipxedir"
+printf 'brand-new' > "$ipxedir/bzImage"
+printf 'fresh-sibling' > "$ipxedir/bzImage.20260701-093344"
+restoreKept
+
+check "an existing file is left alone rather than replaced" \
+    "$([[ $(cat "$ipxedir/bzImage.20260701-093344") == fresh-sibling ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# Nothing kept, nothing to do -- and no error.
+# ---------------------------------------------------------------------------
+kbdir="$work/empty/kernel-backups"
+mkdir -p "$kbdir/keep"
+rm -rf "$ipxedir"
+mkdir -p "$ipxedir"
+restoreKept
+rc=$?
+
+check "an empty keep directory restores nothing and succeeds" \
+    "$([[ $rc -eq 0 && -z $(ls -A "$ipxedir") ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# No keep directory at all: every server before this change, and every one
+# where the admin has kept nothing.
+# ---------------------------------------------------------------------------
+kbdir="$work/nokeep/kernel-backups"
+mkdir -p "$kbdir"
+restoreKept
+rc=$?
+
+check "a missing keep directory is not an error" \
+    "$([[ $rc -eq 0 ]]; echo $?)"
+
+# ---------------------------------------------------------------------------
+# The installer has to create the directory, and has to make it writable by
+# the web user -- marking a file to be kept is a web action, and the copy is
+# what records it.
+# ---------------------------------------------------------------------------
+check "the installer creates kernel-backups/keep" \
+    "$(grep -q 'mkdir -p "\$optdir/kernel-backups/keep"' "$functions"; echo $?)"
+
+check "and gives the web user write access to it" \
+    "$(grep -q 'chown "\${SVC_user}:\${apacheuser}" "\$optdir/kernel-backups/keep"' "$functions"; echo $?)"
+
+printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$pass" "$fail"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
Follows #1687, #1688, #1690 and #1693. Two halves of the same complaint: keeping N versions of a kernel did not mean what an admin would think it meant, and marking one to be kept could not mean anything at all.

## A generation records a kernel, not an installer run

The rotation ran on every install unconditionally, and **not every FOG release ships a new FOS kernel**. Three upgrades carrying one kernel left `gen-1`, `gen-2` and `gen-3` holding three identical copies — the depth someone asked for evaporated silently, and `restorekernel.sh --list` offered three snapshots that were the same snapshot.

So if `gen-1` already holds exactly this capture set, byte for byte, nothing rotates.

Compared **by content and in both directions**, using the same filters as the copy loop so the two cannot disagree about what a generation holds. A file the admin *added* since the last install is a change; so is one they *deleted*, which a one-directional subset test would call unchanged.

## "Keep this kernel" now survives an upgrade

`configureHttpd()` deletes the whole web root and rebuilds it, and a per-release sibling is deliberately **not** part of a generation — it is already a copy of a kernel, and snapshotting it would multiply the same bytes by the generation count. So `bfPinned` on a sibling (written by #1693) survived exactly until the next upgrade, with nothing reporting that it had gone.

`customizations/kernel-backups/keep/` fixes that, and **the copy IS the record.** The restore and the pruner are shell functions running while the web root is being rebuilt with no database in reach, so the alternative was a manifest for them to read — and a copy needs no parsing and cannot drift from what it describes, which is the reasoning `bin/restorekernel.sh` already gives for using xattrs rather than a manifest. It also keeps `/opt/fog/customizations` holding exactly what #1681's own readme says it holds: copies FOG makes of the admin's files. Nothing new appears at the top level of that tree, so no already-installed server's `readme.txt` goes stale — which matters because `_ensureCustomizationsTree()` never overwrites one.

**No sudo helper, no new privileged surface.** Following `packages/secureboot/fog-sign-kernel` was the first instinct, but that helper's entire security property is **taking no arguments** — every path it touches comes from a root-owned config — and one taking a filename gives that up. It buys nothing either way: `kernelfetch()` already writes arbitrary files into `service/ipxe` over SSH with the TFTP credentials, so "the web tier can place a boot file" is a capability it already has. The installer creates `keep/` owned by the service user and group-writable to the web user.

The copy is placed **before** the flag is written and removed **before** the flag is cleared. A flag without a copy promises protection nothing delivers, and the file would be gone after the next upgrade with the record still claiming it was kept.

The six default names are excluded from the keep restore, the same way the generation restore excludes them: picking up the new kernel is the point of an update. Keeping `bzImage` itself is therefore close to meaningless — keep the sibling or a custom name, which is what the tab steers toward.

## Constraints from #1684 respected

`bin/restorekernel.sh` and `bin/revertfog.sh` hardcode `$fogprogramdir/customizations/kernel-backups` and that path still resolves; `_resolveCustomizationsDir()` is still resolved on call, not at source time; the frozen vhost marker naming `docs/SUPPORTED_CUSTOMIZATIONS.md` is untouched. Commented on that issue [here](https://github.com/FOGProject/fogproject/issues/1684#issuecomment-5513729052).

## Verification — including mutation testing

The shell behavior is **executed against fixtures, not read**, and I mutation-tested every new assertion rather than trusting a green run:

| Mutation | Result |
|---|---|
| content change never detected (`cmp` result ignored) | 5 failures |
| reverse/deleted-file check dropped | 8 failures |
| default-name exclusion disabled | 2 failures |
| keep copy claims success without copying | 3 failures |
| all restored | 26/26, 12/12, 12/12 |

That mattered: my **first** version of the default-name assertion passed under mutation, because the fixture had `bzImage` present in the fresh tree and the "leave an existing file alone" guard already prevented the copy — the exclusion was never under test. The discriminating fixture is a default name the fresh tree *lacks*, and that case is now in the suite with a comment saying why.

- `tests/kernel-backup-rotation.test.sh` — extended, 26 checks (was 15). Needed a second `awk` extraction reaching through the **copy** loop, because the dedupe compares against what `gen-1` actually holds and the existing extraction stops before the copy.
- `tests/kernel-keep-survives-upgrade.test.sh` — new, 12 checks.
- `tests/boot-file-keep.test.php` — new, 12 checks. Note it defines `FOG_BASE_DIR` **before** `boot()`: `commons/init.php` only defines it when nothing else has, and defining it afterwards silently does nothing — which is how this test first reported a bug that was entirely its own.
- PHP suite: **222 pass, 29 fail — the same 29 that fail on an unmodified checkout** (no gettext extension on this box).
- `external-cert-detection.test.sh` fails 5 both before and after my change (baselined): Git Bash rewrites `openssl -subj`, so its cert fixtures never build here.
- `bash -n` clean; US-spelling word list run by hand.
- **phpstan not run** — no `composer`/`vendor` on this box.

## Not in this PR

The two genuinely unbounded copy sets — the per-release siblings in the live directory, and `backup/<name>_<stamp>` from web-UI updates — are still unpruned. Bounding them is the natural next step and wants its own change: it deletes boot files rather than declining to copy them, and it needs the keep-list this PR establishes to be in place first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYw9JCZGPeHuse6RTyNPgs
