### PR TITLE
Bring your own web certificate: adopt one, or upload it (GH-1685)

### DIFF
--- a/docs/PKI_ZONES.md
+++ b/docs/PKI_ZONES.md
@@ -610,6 +610,37 @@ set the canonical paths by hand as described under **Certificate paths** above
 and re-run the installer. That route does not consult the chain, and it is
 deliberately not a checkbox on the Certificates page: it is the one case where
 you are telling FOG you know better than its verification.
+
+### Doing it from the Certificates page instead
+
+The **Web server certificate** tab does the same three things without a shell,
+gated on `system.pki` (deny by default, so it is invisible until an
+administrator is granted it):
+
+- **Adopt what is in the customizations directory.** The same detection, the
+  same refusals, and the web server is reloaded, so it takes effect when you
+  click rather than on the next installer run. The tab says what is sitting in
+  the directory before you commit to it — whether the pair matches, and whether
+  a trust path builds.
+- **Upload a certificate and its key.** PEM, a fullchain with the leaf first,
+  or one PKCS#12 (`.p12`/`.pfx`) file carrying key, leaf and chain together —
+  which is what an export from `certlm.msc` or IIS gives you. A passphrase on
+  either is fine. What arrives is written into the customizations directory, so
+  the next installer run adopts it again rather than regenerating over it, and
+  anything already there is kept as `*.replaced`.
+- **Import the issuing root**, on the External root CA tab, when it is not a
+  public CA.
+
+Two limits are deliberate. **A CA certificate is refused as the web leaf** —
+`basicConstraints CA:TRUE` is checked, because a CA private key must not come
+through the web application at all; replacing FOG's own root is a migration and
+the page composes the `installfog.sh` invocation for it instead. And the upload
+route is the only one that sends a private key through PHP, for the length of
+one request: it is written by root and never kept there, but if the certificate
+is a **wildcard** it covers hosts other than this server, so prefer the drop-in
+where your policy allows. See
+[ADR 0036](adr/0036-the-web-tier-changes-pki-through-a-fixed-verb-set.md)'s
+2026-09-02 amendment for the reasoning.
 ## Let's Encrypt and ACME
 
 **FOG does not run an ACME client and will not.** Use `certbot`, `acme.sh`, or

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -5790,6 +5790,18 @@ _installPkiAdminHelper() {
         # does --ca-root, which used to record its own source path and so
         # named a temp file that was gone by the next run.
         echo "PKI_EXTERNAL_ROOT=${webdir}/ca/.externalRoot.pem"
+        # Where a certificate you brought lives, and where the intermediates
+        # that come with one are recorded. adopt-custom-leaf takes NO argument
+        # at all -- it reads this directory out of the config rather than being
+        # handed a path, which is stricter than ADR 0036 asks for rather than an
+        # exception to it.
+        echo "PKI_CUSTOM_DIR=$(_customPkiDir)"
+        echo "PKI_WEB_EXTERNAL_CHAIN=${webdir}/leaf/.externalChain.pem"
+        # The web engine, so the helper can reload it after installing a
+        # certificate. This is the one change it makes that takes effect before
+        # the next installer run; see ADR 0036's 2026-09-02 amendment for why
+        # certificate material differs from the yes/no preferences.
+        echo "WEB_ENGINE=${WEB_server_engine}"
         echo "PKI_CLIENT_CERT=${PKI_client_encrypt_cert}"
         if [[ -f $sbca ]]; then
             echo "PKI_SB_CA_CERT=${sbca}"
@@ -8307,6 +8319,64 @@ _certKeyPairMatches() {
 # chains to a publicly-trusted root needs no chain file from us for the browser
 # to be happy, and createWebIntermediateCA() already honors an admin's chain
 # path on every run. Requiring one here would decline perfectly good setups.
+# Record the intermediates an administrator dropped beside their leaf.
+#
+# Copied to a canonical path with every self-signed certificate REMOVED, and
+# then ${PKI_web_trust_chain} is pointed at it. Both halves are load-bearing.
+#
+# The copy is for the reason the imported root gets one: a setting that records
+# wherever the admin's file happened to be names a temp file by next year
+# (GH-1683).
+#
+# The strip is because _resolveTrustAnchor() anchors every self-signed
+# certificate it finds in the chain file. A root left in there would be trusted
+# by this host as a side effect of supplying a chain, without anybody deciding
+# to trust it -- which is precisely what import-root's self-signed-only rule
+# exists to prevent. An administrator whose root is not trusted yet imports it
+# deliberately, on the Certificates page or with --ca-root.
+#
+# fog-pki-admin's adopt-custom-leaf does the same two things to the same path,
+# so the page and the installer cannot disagree about what this server serves.
+_adoptCustomChain() {
+    local src="$1" out tmpd f subj issuer st=1
+    [[ -n $src && -f $src ]] || return 1
+    command -v openssl >/dev/null 2>&1 || return 1
+    out="$(_pkiZoneDir web)/leaf/.externalChain.pem"
+    mkdir -p "$(dirname "$out")" >>$error_log 2>&1
+    tmpd=$(mktemp -d) || return 1
+    : > "${tmpd}/chain.pem"
+    if _splitPemBundle "$src" "$tmpd"; then
+        for f in "$tmpd"/c*.pem; do
+            [[ -f $f ]] || continue
+            subj=$(openssl x509 -in "$f" -noout -subject 2>/dev/null)
+            issuer=$(openssl x509 -in "$f" -noout -issuer 2>/dev/null)
+            [[ -z $subj ]] && continue
+            [[ ${subj#subject=} == "${issuer#issuer=}" ]] && continue
+            cat "$f" >> "${tmpd}/chain.pem"
+        done
+    fi
+    if [[ -s ${tmpd}/chain.pem ]]; then
+        # Mode, not ownership: the installer is already root, so the file is
+        # root-owned either way -- and forcing it would make this function
+        # untestable outside a root shell for no gain.
+        if install -m 0644 "${tmpd}/chain.pem" "$out" >>$error_log 2>&1; then
+            PKI_web_trust_chain="$out"
+            st=0
+        fi
+    fi
+    rm -rf "$tmpd" >>$error_log 2>&1
+    return $st
+}
+# The optional third name: the intermediates for a leaf you brought.
+#
+# Echoes the path when there is one, and returns 1 when there is not. Optional
+# where the pair is required, because a leaf signed straight off a root needs no
+# intermediates and demanding one would refuse a valid setup.
+_customPkiChain() {
+    local f="$(_customPkiDir)/web-leaf-chain.pem"
+    [[ -f $f ]] || return 1
+    printf '%s' "$f"
+}
 _customPkiPair() {
     local dir cert key
     dir="$(_customPkiDir)"
@@ -10251,7 +10321,7 @@ createSSLCA() {
     # vhost names the files and the certificate names itself.
     _ensureCustomizationsTree
     if ! _externallyManagedLeaf; then
-        local extReason="" extCert="" extKey="" customPair=""
+        local extReason="" extCert="" extKey="" customPair="" customChain=""
         if extReason=$(_detectExternalCertManagement); then
             # Signal 0 first, and it wins outright: a pair sitting in the
             # customizations tree is the admin saying which certificate to use,
@@ -10262,6 +10332,12 @@ createSSLCA() {
             customPair=$(_customPkiPair) && {
                 extCert=$(echo "$customPair" | sed -n 1p)
                 extKey=$(echo "$customPair" | sed -n 2p)
+                # The chain is adopted with the pair rather than separately.
+                # Doing it here, inside the signal-0 arm, is deliberate: the
+                # other signals describe a leaf FOG was ALREADY pointed at, and
+                # repointing the trust chain in those cases would overwrite a
+                # setting the admin may have made by hand.
+                customChain=$(_customPkiChain) && _adoptCustomChain "$customChain"
             }
             if [[ -z $extCert ]]; then
                 extCert=$(_vhostCertPath)

--- a/packages/pki/fog-pki-admin
+++ b/packages/pki/fog-pki-admin
@@ -21,8 +21,8 @@
 # Invoked through sudo by the Certificates page after it has checked
 # system.pki. The split is the same one fog-sign-node-cert draws: the page
 # decides WHO may ask, this decides WHAT may be asked for and holds every
-# path. A compromise of the web application can therefore drive these five
-# verbs and nothing else -- it cannot read a private key, cannot name a file,
+# path. A compromise of the web application can therefore drive this fixed
+# verb set and nothing else -- it cannot read a private key, cannot name a file,
 # and cannot put a byte of its own choosing into .fogsettings.
 #
 # That last one is the reason this script exists at all rather than a sudo
@@ -55,7 +55,7 @@ CONF="/opt/fog/.fog-pki-admin"
 die() { echo "$*" >&2; exit 1; }
 
 [[ $EUID -eq 0 ]] || die "fog-pki-admin must run as root"
-[[ $# -ge 1 ]] || die "usage: fog-pki-admin <status|export|import-root|clear-root|set-preference> [args]"
+[[ $# -ge 1 ]] || die "usage: fog-pki-admin <status|export|import-root|clear-root|adopt-custom-leaf|import-leaf|set-preference> [args]"
 
 verb="$1"
 shift
@@ -80,6 +80,9 @@ shift
 : "${PKI_WEB_VHOST_KEY:=}"
 : "${PKI_SB_CA_KEY:=}"
 : "${PKI_CLIENT_KEY:=}"
+: "${PKI_CUSTOM_DIR:=}"
+: "${PKI_WEB_EXTERNAL_CHAIN:=}"
+: "${WEB_ENGINE:=}"
 
 [[ -d $PKI_STAGING ]] || die "staging directory is not configured"
 
@@ -363,6 +366,234 @@ readSetting() {
     printf '%s' "$line"
 }
 
+# --- bringing your own web leaf ----------------------------------------------
+#
+# Three routes reach this code, and only the last of them ever sees a private
+# key inside PHP: a pair dropped into the customizations tree, a pair uploaded
+# through the page, and a PKCS#12 container. All three converge on
+# adoptCustomLeaf() so there is ONE validation path and one place that can
+# decide to refuse. See ADR 0036's 2026-09-02 amendment for why a leaf key may
+# come this way when a CA key may not.
+
+# Whether $1 (a certificate) and $2 (a private key) are actually a pair.
+#
+# Compares the SUBJECT PUBLIC KEY, not an RSA modulus. `openssl rsa -modulus`
+# cannot read an EC or Ed25519 key at all, so a modulus comparison answers "does
+# not match" for a perfectly good pair, and answers it identically to a genuine
+# mismatch (GH-1393).
+#
+# Reads only the FIRST certificate of $1, because `openssl x509 -in` does. That
+# is not a limitation here, it is the test that matters: the first certificate
+# in the file is the one the web server pairs with the key, and the one
+# _writeWebChainFiles() reads back as the leaf.
+#
+# Ported from _certKeyPairMatches() in lib/common/functions.sh, duplicated for
+# the reason splitBundle() is, and pinned against it by
+# tests/pki-admin-helper.test.sh.
+certKeyPairMatches() {
+    local cert="$1" key="$2" certpub keypub
+    [[ -n $cert && -f $cert && -n $key && -f $key ]] || return 1
+    certpub=$(openssl x509 -pubkey -noout -in "$cert" 2>/dev/null)
+    keypub=$(openssl pkey -pubout -in "$key" 2>/dev/null)
+    [[ -n $certpub && -n $keypub && $certpub == "$keypub" ]]
+}
+
+# The three documented names in the customizations tree. The chain is optional;
+# the other two are not. Three names rather than two does not weaken ADR 0040's
+# "two names, not a glob" -- the reasoning was that FOG must not choose between
+# candidates on its own, and a documented name chooses nothing.
+customLeafCert()  { printf '%s' "${PKI_CUSTOM_DIR%/}/web-leaf.pem"; }
+customLeafKey()   { printf '%s' "${PKI_CUSTOM_DIR%/}/web-leaf.key"; }
+customLeafChain() { printf '%s' "${PKI_CUSTOM_DIR%/}/web-leaf-chain.pem"; }
+
+# Sort supplied certificate material into a leaf, intermediates, and roots.
+#
+# $1 certificate or fullchain, $2 private key, $3 an optional separate chain
+# file, $4 a scratch directory. Writes ${4}/leaf.pem, ${4}/chain.pem and
+# ${4}/roots.pem, and leaves the subjects of any self-signed certificates in
+# $sortedRoots. Returns 1 when nothing in the material matches the key.
+#
+# Classified by PROPERTY, never by position: whichever certificate matches the
+# key is the leaf, self-signed ones are roots, everything else is an
+# intermediate. Position cannot be trusted -- createWebIntermediateCA() writes
+# issuer-first with the root appended, validateExternalCA() writes the root
+# FIRST, and an administrator's own file may be in any order at all.
+#
+# The roots are separated rather than discarded, so the caller can name the
+# issuer somebody still has to import. Leaving one in the chain file would
+# ANCHOR it: rebuildAnchor() here and _resolveTrustAnchor() in the installer
+# both take every self-signed certificate out of ${PKI_WEB_CHAIN}. That would
+# make "trust this root" a decision the upload had quietly already taken, which
+# is exactly what import-root's self-signed-only rule exists to prevent.
+sortLeafMaterial() {
+    local cert="$1" key="$2" extra="$3" dir="$4" f subj
+    sortedRoots=""
+    : > "${dir}/leaf.pem"
+    : > "${dir}/chain.pem"
+    : > "${dir}/roots.pem"
+    mkdir -p "${dir}/split" || return 1
+    splitBundle "$cert" "${dir}/split" || return 1
+    if [[ -n $extra && -f $extra ]]; then
+        mkdir -p "${dir}/split-extra" || return 1
+        if splitBundle "$extra" "${dir}/split-extra"; then
+            for f in "${dir}/split-extra"/c*.pem; do
+                [[ -f $f ]] && cp "$f" "${dir}/split/x${f##*/}"
+            done
+        fi
+    fi
+    for f in "${dir}/split"/*.pem; do
+        [[ -f $f ]] || continue
+        openssl x509 -in "$f" -noout >/dev/null 2>&1 \
+            || die "that file contains something that is not a certificate"
+        if [[ ! -s ${dir}/leaf.pem ]] && certKeyPairMatches "$f" "$key"; then
+            openssl x509 -in "$f" > "${dir}/leaf.pem" 2>/dev/null
+            continue
+        fi
+        if isSelfSigned "$f"; then
+            openssl x509 -in "$f" >> "${dir}/roots.pem" 2>/dev/null
+            subj=$(certField "$f" subject)
+            sortedRoots="${sortedRoots}${subj}"$'\n'
+            continue
+        fi
+        openssl x509 -in "$f" >> "${dir}/chain.pem" 2>/dev/null
+    done
+    [[ -s ${dir}/leaf.pem ]]
+}
+
+# Does a path build for this leaf, against what this server ACTUALLY trusts?
+#
+# ${PKI_WEB_ANCHOR} is the same bundle FOG verifies its own HTTPS self-calls
+# against, so this asks the question that matters rather than a weaker one: an
+# administrator who has imported their corporate root passes, and one who has
+# not is told so before the vhost is repointed.
+verifyLeafChain() {
+    local leaf="$1" chain="$2"
+    [[ -n $PKI_WEB_ANCHOR && -s $PKI_WEB_ANCHOR ]] || return 1
+    if [[ -s $chain ]]; then
+        openssl verify -trusted "$PKI_WEB_ANCHOR" -untrusted "$chain" "$leaf" \
+            >/dev/null 2>&1
+    else
+        openssl verify -trusted "$PKI_WEB_ANCHOR" "$leaf" >/dev/null 2>&1
+    fi
+}
+
+# Refuse anything that would leave this server worse off than it is now.
+#
+# Declining is the safe direction throughout: FOG's own leaf, or the previously
+# adopted one, keeps serving. Installing a certificate the web server cannot
+# start with, or one nothing can build a path to, costs an administrator the
+# management interface they were using to do it.
+checkLeafMaterial() {
+    local cert="$1" key="$2" chain="$3" dir="$4" issuer
+    certKeyPairMatches "$cert" "$key" || {
+        if sortLeafMaterial "$cert" "$key" "$chain" "$dir" 2>/dev/null; then
+            die "the FIRST certificate in that file is not the one matching the key -- put the leaf first, then the intermediates, because that is the one the web server pairs with the key"
+        fi
+        die "that certificate and that private key are not a pair"
+    }
+    sortLeafMaterial "$cert" "$key" "$chain" "$dir" \
+        || die "no certificate in that file matches the private key"
+
+    # The leaf must not be a CA. This is the checked property behind "no CA
+    # private key reaches this channel" -- without it the sentence is a promise
+    # rather than something the helper enforces.
+    if isCACert "${dir}/leaf.pem"; then
+        die "that certificate is a CA (basicConstraints CA:TRUE), not a server certificate -- FOG will not take a CA private key through this page, and a CA is not what a vhost serves"
+    fi
+    openssl x509 -in "${dir}/leaf.pem" -noout -checkend 0 >/dev/null 2>&1 \
+        || die "that certificate has already expired"
+
+    if ! verifyLeafChain "${dir}/leaf.pem" "${dir}/chain.pem"; then
+        issuer=$(certField "${dir}/leaf.pem" issuer)
+        if [[ -s ${dir}/roots.pem ]]; then
+            die "no trust path builds for that certificate. Its issuer is ${issuer}, and the root you supplied is not trusted by this server yet -- import it on this page first, then try again. FOG does not anchor a root just because it arrived beside a certificate."
+        fi
+        die "no trust path builds for that certificate. Its issuer is ${issuer}, and this server has nothing that chains to it -- supply the intermediates, and import the issuing root on this page if it is not a public CA."
+    fi
+    return 0
+}
+
+# Make the running web server serve what was just installed.
+#
+# The one thing in this helper that takes effect before the next installer run,
+# and deliberately: a page whose "use this certificate" button does not change
+# what the server serves is a button that does not work. ADR 0036's amendment
+# records that narrowing, and it is scoped to certificate material -- the three
+# yes/no preferences still wait for the installer, because they are flags it
+# reads back rather than bytes it serves.
+#
+# Reported rather than fatal, for the reason anchorInHostStore() is: the
+# certificate is installed either way, and an administrator who has to reload by
+# hand is better off than one told the import failed over something that landed.
+reloadWebServer() {
+    [[ -n ${WEB_ENGINE:-} ]] || { printf 'reload:unavailable'; return 0; }
+    command -v systemctl >/dev/null 2>&1 || { printf 'reload:unavailable'; return 0; }
+    # reload first, restart only if the engine will not reload -- matching what
+    # the installer does at lib/common/functions.sh's own reload site. A reload
+    # keeps established connections, including the one the admin is clicking in.
+    if systemctl reload "$WEB_ENGINE" >/dev/null 2>&1 \
+        || systemctl restart "$WEB_ENGINE" >/dev/null 2>&1; then
+        printf 'reload:ok'
+    else
+        printf 'reload:failed'
+    fi
+    return 0
+}
+
+# Point this server at the leaf in the customizations tree, and serve it.
+#
+# The canonical paths become SYMLINKS to the administrator's files rather than
+# copies, which is what createSSLCA() does with the same material on an
+# installer run. Agreement between the two matters more than tidiness here: the
+# installer redoes this link on its next run, so if the helper resolved the same
+# input differently, a re-run would silently undo what the page did.
+adoptCustomLeaf() {
+    local cert key chain tmpd out
+    [[ -n $PKI_CUSTOM_DIR ]] || die "no customizations directory is configured -- re-run the FOG installer"
+    [[ -n $PKI_WEB_VHOST_CERT && -n $PKI_WEB_VHOST_KEY ]] || die "no canonical web leaf paths are configured -- re-run the FOG installer"
+    cert=$(customLeafCert)
+    key=$(customLeafKey)
+    chain=$(customLeafChain)
+    [[ -f $cert ]] || die "no certificate at ${cert}"
+    [[ -f $key ]] || die "no private key at ${key} -- both files are required, and they have to be a pair"
+    [[ -f $chain ]] || chain=""
+
+    tmpd=$(mktemp -d) || die "could not create a temporary directory"
+    chmod 0700 "$tmpd" 2>/dev/null
+    checkLeafMaterial "$cert" "$key" "$chain" "$tmpd"
+
+    # The intermediates go to a canonical path of the helper's choosing and
+    # ${PKI_web_trust_chain} is pointed at it -- the same shape import-root uses
+    # for the external root, and for the same reason: a path recorded from
+    # wherever the file happened to arrive is a path that names a temp file by
+    # next year (GH-1683).
+    #
+    # Only when there are intermediates. A leaf signed straight off a root has
+    # none, and repointing the key at an empty file would cost the server the
+    # chain it already had.
+    if [[ -s ${tmpd}/chain.pem && -n $PKI_WEB_EXTERNAL_CHAIN ]]; then
+        install -o root -g root -m 0644 "${tmpd}/chain.pem" "$PKI_WEB_EXTERNAL_CHAIN" 2>/dev/null \
+            || die "could not write ${PKI_WEB_EXTERNAL_CHAIN}"
+        writeSetting PKI_web_trust_chain "$PKI_WEB_EXTERNAL_CHAIN" \
+            || die "the chain was written but could not be recorded in .fogsettings"
+    fi
+
+    mkdir -p "$(dirname "$PKI_WEB_VHOST_CERT")" "$(dirname "$PKI_WEB_VHOST_KEY")" 2>/dev/null
+    ln -sfn "$cert" "$PKI_WEB_VHOST_CERT" 2>/dev/null \
+        || die "could not point ${PKI_WEB_VHOST_CERT} at ${cert}"
+    ln -sfn "$key" "$PKI_WEB_VHOST_KEY" 2>/dev/null \
+        || die "could not point ${PKI_WEB_VHOST_KEY} at ${key}"
+
+    # Rebuilt because the chain file just changed, and the anchor is derived
+    # from it. Not fatal on its own: the leaf is linked and serving either way,
+    # and the anchor is rebuilt again on the next installer run.
+    rebuildAnchor >/dev/null 2>&1 || true
+
+    out="OK $(certField "${tmpd}/leaf.pem" subject) $(reloadWebServer)"
+    rm -rf "$tmpd"
+    echo "$out"
+}
+
 case "$verb" in
 
 status)
@@ -458,6 +689,40 @@ EOF
     fi
     printf '  "trust_store": {"available": %s, "directory": %s, "anchored": %s},\n' \
         "$(jbool $store)" "$(jstr "$storedir")" "$(jbool $anchored)"
+
+    # What is sitting in the customizations tree, so the page can offer to
+    # adopt it -- or say why it cannot -- before anybody clicks. Read-only and
+    # derived, like externally_managed_leaf above: nothing here changes what
+    # the server serves, and the same three questions are asked again by
+    # adopt-custom-leaf, because a status call and a later click are two
+    # different moments and the files may have changed between them.
+    custpresent=0; custpair=0; custchain=0; custsubject=""; custexpiry=""
+    custverifies=0; custroot=""
+    if [[ -n $PKI_CUSTOM_DIR ]]; then
+        custcert=$(customLeafCert)
+        custkey=$(customLeafKey)
+        custchainfile=$(customLeafChain)
+        [[ -f $custcert ]] && custpresent=1
+        [[ -f $custchainfile ]] && custchain=1
+        if [[ -f $custcert && -f $custkey ]] && certKeyPairMatches "$custcert" "$custkey"; then
+            custpair=1
+            custsubject=$(certField "$custcert" subject)
+            custexpiry=$(certField "$custcert" enddate)
+            custtmp=$(mktemp -d 2>/dev/null)
+            if [[ -n $custtmp ]]; then
+                [[ -f $custchainfile ]] || custchainfile=""
+                if sortLeafMaterial "$custcert" "$custkey" "$custchainfile" "$custtmp" 2>/dev/null; then
+                    verifyLeafChain "${custtmp}/leaf.pem" "${custtmp}/chain.pem" && custverifies=1
+                    [[ -s ${custtmp}/roots.pem ]] && custroot=$(certField "${custtmp}/roots.pem" subject)
+                fi
+                rm -rf "$custtmp"
+            fi
+        fi
+    fi
+    printf '  "custom_pki": {"dir": %s, "present": %s, "pair_ok": %s, "chain_file": %s, "subject": %s, "not_after": %s, "chain_verifies": %s, "supplied_root": %s},\n' \
+        "$(jstr "$PKI_CUSTOM_DIR")" "$(jbool $custpresent)" "$(jbool $custpair)" \
+        "$(jbool $custchain)" "$(jstr "$custsubject")" "$(jstr "$custexpiry")" \
+        "$(jbool $custverifies)" "$(jstr "$custroot")"
 
     printf '  "preferences": {'
     first=1
@@ -556,6 +821,115 @@ clear-root)
     setPreferencePath "" || die "could not clear the imported root in .fogsettings"
     rebuildAnchor || die "the certificate was removed but the trust anchor could not be rebuilt"
     echo "OK 0 $(anchorInHostStore)"
+    ;;
+
+adopt-custom-leaf)
+    # No arguments at all -- not even an allowlisted token. The directory comes
+    # from the root-only config, so this verb is stricter than ADR 0036
+    # requires rather than an exception to it. A free-text path field was the
+    # obvious alternative and is the one that ADR rejected: the moment the
+    # caller names a file, the helper's job becomes proving a path is safe.
+    [[ $# -eq 0 ]] || die "usage: fog-pki-admin adopt-custom-leaf"
+    adoptCustomLeaf
+    ;;
+
+import-leaf)
+    # Everything the administrator uploaded arrives under one request id, and
+    # the helper reads it as a blob claiming to be certificate material. The
+    # page validates none of it, on purpose -- PHP is the side that might be
+    # compromised.
+    #
+    # The staged names, all optional except that there must be enough to work
+    # with: <reqid>.pem (leaf or fullchain), <reqid>.key, <reqid>.chain,
+    # <reqid>.p12, <reqid>.pass.
+    #
+    # The passphrase is a FILE, never an argument. This script is invoked
+    # through sudo from a command line the page builds, and an argument is
+    # readable in /proc by every local user for as long as the call lasts.
+    [[ $# -eq 1 ]] || die "usage: fog-pki-admin import-leaf <request-id>"
+    reqid="$1"
+    [[ $reqid =~ ^[a-f0-9]{32}$ ]] || die "malformed request id"
+    [[ -n $PKI_CUSTOM_DIR ]] || die "no customizations directory is configured -- re-run the FOG installer"
+
+    stagedPem="${PKI_STAGING}/${reqid}.pem"
+    stagedKey="${PKI_STAGING}/${reqid}.key"
+    stagedChain="${PKI_STAGING}/${reqid}.chain"
+    stagedP12="${PKI_STAGING}/${reqid}.p12"
+    stagedPass="${PKI_STAGING}/${reqid}.pass"
+
+    tmpd=$(mktemp -d) || die "could not create a temporary directory"
+    trap 'rm -rf "$tmpd"' EXIT
+    chmod 0700 "$tmpd" 2>/dev/null
+    : > "${tmpd}/chain.in"
+
+    if [[ -f $stagedP12 ]]; then
+        # PKCS#12 (RFC 7292) -- one container carrying the key, the leaf and
+        # usually the chain. It is what an administrator exports from certlm.msc
+        # or IIS, and unpacking it here rather than asking them to convert it by
+        # hand is the whole point of accepting it.
+        passin="pass:"
+        [[ -f $stagedPass ]] && passin="file:${stagedPass}"
+        openssl pkcs12 -in "$stagedP12" -passin "$passin" -nokeys -clcerts \
+            -out "${tmpd}/leaf.in" 2>/dev/null \
+            || die "that PKCS#12 file could not be opened -- check the passphrase"
+        [[ -s ${tmpd}/leaf.in ]] || die "that PKCS#12 file carries no certificate"
+        openssl pkcs12 -in "$stagedP12" -passin "$passin" -nokeys -cacerts \
+            -out "${tmpd}/chain.in" 2>/dev/null || : > "${tmpd}/chain.in"
+        # -nodes: the key is written unencrypted because the web server has to
+        # read it at start-up with nobody there to type a passphrase.
+        openssl pkcs12 -in "$stagedP12" -passin "$passin" -nocerts -nodes \
+            -out "${tmpd}/key.in" 2>/dev/null \
+            || die "that PKCS#12 file carries no private key"
+        [[ -s ${tmpd}/key.in ]] || die "that PKCS#12 file carries no private key"
+    else
+        [[ -f $stagedPem ]] || die "no certificate was uploaded"
+        [[ -f $stagedKey ]] || die "no private key was uploaded -- FOG needs the key as well as the certificate, or a PKCS#12 file carrying both"
+        cp "$stagedPem" "${tmpd}/leaf.in"
+        # Normalized through `openssl pkey` rather than installed as handed
+        # over. An encrypted key would leave the web server prompting for a
+        # passphrase at start-up and never getting an answer, and the failure
+        # would arrive as a server that does not come back.
+        if [[ -f $stagedPass ]]; then
+            openssl pkey -in "$stagedKey" -passin "file:${stagedPass}" \
+                -out "${tmpd}/key.in" 2>/dev/null \
+                || die "that private key could not be decrypted -- check the passphrase"
+        else
+            openssl pkey -in "$stagedKey" -out "${tmpd}/key.in" 2>/dev/null \
+                || die "that private key could not be read -- if it is passphrase-protected, supply the passphrase"
+        fi
+        [[ -f $stagedChain ]] && cp "$stagedChain" "${tmpd}/chain.in"
+    fi
+
+    # Checked BEFORE anything is written where the server reads, so a refusal
+    # leaves the previous certificate serving and the customizations tree
+    # untouched.
+    mkdir -p "${tmpd}/check" || die "could not create a temporary directory"
+    checkLeafMaterial "${tmpd}/leaf.in" "${tmpd}/key.in" "${tmpd}/chain.in" "${tmpd}/check"
+
+    # Installed into the customizations tree, which is where a certificate you
+    # brought is documented to live (ADR 0040). Two things follow that no other
+    # destination gives for free: the next installer run adopts it again as
+    # signal 0 rather than regenerating over it, and adopt-custom-leaf and this
+    # verb end up running exactly the same code.
+    #
+    # Anything already there is kept beside it rather than destroyed. This
+    # directory exists for the administrator's own files, so a page that
+    # overwrote one without trace would be spending something it does not own.
+    mkdir -p "$PKI_CUSTOM_DIR" 2>/dev/null
+    chmod 0700 "$PKI_CUSTOM_DIR" 2>/dev/null
+    for f in "$(customLeafCert)" "$(customLeafKey)" "$(customLeafChain)"; do
+        [[ -e $f ]] && mv -f "$f" "${f}.replaced" 2>/dev/null
+    done
+    install -o root -g root -m 0644 "${tmpd}/leaf.in" "$(customLeafCert)" 2>/dev/null \
+        || die "could not write $(customLeafCert)"
+    install -o root -g root -m 0600 "${tmpd}/key.in" "$(customLeafKey)" 2>/dev/null \
+        || die "could not write $(customLeafKey)"
+    if [[ -s ${tmpd}/chain.in ]]; then
+        install -o root -g root -m 0644 "${tmpd}/chain.in" "$(customLeafChain)" 2>/dev/null \
+            || die "could not write $(customLeafChain)"
+    fi
+
+    adoptCustomLeaf
     ;;
 
 set-preference)

--- a/packages/web/management/js/fog/about/fog.about.certificates.js
+++ b/packages/web/management/js/fog/about/fog.about.certificates.js
@@ -1,6 +1,6 @@
 /**
- * The Certificates page: import a root CA, remove one, set the three install
- * preferences.
+ * The Certificates page: import a root CA, remove one, bring your own web
+ * server certificate, set the three install preferences.
  *
  * Everything here posts to ?node=about&sub=certificates, which Authorization
  * gates on system.pki for POST and settings.view for GET. A viewer without the
@@ -14,9 +14,16 @@
 (function($) {
   var rootForm = $('#pki-root-form'),
     importBtn = $('#pki-import-root'),
-    clearBtn = $('#pki-clear-root');
+    clearBtn = $('#pki-clear-root'),
+    leafForm = $('#pki-leaf-form'),
+    adoptBtn = $('#pki-adopt-leaf'),
+    leafBtn = $('#pki-import-leaf');
 
   rootForm.on('submit', function(e) {
+    e.preventDefault();
+  });
+
+  leafForm.on('submit', function(e) {
     e.preventDefault();
   });
 
@@ -52,6 +59,50 @@
         }
         location.reload();
       });
+  });
+
+  adoptBtn.on('click', function(e) {
+    e.preventDefault();
+    if (!window.confirm(
+      'Serve the certificate in the customizations directory instead of the '
+      + 'one FOG issued? The web server is reloaded, so this takes effect now.'
+    )) {
+      return;
+    }
+    adoptBtn.prop('disabled', true);
+    $.apiCall('post', leafForm.attr('action'), {action: 'adoptCustomLeaf'},
+      function(err) {
+        adoptBtn.prop('disabled', false);
+        if (err) {
+          return;
+        }
+        location.reload();
+      });
+  });
+
+  leafBtn.on('click', function(e) {
+    e.preventDefault();
+    if (!window.confirm(
+      'Upload this certificate and its private key, and serve it? The key '
+      + 'passes through the web application for this one request. If it is a '
+      + 'wildcard, it covers hosts other than this server.'
+    )) {
+      return;
+    }
+    leafBtn.prop('disabled', true);
+    // processForm builds the FormData from the form element, so the four file
+    // inputs, the passphrase and the hidden action all travel in one POST --
+    // the helper needs them under a single request id.
+    leafForm.processForm(function(err) {
+      leafBtn.prop('disabled', false);
+      if (err) {
+        return;
+      }
+      // Reloaded rather than patched: adopting a certificate changes the chain
+      // table, the derived "managed elsewhere" state, whether the key-exposure
+      // alarm fires, and this tab's own summary of the directory.
+      location.reload();
+    });
   });
 
   // One handler for all three switches. Each posts only its own key, so two

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -287,6 +287,10 @@ msgstr "1 Stunde"
 msgid "1 Year"
 msgstr "Jährlich"
 
+#, fuzzy
+msgid "1. A certificate already on this server"
+msgstr "Es gibt keine Gruppen auf diesem Server."
+
 msgid "10"
 msgstr ""
 
@@ -305,7 +309,14 @@ msgstr ""
 msgid "2 Minutes"
 msgstr "2 Minuten"
 
+#, fuzzy
+msgid "2. A certificate signing request"
+msgstr "Keine Datei wurde hochgeladen"
+
 msgid "25"
+msgstr ""
+
+msgid "3. Upload a certificate and its key"
 msgstr ""
 
 msgid "30 Days"
@@ -340,12 +351,18 @@ msgstr ""
 msgid "A .tar.gz holding one directory named for the plugin, with config/plugin.config.php inside it."
 msgstr ""
 
+msgid "A CA certificate is refused. Replacing FOG's own root is a migration rather than a setting -- see the Using your own PKI tab."
+msgstr ""
+
 msgid "A FOG username and password."
 msgstr ""
 
 #, fuzzy
 msgid "A LDAP setup already exists with this name!"
 msgstr "Ein LDAP mit diesem Namen ist bereits vorhanden!"
+
+msgid "A PEM certificate with its key, or one PKCS#12 (.p12/.pfx) file carrying both. A full chain is fine -- put the leaf first -- and the intermediates are separated out for you."
+msgstr ""
 
 msgid "A TCP/IP port printer requires an IP address or hostname."
 msgstr ""
@@ -479,6 +496,10 @@ msgstr "Ein Host mit diesem Namen ist bereits vorhanden."
 msgid "A root CA uploaded on this page. Absent unless one was imported."
 msgstr ""
 
+#, php-format
+msgid "A root was supplied alongside it (%s). FOG does not trust a root just because it arrived beside a certificate -- import it deliberately on the External root CA tab, then adopt."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "Ein Gruppenname ist erforderlich!"
@@ -541,6 +562,10 @@ msgstr "Ein Taskstatus mit diesem Namen ist bereits vorhanden!"
 #, fuzzy
 msgid "A task type already exists with this name!"
 msgstr "Ein Task-Typ mit diesem Namen ist bereits vorhanden!"
+
+#, php-format
+msgid "A usable pair is waiting: %s, valid until %s."
+msgstr ""
 
 #, fuzzy
 msgid "A user already exists with this name"
@@ -925,6 +950,10 @@ msgstr "Admingruppe"
 #, fuzzy
 msgid "Administrator (full access)"
 msgstr "Admingruppe"
+
+#, fuzzy
+msgid "Adopt the certificate in that directory"
+msgstr "Erstellen eines Snapin-Jobs fehlgeschlagen"
 
 msgid "Advanced"
 msgstr "Erweitert"
@@ -1641,8 +1670,15 @@ msgid "Certificate download failed"
 msgstr "Download fehlgeschlagen"
 
 #, fuzzy
+msgid "Certificate in use"
+msgstr "Neuen Standort erstellen"
+
+#, fuzzy
 msgid "Certificate management is not configured on this server"
 msgstr "Es gibt keine Images auf diesem Server."
+
+msgid "Certificate, or full chain, leaf first (PEM)"
+msgstr ""
 
 #, fuzzy
 msgid "Certificates"
@@ -2004,11 +2040,19 @@ msgid "Could not send data from file"
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
+msgid "Could not stage the passphrase"
+msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 msgid "Could not stage the uploaded certificate"
+msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
+msgid "Could not stage the uploaded file"
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
@@ -2569,6 +2613,10 @@ msgstr "Download fehlgeschlagen"
 msgid "Downloaded file is not a bootable kernel image"
 msgstr ""
 
+#, php-format
+msgid "Drop %s and %s into %s and FOG adopts them -- no setting to edit. Add %s as well if your CA issued intermediates. The installer does the same thing on its next run, so this button only saves you the wait."
+msgstr ""
+
 msgid "Dropped"
 msgstr "ausgeworfen"
 
@@ -2937,6 +2985,9 @@ msgstr "sichern möchten, können Sie das mit"
 msgid "FOG is unable to communicate with the database"
 msgstr "FOG kann nicht mit der Datenbank verbinden."
 
+msgid "FOG issues its own web server certificate. If you would rather it served one of yours -- from an ACME client, your corporate CA, or a purchased certificate -- there are three ways to say so, and the first two never send the private key to this web application."
+msgstr ""
+
 msgid "FOG refuses to deploy an image to a host that cannot run it."
 msgstr ""
 
@@ -3265,6 +3316,9 @@ msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
 msgstr ""
 
 msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
+msgstr ""
+
+msgid "For sites whose policy is that a private key never moves. Not on this page yet; FOG already does exactly this for storage node certificates, and the same route for the web certificate is tracked as a follow-up."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4576,6 +4630,9 @@ msgstr "Netzwerkschnittstelle nicht bereit, warte auf deren Start"
 #, fuzzy
 msgid "Interface throughput"
 msgstr "Schnittstelle"
+
+msgid "Intermediates, if they are in their own file (PEM, optional)"
+msgstr ""
 
 #, fuzzy
 msgid "Invalid"
@@ -6143,6 +6200,9 @@ msgstr ""
 msgid "No token passed to authenticate this host"
 msgstr "Kein valides Image für diesen Host definiert"
 
+msgid "No trust path builds for it yet, so adopting it would be refused. Supply the intermediates, and import the issuing root on the External root CA tab if it is not a public CA."
+msgstr ""
+
 msgid "No type information available for this column."
 msgstr ""
 
@@ -6265,6 +6325,9 @@ msgid "Not syncing Snapin"
 msgstr "Snapin wird nicht synchronisiert"
 
 msgid "Not yet seen"
+msgstr ""
+
+msgid "Nothing is in that directory yet."
 msgstr ""
 
 msgid "Nothing needs it day to day. Restore it only to issue a new intermediate, or a certificate for a new storage node."
@@ -6496,6 +6559,9 @@ msgstr "Operationsfeld nicht gesetzt: %s"
 msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
+msgid "Or one PKCS#12 file carrying all of it (.p12/.pfx)"
+msgstr ""
+
 msgid "Or there was no number defined for joining session"
 msgstr "oder es wurde keine Nummer für die Beitrittssitzung definiert"
 
@@ -6571,6 +6637,9 @@ msgstr "Partclone ZSTD gesplittet 200MiB"
 
 msgid "Partimage"
 msgstr "Partimage"
+
+msgid "Passphrase, if the PKCS#12 file or the key has one"
+msgstr ""
 
 msgid "Password"
 msgstr "Passwort"
@@ -7065,6 +7134,10 @@ msgstr "Drucker aktualisiert!"
 
 msgid "Printers"
 msgstr "Drucker"
+
+#, fuzzy
+msgid "Private key (PEM)"
+msgstr "Privater Schlüssel ist fehlgeschlagen"
 
 msgid "Private key failed"
 msgstr "Privater Schlüssel ist fehlgeschlagen"
@@ -9141,6 +9214,14 @@ msgid "That certificate is not available on this server."
 msgstr "Es gibt keine Gruppen auf diesem Server."
 
 #, fuzzy
+msgid "That certificate was refused"
+msgstr "Keine Datei wurde hochgeladen"
+
+#, fuzzy
+msgid "That file is too large to be a certificate or a key"
+msgstr "konnte nicht gespeichert werden"
+
+#, fuzzy
 msgid "That file is too large to be a root CA certificate"
 msgstr "konnte nicht gespeichert werden"
 
@@ -9178,6 +9259,10 @@ msgstr ""
 #, fuzzy
 msgid "That session has already started"
 msgstr "Dieser Host ist bereits vorhanden."
+
+#, fuzzy
+msgid "That upload did not arrive intact"
+msgstr "Es gibt keine Images auf diesem Server."
 
 #, fuzzy
 msgid "That upload is no longer available."
@@ -9286,6 +9371,12 @@ msgid "The breakdowns cover every inventoried machine. The range selects invento
 msgstr ""
 
 msgid "The calling user's preferences."
+msgstr ""
+
+msgid "The certificate is installed and recorded, but the web server would not reload, so it is still serving the previous one. Reload it by hand, or re-run the installer."
+msgstr ""
+
+msgid "The certificate is installed and recorded. Reload the web server for it to be served."
 msgstr ""
 
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
@@ -9600,6 +9691,9 @@ msgstr "Es gibt keine Snapins auf diesem Server."
 msgid "There are open slots"
 msgstr "Es gibt offene Slots,"
 
+msgid "There is a certificate in that directory, but no private key that matches it. Both files are required and they have to be a genuine pair, so FOG is leaving its own certificate in place -- adopting a certificate the web server cannot start with would be the worse outcome."
+msgstr ""
+
 msgid "There is a host in a tasking"
 msgstr "Es gibt einen Host in einer Aufgabe"
 
@@ -9737,6 +9831,9 @@ msgstr ""
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
+msgid "This is the one route that sends a private key through this web application. It is written to disk by root and never kept here, but it does pass through for the length of one request. If the certificate is a wildcard it covers hosts other than this one, so prefer route 1 or 2 where your policy allows."
+msgstr ""
+
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
@@ -9774,6 +9871,12 @@ msgid "This server becomes the platform owner, so Microsoft's published CA certi
 msgstr ""
 
 msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
+msgstr ""
+
+msgid "This server is already serving a certificate managed outside FOG, so FOG will not reissue or re-key it. That is derived from where the certificate actually is, not from a setting."
+msgstr ""
+
+msgid "This server is now serving that certificate, and the web server has been reloaded."
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -10231,7 +10334,13 @@ msgstr "Berichte hochladen"
 msgid "Upload Reports"
 msgstr "Berichte hochladen"
 
+msgid "Upload a certificate and its key, or one PKCS#12 file carrying both"
+msgstr ""
+
 msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
+
+msgid "Upload and use it"
 msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -292,6 +292,10 @@ msgstr "1 hour"
 msgid "1 Year"
 msgstr "Yearly"
 
+#, fuzzy
+msgid "1. A certificate already on this server"
+msgstr "There are no groups on this server."
+
 msgid "10"
 msgstr ""
 
@@ -310,7 +314,14 @@ msgstr ""
 msgid "2 Minutes"
 msgstr "2 Minutes"
 
+#, fuzzy
+msgid "2. A certificate signing request"
+msgstr "No file was uploaded"
+
 msgid "25"
+msgstr ""
+
+msgid "3. Upload a certificate and its key"
 msgstr ""
 
 msgid "30 Days"
@@ -345,12 +356,18 @@ msgstr ""
 msgid "A .tar.gz holding one directory named for the plugin, with config/plugin.config.php inside it."
 msgstr ""
 
+msgid "A CA certificate is refused. Replacing FOG's own root is a migration rather than a setting -- see the Using your own PKI tab."
+msgstr ""
+
 msgid "A FOG username and password."
 msgstr ""
 
 #, fuzzy
 msgid "A LDAP setup already exists with this name!"
 msgstr "An image already exists with this name!"
+
+msgid "A PEM certificate with its key, or one PKCS#12 (.p12/.pfx) file carrying both. A full chain is fine -- put the leaf first -- and the intermediates are separated out for you."
+msgstr ""
 
 msgid "A TCP/IP port printer requires an IP address or hostname."
 msgstr ""
@@ -484,6 +501,10 @@ msgstr "A hostname with that name already exists."
 msgid "A root CA uploaded on this page. Absent unless one was imported."
 msgstr ""
 
+#, php-format
+msgid "A root was supplied alongside it (%s). FOG does not trust a root just because it arrived beside a certificate -- import it deliberately on the External root CA tab, then adopt."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "An image name is required!"
@@ -546,6 +567,10 @@ msgstr "An image already exists with this name!"
 #, fuzzy
 msgid "A task type already exists with this name!"
 msgstr "An image already exists with this name!"
+
+#, php-format
+msgid "A usable pair is waiting: %s, valid until %s."
+msgstr ""
 
 #, fuzzy
 msgid "A user already exists with this name"
@@ -929,6 +954,10 @@ msgstr "Modify Group"
 #, fuzzy
 msgid "Administrator (full access)"
 msgstr "Modify Group"
+
+#, fuzzy
+msgid "Adopt the certificate in that directory"
+msgstr "Failed to create Snapin Job"
 
 msgid "Advanced"
 msgstr "Advanced"
@@ -1644,8 +1673,15 @@ msgid "Certificate download failed"
 msgstr "Download Failed"
 
 #, fuzzy
+msgid "Certificate in use"
+msgstr "Create New %s"
+
+#, fuzzy
 msgid "Certificate management is not configured on this server"
 msgstr "There are no images on this server."
+
+msgid "Certificate, or full chain, leaf first (PEM)"
+msgstr ""
 
 #, fuzzy
 msgid "Certificates"
@@ -2006,11 +2042,19 @@ msgid "Could not send data from file"
 msgstr "Could not read tmp file."
 
 #, fuzzy
+msgid "Could not stage the passphrase"
+msgstr "Could not read tmp file."
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "Could not read tmp file."
 
 #, fuzzy
 msgid "Could not stage the uploaded certificate"
+msgstr "Could not read tmp file."
+
+#, fuzzy
+msgid "Could not stage the uploaded file"
 msgstr "Could not read tmp file."
 
 #, fuzzy
@@ -2572,6 +2616,10 @@ msgstr "Download Failed"
 msgid "Downloaded file is not a bootable kernel image"
 msgstr ""
 
+#, php-format
+msgid "Drop %s and %s into %s and FOG adopts them -- no setting to edit. Add %s as well if your CA issued intermediates. The installer does the same thing on its next run, so this button only saves you the wait."
+msgstr ""
+
 msgid "Dropped"
 msgstr "Dropped"
 
@@ -2939,6 +2987,9 @@ msgstr ""
 msgid "FOG is unable to communicate with the database"
 msgstr ""
 
+msgid "FOG issues its own web server certificate. If you would rather it served one of yours -- from an ACME client, your corporate CA, or a purchased certificate -- there are three ways to say so, and the first two never send the private key to this web application."
+msgstr ""
+
 msgid "FOG refuses to deploy an image to a host that cannot run it."
 msgstr ""
 
@@ -3267,6 +3318,9 @@ msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
 msgstr ""
 
 msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
+msgstr ""
+
+msgid "For sites whose policy is that a private key never moves. Not on this page yet; FOG already does exactly this for storage node certificates, and the same route for the web certificate is tracked as a follow-up."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4578,6 +4632,9 @@ msgstr ""
 #, fuzzy
 msgid "Interface throughput"
 msgstr "Interface"
+
+msgid "Intermediates, if they are in their own file (PEM, optional)"
+msgstr ""
 
 #, fuzzy
 msgid "Invalid"
@@ -6155,6 +6212,9 @@ msgstr ""
 msgid "No token passed to authenticate this host"
 msgstr "No Image defined for this host"
 
+msgid "No trust path builds for it yet, so adopting it would be refused. Supply the intermediates, and import the issuing root on the External root CA tab if it is not a public CA."
+msgstr ""
+
 msgid "No type information available for this column."
 msgstr ""
 
@@ -6276,6 +6336,9 @@ msgid "Not syncing Snapin"
 msgstr "No connection to get snapin"
 
 msgid "Not yet seen"
+msgstr ""
+
+msgid "Nothing is in that directory yet."
 msgstr ""
 
 msgid "Nothing needs it day to day. Restore it only to issue a new intermediate, or a certificate for a new storage node."
@@ -6507,6 +6570,9 @@ msgstr "Operation Field not set: %s"
 msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
+msgid "Or one PKCS#12 file carrying all of it (.p12/.pfx)"
+msgstr ""
+
 msgid "Or there was no number defined for joining session"
 msgstr ""
 
@@ -6582,6 +6648,9 @@ msgstr "Partclone"
 
 msgid "Partimage"
 msgstr "Partimage"
+
+msgid "Passphrase, if the PKCS#12 file or the key has one"
+msgstr ""
 
 msgid "Password"
 msgstr "Password"
@@ -7076,6 +7145,10 @@ msgstr "Printer updated!"
 
 msgid "Printers"
 msgstr "Printers"
+
+#, fuzzy
+msgid "Private key (PEM)"
+msgstr "Private key failed"
 
 msgid "Private key failed"
 msgstr "Private key failed"
@@ -9150,6 +9223,14 @@ msgid "That certificate is not available on this server."
 msgstr "There are no groups on this server."
 
 #, fuzzy
+msgid "That certificate was refused"
+msgstr "No file was uploaded"
+
+#, fuzzy
+msgid "That file is too large to be a certificate or a key"
+msgstr "has failed to save"
+
+#, fuzzy
 msgid "That file is too large to be a root CA certificate"
 msgstr "has failed to save"
 
@@ -9187,6 +9268,10 @@ msgstr ""
 #, fuzzy
 msgid "That session has already started"
 msgstr "Printer already exists"
+
+#, fuzzy
+msgid "That upload did not arrive intact"
+msgstr "There are no images on this server."
 
 #, fuzzy
 msgid "That upload is no longer available."
@@ -9295,6 +9380,12 @@ msgid "The breakdowns cover every inventoried machine. The range selects invento
 msgstr ""
 
 msgid "The calling user's preferences."
+msgstr ""
+
+msgid "The certificate is installed and recorded, but the web server would not reload, so it is still serving the previous one. Reload it by hand, or re-run the installer."
+msgstr ""
+
+msgid "The certificate is installed and recorded. Reload the web server for it to be served."
 msgstr ""
 
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
@@ -9609,6 +9700,9 @@ msgstr "There are no snapins on this server."
 msgid "There are open slots"
 msgstr "There are open slots, but"
 
+msgid "There is a certificate in that directory, but no private key that matches it. Both files are required and they have to be a genuine pair, so FOG is leaving its own certificate in place -- adopting a certificate the web server cannot start with would be the worse outcome."
+msgstr ""
+
 msgid "There is a host in a tasking"
 msgstr "There is a host in a tasking"
 
@@ -9745,6 +9839,9 @@ msgstr ""
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
+msgid "This is the one route that sends a private key through this web application. It is written to disk by root and never kept here, but it does pass through for the length of one request. If the certificate is a wildcard it covers hosts other than this one, so prefer route 1 or 2 where your policy allows."
+msgstr ""
+
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
@@ -9782,6 +9879,12 @@ msgid "This server becomes the platform owner, so Microsoft's published CA certi
 msgstr ""
 
 msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
+msgstr ""
+
+msgid "This server is already serving a certificate managed outside FOG, so FOG will not reissue or re-key it. That is derived from where the certificate actually is, not from a setting."
+msgstr ""
+
+msgid "This server is now serving that certificate, and the web server has been reloaded."
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -10239,7 +10342,13 @@ msgstr "Upload Reports"
 msgid "Upload Reports"
 msgstr "Upload Reports"
 
+msgid "Upload a certificate and its key, or one PKCS#12 file carrying both"
+msgstr ""
+
 msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
+
+msgid "Upload and use it"
 msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -290,6 +290,10 @@ msgstr "1 hora"
 msgid "1 Year"
 msgstr "Anual"
 
+#, fuzzy
+msgid "1. A certificate already on this server"
+msgstr "No hay grupos en este servidor."
+
 msgid "10"
 msgstr ""
 
@@ -308,7 +312,14 @@ msgstr ""
 msgid "2 Minutes"
 msgstr "2 minutos"
 
+#, fuzzy
+msgid "2. A certificate signing request"
+msgstr "Ningún archivo fue subido"
+
 msgid "25"
+msgstr ""
+
+msgid "3. Upload a certificate and its key"
 msgstr ""
 
 msgid "30 Days"
@@ -343,12 +354,18 @@ msgstr ""
 msgid "A .tar.gz holding one directory named for the plugin, with config/plugin.config.php inside it."
 msgstr ""
 
+msgid "A CA certificate is refused. Replacing FOG's own root is a migration rather than a setting -- see the Using your own PKI tab."
+msgstr ""
+
 msgid "A FOG username and password."
 msgstr ""
 
 #, fuzzy
 msgid "A LDAP setup already exists with this name!"
 msgstr "Una imagen ya existe con este nombre!"
+
+msgid "A PEM certificate with its key, or one PKCS#12 (.p12/.pfx) file carrying both. A full chain is fine -- put the leaf first -- and the intermediates are separated out for you."
+msgstr ""
 
 msgid "A TCP/IP port printer requires an IP address or hostname."
 msgstr ""
@@ -482,6 +499,10 @@ msgstr "Sesión con ese nombre ya existe"
 msgid "A root CA uploaded on this page. Absent unless one was imported."
 msgstr ""
 
+#, php-format
+msgid "A root was supplied alongside it (%s). FOG does not trust a root just because it arrived beside a certificate -- import it deliberately on the External root CA tab, then adopt."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "Se requiere un nombre de imagen!"
@@ -544,6 +565,10 @@ msgstr "Una imagen ya existe con este nombre!"
 #, fuzzy
 msgid "A task type already exists with this name!"
 msgstr "Una imagen ya existe con este nombre!"
+
+#, php-format
+msgid "A usable pair is waiting: %s, valid until %s."
+msgstr ""
 
 #, fuzzy
 msgid "A user already exists with this name"
@@ -939,6 +964,10 @@ msgstr "modificar Grupo"
 #, fuzzy
 msgid "Administrator (full access)"
 msgstr "modificar Grupo"
+
+#, fuzzy
+msgid "Adopt the certificate in that directory"
+msgstr "No se pudo crear Complemento de empleo"
 
 msgid "Advanced"
 msgstr "Avanzado"
@@ -1661,8 +1690,15 @@ msgid "Certificate download failed"
 msgstr "Descarga fracasó"
 
 #, fuzzy
+msgid "Certificate in use"
+msgstr "Crear nuevo grupo"
+
+#, fuzzy
 msgid "Certificate management is not configured on this server"
 msgstr "No hay grupos en este servidor."
+
+msgid "Certificate, or full chain, leaf first (PEM)"
+msgstr ""
 
 #, fuzzy
 msgid "Certificates"
@@ -2026,11 +2062,19 @@ msgid "Could not send data from file"
 msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
+msgid "Could not stage the passphrase"
+msgstr "No se pudo leer el archivo tmp."
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
 msgid "Could not stage the uploaded certificate"
+msgstr "No se pudo leer el archivo tmp."
+
+#, fuzzy
+msgid "Could not stage the uploaded file"
 msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
@@ -2603,6 +2647,10 @@ msgstr "Descarga fracasó"
 msgid "Downloaded file is not a bootable kernel image"
 msgstr ""
 
+#, php-format
+msgid "Drop %s and %s into %s and FOG adopts them -- no setting to edit. Add %s as well if your CA issued intermediates. The installer does the same thing on its next run, so this button only saves you the wait."
+msgstr ""
+
 msgid "Dropped"
 msgstr "Caído"
 
@@ -2978,6 +3026,9 @@ msgstr ""
 msgid "FOG is unable to communicate with the database"
 msgstr ""
 
+msgid "FOG issues its own web server certificate. If you would rather it served one of yours -- from an ACME client, your corporate CA, or a purchased certificate -- there are three ways to say so, and the first two never send the private key to this web application."
+msgstr ""
+
 msgid "FOG refuses to deploy an image to a host that cannot run it."
 msgstr ""
 
@@ -3316,6 +3367,9 @@ msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
 msgstr ""
 
 msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
+msgstr ""
+
+msgid "For sites whose policy is that a private key never moves. Not on this page yet; FOG already does exactly this for storage node certificates, and the same route for the web certificate is tracked as a follow-up."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4653,6 +4707,9 @@ msgid "Interface not ready, waiting for it to come up"
 msgstr ""
 
 msgid "Interface throughput"
+msgstr ""
+
+msgid "Intermediates, if they are in their own file (PEM, optional)"
 msgstr ""
 
 #, fuzzy
@@ -6264,6 +6321,9 @@ msgstr ""
 msgid "No token passed to authenticate this host"
 msgstr "No se ha definido de este alojamiento imagen"
 
+msgid "No trust path builds for it yet, so adopting it would be refused. Supply the intermediates, and import the issuing root on the External root CA tab if it is not a public CA."
+msgstr ""
+
 msgid "No type information available for this column."
 msgstr ""
 
@@ -6387,6 +6447,9 @@ msgid "Not syncing Snapin"
 msgstr ""
 
 msgid "Not yet seen"
+msgstr ""
+
+msgid "Nothing is in that directory yet."
 msgstr ""
 
 msgid "Nothing needs it day to day. Restore it only to issue a new intermediate, or a certificate for a new storage node."
@@ -6617,6 +6680,9 @@ msgstr "Operación de no activado: %s"
 msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
+msgid "Or one PKCS#12 file carrying all of it (.p12/.pfx)"
+msgstr ""
+
 msgid "Or there was no number defined for joining session"
 msgstr ""
 
@@ -6694,6 +6760,9 @@ msgstr "Partclone"
 
 msgid "Partimage"
 msgstr "partimage"
+
+msgid "Passphrase, if the PKCS#12 file or the key has one"
+msgstr ""
 
 #, fuzzy
 msgid "Password"
@@ -7198,6 +7267,10 @@ msgstr "Impresora actualiza!"
 #, fuzzy
 msgid "Printers"
 msgstr "impresora IP"
+
+#, fuzzy
+msgid "Private key (PEM)"
+msgstr "clave privada fracasó"
 
 msgid "Private key failed"
 msgstr "clave privada fracasó"
@@ -9314,6 +9387,14 @@ msgid "That certificate is not available on this server."
 msgstr "No hay grupos en este servidor."
 
 #, fuzzy
+msgid "That certificate was refused"
+msgstr "Ningún archivo fue subido"
+
+#, fuzzy
+msgid "That file is too large to be a certificate or a key"
+msgstr "no ha logrado ahorrar"
+
+#, fuzzy
 msgid "That file is too large to be a root CA certificate"
 msgstr "no ha logrado ahorrar"
 
@@ -9351,6 +9432,10 @@ msgstr ""
 #, fuzzy
 msgid "That session has already started"
 msgstr "Impresora ya existe"
+
+#, fuzzy
+msgid "That upload did not arrive intact"
+msgstr "No hay grupos en este servidor."
 
 #, fuzzy
 msgid "That upload is no longer available."
@@ -9457,6 +9542,12 @@ msgid "The breakdowns cover every inventoried machine. The range selects invento
 msgstr ""
 
 msgid "The calling user's preferences."
+msgstr ""
+
+msgid "The certificate is installed and recorded, but the web server would not reload, so it is still serving the previous one. Reload it by hand, or re-run the installer."
+msgstr ""
+
+msgid "The certificate is installed and recorded. Reload the web server for it to be served."
 msgstr ""
 
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
@@ -9774,6 +9865,9 @@ msgstr "No hay grupos en este servidor."
 msgid "There are open slots"
 msgstr "Existen"
 
+msgid "There is a certificate in that directory, but no private key that matches it. Both files are required and they have to be a genuine pair, so FOG is leaving its own certificate in place -- adopting a certificate the web server cannot start with would be the worse outcome."
+msgstr ""
+
 msgid "There is a host in a tasking"
 msgstr "Hay una gran cantidad en una tarea"
 
@@ -9908,6 +10002,9 @@ msgstr ""
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
+msgid "This is the one route that sends a private key through this web application. It is written to disk by root and never kept here, but it does pass through for the length of one request. If the certificate is a wildcard it covers hosts other than this one, so prefer route 1 or 2 where your policy allows."
+msgstr ""
+
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
@@ -9945,6 +10042,12 @@ msgid "This server becomes the platform owner, so Microsoft's published CA certi
 msgstr ""
 
 msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
+msgstr ""
+
+msgid "This server is already serving a certificate managed outside FOG, so FOG will not reissue or re-key it. That is derived from where the certificate actually is, not from a setting."
+msgstr ""
+
+msgid "This server is now serving that certificate, and the web server has been reloaded."
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -10401,7 +10504,13 @@ msgstr "Subir archivo"
 msgid "Upload Reports"
 msgstr "Subir archivo"
 
+msgid "Upload a certificate and its key, or one PKCS#12 file carrying both"
+msgstr ""
+
 msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
+
+msgid "Upload and use it"
 msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -287,6 +287,10 @@ msgstr "1 Stunde"
 msgid "1 Year"
 msgstr "Jährlich"
 
+#, fuzzy
+msgid "1. A certificate already on this server"
+msgstr "Es gibt keine Gruppen auf diesem Server."
+
 msgid "10"
 msgstr ""
 
@@ -305,7 +309,14 @@ msgstr ""
 msgid "2 Minutes"
 msgstr "2 Minuten"
 
+#, fuzzy
+msgid "2. A certificate signing request"
+msgstr "Keine Datei wurde hochgeladen"
+
 msgid "25"
+msgstr ""
+
+msgid "3. Upload a certificate and its key"
 msgstr ""
 
 msgid "30 Days"
@@ -340,12 +351,18 @@ msgstr ""
 msgid "A .tar.gz holding one directory named for the plugin, with config/plugin.config.php inside it."
 msgstr ""
 
+msgid "A CA certificate is refused. Replacing FOG's own root is a migration rather than a setting -- see the Using your own PKI tab."
+msgstr ""
+
 msgid "A FOG username and password."
 msgstr ""
 
 #, fuzzy
 msgid "A LDAP setup already exists with this name!"
 msgstr "Ein LDAP mit diesem Namen ist bereits vorhanden!"
+
+msgid "A PEM certificate with its key, or one PKCS#12 (.p12/.pfx) file carrying both. A full chain is fine -- put the leaf first -- and the intermediates are separated out for you."
+msgstr ""
 
 msgid "A TCP/IP port printer requires an IP address or hostname."
 msgstr ""
@@ -479,6 +496,10 @@ msgstr "Ein Host mit diesem Namen ist bereits vorhanden."
 msgid "A root CA uploaded on this page. Absent unless one was imported."
 msgstr ""
 
+#, php-format
+msgid "A root was supplied alongside it (%s). FOG does not trust a root just because it arrived beside a certificate -- import it deliberately on the External root CA tab, then adopt."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "Ein Gruppenname ist erforderlich!"
@@ -541,6 +562,10 @@ msgstr "Ein Taskstatus mit diesem Namen ist bereits vorhanden!"
 #, fuzzy
 msgid "A task type already exists with this name!"
 msgstr "Ein Task-Typ mit diesem Namen ist bereits vorhanden!"
+
+#, php-format
+msgid "A usable pair is waiting: %s, valid until %s."
+msgstr ""
 
 #, fuzzy
 msgid "A user already exists with this name"
@@ -925,6 +950,10 @@ msgstr "Admingruppe"
 #, fuzzy
 msgid "Administrator (full access)"
 msgstr "Admingruppe"
+
+#, fuzzy
+msgid "Adopt the certificate in that directory"
+msgstr "Erstellen eines Snapin-Jobs fehlgeschlagen"
 
 msgid "Advanced"
 msgstr "Erweitert"
@@ -1641,8 +1670,15 @@ msgid "Certificate download failed"
 msgstr "Download fehlgeschlagen"
 
 #, fuzzy
+msgid "Certificate in use"
+msgstr "Neuen Standort erstellen"
+
+#, fuzzy
 msgid "Certificate management is not configured on this server"
 msgstr "Es gibt keine Images auf diesem Server."
+
+msgid "Certificate, or full chain, leaf first (PEM)"
+msgstr ""
 
 #, fuzzy
 msgid "Certificates"
@@ -2004,11 +2040,19 @@ msgid "Could not send data from file"
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
+msgid "Could not stage the passphrase"
+msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
 msgid "Could not stage the uploaded certificate"
+msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
+msgid "Could not stage the uploaded file"
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
@@ -2569,6 +2613,10 @@ msgstr "Download fehlgeschlagen"
 msgid "Downloaded file is not a bootable kernel image"
 msgstr ""
 
+#, php-format
+msgid "Drop %s and %s into %s and FOG adopts them -- no setting to edit. Add %s as well if your CA issued intermediates. The installer does the same thing on its next run, so this button only saves you the wait."
+msgstr ""
+
 msgid "Dropped"
 msgstr "ausgeworfen"
 
@@ -2937,6 +2985,9 @@ msgstr "sichern möchten, können Sie das mit"
 msgid "FOG is unable to communicate with the database"
 msgstr "FOG kann nicht mit der Datenbank verbinden."
 
+msgid "FOG issues its own web server certificate. If you would rather it served one of yours -- from an ACME client, your corporate CA, or a purchased certificate -- there are three ways to say so, and the first two never send the private key to this web application."
+msgstr ""
+
 msgid "FOG refuses to deploy an image to a host that cannot run it."
 msgstr ""
 
@@ -3265,6 +3316,9 @@ msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
 msgstr ""
 
 msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
+msgstr ""
+
+msgid "For sites whose policy is that a private key never moves. Not on this page yet; FOG already does exactly this for storage node certificates, and the same route for the web certificate is tracked as a follow-up."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4577,6 +4631,9 @@ msgstr "Schnittstelle nicht bereit, warten."
 #, fuzzy
 msgid "Interface throughput"
 msgstr "Schnittstelle"
+
+msgid "Intermediates, if they are in their own file (PEM, optional)"
+msgstr ""
 
 #, fuzzy
 msgid "Invalid"
@@ -6144,6 +6201,9 @@ msgstr ""
 msgid "No token passed to authenticate this host"
 msgstr "Kein valides Image für diesen Host definiert"
 
+msgid "No trust path builds for it yet, so adopting it would be refused. Supply the intermediates, and import the issuing root on the External root CA tab if it is not a public CA."
+msgstr ""
+
 msgid "No type information available for this column."
 msgstr ""
 
@@ -6266,6 +6326,9 @@ msgid "Not syncing Snapin"
 msgstr "Snapin wird nicht synchronisiert"
 
 msgid "Not yet seen"
+msgstr ""
+
+msgid "Nothing is in that directory yet."
 msgstr ""
 
 msgid "Nothing needs it day to day. Restore it only to issue a new intermediate, or a certificate for a new storage node."
@@ -6497,6 +6560,9 @@ msgstr "Operationsfeld nicht gesetzt: %s"
 msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
+msgid "Or one PKCS#12 file carrying all of it (.p12/.pfx)"
+msgstr ""
+
 msgid "Or there was no number defined for joining session"
 msgstr "oder es wurde keine Nummer für die Beitrittssitzung definiert"
 
@@ -6572,6 +6638,9 @@ msgstr "Partclone ZSTD gesplittet 200MiB"
 
 msgid "Partimage"
 msgstr "Partimage"
+
+msgid "Passphrase, if the PKCS#12 file or the key has one"
+msgstr ""
 
 msgid "Password"
 msgstr "Passwort"
@@ -7066,6 +7135,10 @@ msgstr "Drucker aktualisiert!"
 
 msgid "Printers"
 msgstr "Drucker"
+
+#, fuzzy
+msgid "Private key (PEM)"
+msgstr "Privater Schlüssel ist fehlgeschlagen"
 
 msgid "Private key failed"
 msgstr "Privater Schlüssel ist fehlgeschlagen"
@@ -9142,6 +9215,14 @@ msgid "That certificate is not available on this server."
 msgstr "Es gibt keine Gruppen auf diesem Server."
 
 #, fuzzy
+msgid "That certificate was refused"
+msgstr "Keine Datei wurde hochgeladen"
+
+#, fuzzy
+msgid "That file is too large to be a certificate or a key"
+msgstr "konnte nicht gespeichert werden"
+
+#, fuzzy
 msgid "That file is too large to be a root CA certificate"
 msgstr "konnte nicht gespeichert werden"
 
@@ -9179,6 +9260,10 @@ msgstr ""
 #, fuzzy
 msgid "That session has already started"
 msgstr "Dieser Host ist bereits vorhanden."
+
+#, fuzzy
+msgid "That upload did not arrive intact"
+msgstr "Es gibt keine Images auf diesem Server."
 
 #, fuzzy
 msgid "That upload is no longer available."
@@ -9287,6 +9372,12 @@ msgid "The breakdowns cover every inventoried machine. The range selects invento
 msgstr ""
 
 msgid "The calling user's preferences."
+msgstr ""
+
+msgid "The certificate is installed and recorded, but the web server would not reload, so it is still serving the previous one. Reload it by hand, or re-run the installer."
+msgstr ""
+
+msgid "The certificate is installed and recorded. Reload the web server for it to be served."
 msgstr ""
 
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
@@ -9601,6 +9692,9 @@ msgstr "Es gibt keine Snapins auf diesem Server."
 msgid "There are open slots"
 msgstr "Es gibt offene Slots,"
 
+msgid "There is a certificate in that directory, but no private key that matches it. Both files are required and they have to be a genuine pair, so FOG is leaving its own certificate in place -- adopting a certificate the web server cannot start with would be the worse outcome."
+msgstr ""
+
 msgid "There is a host in a tasking"
 msgstr "Es gibt einen Host in einer Aufgabe"
 
@@ -9738,6 +9832,9 @@ msgstr ""
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
+msgid "This is the one route that sends a private key through this web application. It is written to disk by root and never kept here, but it does pass through for the length of one request. If the certificate is a wildcard it covers hosts other than this one, so prefer route 1 or 2 where your policy allows."
+msgstr ""
+
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
@@ -9775,6 +9872,12 @@ msgid "This server becomes the platform owner, so Microsoft's published CA certi
 msgstr ""
 
 msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
+msgstr ""
+
+msgid "This server is already serving a certificate managed outside FOG, so FOG will not reissue or re-key it. That is derived from where the certificate actually is, not from a setting."
+msgstr ""
+
+msgid "This server is now serving that certificate, and the web server has been reloaded."
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -10232,7 +10335,13 @@ msgstr "Berichte hochladen"
 msgid "Upload Reports"
 msgstr "Berichte hochladen"
 
+msgid "Upload a certificate and its key, or one PKCS#12 file carrying both"
+msgstr ""
+
 msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
+
+msgid "Upload and use it"
 msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -293,6 +293,10 @@ msgstr "1 heure"
 msgid "1 Year"
 msgstr "Annuel"
 
+#, fuzzy
+msgid "1. A certificate already on this server"
+msgstr "Il n'y a pas de groupes sur ce serveur."
+
 msgid "10"
 msgstr ""
 
@@ -311,7 +315,14 @@ msgstr ""
 msgid "2 Minutes"
 msgstr "2 minutes"
 
+#, fuzzy
+msgid "2. A certificate signing request"
+msgstr "Aucun fichier a été téléchargé"
+
 msgid "25"
+msgstr ""
+
+msgid "3. Upload a certificate and its key"
 msgstr ""
 
 msgid "30 Days"
@@ -346,12 +357,18 @@ msgstr ""
 msgid "A .tar.gz holding one directory named for the plugin, with config/plugin.config.php inside it."
 msgstr ""
 
+msgid "A CA certificate is refused. Replacing FOG's own root is a migration rather than a setting -- see the Using your own PKI tab."
+msgstr ""
+
 msgid "A FOG username and password."
 msgstr ""
 
 #, fuzzy
 msgid "A LDAP setup already exists with this name!"
 msgstr "Une image existe déjà avec ce nom!"
+
+msgid "A PEM certificate with its key, or one PKCS#12 (.p12/.pfx) file carrying both. A full chain is fine -- put the leaf first -- and the intermediates are separated out for you."
+msgstr ""
 
 msgid "A TCP/IP port printer requires an IP address or hostname."
 msgstr ""
@@ -485,6 +502,10 @@ msgstr "Un nom d'hôte avec ce nom existe déjà."
 msgid "A root CA uploaded on this page. Absent unless one was imported."
 msgstr ""
 
+#, php-format
+msgid "A root was supplied alongside it (%s). FOG does not trust a root just because it arrived beside a certificate -- import it deliberately on the External root CA tab, then adopt."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "Un nom de l'image est nécessaire!"
@@ -547,6 +568,10 @@ msgstr "Une image existe déjà avec ce nom!"
 #, fuzzy
 msgid "A task type already exists with this name!"
 msgstr "Une image existe déjà avec ce nom!"
+
+#, php-format
+msgid "A usable pair is waiting: %s, valid until %s."
+msgstr ""
 
 #, fuzzy
 msgid "A user already exists with this name"
@@ -930,6 +955,10 @@ msgstr "Modifier Groupe"
 #, fuzzy
 msgid "Administrator (full access)"
 msgstr "Modifier Groupe"
+
+#, fuzzy
+msgid "Adopt the certificate in that directory"
+msgstr "Échec de la création d'emploi Snapin"
 
 msgid "Advanced"
 msgstr "Avancée"
@@ -1645,8 +1674,15 @@ msgid "Certificate download failed"
 msgstr "Échec du téléchargement"
 
 #, fuzzy
+msgid "Certificate in use"
+msgstr "Créer un nouveau %s"
+
+#, fuzzy
 msgid "Certificate management is not configured on this server"
 msgstr "Il n'y a pas d'images sur ce serveur."
+
+msgid "Certificate, or full chain, leaf first (PEM)"
+msgstr ""
 
 #, fuzzy
 msgid "Certificates"
@@ -2008,11 +2044,19 @@ msgid "Could not send data from file"
 msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
+msgid "Could not stage the passphrase"
+msgstr "Impossible de lire le fichier tmp."
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
 msgid "Could not stage the uploaded certificate"
+msgstr "Impossible de lire le fichier tmp."
+
+#, fuzzy
+msgid "Could not stage the uploaded file"
 msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
@@ -2573,6 +2617,10 @@ msgstr "Échec du téléchargement"
 msgid "Downloaded file is not a bootable kernel image"
 msgstr ""
 
+#, php-format
+msgid "Drop %s and %s into %s and FOG adopts them -- no setting to edit. Add %s as well if your CA issued intermediates. The installer does the same thing on its next run, so this button only saves you the wait."
+msgstr ""
+
 msgid "Dropped"
 msgstr "Chuté"
 
@@ -2940,6 +2988,9 @@ msgstr ""
 msgid "FOG is unable to communicate with the database"
 msgstr ""
 
+msgid "FOG issues its own web server certificate. If you would rather it served one of yours -- from an ACME client, your corporate CA, or a purchased certificate -- there are three ways to say so, and the first two never send the private key to this web application."
+msgstr ""
+
 msgid "FOG refuses to deploy an image to a host that cannot run it."
 msgstr ""
 
@@ -3268,6 +3319,9 @@ msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
 msgstr ""
 
 msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
+msgstr ""
+
+msgid "For sites whose policy is that a private key never moves. Not on this page yet; FOG already does exactly this for storage node certificates, and the same route for the web certificate is tracked as a follow-up."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4579,6 +4633,9 @@ msgstr ""
 #, fuzzy
 msgid "Interface throughput"
 msgstr "Interface"
+
+msgid "Intermediates, if they are in their own file (PEM, optional)"
+msgstr ""
 
 #, fuzzy
 msgid "Invalid"
@@ -6142,6 +6199,9 @@ msgstr ""
 msgid "No token passed to authenticate this host"
 msgstr "Pas d'image définie pour cet hôte"
 
+msgid "No trust path builds for it yet, so adopting it would be refused. Supply the intermediates, and import the issuing root on the External root CA tab if it is not a public CA."
+msgstr ""
+
 msgid "No type information available for this column."
 msgstr ""
 
@@ -6263,6 +6323,9 @@ msgid "Not syncing Snapin"
 msgstr "Pas de connexion pour obtenir SnapIn"
 
 msgid "Not yet seen"
+msgstr ""
+
+msgid "Nothing is in that directory yet."
 msgstr ""
 
 msgid "Nothing needs it day to day. Restore it only to issue a new intermediate, or a certificate for a new storage node."
@@ -6494,6 +6557,9 @@ msgstr "Opération pas définie: %s"
 msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
+msgid "Or one PKCS#12 file carrying all of it (.p12/.pfx)"
+msgstr ""
+
 msgid "Or there was no number defined for joining session"
 msgstr ""
 
@@ -6569,6 +6635,9 @@ msgstr "partclone"
 
 msgid "Partimage"
 msgstr "Partimage"
+
+msgid "Passphrase, if the PKCS#12 file or the key has one"
+msgstr ""
 
 msgid "Password"
 msgstr "Mot de passe"
@@ -7063,6 +7132,10 @@ msgstr "Imprimante mis à jour!"
 
 msgid "Printers"
 msgstr "Imprimantes"
+
+#, fuzzy
+msgid "Private key (PEM)"
+msgstr "La clé privée a échoué"
 
 msgid "Private key failed"
 msgstr "La clé privée a échoué"
@@ -9135,6 +9208,14 @@ msgid "That certificate is not available on this server."
 msgstr "Il n'y a pas de groupes sur ce serveur."
 
 #, fuzzy
+msgid "That certificate was refused"
+msgstr "Aucun fichier a été téléchargé"
+
+#, fuzzy
+msgid "That file is too large to be a certificate or a key"
+msgstr "n'a pas réussi à sauver"
+
+#, fuzzy
 msgid "That file is too large to be a root CA certificate"
 msgstr "n'a pas réussi à sauver"
 
@@ -9172,6 +9253,10 @@ msgstr ""
 #, fuzzy
 msgid "That session has already started"
 msgstr "Imprimante existe déjà"
+
+#, fuzzy
+msgid "That upload did not arrive intact"
+msgstr "Il n'y a pas d'images sur ce serveur."
 
 #, fuzzy
 msgid "That upload is no longer available."
@@ -9280,6 +9365,12 @@ msgid "The breakdowns cover every inventoried machine. The range selects invento
 msgstr ""
 
 msgid "The calling user's preferences."
+msgstr ""
+
+msgid "The certificate is installed and recorded, but the web server would not reload, so it is still serving the previous one. Reload it by hand, or re-run the installer."
+msgstr ""
+
+msgid "The certificate is installed and recorded. Reload the web server for it to be served."
 msgstr ""
 
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
@@ -9594,6 +9685,9 @@ msgstr "Il n'y a pas snapins sur ce serveur."
 msgid "There are open slots"
 msgstr "Il y a des fentes ouvertes, mais"
 
+msgid "There is a certificate in that directory, but no private key that matches it. Both files are required and they have to be a genuine pair, so FOG is leaving its own certificate in place -- adopting a certificate the web server cannot start with would be the worse outcome."
+msgstr ""
+
 msgid "There is a host in a tasking"
 msgstr "Il y a une foule dans un tasking"
 
@@ -9730,6 +9824,9 @@ msgstr ""
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
+msgid "This is the one route that sends a private key through this web application. It is written to disk by root and never kept here, but it does pass through for the length of one request. If the certificate is a wildcard it covers hosts other than this one, so prefer route 1 or 2 where your policy allows."
+msgstr ""
+
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
@@ -9767,6 +9864,12 @@ msgid "This server becomes the platform owner, so Microsoft's published CA certi
 msgstr ""
 
 msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
+msgstr ""
+
+msgid "This server is already serving a certificate managed outside FOG, so FOG will not reissue or re-key it. That is derived from where the certificate actually is, not from a setting."
+msgstr ""
+
+msgid "This server is now serving that certificate, and the web server has been reloaded."
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -10225,7 +10328,13 @@ msgstr "Télécharger Rapports"
 msgid "Upload Reports"
 msgstr "Télécharger Rapports"
 
+msgid "Upload a certificate and its key, or one PKCS#12 file carrying both"
+msgstr ""
+
 msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
+
+msgid "Upload and use it"
 msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -291,6 +291,10 @@ msgstr "1 ora"
 msgid "1 Year"
 msgstr "Annuale"
 
+#, fuzzy
+msgid "1. A certificate already on this server"
+msgstr "Non ci sono gruppi su questo server"
+
 msgid "10"
 msgstr ""
 
@@ -309,7 +313,14 @@ msgstr ""
 msgid "2 Minutes"
 msgstr "2 minuti"
 
+#, fuzzy
+msgid "2. A certificate signing request"
+msgstr "Nessun file è stato caricato"
+
 msgid "25"
+msgstr ""
+
+msgid "3. Upload a certificate and its key"
 msgstr ""
 
 msgid "30 Days"
@@ -344,11 +355,17 @@ msgstr ""
 msgid "A .tar.gz holding one directory named for the plugin, with config/plugin.config.php inside it."
 msgstr ""
 
+msgid "A CA certificate is refused. Replacing FOG's own root is a migration rather than a setting -- see the Using your own PKI tab."
+msgstr ""
+
 msgid "A FOG username and password."
 msgstr ""
 
 msgid "A LDAP setup already exists with this name!"
 msgstr "Un'impostazione LDAP esiste già con questo nome!"
+
+msgid "A PEM certificate with its key, or one PKCS#12 (.p12/.pfx) file carrying both. A full chain is fine -- put the leaf first -- and the intermediates are separated out for you."
+msgstr ""
 
 msgid "A TCP/IP port printer requires an IP address or hostname."
 msgstr ""
@@ -475,6 +492,10 @@ msgstr "Un nome host con questo nome esiste già"
 msgid "A root CA uploaded on this page. Absent unless one was imported."
 msgstr ""
 
+#, php-format
+msgid "A root was supplied alongside it (%s). FOG does not trust a root just because it arrived beside a certificate -- import it deliberately on the External root CA tab, then adopt."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "È richiesto un nome di gruppo!"
@@ -534,6 +555,10 @@ msgstr "Uno stato di attività già esiste con questo nome!"
 
 msgid "A task type already exists with this name!"
 msgstr "Un tipo di attività esiste già con questo nome!"
+
+#, php-format
+msgid "A usable pair is waiting: %s, valid until %s."
+msgstr ""
 
 msgid "A user already exists with this name"
 msgstr "Esiste già un utente con questo nome!"
@@ -903,6 +928,10 @@ msgstr "Gruppo amministrativo"
 #, fuzzy
 msgid "Administrator (full access)"
 msgstr "Gruppo amministrativo"
+
+#, fuzzy
+msgid "Adopt the certificate in that directory"
+msgstr "Impossibile creare Snapin lavoro"
 
 msgid "Advanced"
 msgstr "Avanzate"
@@ -1601,8 +1630,15 @@ msgid "Certificate download failed"
 msgstr "Scaricamento fallito"
 
 #, fuzzy
+msgid "Certificate in use"
+msgstr "Crea nuova posizione"
+
+#, fuzzy
 msgid "Certificate management is not configured on this server"
 msgstr "Non ci sono immagini su questo server"
+
+msgid "Certificate, or full chain, leaf first (PEM)"
+msgstr ""
 
 #, fuzzy
 msgid "Certificates"
@@ -1948,11 +1984,19 @@ msgid "Could not send data from file"
 msgstr "Impossibile leggere il file tmp."
 
 #, fuzzy
+msgid "Could not stage the passphrase"
+msgstr "Impossibile leggere il file tmp."
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "Impossibile leggere il file tmp."
 
 #, fuzzy
 msgid "Could not stage the uploaded certificate"
+msgstr "Impossibile leggere il file tmp."
+
+#, fuzzy
+msgid "Could not stage the uploaded file"
 msgstr "Impossibile leggere il file tmp."
 
 #, fuzzy
@@ -2505,6 +2549,10 @@ msgstr "Scaricamento fallito"
 msgid "Downloaded file is not a bootable kernel image"
 msgstr ""
 
+#, php-format
+msgid "Drop %s and %s into %s and FOG adopts them -- no setting to edit. Add %s as well if your CA issued intermediates. The installer does the same thing on its next run, so this button only saves you the wait."
+msgstr ""
+
 msgid "Dropped"
 msgstr "Dropped"
 
@@ -2866,6 +2914,9 @@ msgstr "FOG database è possibile farlo utilizzando"
 msgid "FOG is unable to communicate with the database"
 msgstr "FOG non è in grado di comunicare con il database"
 
+msgid "FOG issues its own web server certificate. If you would rather it served one of yours -- from an ACME client, your corporate CA, or a purchased certificate -- there are three ways to say so, and the first two never send the private key to this web application."
+msgstr ""
+
 msgid "FOG refuses to deploy an image to a host that cannot run it."
 msgstr ""
 
@@ -3185,6 +3236,9 @@ msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
 msgstr ""
 
 msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
+msgstr ""
+
+msgid "For sites whose policy is that a private key never moves. Not on this page yet; FOG already does exactly this for storage node certificates, and the same route for the web certificate is tracked as a follow-up."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4452,6 +4506,9 @@ msgstr "Interfaccia non pronta, in attesa che venga visualizzata"
 #, fuzzy
 msgid "Interface throughput"
 msgstr "Interfaccia"
+
+msgid "Intermediates, if they are in their own file (PEM, optional)"
+msgstr ""
 
 msgid "Invalid"
 msgstr "Non valido"
@@ -5962,6 +6019,9 @@ msgstr ""
 msgid "No token passed to authenticate this host"
 msgstr "Nessuna Imagine valida definita per questo host"
 
+msgid "No trust path builds for it yet, so adopting it would be refused. Supply the intermediates, and import the issuing root on the External root CA tab if it is not a public CA."
+msgstr ""
+
 msgid "No type information available for this column."
 msgstr ""
 
@@ -6078,6 +6138,9 @@ msgid "Not syncing Snapin"
 msgstr "Non sincronizzazione gli Snapin"
 
 msgid "Not yet seen"
+msgstr ""
+
+msgid "Nothing is in that directory yet."
 msgstr ""
 
 msgid "Nothing needs it day to day. Restore it only to issue a new intermediate, or a certificate for a new storage node."
@@ -6305,6 +6368,9 @@ msgstr "Campo operazione non impostato"
 msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
+msgid "Or one PKCS#12 file carrying all of it (.p12/.pfx)"
+msgstr ""
+
 msgid "Or there was no number defined for joining session"
 msgstr "Oppure non è stato definito alcun numero per l'accesso alla sessione"
 
@@ -6376,6 +6442,9 @@ msgstr "Partclone zstd diviso per 200MiB"
 
 msgid "Partimage"
 msgstr "partimage"
+
+msgid "Passphrase, if the PKCS#12 file or the key has one"
+msgstr ""
 
 msgid "Password"
 msgstr "parola d'ordine"
@@ -6856,6 +6925,10 @@ msgstr "aggiornato stampante!"
 
 msgid "Printers"
 msgstr "Stampanti"
+
+#, fuzzy
+msgid "Private key (PEM)"
+msgstr "Chiave privata non è riuscita"
 
 msgid "Private key failed"
 msgstr "Chiave privata non è riuscita"
@@ -8857,6 +8930,14 @@ msgid "That certificate is not available on this server."
 msgstr "Non ci sono gruppi su questo server"
 
 #, fuzzy
+msgid "That certificate was refused"
+msgstr "Nessun file è stato caricato"
+
+#, fuzzy
+msgid "That file is too large to be a certificate or a key"
+msgstr "fallito il salvataggio"
+
+#, fuzzy
 msgid "That file is too large to be a root CA certificate"
 msgstr "fallito il salvataggio"
 
@@ -8894,6 +8975,10 @@ msgstr ""
 #, fuzzy
 msgid "That session has already started"
 msgstr "Questo host esiste già"
+
+#, fuzzy
+msgid "That upload did not arrive intact"
+msgstr "Non ci sono immagini su questo server"
 
 #, fuzzy
 msgid "That upload is no longer available."
@@ -9001,6 +9086,12 @@ msgid "The breakdowns cover every inventoried machine. The range selects invento
 msgstr ""
 
 msgid "The calling user's preferences."
+msgstr ""
+
+msgid "The certificate is installed and recorded, but the web server would not reload, so it is still serving the previous one. Reload it by hand, or re-run the installer."
+msgstr ""
+
+msgid "The certificate is installed and recorded. Reload the web server for it to be served."
 msgstr ""
 
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
@@ -9310,6 +9401,9 @@ msgstr "Non ci sono snapins su questo server"
 msgid "There are open slots"
 msgstr "Ci sono slot aperti"
 
+msgid "There is a certificate in that directory, but no private key that matches it. Both files are required and they have to be a genuine pair, so FOG is leaving its own certificate in place -- adopting a certificate the web server cannot start with would be the worse outcome."
+msgstr ""
+
 msgid "There is a host in a tasking"
 msgstr "C'è un host con un compito"
 
@@ -9445,6 +9539,9 @@ msgstr ""
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
+msgid "This is the one route that sends a private key through this web application. It is written to disk by root and never kept here, but it does pass through for the length of one request. If the certificate is a wildcard it covers hosts other than this one, so prefer route 1 or 2 where your policy allows."
+msgstr ""
+
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
@@ -9482,6 +9579,12 @@ msgid "This server becomes the platform owner, so Microsoft's published CA certi
 msgstr ""
 
 msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
+msgstr ""
+
+msgid "This server is already serving a certificate managed outside FOG, so FOG will not reissue or re-key it. That is derived from where the certificate actually is, not from a setting."
+msgstr ""
+
+msgid "This server is now serving that certificate, and the web server has been reloaded."
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9928,7 +10031,13 @@ msgstr "Carica Report"
 msgid "Upload Reports"
 msgstr "Carica Report"
 
+msgid "Upload a certificate and its key, or one PKCS#12 file carrying both"
+msgstr ""
+
 msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
+
+msgid "Upload and use it"
 msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -283,6 +283,10 @@ msgstr "1時間"
 msgid "1 Year"
 msgstr "年単位"
 
+#, fuzzy
+msgid "1. A certificate already on this server"
+msgstr "このサーバーにはグループがありません"
+
 msgid "10"
 msgstr ""
 
@@ -301,7 +305,14 @@ msgstr ""
 msgid "2 Minutes"
 msgstr "2分"
 
+#, fuzzy
+msgid "2. A certificate signing request"
+msgstr "ファイルはアップロードされませんでした"
+
 msgid "25"
+msgstr ""
+
+msgid "3. Upload a certificate and its key"
 msgstr ""
 
 msgid "30 Days"
@@ -336,11 +347,17 @@ msgstr ""
 msgid "A .tar.gz holding one directory named for the plugin, with config/plugin.config.php inside it."
 msgstr ""
 
+msgid "A CA certificate is refused. Replacing FOG's own root is a migration rather than a setting -- see the Using your own PKI tab."
+msgstr ""
+
 msgid "A FOG username and password."
 msgstr ""
 
 msgid "A LDAP setup already exists with this name!"
 msgstr "この名前の LDAP 設定は既に存在します！"
+
+msgid "A PEM certificate with its key, or one PKCS#12 (.p12/.pfx) file carrying both. A full chain is fine -- put the leaf first -- and the intermediates are separated out for you."
+msgstr ""
 
 msgid "A TCP/IP port printer requires an IP address or hostname."
 msgstr ""
@@ -464,6 +481,10 @@ msgstr "その名前のホストは既に存在します"
 msgid "A root CA uploaded on this page. Absent unless one was imported."
 msgstr ""
 
+#, php-format
+msgid "A root was supplied alongside it (%s). FOG does not trust a root just because it arrived beside a certificate -- import it deliberately on the External root CA tab, then adopt."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "名前は必須です！"
@@ -520,6 +541,10 @@ msgstr "この名前のタスク状態は既に存在します！"
 
 msgid "A task type already exists with this name!"
 msgstr "この名前のタスクタイプは既に存在します！"
+
+#, php-format
+msgid "A usable pair is waiting: %s, valid until %s."
+msgstr ""
 
 msgid "A user already exists with this name"
 msgstr "この名前のユーザーは既に存在します"
@@ -884,6 +909,10 @@ msgstr ""
 
 msgid "Administrator (full access)"
 msgstr ""
+
+#, fuzzy
+msgid "Adopt the certificate in that directory"
+msgstr "スナップインジョブの作成に失敗しました"
 
 msgid "Advanced"
 msgstr "詳細"
@@ -1584,8 +1613,15 @@ msgid "Certificate download failed"
 msgstr "ダウンロードに失敗しました"
 
 #, fuzzy
+msgid "Certificate in use"
+msgstr "新しいロケーションを作成"
+
+#, fuzzy
 msgid "Certificate management is not configured on this server"
 msgstr "このサーバーにはグループがありません"
+
+msgid "Certificate, or full chain, leaf first (PEM)"
+msgstr ""
 
 #, fuzzy
 msgid "Certificates"
@@ -1932,11 +1968,19 @@ msgid "Could not send data from file"
 msgstr "一時ファイルを読み取れませんでした。"
 
 #, fuzzy
+msgid "Could not stage the passphrase"
+msgstr "一時ファイルを読み取れませんでした。"
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "一時ファイルを読み取れませんでした。"
 
 #, fuzzy
 msgid "Could not stage the uploaded certificate"
+msgstr "一時ファイルを読み取れませんでした。"
+
+#, fuzzy
+msgid "Could not stage the uploaded file"
 msgstr "一時ファイルを読み取れませんでした。"
 
 #, fuzzy
@@ -2490,6 +2534,10 @@ msgstr "ダウンロードに失敗しました"
 msgid "Downloaded file is not a bootable kernel image"
 msgstr ""
 
+#, php-format
+msgid "Drop %s and %s into %s and FOG adopts them -- no setting to edit. Add %s as well if your CA issued intermediates. The installer does the same thing on its next run, so this button only saves you the wait."
+msgstr ""
+
 msgid "Dropped"
 msgstr "切断済み"
 
@@ -2848,6 +2896,9 @@ msgstr "FOG データベースは、次を使用して操作できます"
 msgid "FOG is unable to communicate with the database"
 msgstr "FOG はデータベースと通信できません"
 
+msgid "FOG issues its own web server certificate. If you would rather it served one of yours -- from an ACME client, your corporate CA, or a purchased certificate -- there are three ways to say so, and the first two never send the private key to this web application."
+msgstr ""
+
 msgid "FOG refuses to deploy an image to a host that cannot run it."
 msgstr ""
 
@@ -3161,6 +3212,9 @@ msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
 msgstr ""
 
 msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
+msgstr ""
+
+msgid "For sites whose policy is that a private key never moves. Not on this page yet; FOG already does exactly this for storage node certificates, and the same route for the web certificate is tracked as a follow-up."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4418,6 +4472,9 @@ msgstr "インターフェイスの準備ができていません。起動を待
 #, fuzzy
 msgid "Interface throughput"
 msgstr "インターフェイス"
+
+msgid "Intermediates, if they are in their own file (PEM, optional)"
+msgstr ""
 
 msgid "Invalid"
 msgstr "無効"
@@ -5927,6 +5984,9 @@ msgstr ""
 msgid "No token passed to authenticate this host"
 msgstr "このホストを認証するためのトークンが渡されていません"
 
+msgid "No trust path builds for it yet, so adopting it would be refused. Supply the intermediates, and import the issuing root on the External root CA tab if it is not a public CA."
+msgstr ""
+
 #, fuzzy
 msgid "No type information available for this column."
 msgstr "このグループで利用可能なアクティビティ情報はありません"
@@ -6045,6 +6105,9 @@ msgstr "スナップインを同期していません"
 #, fuzzy
 msgid "Not yet seen"
 msgstr "未設定"
+
+msgid "Nothing is in that directory yet."
+msgstr ""
 
 msgid "Nothing needs it day to day. Restore it only to issue a new intermediate, or a certificate for a new storage node."
 msgstr ""
@@ -6274,6 +6337,9 @@ msgstr "操作フィールドが設定されていません"
 msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
+msgid "Or one PKCS#12 file carrying all of it (.p12/.pfx)"
+msgstr ""
+
 msgid "Or there was no number defined for joining session"
 msgstr "または、参加するセッション番号が指定されていません"
 
@@ -6346,6 +6412,9 @@ msgstr "Partclone Zstd Split 200MiB"
 
 msgid "Partimage"
 msgstr "Partimage"
+
+msgid "Passphrase, if the PKCS#12 file or the key has one"
+msgstr ""
 
 msgid "Password"
 msgstr "パスワード"
@@ -6827,6 +6896,10 @@ msgstr "プリンターを更新しました！"
 
 msgid "Printers"
 msgstr "プリンター"
+
+#, fuzzy
+msgid "Private key (PEM)"
+msgstr "秘密鍵の処理に失敗しました"
 
 msgid "Private key failed"
 msgstr "秘密鍵の処理に失敗しました"
@@ -8801,6 +8874,14 @@ msgid "That certificate is not available on this server."
 msgstr "このサーバーにはグループがありません"
 
 #, fuzzy
+msgid "That certificate was refused"
+msgstr "ファイルはアップロードされませんでした"
+
+#, fuzzy
+msgid "That file is too large to be a certificate or a key"
+msgstr "保存に失敗しました"
+
+#, fuzzy
 msgid "That file is too large to be a root CA certificate"
 msgstr "保存に失敗しました"
 
@@ -8838,6 +8919,10 @@ msgstr ""
 #, fuzzy
 msgid "That session has already started"
 msgstr "このホストは既に存在します"
+
+#, fuzzy
+msgid "That upload did not arrive intact"
+msgstr "このサーバーにはイメージがありません"
 
 #, fuzzy
 msgid "That upload is no longer available."
@@ -8945,6 +9030,12 @@ msgid "The breakdowns cover every inventoried machine. The range selects invento
 msgstr ""
 
 msgid "The calling user's preferences."
+msgstr ""
+
+msgid "The certificate is installed and recorded, but the web server would not reload, so it is still serving the previous one. Reload it by hand, or re-run the installer."
+msgstr ""
+
+msgid "The certificate is installed and recorded. Reload the web server for it to be served."
 msgstr ""
 
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
@@ -9256,6 +9347,9 @@ msgstr "このサーバーにはスナップインがありません"
 msgid "There are open slots"
 msgstr "空きスロットがあります"
 
+msgid "There is a certificate in that directory, but no private key that matches it. Both files are required and they have to be a genuine pair, so FOG is leaving its own certificate in place -- adopting a certificate the web server cannot start with would be the worse outcome."
+msgstr ""
+
 msgid "There is a host in a tasking"
 msgstr "タスク実行中のホストがあります"
 
@@ -9390,6 +9484,9 @@ msgstr ""
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
+msgid "This is the one route that sends a private key through this web application. It is written to disk by root and never kept here, but it does pass through for the length of one request. If the certificate is a wildcard it covers hosts other than this one, so prefer route 1 or 2 where your policy allows."
+msgstr ""
+
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
@@ -9427,6 +9524,12 @@ msgid "This server becomes the platform owner, so Microsoft's published CA certi
 msgstr ""
 
 msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
+msgstr ""
+
+msgid "This server is already serving a certificate managed outside FOG, so FOG will not reissue or re-key it. That is derived from where the certificate actually is, not from a setting."
+msgstr ""
+
+msgid "This server is now serving that certificate, and the web server has been reloaded."
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -9871,7 +9974,13 @@ msgstr "レポートをアップロード"
 msgid "Upload Reports"
 msgstr "レポートをアップロード"
 
+msgid "Upload a certificate and its key, or one PKCS#12 file carrying both"
+msgstr ""
+
 msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
+
+msgid "Upload and use it"
 msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -266,6 +266,9 @@ msgstr ""
 msgid "1 Year"
 msgstr ""
 
+msgid "1. A certificate already on this server"
+msgstr ""
+
 msgid "10"
 msgstr ""
 
@@ -284,7 +287,13 @@ msgstr ""
 msgid "2 Minutes"
 msgstr ""
 
+msgid "2. A certificate signing request"
+msgstr ""
+
 msgid "25"
+msgstr ""
+
+msgid "3. Upload a certificate and its key"
 msgstr ""
 
 msgid "30 Days"
@@ -317,10 +326,16 @@ msgstr ""
 msgid "A .tar.gz holding one directory named for the plugin, with config/plugin.config.php inside it."
 msgstr ""
 
+msgid "A CA certificate is refused. Replacing FOG's own root is a migration rather than a setting -- see the Using your own PKI tab."
+msgstr ""
+
 msgid "A FOG username and password."
 msgstr ""
 
 msgid "A LDAP setup already exists with this name!"
+msgstr ""
+
+msgid "A PEM certificate with its key, or one PKCS#12 (.p12/.pfx) file carrying both. A full chain is fine -- put the leaf first -- and the intermediates are separated out for you."
 msgstr ""
 
 msgid "A TCP/IP port printer requires an IP address or hostname."
@@ -431,6 +446,10 @@ msgstr ""
 msgid "A root CA uploaded on this page. Absent unless one was imported."
 msgstr ""
 
+#, php-format
+msgid "A root was supplied alongside it (%s). FOG does not trust a root just because it arrived beside a certificate -- import it deliberately on the External root CA tab, then adopt."
+msgstr ""
+
 msgid "A scheduled time is required"
 msgstr ""
 
@@ -480,6 +499,10 @@ msgid "A task state already exists with this name!"
 msgstr ""
 
 msgid "A task type already exists with this name!"
+msgstr ""
+
+#, php-format
+msgid "A usable pair is waiting: %s, valid until %s."
 msgstr ""
 
 msgid "A user already exists with this name"
@@ -797,6 +820,9 @@ msgid "Administrator"
 msgstr ""
 
 msgid "Administrator (full access)"
+msgstr ""
+
+msgid "Adopt the certificate in that directory"
 msgstr ""
 
 msgid "Advanced"
@@ -1414,7 +1440,13 @@ msgstr ""
 msgid "Certificate download failed"
 msgstr ""
 
+msgid "Certificate in use"
+msgstr ""
+
 msgid "Certificate management is not configured on this server"
+msgstr ""
+
+msgid "Certificate, or full chain, leaf first (PEM)"
 msgstr ""
 
 msgid "Certificates"
@@ -1726,10 +1758,16 @@ msgstr ""
 msgid "Could not send data from file"
 msgstr ""
 
+msgid "Could not stage the passphrase"
+msgstr ""
+
 msgid "Could not stage the upload."
 msgstr ""
 
 msgid "Could not stage the uploaded certificate"
+msgstr ""
+
+msgid "Could not stage the uploaded file"
 msgstr ""
 
 msgid "Could not update host"
@@ -2210,6 +2248,10 @@ msgstr ""
 msgid "Downloaded file is not a bootable kernel image"
 msgstr ""
 
+#, php-format
+msgid "Drop %s and %s into %s and FOG adopts them -- no setting to edit. Add %s as well if your CA issued intermediates. The installer does the same thing on its next run, so this button only saves you the wait."
+msgstr ""
+
 msgid "Dropped"
 msgstr ""
 
@@ -2537,6 +2579,9 @@ msgstr ""
 msgid "FOG is unable to communicate with the database"
 msgstr ""
 
+msgid "FOG issues its own web server certificate. If you would rather it served one of yours -- from an ACME client, your corporate CA, or a purchased certificate -- there are three ways to say so, and the first two never send the private key to this web application."
+msgstr ""
+
 msgid "FOG refuses to deploy an image to a host that cannot run it."
 msgstr ""
 
@@ -2814,6 +2859,9 @@ msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
 msgstr ""
 
 msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
+msgstr ""
+
+msgid "For sites whose policy is that a private key never moves. Not on this page yet; FOG already does exactly this for storage node certificates, and the same route for the web certificate is tracked as a follow-up."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -3914,6 +3962,9 @@ msgid "Interface not ready, waiting for it to come up"
 msgstr ""
 
 msgid "Interface throughput"
+msgstr ""
+
+msgid "Intermediates, if they are in their own file (PEM, optional)"
 msgstr ""
 
 msgid "Invalid"
@@ -5248,6 +5299,9 @@ msgstr ""
 msgid "No token passed to authenticate this host"
 msgstr ""
 
+msgid "No trust path builds for it yet, so adopting it would be refused. Supply the intermediates, and import the issuing root on the External root CA tab if it is not a public CA."
+msgstr ""
+
 msgid "No type information available for this column."
 msgstr ""
 
@@ -5354,6 +5408,9 @@ msgid "Not syncing Snapin"
 msgstr ""
 
 msgid "Not yet seen"
+msgstr ""
+
+msgid "Nothing is in that directory yet."
 msgstr ""
 
 msgid "Nothing needs it day to day. Restore it only to issue a new intermediate, or a certificate for a new storage node."
@@ -5556,6 +5613,9 @@ msgstr ""
 msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
+msgid "Or one PKCS#12 file carrying all of it (.p12/.pfx)"
+msgstr ""
+
 msgid "Or there was no number defined for joining session"
 msgstr ""
 
@@ -5623,6 +5683,9 @@ msgid "Partclone Zstd Split 200MiB"
 msgstr ""
 
 msgid "Partimage"
+msgstr ""
+
+msgid "Passphrase, if the PKCS#12 file or the key has one"
 msgstr ""
 
 msgid "Password"
@@ -6042,6 +6105,9 @@ msgid "Printer updated!"
 msgstr ""
 
 msgid "Printers"
+msgstr ""
+
+msgid "Private key (PEM)"
 msgstr ""
 
 msgid "Private key failed"
@@ -7794,6 +7860,12 @@ msgstr ""
 msgid "That certificate is not available on this server."
 msgstr ""
 
+msgid "That certificate was refused"
+msgstr ""
+
+msgid "That file is too large to be a certificate or a key"
+msgstr ""
+
 msgid "That file is too large to be a root CA certificate"
 msgstr ""
 
@@ -7825,6 +7897,9 @@ msgid "That name is too long"
 msgstr ""
 
 msgid "That session has already started"
+msgstr ""
+
+msgid "That upload did not arrive intact"
 msgstr ""
 
 msgid "That upload is no longer available."
@@ -7925,6 +8000,12 @@ msgid "The breakdowns cover every inventoried machine. The range selects invento
 msgstr ""
 
 msgid "The calling user's preferences."
+msgstr ""
+
+msgid "The certificate is installed and recorded, but the web server would not reload, so it is still serving the previous one. Reload it by hand, or re-run the installer."
+msgstr ""
+
+msgid "The certificate is installed and recorded. Reload the web server for it to be served."
 msgstr ""
 
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
@@ -8214,6 +8295,9 @@ msgstr ""
 msgid "There are open slots"
 msgstr ""
 
+msgid "There is a certificate in that directory, but no private key that matches it. Both files are required and they have to be a genuine pair, so FOG is leaving its own certificate in place -- adopting a certificate the web server cannot start with would be the worse outcome."
+msgstr ""
+
 msgid "There is a host in a tasking"
 msgstr ""
 
@@ -8346,6 +8430,9 @@ msgstr ""
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
+msgid "This is the one route that sends a private key through this web application. It is written to disk by root and never kept here, but it does pass through for the length of one request. If the certificate is a wildcard it covers hosts other than this one, so prefer route 1 or 2 where your policy allows."
+msgstr ""
+
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
@@ -8381,6 +8468,12 @@ msgid "This server becomes the platform owner, so Microsoft's published CA certi
 msgstr ""
 
 msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
+msgstr ""
+
+msgid "This server is already serving a certificate managed outside FOG, so FOG will not reissue or re-key it. That is derived from where the certificate actually is, not from a setting."
+msgstr ""
+
+msgid "This server is now serving that certificate, and the web server has been reloaded."
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -8776,7 +8869,13 @@ msgstr ""
 msgid "Upload Reports"
 msgstr ""
 
+msgid "Upload a certificate and its key, or one PKCS#12 file carrying both"
+msgstr ""
+
 msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
+
+msgid "Upload and use it"
 msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -292,6 +292,10 @@ msgstr "1 hora"
 msgid "1 Year"
 msgstr "Anual"
 
+#, fuzzy
+msgid "1. A certificate already on this server"
+msgstr "Não existem grupos neste servidor."
+
 msgid "10"
 msgstr ""
 
@@ -310,7 +314,14 @@ msgstr ""
 msgid "2 Minutes"
 msgstr "2 minutos"
 
+#, fuzzy
+msgid "2. A certificate signing request"
+msgstr "Nenhum arquivo foi transferido"
+
 msgid "25"
+msgstr ""
+
+msgid "3. Upload a certificate and its key"
 msgstr ""
 
 msgid "30 Days"
@@ -345,12 +356,18 @@ msgstr ""
 msgid "A .tar.gz holding one directory named for the plugin, with config/plugin.config.php inside it."
 msgstr ""
 
+msgid "A CA certificate is refused. Replacing FOG's own root is a migration rather than a setting -- see the Using your own PKI tab."
+msgstr ""
+
 msgid "A FOG username and password."
 msgstr ""
 
 #, fuzzy
 msgid "A LDAP setup already exists with this name!"
 msgstr "Uma imagem já existe com este nome!"
+
+msgid "A PEM certificate with its key, or one PKCS#12 (.p12/.pfx) file carrying both. A full chain is fine -- put the leaf first -- and the intermediates are separated out for you."
+msgstr ""
 
 msgid "A TCP/IP port printer requires an IP address or hostname."
 msgstr ""
@@ -484,6 +501,10 @@ msgstr "Um nome de host com esse nome já existe."
 msgid "A root CA uploaded on this page. Absent unless one was imported."
 msgstr ""
 
+#, php-format
+msgid "A root was supplied alongside it (%s). FOG does not trust a root just because it arrived beside a certificate -- import it deliberately on the External root CA tab, then adopt."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "Um nome de imagem é necessário!"
@@ -546,6 +567,10 @@ msgstr "Uma imagem já existe com este nome!"
 #, fuzzy
 msgid "A task type already exists with this name!"
 msgstr "Uma imagem já existe com este nome!"
+
+#, php-format
+msgid "A usable pair is waiting: %s, valid until %s."
+msgstr ""
 
 #, fuzzy
 msgid "A user already exists with this name"
@@ -929,6 +954,10 @@ msgstr "modificar Grupo"
 #, fuzzy
 msgid "Administrator (full access)"
 msgstr "modificar Grupo"
+
+#, fuzzy
+msgid "Adopt the certificate in that directory"
+msgstr "Falha ao criar Snapin Job"
 
 msgid "Advanced"
 msgstr "avançado"
@@ -1644,8 +1673,15 @@ msgid "Certificate download failed"
 msgstr "Falha no download"
 
 #, fuzzy
+msgid "Certificate in use"
+msgstr "Criar novo %s"
+
+#, fuzzy
 msgid "Certificate management is not configured on this server"
 msgstr "Não há imagens neste servidor."
+
+msgid "Certificate, or full chain, leaf first (PEM)"
+msgstr ""
 
 #, fuzzy
 msgid "Certificates"
@@ -2007,11 +2043,19 @@ msgid "Could not send data from file"
 msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
+msgid "Could not stage the passphrase"
+msgstr "Não foi possível ler o arquivo tmp."
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
 msgid "Could not stage the uploaded certificate"
+msgstr "Não foi possível ler o arquivo tmp."
+
+#, fuzzy
+msgid "Could not stage the uploaded file"
 msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
@@ -2572,6 +2616,10 @@ msgstr "Falha no download"
 msgid "Downloaded file is not a bootable kernel image"
 msgstr ""
 
+#, php-format
+msgid "Drop %s and %s into %s and FOG adopts them -- no setting to edit. Add %s as well if your CA issued intermediates. The installer does the same thing on its next run, so this button only saves you the wait."
+msgstr ""
+
 msgid "Dropped"
 msgstr "Desistiu"
 
@@ -2939,6 +2987,9 @@ msgstr ""
 msgid "FOG is unable to communicate with the database"
 msgstr ""
 
+msgid "FOG issues its own web server certificate. If you would rather it served one of yours -- from an ACME client, your corporate CA, or a purchased certificate -- there are three ways to say so, and the first two never send the private key to this web application."
+msgstr ""
+
 msgid "FOG refuses to deploy an image to a host that cannot run it."
 msgstr ""
 
@@ -3267,6 +3318,9 @@ msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
 msgstr ""
 
 msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
+msgstr ""
+
+msgid "For sites whose policy is that a private key never moves. Not on this page yet; FOG already does exactly this for storage node certificates, and the same route for the web certificate is tracked as a follow-up."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4578,6 +4632,9 @@ msgstr ""
 #, fuzzy
 msgid "Interface throughput"
 msgstr "Interface"
+
+msgid "Intermediates, if they are in their own file (PEM, optional)"
+msgstr ""
 
 #, fuzzy
 msgid "Invalid"
@@ -6142,6 +6199,9 @@ msgstr ""
 msgid "No token passed to authenticate this host"
 msgstr "Sem Imagem definida para este alojamento"
 
+msgid "No trust path builds for it yet, so adopting it would be refused. Supply the intermediates, and import the issuing root on the External root CA tab if it is not a public CA."
+msgstr ""
+
 msgid "No type information available for this column."
 msgstr ""
 
@@ -6263,6 +6323,9 @@ msgid "Not syncing Snapin"
 msgstr "Sem conexão para obter Snapin"
 
 msgid "Not yet seen"
+msgstr ""
+
+msgid "Nothing is in that directory yet."
 msgstr ""
 
 msgid "Nothing needs it day to day. Restore it only to issue a new intermediate, or a certificate for a new storage node."
@@ -6494,6 +6557,9 @@ msgstr "Campo operação não definido: %s"
 msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
+msgid "Or one PKCS#12 file carrying all of it (.p12/.pfx)"
+msgstr ""
+
 msgid "Or there was no number defined for joining session"
 msgstr ""
 
@@ -6569,6 +6635,9 @@ msgstr "partclone"
 
 msgid "Partimage"
 msgstr "Partimage"
+
+msgid "Passphrase, if the PKCS#12 file or the key has one"
+msgstr ""
 
 msgid "Password"
 msgstr "Senha"
@@ -7063,6 +7132,10 @@ msgstr "Impressora atualizado!"
 
 msgid "Printers"
 msgstr "impressoras"
+
+#, fuzzy
+msgid "Private key (PEM)"
+msgstr "chave privada falhou"
 
 msgid "Private key failed"
 msgstr "chave privada falhou"
@@ -9137,6 +9210,14 @@ msgid "That certificate is not available on this server."
 msgstr "Não existem grupos neste servidor."
 
 #, fuzzy
+msgid "That certificate was refused"
+msgstr "Nenhum arquivo foi transferido"
+
+#, fuzzy
+msgid "That file is too large to be a certificate or a key"
+msgstr "não foi capaz de salvar"
+
+#, fuzzy
 msgid "That file is too large to be a root CA certificate"
 msgstr "não foi capaz de salvar"
 
@@ -9174,6 +9255,10 @@ msgstr ""
 #, fuzzy
 msgid "That session has already started"
 msgstr "Impressora já existe"
+
+#, fuzzy
+msgid "That upload did not arrive intact"
+msgstr "Não há imagens neste servidor."
 
 #, fuzzy
 msgid "That upload is no longer available."
@@ -9282,6 +9367,12 @@ msgid "The breakdowns cover every inventoried machine. The range selects invento
 msgstr ""
 
 msgid "The calling user's preferences."
+msgstr ""
+
+msgid "The certificate is installed and recorded, but the web server would not reload, so it is still serving the previous one. Reload it by hand, or re-run the installer."
+msgstr ""
+
+msgid "The certificate is installed and recorded. Reload the web server for it to be served."
 msgstr ""
 
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
@@ -9596,6 +9687,9 @@ msgstr "Não há snapins neste servidor."
 msgid "There are open slots"
 msgstr "Há slots abertos, mas"
 
+msgid "There is a certificate in that directory, but no private key that matches it. Both files are required and they have to be a genuine pair, so FOG is leaving its own certificate in place -- adopting a certificate the web server cannot start with would be the worse outcome."
+msgstr ""
+
 msgid "There is a host in a tasking"
 msgstr "Há uma série de tarefas"
 
@@ -9732,6 +9826,9 @@ msgstr ""
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
+msgid "This is the one route that sends a private key through this web application. It is written to disk by root and never kept here, but it does pass through for the length of one request. If the certificate is a wildcard it covers hosts other than this one, so prefer route 1 or 2 where your policy allows."
+msgstr ""
+
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
@@ -9769,6 +9866,12 @@ msgid "This server becomes the platform owner, so Microsoft's published CA certi
 msgstr ""
 
 msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
+msgstr ""
+
+msgid "This server is already serving a certificate managed outside FOG, so FOG will not reissue or re-key it. That is derived from where the certificate actually is, not from a setting."
+msgstr ""
+
+msgid "This server is now serving that certificate, and the web server has been reloaded."
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -10227,7 +10330,13 @@ msgstr "carregar relatórios"
 msgid "Upload Reports"
 msgstr "carregar relatórios"
 
+msgid "Upload a certificate and its key, or one PKCS#12 file carrying both"
+msgstr ""
+
 msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
+
+msgid "Upload and use it"
 msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -292,6 +292,10 @@ msgstr "1小时"
 msgid "1 Year"
 msgstr "每年"
 
+#, fuzzy
+msgid "1. A certificate already on this server"
+msgstr "有此服务器上没有组。"
+
 msgid "10"
 msgstr ""
 
@@ -310,7 +314,14 @@ msgstr ""
 msgid "2 Minutes"
 msgstr "2分钟"
 
+#, fuzzy
+msgid "2. A certificate signing request"
+msgstr "没有文件被上传"
+
 msgid "25"
+msgstr ""
+
+msgid "3. Upload a certificate and its key"
 msgstr ""
 
 msgid "30 Days"
@@ -345,12 +356,18 @@ msgstr ""
 msgid "A .tar.gz holding one directory named for the plugin, with config/plugin.config.php inside it."
 msgstr ""
 
+msgid "A CA certificate is refused. Replacing FOG's own root is a migration rather than a setting -- see the Using your own PKI tab."
+msgstr ""
+
 msgid "A FOG username and password."
 msgstr ""
 
 #, fuzzy
 msgid "A LDAP setup already exists with this name!"
 msgstr "图像已经存在具有此名称！"
+
+msgid "A PEM certificate with its key, or one PKCS#12 (.p12/.pfx) file carrying both. A full chain is fine -- put the leaf first -- and the intermediates are separated out for you."
+msgstr ""
 
 msgid "A TCP/IP port printer requires an IP address or hostname."
 msgstr ""
@@ -484,6 +501,10 @@ msgstr "使用此名称的主机名已经存在。"
 msgid "A root CA uploaded on this page. Absent unless one was imported."
 msgstr ""
 
+#, php-format
+msgid "A root was supplied alongside it (%s). FOG does not trust a root just because it arrived beside a certificate -- import it deliberately on the External root CA tab, then adopt."
+msgstr ""
+
 #, fuzzy
 msgid "A scheduled time is required"
 msgstr "图像名是必需的！"
@@ -546,6 +567,10 @@ msgstr "图像已经存在具有此名称！"
 #, fuzzy
 msgid "A task type already exists with this name!"
 msgstr "图像已经存在具有此名称！"
+
+#, php-format
+msgid "A usable pair is waiting: %s, valid until %s."
+msgstr ""
 
 #, fuzzy
 msgid "A user already exists with this name"
@@ -929,6 +954,10 @@ msgstr "修改组"
 #, fuzzy
 msgid "Administrator (full access)"
 msgstr "修改组"
+
+#, fuzzy
+msgid "Adopt the certificate in that directory"
+msgstr "无法创建管理单元工作"
 
 msgid "Advanced"
 msgstr "高级"
@@ -1644,8 +1673,15 @@ msgid "Certificate download failed"
 msgstr "下载失败"
 
 #, fuzzy
+msgid "Certificate in use"
+msgstr "新建%s"
+
+#, fuzzy
 msgid "Certificate management is not configured on this server"
 msgstr "有此服务器上没有图像。"
+
+msgid "Certificate, or full chain, leaf first (PEM)"
+msgstr ""
 
 #, fuzzy
 msgid "Certificates"
@@ -2007,11 +2043,19 @@ msgid "Could not send data from file"
 msgstr "无法读取tmp文件。"
 
 #, fuzzy
+msgid "Could not stage the passphrase"
+msgstr "无法读取tmp文件。"
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "无法读取tmp文件。"
 
 #, fuzzy
 msgid "Could not stage the uploaded certificate"
+msgstr "无法读取tmp文件。"
+
+#, fuzzy
+msgid "Could not stage the uploaded file"
 msgstr "无法读取tmp文件。"
 
 #, fuzzy
@@ -2572,6 +2616,10 @@ msgstr "下载失败"
 msgid "Downloaded file is not a bootable kernel image"
 msgstr ""
 
+#, php-format
+msgid "Drop %s and %s into %s and FOG adopts them -- no setting to edit. Add %s as well if your CA issued intermediates. The installer does the same thing on its next run, so this button only saves you the wait."
+msgstr ""
+
 msgid "Dropped"
 msgstr "下降"
 
@@ -2939,6 +2987,9 @@ msgstr ""
 msgid "FOG is unable to communicate with the database"
 msgstr ""
 
+msgid "FOG issues its own web server certificate. If you would rather it served one of yours -- from an ACME client, your corporate CA, or a purchased certificate -- there are three ways to say so, and the first two never send the private key to this web application."
+msgstr ""
+
 msgid "FOG refuses to deploy an image to a host that cannot run it."
 msgstr ""
 
@@ -3267,6 +3318,9 @@ msgid "For ipxe command related items (e.g. colour, cpair, etc...) click "
 msgstr ""
 
 msgid "For service accounts and unattended integrations. The token acts with that user's roles, and the audit log records that you issued it for them."
+msgstr ""
+
+msgid "For sites whose policy is that a private key never moves. Not on this page yet; FOG already does exactly this for storage node certificates, and the same route for the web certificate is tracked as a follow-up."
 msgstr ""
 
 msgid "Forbidden (disallowed Origin)"
@@ -4578,6 +4632,9 @@ msgstr ""
 #, fuzzy
 msgid "Interface throughput"
 msgstr "接口"
+
+msgid "Intermediates, if they are in their own file (PEM, optional)"
+msgstr ""
 
 #, fuzzy
 msgid "Invalid"
@@ -6142,6 +6199,9 @@ msgstr ""
 msgid "No token passed to authenticate this host"
 msgstr "没有找到主机定义图片"
 
+msgid "No trust path builds for it yet, so adopting it would be refused. Supply the intermediates, and import the issuing root on the External root CA tab if it is not a public CA."
+msgstr ""
+
 msgid "No type information available for this column."
 msgstr ""
 
@@ -6263,6 +6323,9 @@ msgid "Not syncing Snapin"
 msgstr "无连接来获取管理单元"
 
 msgid "Not yet seen"
+msgstr ""
+
+msgid "Nothing is in that directory yet."
 msgstr ""
 
 msgid "Nothing needs it day to day. Restore it only to issue a new intermediate, or a certificate for a new storage node."
@@ -6494,6 +6557,9 @@ msgstr "操作字段没有设置： %s"
 msgid "Optional. Pick a type to pre-fill the command fields below; you can still edit them afterward. The Chocolatey entry expects the uploaded file to be a Chocolatey packages.config naming the packages to install."
 msgstr ""
 
+msgid "Or one PKCS#12 file carrying all of it (.p12/.pfx)"
+msgstr ""
+
 msgid "Or there was no number defined for joining session"
 msgstr ""
 
@@ -6569,6 +6635,9 @@ msgstr "Partclone"
 
 msgid "Partimage"
 msgstr "Partimage"
+
+msgid "Passphrase, if the PKCS#12 file or the key has one"
+msgstr ""
 
 msgid "Password"
 msgstr "密码"
@@ -7063,6 +7132,10 @@ msgstr "打印机更新！"
 
 msgid "Printers"
 msgstr "打印机"
+
+#, fuzzy
+msgid "Private key (PEM)"
+msgstr "私钥失败"
 
 msgid "Private key failed"
 msgstr "私钥失败"
@@ -9137,6 +9210,14 @@ msgid "That certificate is not available on this server."
 msgstr "有此服务器上没有组。"
 
 #, fuzzy
+msgid "That certificate was refused"
+msgstr "没有文件被上传"
+
+#, fuzzy
+msgid "That file is too large to be a certificate or a key"
+msgstr "未能保存"
+
+#, fuzzy
 msgid "That file is too large to be a root CA certificate"
 msgstr "未能保存"
 
@@ -9174,6 +9255,10 @@ msgstr ""
 #, fuzzy
 msgid "That session has already started"
 msgstr "打印机已经存在"
+
+#, fuzzy
+msgid "That upload did not arrive intact"
+msgstr "有此服务器上没有图像。"
 
 #, fuzzy
 msgid "That upload is no longer available."
@@ -9282,6 +9367,12 @@ msgid "The breakdowns cover every inventoried machine. The range selects invento
 msgstr ""
 
 msgid "The calling user's preferences."
+msgstr ""
+
+msgid "The certificate is installed and recorded, but the web server would not reload, so it is still serving the previous one. Reload it by hand, or re-run the installer."
+msgstr ""
+
+msgid "The certificate is installed and recorded. Reload the web server for it to be served."
 msgstr ""
 
 msgid "The certificate management helper is not installed on this server, so this page can only show what it can read for itself. Re-run the installer to enable it. On a storage node this is expected: a node has no CA of its own."
@@ -9596,6 +9687,9 @@ msgstr "有此服务器上没有snapins。"
 msgid "There are open slots"
 msgstr "有开口槽，但"
 
+msgid "There is a certificate in that directory, but no private key that matches it. Both files are required and they have to be a genuine pair, so FOG is leaving its own certificate in place -- adopting a certificate the web server cannot start with would be the worse outcome."
+msgstr ""
+
 msgid "There is a host in a tasking"
 msgstr "有在一个任务的主机"
 
@@ -9732,6 +9826,9 @@ msgstr ""
 msgid "This is the minimum space for the host this is deploying to."
 msgstr ""
 
+msgid "This is the one route that sends a private key through this web application. It is written to disk by root and never kept here, but it does pass through for the length of one request. If the certificate is a wildcard it covers hosts other than this one, so prefer route 1 or 2 where your policy allows."
+msgstr ""
+
 msgid "This is the only time it will be shown. FOG stores only a hash of it and cannot show it again. If you lose it, delete this token and issue another."
 msgstr ""
 
@@ -9769,6 +9866,12 @@ msgid "This server becomes the platform owner, so Microsoft's published CA certi
 msgstr ""
 
 msgid "This server has not published the automatic Secure Boot enrollment blobs (PK.auth, KEK.auth and db.auth), so automatic enrollment is unavailable. There are three reasons that happens:"
+msgstr ""
+
+msgid "This server is already serving a certificate managed outside FOG, so FOG will not reissue or re-key it. That is derived from where the certificate actually is, not from a setting."
+msgstr ""
+
+msgid "This server is now serving that certificate, and the web server has been reloaded."
 msgstr ""
 
 msgid "This server records which person signed in to which machine, and when, and no retention window is set. Click"
@@ -10227,7 +10330,13 @@ msgstr "上传报告"
 msgid "Upload Reports"
 msgstr "上传报告"
 
+msgid "Upload a certificate and its key, or one PKCS#12 file carrying both"
+msgstr ""
+
 msgid "Upload a root CA certificate to have this server trust it. It is added to the host's own trust store, so every HTTPS call this server makes will accept a certificate issued beneath it, and it is re-applied on every later installer run."
+msgstr ""
+
+msgid "Upload and use it"
 msgstr ""
 
 msgid "Upload file extension must be, jpg, jpeg, or png"

--- a/packages/web/src/Pages/FOGConfigurationPage.php
+++ b/packages/web/src/Pages/FOGConfigurationPage.php
@@ -499,6 +499,11 @@ class FOGConfigurationPage extends FOGPage
                 $this->_certificateExternalRoot($status, $mayEdit)
             ],
             [
+                'pki-web-leaf',
+                _('Web server certificate'),
+                $this->_certificateWebLeaf($status, $mayEdit)
+            ],
+            [
                 'pki-preferences',
                 _('Install preferences'),
                 $this->_certificatePreferences($status, $mayEdit)
@@ -854,6 +859,244 @@ class FOGConfigurationPage extends FOGPage
             . '</form>';
     }
     /**
+     * Bring your own web server certificate: adopt one already on the server,
+     * or upload one.
+     *
+     * Three routes, in the order they are offered, and the order is the point.
+     * The first two never send a private key to this application at all; the
+     * third does, for one request, because a wildcard an administrator already
+     * holds is the common case and refusing it sends them back to the command
+     * line for something every other appliance does in a form.
+     *
+     * What this page must never accept is a CA key. The helper enforces it by
+     * refusing a leaf carrying CA:TRUE, which is what makes "no CA private key
+     * reaches this channel" a checked property rather than a promise. See
+     * ADR 0036's 2026-09-02 amendment for the reasoning and for the blast-radius
+     * difference that justifies treating a leaf differently at all.
+     *
+     * @param array|null $status  the helper's report.
+     * @param bool       $mayEdit does the caller hold system.pki.
+     *
+     * @return string '' when there is no helper to drive.
+     */
+    private function _certificateWebLeaf($status, $mayEdit)
+    {
+        if (null === $status) {
+            return '';
+        }
+        $custom = (array) ($status['custom_pki'] ?? []);
+        $dir = (string) ($custom['dir'] ?? '');
+        $managed = !empty($status['externally_managed_leaf']);
+
+        $body = '<p class="form-text">' . _(
+            'FOG issues its own web server certificate. If you would rather it '
+            . 'served one of yours -- from an ACME client, your corporate CA, or '
+            . 'a purchased certificate -- there are three ways to say so, and the '
+            . 'first two never send the private key to this web application.'
+        ) . '</p>';
+
+        if ($managed) {
+            $body .= '<p class="text-info">' . _(
+                'This server is already serving a certificate managed outside '
+                . 'FOG, so FOG will not reissue or re-key it. That is derived '
+                . 'from where the certificate actually is, not from a setting.'
+            ) . '</p>';
+        }
+
+        // Route one. Reported before it is offered, because "there is a pair
+        // waiting here" and "it would be refused for this reason" are both
+        // things an administrator wants before clicking, not after.
+        $body .= '<h5>' . _('1. A certificate already on this server') . '</h5>';
+        $body .= '<p class="form-text">' . sprintf(
+            _(
+                'Drop %s and %s into %s and FOG adopts them -- no setting to '
+                . 'edit. Add %s as well if your CA issued intermediates. The '
+                . 'installer does the same thing on its next run, so this button '
+                . 'only saves you the wait.'
+            ),
+            '<code>web-leaf.pem</code>',
+            '<code>web-leaf.key</code>',
+            '<code>' . \Initiator::e($dir) . '</code>',
+            '<code>web-leaf-chain.pem</code>'
+        ) . '</p>';
+
+        if (empty($custom['present'])) {
+            $body .= '<p class="form-text">' . _(
+                'Nothing is in that directory yet.'
+            ) . '</p>';
+        } elseif (empty($custom['pair_ok'])) {
+            $body .= '<p class="text-warning">' . _(
+                'There is a certificate in that directory, but no private key '
+                . 'that matches it. Both files are required and they have to be '
+                . 'a genuine pair, so FOG is leaving its own certificate in '
+                . 'place -- adopting a certificate the web server cannot start '
+                . 'with would be the worse outcome.'
+            ) . '</p>';
+        } else {
+            $body .= '<p class="text-success">' . sprintf(
+                _('A usable pair is waiting: %s, valid until %s.'),
+                '<strong>' . \Initiator::e((string) $custom['subject']) . '</strong>',
+                \Initiator::e((string) $custom['not_after'])
+            ) . '</p>';
+            if (empty($custom['chain_verifies'])) {
+                $body .= '<p class="text-warning">' . _(
+                    'No trust path builds for it yet, so adopting it would be '
+                    . 'refused. Supply the intermediates, and import the issuing '
+                    . 'root on the External root CA tab if it is not a public CA.'
+                ) . '</p>';
+                if (!empty($custom['supplied_root'])) {
+                    $body .= '<p class="form-text">' . sprintf(
+                        _(
+                            'A root was supplied alongside it (%s). FOG does not '
+                            . 'trust a root just because it arrived beside a '
+                            . 'certificate -- import it deliberately on the '
+                            . 'External root CA tab, then adopt.'
+                        ),
+                        '<strong>' . \Initiator::e((string) $custom['supplied_root']) . '</strong>'
+                    ) . '</p>';
+                }
+            }
+        }
+
+        // Route two, reference only for now: the CSR flow is the follow-up
+        // this page's helper does not carry a verb for yet. Named rather than
+        // omitted, because "keys never leave the host" is a policy plenty of
+        // sites have and they should be able to see it is coming.
+        $body .= '<h5>' . _('2. A certificate signing request') . '</h5>';
+        $body .= '<p class="form-text">' . _(
+            'For sites whose policy is that a private key never moves. Not on '
+            . 'this page yet; FOG already does exactly this for storage node '
+            . 'certificates, and the same route for the web certificate is '
+            . 'tracked as a follow-up.'
+        ) . '</p>';
+
+        $body .= '<h5>' . _('3. Upload a certificate and its key') . '</h5>';
+        $body .= '<p class="form-text">' . _(
+            'A PEM certificate with its key, or one PKCS#12 (.p12/.pfx) file '
+            . 'carrying both. A full chain is fine -- put the leaf first -- and '
+            . 'the intermediates are separated out for you.'
+        ) . '</p>';
+        $body .= '<p class="text-warning">' . _(
+            'This is the one route that sends a private key through this web '
+            . 'application. It is written to disk by root and never kept here, '
+            . 'but it does pass through for the length of one request. If the '
+            . 'certificate is a wildcard it covers hosts other than this one, so '
+            . 'prefer route 1 or 2 where your policy allows.'
+        ) . '</p>';
+        $body .= '<p class="form-text">' . _(
+            'A CA certificate is refused. Replacing FOG\'s own root is a '
+            . 'migration rather than a setting -- see the Using your own PKI tab.'
+        ) . '</p>';
+
+        if (!$mayEdit) {
+            return $this->_box('', $body);
+        }
+
+        $buttons = '';
+        if (!empty($custom['pair_ok'])) {
+            $buttons .= self::makeButton(
+                'pki-adopt-leaf',
+                _('Adopt the certificate in that directory'),
+                'btn btn-secondary float-end'
+            );
+        }
+
+        $body .= '<hr>';
+        $body .= '<label class="form-label" for="pki-leaf-file">'
+            . _('Certificate, or full chain, leaf first (PEM)') . '</label>';
+        $body .= self::makeInput(
+            'form-control',
+            'leafcert',
+            '',
+            'file',
+            'pki-leaf-file',
+            '',
+            false,
+            false,
+            -1,
+            -1,
+            'accept=".pem,.crt,.cer"'
+        );
+        $body .= '<label class="form-label" for="pki-leaf-key">'
+            . _('Private key (PEM)') . '</label>';
+        $body .= self::makeInput(
+            'form-control',
+            'leafkey',
+            '',
+            'file',
+            'pki-leaf-key',
+            '',
+            false,
+            false,
+            -1,
+            -1,
+            'accept=".pem,.key"'
+        );
+        $body .= '<label class="form-label" for="pki-leaf-chain">'
+            . _('Intermediates, if they are in their own file (PEM, optional)')
+            . '</label>';
+        $body .= self::makeInput(
+            'form-control',
+            'leafchain',
+            '',
+            'file',
+            'pki-leaf-chain',
+            '',
+            false,
+            false,
+            -1,
+            -1,
+            'accept=".pem,.crt,.cer"'
+        );
+        $body .= '<label class="form-label" for="pki-leaf-p12">'
+            . _('Or one PKCS#12 file carrying all of it (.p12/.pfx)') . '</label>';
+        $body .= self::makeInput(
+            'form-control',
+            'leafp12',
+            '',
+            'file',
+            'pki-leaf-p12',
+            '',
+            false,
+            false,
+            -1,
+            -1,
+            'accept=".p12,.pfx"'
+        );
+        $body .= '<label class="form-label" for="pki-leaf-pass">'
+            . _('Passphrase, if the PKCS#12 file or the key has one') . '</label>';
+        $body .= self::makeInput(
+            'form-control',
+            'leafpass',
+            '',
+            'password',
+            'pki-leaf-pass',
+            '',
+            false,
+            false,
+            -1,
+            -1,
+            'autocomplete="new-password"'
+        );
+        $body .= self::makeInput('', 'action', '', 'hidden', 'pki-leaf-action', 'importLeaf');
+        $buttons .= self::makeButton(
+            'pki-import-leaf',
+            _('Upload and use it'),
+            'btn btn-primary float-end'
+        );
+
+        return self::makeFormTag(
+            '',
+            'pki-leaf-form',
+            $this->formAction,
+            'post',
+            'multipart/form-data',
+            true
+        )
+            . $this->_box('', $body, ['footer' => $buttons])
+            . '</form>';
+    }
+    /**
      * The three install preferences that decide what FOG does to the web
      * certificate on its next run.
      *
@@ -1114,6 +1357,12 @@ class FOGConfigurationPage extends FOGPage
                 case 'clearRoot':
                     $this->_pkiClearRoot();
                     break;
+                case 'adoptCustomLeaf':
+                    $this->_pkiAdoptCustomLeaf();
+                    break;
+                case 'importLeaf':
+                    $this->_pkiImportLeaf();
+                    break;
                 case 'setPreference':
                     $this->_pkiSetPreference();
                     break;
@@ -1129,6 +1378,183 @@ class FOGConfigurationPage extends FOGPage
                 ]
             );
         }
+    }
+    /**
+     * Adopt the pair sitting in the customizations directory.
+     *
+     * Posts nothing but the action. The verb takes no argument either -- the
+     * directory comes out of the helper's own root-only config, so this is
+     * stricter than ADR 0036's rule rather than an exception to it. A free-text
+     * path field was the obvious alternative and is the one that ADR rejected:
+     * the moment the caller names a file, the helper's job becomes proving a
+     * path is safe.
+     *
+     * @return void
+     */
+    private function _pkiAdoptCustomLeaf()
+    {
+        $res = self::_pkiRun(['adopt-custom-leaf']);
+        if (!$res['ok']) {
+            throw new \Exception(
+                $res['out'] ?: _('That certificate was refused')
+            );
+        }
+        $this->_jsonExit(
+            HTTPResponseCodes::HTTP_SUCCESS,
+            [
+                'msg' => self::_pkiLeafMessage($res['out']),
+                'title' => _('Certificate in use')
+            ]
+        );
+    }
+    /**
+     * Stage an uploaded certificate, key, chain and passphrase, and hand the
+     * lot to the helper under one request id.
+     *
+     * Nothing is validated here beyond the uploads themselves -- not the PEM
+     * framing, not the key, not the pair. The helper parses all of it, refuses
+     * a CA, refuses an expired certificate, refuses a chain that does not
+     * build, and chooses every destination, because this side is the side that
+     * might be compromised.
+     *
+     * The passphrase is staged as a FILE and never passed as an argument: this
+     * builds a command line for sudo, and an argument is readable in /proc by
+     * every local user for as long as the call lasts.
+     *
+     * @return void
+     */
+    private function _pkiImportLeaf()
+    {
+        $staging = self::_pkiStagingDir();
+        if (!$staging) {
+            throw new \Exception(
+                _('Certificate management is not configured on this server')
+            );
+        }
+        // A certificate and key are a few kilobytes; a PKCS#12 with a chain in
+        // it is a few more. Capped before anything is written into the staging
+        // directory rather than after.
+        $fields = [
+            'leafcert' => 'pem',
+            'leafkey' => 'key',
+            'leafchain' => 'chain',
+            'leafp12' => 'p12'
+        ];
+        $reqid = bin2hex(random_bytes(16));
+        $staged = [];
+        $have = false;
+        $res = ['ok' => false, 'out' => ''];
+        try {
+            foreach ($fields as $field => $ext) {
+                if (!isset($_FILES[$field])
+                    || UPLOAD_ERR_NO_FILE === ($_FILES[$field]['error'] ?? UPLOAD_ERR_NO_FILE)
+                ) {
+                    continue;
+                }
+                if (UPLOAD_ERR_OK !== ($_FILES[$field]['error'] ?? UPLOAD_ERR_NO_FILE)) {
+                    throw new UploadException($_FILES[$field]['error']);
+                }
+                if (!is_uploaded_file($_FILES[$field]['tmp_name'] ?? '')) {
+                    throw new \Exception(_('That upload did not arrive intact'));
+                }
+                if (($_FILES[$field]['size'] ?? 0) > 256 * 1024) {
+                    throw new \Exception(
+                        _('That file is too large to be a certificate or a key')
+                    );
+                }
+                $dest = $staging . DS . $reqid . '.' . $ext;
+                if (!move_uploaded_file($_FILES[$field]['tmp_name'], $dest)) {
+                    throw new \Exception(_('Could not stage the uploaded file'));
+                }
+                $staged[] = $dest;
+                $have = true;
+            }
+            if (!$have) {
+                throw new \Exception(
+                    _(
+                        'Upload a certificate and its key, or one PKCS#12 file '
+                        . 'carrying both'
+                    )
+                );
+            }
+            $pass = (string) filter_input(INPUT_POST, 'leafpass');
+            if ('' !== $pass) {
+                $dest = $staging . DS . $reqid . '.pass';
+                // 0600 before the bytes land, not after: the staging directory
+                // is the web user's own, so the window where the group could
+                // read it is the window worth not having.
+                if (!touch($dest) || !chmod($dest, 0600)) {
+                    throw new \Exception(_('Could not stage the passphrase'));
+                }
+                // Staged and restricted BEFORE the secret lands in it. fopen()
+                // would create the file at the umask's mode and leave a window
+                // in which it is group-readable, and the group on the staging
+                // directory is the web user's own.
+                $staged[] = $dest;
+                if (false === file_put_contents($dest, $pass)) {
+                    throw new \Exception(_('Could not stage the passphrase'));
+                }
+            }
+            $res = self::_pkiRun(['import-leaf', $reqid]);
+        } finally {
+            // Unconditional, and in a finally so a throw on the way in cannot
+            // leave a private key sitting in a directory the web user can read.
+            foreach ($staged as $file) {
+                if (file_exists($file)) {
+                    unlink($file);
+                }
+            }
+        }
+        if (!$res['ok']) {
+            throw new \Exception(
+                $res['out'] ?: _('That certificate was refused')
+            );
+        }
+        $this->_jsonExit(
+            HTTPResponseCodes::HTTP_SUCCESS,
+            [
+                'msg' => self::_pkiLeafMessage($res['out']),
+                'title' => _('Certificate in use')
+            ]
+        );
+    }
+    /**
+     * Turn the helper's "OK <subject> reload:<state>" line into something an
+     * administrator can act on.
+     *
+     * The reload state matters enough to report rather than swallow. Unlike the
+     * three install preferences, a certificate change is meant to take effect
+     * at once -- so "installed, but the web server did not reload" is a
+     * different situation from success, and the thing to do about it is
+     * different too.
+     *
+     * @param string $out the helper's success line.
+     *
+     * @return string
+     */
+    private static function _pkiLeafMessage($out)
+    {
+        $reload = '';
+        if (preg_match('/reload:([a-z]+)$/', trim($out), $m)) {
+            $reload = $m[1];
+        }
+        if ('ok' === $reload) {
+            return _(
+                'This server is now serving that certificate, and the web '
+                . 'server has been reloaded.'
+            );
+        }
+        if ('failed' === $reload) {
+            return _(
+                'The certificate is installed and recorded, but the web server '
+                . 'would not reload, so it is still serving the previous one. '
+                . 'Reload it by hand, or re-run the installer.'
+            );
+        }
+        return _(
+            'The certificate is installed and recorded. Reload the web server '
+            . 'for it to be served.'
+        );
     }
     /**
      * Stage an uploaded root CA and hand it to the helper.

--- a/tests/external-cert-detection.test.sh
+++ b/tests/external-cert-detection.test.sh
@@ -348,6 +348,71 @@ else
     ok "O: an empty PKI_custom_dir leaves a FOG-issued leaf alone"
 fi
 
+
+# P. The optional third name. A leaf signed straight off a root needs no
+#    intermediates, so demanding one would refuse a valid setup -- hence
+#    _customPkiChain() returns 1 rather than dying when the file is absent.
+reset_env
+if _customPkiChain >/dev/null 2>&1; then
+    bad "P: _customPkiChain claimed a chain file that is not there"
+else
+    ok "P: no chain file is not an error"
+fi
+printf 'not-a-chain\n' > "$WORK/custom-pki/web-leaf-chain.pem"
+reset_env
+if [[ $(_customPkiChain) == "$WORK/custom-pki/web-leaf-chain.pem" ]]; then
+    ok "P2: _customPkiChain names the third documented file when it exists"
+else
+    bad "P2: _customPkiChain did not return the chain path"
+fi
+rm -f "$WORK/custom-pki/web-leaf-chain.pem"
+
+# Q. _adoptCustomChain() strips self-signed certificates out of what it
+#    records, and this is the assertion that matters most in this file.
+#    _resolveTrustAnchor() anchors every self-signed certificate it finds in
+#    ${PKI_web_trust_chain}, so a root left in the chain would be trusted by
+#    this host as a side effect of an admin supplying a chain -- turning the
+#    deliberate import on the Certificates page into theatre.
+if [[ -f $WORK/ssl/ca.pem && -f $WORK/zoned/int.pem ]]; then
+    reset_env
+    # A chain file carrying an intermediate AND the self-signed root.
+    cat "$WORK/zoned/int.pem" "$WORK/ssl/ca.pem" > "$WORK/custom-pki/web-leaf-chain.pem" 2>/dev/null
+    if _adoptCustomChain "$WORK/custom-pki/web-leaf-chain.pem" >/dev/null 2>&1; then
+        out="$(_pkiZoneDir web)/leaf/.externalChain.pem"
+        check "$(grep -c 'BEGIN CERTIFICATE' "$out" 2>/dev/null)" "1" \
+            "Q: the recorded chain keeps one certificate, not two"
+        if grep -q 'BEGIN CERTIFICATE' "$out" 2>/dev/null; then
+            rm -rf "$WORK/qq"; mkdir -p "$WORK/qq"
+            awk -v d="$WORK/qq" '/BEGIN CERTIFICATE/{n++} n{print > (d "/c" n ".pem")}' "$out"
+            qsubj=$(openssl x509 -in "$WORK/qq/c1.pem" -noout -subject 2>/dev/null | sed 's/ *= */=/g')
+            qissuer=$(openssl x509 -in "$WORK/qq/c1.pem" -noout -issuer 2>/dev/null | sed 's/ *= */=/g')
+            if [[ ${qsubj#subject=} == "${qissuer#issuer=}" ]]; then
+                bad "Q2: the certificate left in the chain is self-signed -- it would be anchored"
+            else
+                ok "Q2: what is left in the chain is an intermediate, never a root"
+            fi
+        fi
+        # And ${PKI_web_trust_chain} is repointed at the canonical copy, not at
+        # wherever the admin's file happened to be -- the GH-1683 lesson.
+        check "$PKI_web_trust_chain" "$(_pkiZoneDir web)/leaf/.externalChain.pem" \
+            "Q3: the chain is recorded at a canonical path"
+    else
+        bad "Q: _adoptCustomChain refused a chain carrying an intermediate"
+    fi
+
+    # Q4. A chain file with NOTHING but a root in it records nothing. There is
+    #     no intermediate to serve, and repointing the setting at an empty file
+    #     would cost the server the chain it already had.
+    reset_env
+    before="$PKI_web_trust_chain"
+    cp "$WORK/ssl/ca.pem" "$WORK/custom-pki/web-leaf-chain.pem"
+    _adoptCustomChain "$WORK/custom-pki/web-leaf-chain.pem" >/dev/null 2>&1
+    check "$PKI_web_trust_chain" "$before" \
+        "Q4: a chain of only a root records nothing and leaves the setting alone"
+    rm -f "$WORK/custom-pki/web-leaf-chain.pem"
+else
+    echo "  SKIP  Q: the openssl fixtures for a chain were not built"
+fi
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]] || exit 1
 exit 0

--- a/tests/pki-admin-helper.test.sh
+++ b/tests/pki-admin-helper.test.sh
@@ -9,6 +9,13 @@
 # AS SHELL on the next installer run. Everything below is a refusal that has to
 # hold, or a value that has to survive intact.
 #
+# The web leaf half is newer and the same shape. A leaf private key MAY come
+# through this channel and a CA key may not, so the CA:TRUE refusal below is
+# what makes that sentence a checked property rather than a promise -- and every
+# refusal is checked against "is the vhost still pointing where it was", because
+# a helper that refused after repointing it would pass a weaker test while
+# costing an administrator the console they were using.
+#
 # The .fogsettings half is the one worth stating plainly. Writing an
 # unvalidated value into a file root later sources is a root shell with extra
 # steps, so set-preference matches its value against ^(yes|no)$ and its key
@@ -62,7 +69,11 @@ CONF="$FOGDIR/.fog-pki-admin"
 SETTINGS="$FOGDIR/.fogsettings"
 STAGING="$FOGDIR/pkiadmin-staging"
 ZONE="$FOGDIR/pki/web"
-mkdir -p "$FOGDIR" "$STAGING" "$ZONE/ca" "$ZONE/leaf" "$FOGDIR/pki/root/ca" "$FOGDIR/pki/client/leaf"
+# A SIBLING of the pki tree, never a directory inside it -- that is the whole
+# mechanism _externallyManagedLeaf() keys off, per ADR 0040.
+CUSTOM="$FOGDIR/customizations/pki"
+mkdir -p "$FOGDIR" "$STAGING" "$ZONE/ca" "$ZONE/leaf" "$FOGDIR/pki/root/ca" \
+    "$FOGDIR/pki/client/leaf" "$CUSTOM"
 
 WORK="$(mktemp -d)"
 PASS=0; FAIL=0
@@ -110,6 +121,11 @@ openssl req -x509 -newkey rsa:2048 -nodes -days 3650 -subj "/CN=selfsigned.examp
     -keyout "$WORK/selfleaf.key" -out "$WORK/selfleaf.pem" >/dev/null 2>&1
 mkint  corpint "Corp Issuing CA" corp
 mkleaf plain   "www.example.org" corp
+# Issued by the corporate INTERMEDIATE, so adopting it needs both an
+# intermediate in the chain file and the corporate root anchored. A leaf signed
+# straight off a root would pass the chain checks with the chain file empty and
+# leave the interesting case untested.
+mkleaf corpleaf "corpleaf.example.org" corpint
 
 # An expired root has to be MINTED expired: openssl req -days cannot go
 # negative, so back-date with -not_before/-not_after via a CA-signed self
@@ -152,6 +168,9 @@ PKI_SB_CA_KEY=$FOGDIR/pki/secureboot/ca/.fogSBCA.key
 PKI_CLIENT_KEY=$FOGDIR/pki/client/leaf/.srvprivate.key
 PKI_SETTINGS=$SETTINGS
 PKI_STAGING=$STAGING
+PKI_CUSTOM_DIR=$CUSTOM
+PKI_WEB_EXTERNAL_CHAIN=$ZONE/leaf/.externalChain.pem
+WEB_ENGINE=
 EOF
 chmod 0600 "$CONF"
 
@@ -164,6 +183,10 @@ writeSettingsFixture() {
 PKI_sb_enabled='yes'
 PKI_web_cert_publicly_trusted='no'
 PKI_web_external_root_cert=''
+## Present because adopt-custom-leaf rewrites it, and writeSetting refuses a
+## key the file does not already carry -- without this line the chain
+## assertions would pass for the wrong reason.
+PKI_web_trust_chain='/opt/fog/pki/web/ca/.fogWebCAchain.pem'
 
 ## WEB
 WEB_https_redirect='no'
@@ -411,6 +434,217 @@ grep -v '^BOOT_rebuild_ipxe_with_my_ca=' "$SETTINGS" > "$SETTINGS.x" && mv "$SET
 "$HELPER" set-preference BOOT_rebuild_ipxe_with_my_ca yes >/dev/null 2>&1
 check "$?" "1" "set-preference refuses a key the file does not already carry"
 check "$(grep -c '^BOOT_rebuild_ipxe_with_my_ca=' "$SETTINGS")" "0" "and appends nothing"
+
+echo
+echo "== bringing your own web leaf: what has to be refused =="
+# The whole point of this block is that every refusal leaves the server
+# SERVING WHAT IT WAS SERVING. A helper that refused after repointing the vhost
+# would pass an exit-code assertion and cost an administrator their console, so
+# the vhost link is re-checked after each one.
+vhostUnchanged() { # <label>
+    if [[ -L $ZONE/leaf/.webLeaf.pem ]]; then
+        bad "$1 (the vhost was repointed anyway)"
+    else
+        ok "$1"
+    fi
+}
+
+"$HELPER" adopt-custom-leaf >/dev/null 2>&1
+check "$?" "1" "adopt refuses when the customizations directory is empty"
+
+install -m 0644 "$WORK/corpleaf.pem" "$CUSTOM/web-leaf.pem"
+out=$("$HELPER" adopt-custom-leaf 2>&1)
+check "$?" "1" "adopt refuses a certificate with no key"
+case "$out" in
+    *"both files are required"*) ok "and says both files are required" ;;
+    *)                           bad "the refusal blamed something else: $out" ;;
+esac
+
+# A real key, but not this certificate's. The pair test is the one thing
+# standing between an upload and a web server that will not start.
+install -m 0600 "$WORK/corpint.key" "$CUSTOM/web-leaf.key"
+out=$("$HELPER" adopt-custom-leaf 2>&1)
+check "$?" "1" "adopt refuses a certificate and key that are not a pair"
+vhostUnchanged "and leaves the vhost alone"
+
+# The genuine pair, but this server has never been told to trust Corp Root.
+install -m 0600 "$WORK/corpleaf.key" "$CUSTOM/web-leaf.key"
+install -m 0644 "$WORK/corpint.pem"  "$CUSTOM/web-leaf-chain.pem"
+out=$("$HELPER" adopt-custom-leaf 2>&1)
+check "$?" "1" "adopt refuses a leaf with no trust path"
+case "$out" in
+    *"Corp Issuing CA"*) ok "and names the issuer it could not reach" ;;
+    *)                   bad "the refusal did not name the issuer: $out" ;;
+esac
+vhostUnchanged "and leaves the vhost alone"
+
+echo
+echo "== the CA:TRUE refusal, which is what 'no CA key here' actually means =="
+install -m 0644 "$WORK/corpint.pem" "$CUSTOM/web-leaf.pem"
+install -m 0600 "$WORK/corpint.key" "$CUSTOM/web-leaf.key"
+rm -f "$CUSTOM/web-leaf-chain.pem"
+out=$("$HELPER" adopt-custom-leaf 2>&1)
+check "$?" "1" "adopt refuses a CA certificate offered as the web leaf"
+case "$out" in
+    *"CA:TRUE"*) ok "and says which property refused it" ;;
+    *)           bad "the refusal did not name basicConstraints: $out" ;;
+esac
+vhostUnchanged "and leaves the vhost alone"
+
+echo
+echo "== adopting a leaf, once its root is trusted =="
+id=$(stage "$WORK/corp.pem")
+"$HELPER" import-root "$id" >/dev/null 2>&1
+check "$?" "0" "the corporate root imports"
+
+install -m 0644 "$WORK/corpleaf.pem" "$CUSTOM/web-leaf.pem"
+install -m 0600 "$WORK/corpleaf.key" "$CUSTOM/web-leaf.key"
+install -m 0644 "$WORK/corpint.pem"  "$CUSTOM/web-leaf-chain.pem"
+out=$("$HELPER" adopt-custom-leaf 2>&1)
+check "$?" "0" "adopt succeeds once a path builds"
+check "$(readlink "$ZONE/leaf/.webLeaf.pem")" "$CUSTOM/web-leaf.pem" \
+    "the canonical certificate path points AT the admin's file"
+check "$(readlink "$ZONE/leaf/.webLeaf.key")" "$CUSTOM/web-leaf.key" \
+    "and so does the key path"
+# A symlink, not a copy, because createSSLCA() does the same thing with the
+# same material on its next run. If the helper copied instead, the installer
+# would silently undo the page.
+check "$(settingOf PKI_web_trust_chain)" "$ZONE/leaf/.externalChain.pem" \
+    "the chain is recorded at a canonical path, not where the admin's file was"
+check "$(grep -c 'BEGIN CERTIFICATE' "$ZONE/leaf/.externalChain.pem")" "1" \
+    "the chain file holds the intermediate"
+
+echo
+echo "== a root in the supplied material is reported, never anchored =="
+# The load-bearing one. rebuildAnchor() and _resolveTrustAnchor() both take
+# every self-signed certificate out of the chain file, so a root left in there
+# would be trusted as a side effect of supplying a chain -- and the deliberate
+# import on this page would be theatre.
+cat "$WORK/corpleaf.pem" "$WORK/corpint.pem" "$WORK/corp.pem" > "$CUSTOM/web-leaf.pem"
+rm -f "$CUSTOM/web-leaf-chain.pem"
+"$HELPER" adopt-custom-leaf >/dev/null 2>&1
+check "$?" "0" "a fullchain with the root appended is adopted"
+check "$(grep -c 'BEGIN CERTIFICATE' "$ZONE/leaf/.externalChain.pem")" "1" \
+    "and the chain file holds ONLY the intermediate"
+rm -rf "$WORK/cc"; mkdir -p "$WORK/cc"
+awk -v d="$WORK/cc" '/BEGIN CERTIFICATE/{n++} n{print > (d "/c" n ".pem")}' \
+    "$ZONE/leaf/.externalChain.pem"
+check "$(subjectOf "$WORK/cc/c1.pem")" "subject=CN=Corp Issuing CA" \
+    "the certificate in the chain is the intermediate, not the root"
+
+echo
+echo "== a fullchain has to lead with its leaf =="
+# openssl x509 -in reads only the first certificate, and _writeWebChainFiles()
+# relies on that to assemble what the web server serves. A file whose first
+# certificate is not the leaf would be adopted into a vhost that cannot start.
+cat "$WORK/corpint.pem" "$WORK/corpleaf.pem" > "$CUSTOM/web-leaf.pem"
+out=$("$HELPER" adopt-custom-leaf 2>&1)
+check "$?" "1" "adopt refuses a fullchain whose first certificate is not the leaf"
+case "$out" in
+    *"put the leaf first"*) ok "and says how to fix it" ;;
+    *)                      bad "the refusal did not say how to fix it: $out" ;;
+esac
+
+echo
+echo "== import-leaf: the upload channel =="
+rm -f "$CUSTOM/"web-leaf*
+id=$(openssl rand -hex 16)
+cat "$WORK/corpleaf.pem" "$WORK/corpint.pem" > "$STAGING/$id.pem"
+cp "$WORK/corpleaf.key" "$STAGING/$id.key"
+out=$("$HELPER" import-leaf "$id" 2>&1)
+check "$?" "0" "a PEM certificate and key upload, and are adopted"
+check "$(subjectOf "$CUSTOM/web-leaf.pem")" "subject=CN=corpleaf.example.org" \
+    "the material lands in the customizations tree, where the installer will find it again"
+check "$(stat -c '%a' "$CUSTOM/web-leaf.key" 2>/dev/null)" "600" \
+    "and the private key is not group-readable"
+
+id=$(openssl rand -hex 16)
+cp "$WORK/corpleaf.pem" "$STAGING/$id.pem"
+"$HELPER" import-leaf "$id" >/dev/null 2>&1
+check "$?" "1" "import-leaf refuses a certificate with no key"
+
+id=$(openssl rand -hex 16)
+"$HELPER" import-leaf "$id" >/dev/null 2>&1
+check "$?" "1" "import-leaf refuses a request id with nothing staged under it"
+"$HELPER" import-leaf "../../etc/shadow" >/dev/null 2>&1
+check "$?" "1" "and refuses a request id that is not 32 hex characters"
+
+echo
+echo "== import-leaf: PKCS#12, and the passphrase that must not be an argument =="
+# The passphrase travels as a FILE under the same request id. This helper is
+# started from a command line the web tier builds, and an argument is readable
+# in /proc by every local user for as long as the call lasts -- so the file is
+# not a convenience, it is the reason this is safe to offer at all.
+check "$(grep -c 'passin "\$passin"' "$HELPER")" "3" \
+    "the PKCS#12 reads take their passphrase from a file: URI"
+check "$(grep -c 'file:\${stagedPass}' "$HELPER")" "2" \
+    "and the file is the staged one, never a value on the command line"
+
+id=$(openssl rand -hex 16)
+openssl pkcs12 -export -out "$STAGING/$id.p12" -inkey "$WORK/corpleaf.key" \
+    -in "$WORK/corpleaf.pem" -certfile "$WORK/corpint.pem" \
+    -passout pass:s3cret >/dev/null 2>&1
+if [[ -s $STAGING/$id.p12 ]]; then
+    rm -f "$CUSTOM/"web-leaf*
+    printf 's3cret' > "$STAGING/$id.pass"
+    out=$("$HELPER" import-leaf "$id" 2>&1)
+    check "$?" "0" "a PKCS#12 container unpacks and is adopted"
+    check "$(subjectOf "$CUSTOM/web-leaf.pem")" "subject=CN=corpleaf.example.org" \
+        "with the same leaf the PEM route produced"
+    check "$(openssl pkey -in "$CUSTOM/web-leaf.key" -noout >/dev/null 2>&1; echo $?)" "0" \
+        "and a key the web server can read without a passphrase"
+
+    # The wrong passphrase must fail as a passphrase problem, not as a
+    # mangled-certificate one: an administrator retyping a password needs to be
+    # told that is what went wrong.
+    id=$(openssl rand -hex 16)
+    openssl pkcs12 -export -out "$STAGING/$id.p12" -inkey "$WORK/corpleaf.key" \
+        -in "$WORK/corpleaf.pem" -passout pass:s3cret >/dev/null 2>&1
+    printf 'wrong' > "$STAGING/$id.pass"
+    out=$("$HELPER" import-leaf "$id" 2>&1)
+    check "$?" "1" "a wrong passphrase is refused"
+    case "$out" in
+        *passphrase*) ok "and the message says it was the passphrase" ;;
+        *)            bad "the refusal blamed something else: $out" ;;
+    esac
+else
+    echo "  SKIP  this openssl would not write a PKCS#12 fixture"
+fi
+
+echo
+echo "== existing files in the customizations tree are not destroyed =="
+# This directory exists for the administrator's own files. A page that
+# overwrote one without trace would be spending something it does not own.
+rm -f "$CUSTOM/"web-leaf*
+printf 'admin-put-this-here\n' > "$CUSTOM/web-leaf.pem"
+id=$(openssl rand -hex 16)
+cp "$WORK/corpleaf.pem" "$STAGING/$id.pem"
+cp "$WORK/corpleaf.key" "$STAGING/$id.key"
+"$HELPER" import-leaf "$id" >/dev/null 2>&1
+check "$?" "0" "an upload over an existing file succeeds"
+check "$(cat "$CUSTOM/web-leaf.pem.replaced" 2>/dev/null)" "admin-put-this-here" \
+    "and what was there is kept beside it"
+
+echo
+echo "== status reports the tree, without changing anything =="
+rm -f "$CUSTOM/"web-leaf*
+install -m 0644 "$WORK/corpleaf.pem" "$CUSTOM/web-leaf.pem"
+install -m 0600 "$WORK/corpleaf.key" "$CUSTOM/web-leaf.key"
+st=$("$HELPER" status 2>/dev/null)
+case "$st" in
+    *'"pair_ok": true'*) ok "status sees a usable pair" ;;
+    *)                   bad "status did not report the pair" ;;
+esac
+case "$st" in
+    *'"subject": "CN=corpleaf.example.org"'*) ok "and names it" ;;
+    *)                                        bad "status did not name the subject" ;;
+esac
+install -m 0600 "$WORK/corpint.key" "$CUSTOM/web-leaf.key"
+st=$("$HELPER" status 2>/dev/null)
+case "$st" in
+    *'"pair_ok": false'*) ok "and says so when the key does not match" ;;
+    *)                    bad "status called a mismatched pair usable" ;;
+esac
 
 echo
 echo "== the helper refuses to run without its config =="


### PR DESCRIPTION
Implements the first two of the three routes ADR 0036's 2026-09-02 amendment (#1691) authorised. The Certificates page could import a root CA and nothing else — an administrator whose leaf was already on disk had no route through the UI at all.

## What you can now do

A new **Web server certificate** tab, gated on `system.pki` as the rest of the page is:

| route | verb | does a key transit PHP? |
|---|---|---|
| adopt what is in `/etc/fog/customizations/pki` | `adopt-custom-leaf` | **no** |
| upload a PEM leaf + key, a fullchain, or a PKCS#12 | `import-leaf <reqid>` | yes, for one request |
| CSR out, certificate in | — | not in this PR, see below |

`adopt-custom-leaf` takes **no argument at all**. The directory comes out of the helper's own `0600 root:root` config, so the verb is *stricter* than ADR 0036 asks rather than an exception to it. A free-text path field is the alternative that ADR already rejected, and #1681's sibling directory is what makes a fixed location possible instead.

`import-leaf` accepts what administrators actually hold — a PEM leaf with its key, a fullchain with the leaf first, or one PKCS#12 (`.p12`/`.pfx`) carrying all of it, which is what an export from `certlm.msc` or IIS gives you. Whatever arrives is written into the customizations tree and then adopted by **exactly the code above**, so the next installer run finds it as signal 0 rather than regenerating over it, and there is one place that can decide to refuse. Anything already in that directory is kept as `*.replaced` — it exists for the administrator's own files, so overwriting one without trace would be spending something the page does not own.

`status` gained a read-only `custom_pki` object, so the tab can say what is waiting in the directory, whether the pair matches and whether a path builds, **before** anyone clicks.

## The refusals are the feature

- **A leaf carrying `CA:TRUE` is refused.** This is what makes "no CA private key reaches this channel" a checked property rather than a promise.
- **A pair that is not a pair is refused** — by subject public key, not an RSA modulus, so an EC pair is judged correctly (GH-1393).
- **An expired leaf is refused.**
- **A leaf whose chain does not build against what this server actually trusts is refused**, naming the issuer it could not reach. Adopting one trades a working server for one whose own HTTPS self-calls stop verifying, which `tests/selfcall-verification.test.sh` exists to catch.

Every refusal is asserted against *"is the vhost still pointing where it was"*, not merely against a non-zero exit — a helper that refused after repointing it would pass the weaker test while costing an administrator the console they were using.

## Two things worth a reviewer's attention

**A root in the supplied material is reported, never anchored — and that needed a strip, not just a policy.** `rebuildAnchor()` here and `_resolveTrustAnchor()` in the installer both take every self-signed certificate out of the recorded chain file. So a root left in there would be trusted as a side effect of supplying a chain, and the deliberate import on this page would be theatre. Both the helper and the installer now strip self-signed certificates out of what they record, **to the same canonical path**, so the page and `installfog.sh` cannot disagree about what this server serves. `tests/external-cert-detection.test.sh` case Q2 pins it.

**The leaf slot receives exactly one certificate.** A fullchain is split before anything is written, and a fullchain whose *first* certificate is not the leaf is refused with instructions rather than adopted. `openssl x509 -in` reads only the first certificate, which is what `_writeWebChainFiles()` relies on, and GH-863 is what happens when that assumption breaks quietly: one more copy of the intermediate per run, fourteen on a live server, and every HTTPS netboot dead at `boot.php` while browsers shrugged.

## Takes effect on the click

Certificate material relinks `PKI_web_vhost_cert`/`_key` and reloads the web server. The vhost needs no rewrite because it already names those canonical paths, so relink plus reload is the whole of it. This is the narrowing ADR 0036's amendment records, and it is scoped to certificate material — the three yes/no preferences are untouched and still wait for the installer, because they are flags it reads back rather than bytes it serves.

## The passphrase is a file, not an argument

`_pkiRun()` builds a command line and `exec()`s it, so an argument is readable in `/proc` by every local user for the length of the call. The passphrase is staged as a second file under the same `reqid` and read with `openssl -passin file:`. The page `touch`es and `chmod 0600`s it **before** the secret lands in it — `fopen()` would create it at the umask's mode and leave a window in which it is group-readable, and the group on the staging directory is the web user's own. Every staged file is unlinked in a `finally`, so a throw on the way in cannot leave a private key where the web user can read it.

## Not in this PR

- **The CSR-out/cert-in route.** It needs the installer's SAN derivation ported into the helper (`$PKI_san_ip_addresses`, `FOG_WEB_HOST`, ADR 0018's name resolution), which is a bigger piece than the two routes here. The tab names it rather than omitting it, since "keys never leave the host" is a real policy and administrators should see it is coming.
- **#1692** carries the redirect/netboot half of the amendment.

## Verification

- `tests/external-cert-detection.test.sh` gains six cases: the optional third filename `web-leaf-chain.pem`, and the self-signed strip in `_adoptCustomChain()` including that what is left is an intermediate and never a root. **34 passed, 1 failed locally** — the failure is a pre-existing symlink case this box cannot run, identical before and after (baseline 28/1).
- `tests/pki-admin-helper.test.sh` gains the leaf channel end to end: every refusal above, both upload shapes, the wrong-passphrase message, the `.replaced` preservation, the passphrase-is-a-file property asserted against the helper's own source, and `status` reporting the tree. **It first runs for real in CI** — it needs uid 0 and this box has neither `unshare` nor root, so it SKIPs locally. Same honest position #1681 was in.
- `trust-anchor`, `pki-idempotence`, `web-chain-feedback`, `install-settings-resolution` and `fogsettings-migration` are all green locally and unchanged from baseline.
- The verbs were also driven end to end against a real root → intermediate → leaf fixture chain outside the repo, covering all eleven cases above; that is what caught the fullchain-ordering hole and the `install -o root -g root` that would have made `_adoptCustomChain()` untestable outside a root shell.
- `phpstan` could not run here — no `composer` and no `vendor/` on this box — so both passes run first in CI. The PHP change is one file, inside an existing class, following `_pkiImportRoot()`'s shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
