### PR TITLE
Netboot transport is its own switch, and the redirect says what it costs (GH-1692)

### DIFF
--- a/docs/PKI_ZONES.md
+++ b/docs/PKI_ZONES.md
@@ -739,6 +739,17 @@ HTTPS netboot has a `TRUST=`-rebuilt iPXE making it work, and dropping it to
 HTTP would break a working setup to fix a problem its admin does not have.
 Override either way with `--netboot-proto http|https`.
 
+The same choice is on the Certificates page, under **Install preferences**, as
+`BOOT_url_proto`. Two things to know before using it. It is **not** what the
+HTTP-to-HTTPS redirect on that card does — the redirect never applies to the
+paths a bootloader fetches for itself, and the two are separate settings.
+And choosing `https` there **forces** it: the installer stops deriving the
+transport and keeps what you set, because an explicit value is what
+`BOOT_url_proto_forced` records. So it is a decision to take together with
+`PKI_web_cert_publicly_trusted` and `BOOT_rebuild_ipxe_with_my_ca`, which is
+how the page presents it — an https netboot iPXE cannot validate stops every
+boot at `boot.php`, with nothing server-side saying why.
+
 **Public Let's Encrypt for netboot** works only on an FQDN in a domain you
 control — it need not be publicly reachable, DNS-01 is enough — and only on
 that exact FQDN, not a short hostname and not an IP.

--- a/packages/pki/fog-pki-admin
+++ b/packages/pki/fog-pki-admin
@@ -30,10 +30,11 @@
 # installer run, so a helper that wrote arbitrary key=value pairs into it
 # would be a root shell with extra steps. Hence:
 #
-#  - set-preference takes a key from a three-entry allowlist and a value
-#    matching ^(yes|no)$. Nothing else reaches the file, and the key must
-#    already be present -- this never invents a line, so it cannot move the
-#    category blocks writeUpdateFile() maintains.
+#  - set-preference takes a key from a fixed allowlist and a value matching
+#    that key's own literal pattern -- ^(yes|no)$ for the three switches,
+#    ^(http|https)$ for the netboot transport. Nothing else reaches the file,
+#    and the key must already be present -- this never invents a line, so it
+#    cannot move the category blocks writeUpdateFile() maintains.
 #  - export takes a SLOT NAME, never a path. The slot resolves to a path from
 #    the root-only config, and every slot is a public certificate.
 #  - import-root parses what it was handed before believing any of it, keeps
@@ -83,16 +84,41 @@ shift
 
 [[ -d $PKI_STAGING ]] || die "staging directory is not configured"
 
-# The three keys this may write, and the only ones it may. Every one is a
-# yes/no install preference -- nothing here names a path, holds a secret, or
-# takes effect without the installer running again.
+# The keys this may write, and the only ones it may. Every one is an install
+# preference the installer reads back -- nothing here names a path, holds a
+# secret, or takes effect without the installer running again.
 #
-# BOOT_url_proto_forced is deliberately absent even though it is the same
-# shape. Forcing netboot to HTTPS with neither steering key set is the case
-# GH-1116 calls "legal but warned": it breaks PXE for machines that have no
-# way to fix themselves, which is the one failure a web form must not be able
-# to cause by a misclick.
-PREF_KEYS="PKI_web_cert_publicly_trusted WEB_https_redirect BOOT_rebuild_ipxe_with_my_ca"
+# BOOT_url_proto is the fourth, and adding it REVERSED a rejected alternative
+# in ADR 0036 rather than extending an accepted one. That ADR refused
+# "BOOT_url_proto_forced in the allowlist" because forcing netboot to HTTPS
+# with neither steering key set is GH-1116's "legal but warned" case: it breaks
+# PXE for machines that have no way to fix themselves. Writing BOOT_url_proto
+# achieves the same thing, since _resolveInstallMode() sets the forced flag
+# whenever an explicit value is supplied.
+#
+# What answers that objection is the two conditions it named, and they are met
+# in the PAGE, not here: the switch is never offered on its own -- it is one
+# decision with BOOT_rebuild_ipxe_with_my_ca and PKI_web_cert_publicly_trusted,
+# because "can iPXE validate what this server serves" is one question -- and it
+# is not a misclick, because the page states the cost at the point of change.
+# See ADR 0036's 2026-09-02 amendment. The gate is still system.pki, deny by
+# default.
+PREF_KEYS="PKI_web_cert_publicly_trusted WEB_https_redirect BOOT_rebuild_ipxe_with_my_ca BOOT_url_proto"
+
+# The value domain, per key.
+#
+# It was one ^(yes|no)$ for all three, and that pattern is the security
+# boundary rather than a validation nicety: .fogsettings is sourced as shell by
+# root on the next installer run, so a value that is not matched against a
+# literal pattern is a root shell with extra steps. Making the domain per-key
+# does not relax that -- every key still names a FIXED SET, which is what
+# ADR 0036's rule requires. It is the implementation that generalizes.
+prefPattern() {
+    case "$1" in
+        BOOT_url_proto) printf '%s' '^(http|https)$' ;;
+        *)              printf '%s' '^(yes|no)$' ;;
+    esac
+}
 
 # Where each downloadable slot lives. Public certificates only: this is the
 # whole reason export takes a slot name rather than a path, so adding a
@@ -559,7 +585,7 @@ clear-root)
     ;;
 
 set-preference)
-    [[ $# -eq 2 ]] || die "usage: fog-pki-admin set-preference <key> <yes|no>"
+    [[ $# -eq 2 ]] || die "usage: fog-pki-admin set-preference <key> <value>"
     key="$1"
     value="$2"
     ok=0
@@ -567,8 +593,11 @@ set-preference)
     [[ $ok -eq 1 ]] || die "not a settable preference: ${key}"
     # The whole security argument for this verb. .fogsettings is sourced as
     # shell by root, so the value is matched against a literal pattern rather
-    # than quoted and hoped over.
-    [[ $value =~ ^(yes|no)$ ]] || die "value must be yes or no"
+    # than quoted and hoped over. The pattern comes from prefPattern(), which
+    # holds one fixed set per key -- an unquoted right-hand side, because a
+    # quoted one would match the pattern as a literal string.
+    pattern=$(prefPattern "$key")
+    [[ $value =~ $pattern ]] || die "value for ${key} must match ${pattern}"
     writeSetting "$key" "$value" || die "could not update ${key} in .fogsettings"
     echo "OK"
     ;;

--- a/packages/web/management/js/fog/about/fog.about.certificates.js
+++ b/packages/web/management/js/fog/about/fog.about.certificates.js
@@ -54,6 +54,36 @@
       });
   });
 
+  // The netboot transport is a select, not a switch, so it posts its own word
+  // rather than a flag. Same one-key-per-call shape as the switches below: the
+  // helper rewrites a single .fogsettings line per call, so two administrators
+  // changing different settings cannot overwrite each other's.
+  $('.pki-pref-select').on('change', function() {
+    var sel = $(this),
+      wanted = sel.val(),
+      previous = sel.data('previous') || wanted;
+    sel.prop('disabled', true);
+    $.apiCall('post', sel.data('action'), {
+      action: 'setPreference',
+      key: sel.data('key'),
+      value: wanted
+    }, function(err) {
+      sel.prop('disabled', false);
+      if (err) {
+        // Put it back to what the server still holds, for the reason the
+        // switches do: this card's whole job is to say what the next installer
+        // run will do, and a control that lies about that is worse than none.
+        sel.val(previous);
+        return;
+      }
+      sel.data('previous', wanted);
+    });
+  }).each(function() {
+    // Remember the starting value, so a rejected change has something to
+    // revert to -- `change` has already replaced it by the time we are called.
+    $(this).data('previous', $(this).val());
+  });
+
   // One handler for all three switches. Each posts only its own key, so two
   // administrators changing different preferences cannot overwrite each
   // other's -- the helper rewrites a single line of .fogsettings per call.

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -3696,6 +3696,9 @@ msgstr ""
 msgid "HTML Error Code"
 msgstr "Fehlercode"
 
+msgid "HTTPS netboot is one decision, not three."
+msgstr ""
+
 msgid "Hard - require a valid certificate"
 msgstr ""
 
@@ -4140,6 +4143,9 @@ msgid "If disabled, the client will not make changes until all users are logged 
 msgstr ""
 
 msgid "If that chain loads but the network never comes up, the firmware's own UEFI network stack is at fault. Point the boot filename at"
+msgstr ""
+
+msgid "If the served certificate carries no name the netboot URL could use, the install STOPS and prints the names it does carry, rather than writing a default.ipxe that cannot boot. Re-issue for the name you need, or set this back to http."
 msgstr ""
 
 msgid "If this is an upgrade"
@@ -5515,6 +5521,9 @@ msgstr "Zugeordnetes Image"
 msgid "Machines imaged"
 msgstr "Zugeordnetes Image"
 
+msgid "Machines that PXE boot cannot fix this themselves. That is the whole reason this is a deliberate setting rather than a default."
+msgstr ""
+
 msgid "Main Menu"
 msgstr "Hauptmenü"
 
@@ -5916,6 +5925,9 @@ msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
 #, fuzzy
 msgid "Nested group search failed"
 msgstr "Benutzer-Update fehlgeschlagen"
+
+msgid "Netboot fetches boot.php over"
+msgstr ""
 
 msgid "Network Information"
 msgstr "Netzwerkinformationen"
@@ -6464,7 +6476,7 @@ msgstr "MAC-Adresse"
 msgid "Off - direct membership only"
 msgstr ""
 
-msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place. It does NOT affect netboot -- that is the separate setting below. Turning it on is not fully reversible: it also sends HSTS, and a browser that has seen that header refuses plain HTTP to this host for six months out of its own cache, whatever this server later says."
 msgstr ""
 
 #, fuzzy
@@ -7990,6 +8002,9 @@ msgid "Self-signed"
 msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
+
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"
@@ -10198,6 +10213,9 @@ msgstr ""
 msgid "Unclassified"
 msgstr "zugeordneter Host"
 
+msgid "Under https, the netboot URL has to address this server by a name the served certificate actually carries, so FOG_WEB_HOST becomes a record rather than a control -- rewritten on every run, and an edit through FOG Settings will not survive."
+msgstr ""
+
 msgid "Unicast"
 msgstr "Unicast"
 
@@ -11262,6 +11280,12 @@ msgstr "Stunde"
 msgid "hr"
 msgstr "Stunde"
 
+msgid "http"
+msgstr ""
+
+msgid "https"
+msgstr ""
+
 #, fuzzy
 msgid "iPXE Config Update Fail"
 msgstr "Snapin Update fehlgeschlagen"
@@ -11303,6 +11327,9 @@ msgstr "iPXE neuen Menü-Eintrag"
 #, fuzzy
 msgid "iPXE config successfully stored!"
 msgstr "Einstellungen erfolgreich gespeichert!"
+
+msgid "iPXE validates TLS strictly, has no insecure mode, and will not chain a private CA it has never been given. So https netboot works only if the certificate is publicly trusted, or iPXE has been rebuilt with this server's CA embedded."
+msgstr ""
 
 msgid "iPrint Printer"
 msgstr "iPrint Drucker"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -3698,6 +3698,9 @@ msgstr ""
 msgid "HTML Error Code"
 msgstr "Error Code"
 
+msgid "HTTPS netboot is one decision, not three."
+msgstr ""
+
 msgid "Hard - require a valid certificate"
 msgstr ""
 
@@ -4142,6 +4145,9 @@ msgid "If disabled, the client will not make changes until all users are logged 
 msgstr ""
 
 msgid "If that chain loads but the network never comes up, the firmware's own UEFI network stack is at fault. Point the boot filename at"
+msgstr ""
+
+msgid "If the served certificate carries no name the netboot URL could use, the install STOPS and prints the names it does carry, rather than writing a default.ipxe that cannot boot. Re-issue for the name you need, or set this back to http."
 msgstr ""
 
 msgid "If this is an upgrade"
@@ -5527,6 +5533,9 @@ msgstr "Assigned Image"
 msgid "Machines imaged"
 msgstr "Assigned Image"
 
+msgid "Machines that PXE boot cannot fix this themselves. That is the whole reason this is a deliberate setting rather than a default."
+msgstr ""
+
 msgid "Main Menu"
 msgstr "Main Menu"
 
@@ -5928,6 +5937,9 @@ msgstr "Event must be a string"
 #, fuzzy
 msgid "Nested group search failed"
 msgstr "User update failed"
+
+msgid "Netboot fetches boot.php over"
+msgstr ""
 
 msgid "Network Information"
 msgstr "Network Information"
@@ -6475,7 +6487,7 @@ msgstr "MAC Address List"
 msgid "Off - direct membership only"
 msgstr ""
 
-msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place. It does NOT affect netboot -- that is the separate setting below. Turning it on is not fully reversible: it also sends HSTS, and a browser that has seen that header refuses plain HTTP to this host for six months out of its own cache, whatever this server later says."
 msgstr ""
 
 #, fuzzy
@@ -8001,6 +8013,9 @@ msgid "Self-signed"
 msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
+
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"
@@ -10207,6 +10222,9 @@ msgstr ""
 msgid "Unclassified"
 msgstr "No node associated"
 
+msgid "Under https, the netboot URL has to address this server by a name the served certificate actually carries, so FOG_WEB_HOST becomes a record rather than a control -- rewritten on every run, and an edit through FOG Settings will not survive."
+msgstr ""
+
 msgid "Unicast"
 msgstr "Unicast"
 
@@ -11268,6 +11286,12 @@ msgstr "1 hour"
 msgid "hr"
 msgstr "here"
 
+msgid "http"
+msgstr ""
+
+msgid "https"
+msgstr ""
+
 #, fuzzy
 msgid "iPXE Config Update Fail"
 msgstr "Snapin update failed"
@@ -11309,6 +11333,9 @@ msgstr "iPXE New Menu Entry"
 #, fuzzy
 msgid "iPXE config successfully stored!"
 msgstr "has been successfully updated"
+
+msgid "iPXE validates TLS strictly, has no insecure mode, and will not chain a private CA it has never been given. So https netboot works only if the certificate is publicly trusted, or iPXE has been rebuilt with this server's CA embedded."
+msgstr ""
 
 msgid "iPrint Printer"
 msgstr "iPrint Printer"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3749,6 +3749,9 @@ msgstr ""
 msgid "HTML Error Code"
 msgstr "Error"
 
+msgid "HTTPS netboot is one decision, not three."
+msgstr ""
+
 msgid "Hard - require a valid certificate"
 msgstr ""
 
@@ -4210,6 +4213,9 @@ msgid "If disabled, the client will not make changes until all users are logged 
 msgstr ""
 
 msgid "If that chain loads but the network never comes up, the firmware's own UEFI network stack is at fault. Point the boot filename at"
+msgstr ""
+
+msgid "If the served certificate carries no name the netboot URL could use, the install STOPS and prints the names it does carry, rather than writing a default.ipxe that cannot boot. Re-issue for the name you need, or set this back to http."
 msgstr ""
 
 msgid "If this is an upgrade"
@@ -5619,6 +5625,9 @@ msgstr "imagen asignado"
 msgid "Machines imaged"
 msgstr "imagen asignado"
 
+msgid "Machines that PXE boot cannot fix this themselves. That is the whole reason this is a deliberate setting rather than a default."
+msgstr ""
+
 #, fuzzy
 msgid "Main Menu"
 msgstr "Ocultar menú"
@@ -6032,6 +6041,9 @@ msgstr "Evento debe ser una cadena"
 #, fuzzy
 msgid "Nested group search failed"
 msgstr "actualización Valoración falló"
+
+msgid "Netboot fetches boot.php over"
+msgstr ""
 
 msgid "Network Information"
 msgstr "Información de la red"
@@ -6586,7 +6598,7 @@ msgstr ""
 msgid "Off - direct membership only"
 msgstr ""
 
-msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place. It does NOT affect netboot -- that is the separate setting below. Turning it on is not fully reversible: it also sends HSTS, and a browser that has seen that header refuses plain HTTP to this host for six months out of its own cache, whatever this server later says."
 msgstr ""
 
 msgid "Offered to every user on this grid."
@@ -8130,6 +8142,9 @@ msgid "Self-signed"
 msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
+
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"
@@ -10366,6 +10381,9 @@ msgstr ""
 msgid "Unclassified"
 msgstr "No nodo asociado"
 
+msgid "Under https, the netboot URL has to address this server by a name the served certificate actually carries, so FOG_WEB_HOST becomes a record rather than a control -- rewritten on every run, and an edit through FOG Settings will not survive."
+msgstr ""
+
 #, fuzzy
 msgid "Unicast"
 msgstr "multidifusión"
@@ -11434,6 +11452,12 @@ msgstr "1 hora"
 msgid "hr"
 msgstr "aquí"
 
+msgid "http"
+msgstr ""
+
+msgid "https"
+msgstr ""
+
 #, fuzzy
 msgid "iPXE Config Update Fail"
 msgstr "actualización de servicio no pudo"
@@ -11476,6 +11500,9 @@ msgstr "Crear nueva entrada de menú gpxe"
 #, fuzzy
 msgid "iPXE config successfully stored!"
 msgstr "se ha actualizado correctamente"
+
+msgid "iPXE validates TLS strictly, has no insecure mode, and will not chain a private CA it has never been given. So https netboot works only if the certificate is publicly trusted, or iPXE has been rebuilt with this server's CA embedded."
+msgstr ""
 
 msgid "iPrint Printer"
 msgstr "impresora iPrint"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3696,6 +3696,9 @@ msgstr ""
 msgid "HTML Error Code"
 msgstr "Fehlercode"
 
+msgid "HTTPS netboot is one decision, not three."
+msgstr ""
+
 msgid "Hard - require a valid certificate"
 msgstr ""
 
@@ -4140,6 +4143,9 @@ msgid "If disabled, the client will not make changes until all users are logged 
 msgstr ""
 
 msgid "If that chain loads but the network never comes up, the firmware's own UEFI network stack is at fault. Point the boot filename at"
+msgstr ""
+
+msgid "If the served certificate carries no name the netboot URL could use, the install STOPS and prints the names it does carry, rather than writing a default.ipxe that cannot boot. Re-issue for the name you need, or set this back to http."
 msgstr ""
 
 msgid "If this is an upgrade"
@@ -5516,6 +5522,9 @@ msgstr "Zugeordnetes Image"
 msgid "Machines imaged"
 msgstr "Zugeordnetes Image"
 
+msgid "Machines that PXE boot cannot fix this themselves. That is the whole reason this is a deliberate setting rather than a default."
+msgstr ""
+
 msgid "Main Menu"
 msgstr "Hauptmenü"
 
@@ -5917,6 +5926,9 @@ msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
 #, fuzzy
 msgid "Nested group search failed"
 msgstr "Benutzer-Update fehlgeschlagen"
+
+msgid "Netboot fetches boot.php over"
+msgstr ""
 
 msgid "Network Information"
 msgstr "Netzwerkinformationen"
@@ -6465,7 +6477,7 @@ msgstr "MAC-Adresse"
 msgid "Off - direct membership only"
 msgstr ""
 
-msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place. It does NOT affect netboot -- that is the separate setting below. Turning it on is not fully reversible: it also sends HSTS, and a browser that has seen that header refuses plain HTTP to this host for six months out of its own cache, whatever this server later says."
 msgstr ""
 
 #, fuzzy
@@ -7991,6 +8003,9 @@ msgid "Self-signed"
 msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
+
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"
@@ -10199,6 +10214,9 @@ msgstr ""
 msgid "Unclassified"
 msgstr "zugeordneter Host"
 
+msgid "Under https, the netboot URL has to address this server by a name the served certificate actually carries, so FOG_WEB_HOST becomes a record rather than a control -- rewritten on every run, and an edit through FOG Settings will not survive."
+msgstr ""
+
 msgid "Unicast"
 msgstr "Unicast"
 
@@ -11263,6 +11281,12 @@ msgstr "Stunde"
 msgid "hr"
 msgstr "Stunde"
 
+msgid "http"
+msgstr ""
+
+msgid "https"
+msgstr ""
+
 #, fuzzy
 msgid "iPXE Config Update Fail"
 msgstr "Snapin Update fehlgeschlagen"
@@ -11304,6 +11328,9 @@ msgstr "iPXE neuen Menü-Eintrag"
 #, fuzzy
 msgid "iPXE config successfully stored!"
 msgstr "Einstellungen erfolgreich gespeichert!"
+
+msgid "iPXE validates TLS strictly, has no insecure mode, and will not chain a private CA it has never been given. So https netboot works only if the certificate is publicly trusted, or iPXE has been rebuilt with this server's CA embedded."
+msgstr ""
 
 msgid "iPrint Printer"
 msgstr "iPrint Drucker"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -3699,6 +3699,9 @@ msgstr ""
 msgid "HTML Error Code"
 msgstr "Code d'erreur"
 
+msgid "HTTPS netboot is one decision, not three."
+msgstr ""
+
 msgid "Hard - require a valid certificate"
 msgstr ""
 
@@ -4143,6 +4146,9 @@ msgid "If disabled, the client will not make changes until all users are logged 
 msgstr ""
 
 msgid "If that chain loads but the network never comes up, the firmware's own UEFI network stack is at fault. Point the boot filename at"
+msgstr ""
+
+msgid "If the served certificate carries no name the netboot URL could use, the install STOPS and prints the names it does carry, rather than writing a default.ipxe that cannot boot. Re-issue for the name you need, or set this back to http."
 msgstr ""
 
 msgid "If this is an upgrade"
@@ -5515,6 +5521,9 @@ msgstr "Assigné image"
 msgid "Machines imaged"
 msgstr "Assigné image"
 
+msgid "Machines that PXE boot cannot fix this themselves. That is the whole reason this is a deliberate setting rather than a default."
+msgstr ""
+
 msgid "Main Menu"
 msgstr "Menu principal"
 
@@ -5915,6 +5924,9 @@ msgstr "Événement doit être une chaîne"
 #, fuzzy
 msgid "Nested group search failed"
 msgstr "mise à jour de l'utilisateur a échoué"
+
+msgid "Netboot fetches boot.php over"
+msgstr ""
 
 msgid "Network Information"
 msgstr "Réseau d'information"
@@ -6462,7 +6474,7 @@ msgstr "MAC Address List"
 msgid "Off - direct membership only"
 msgstr ""
 
-msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place. It does NOT affect netboot -- that is the separate setting below. Turning it on is not fully reversible: it also sends HSTS, and a browser that has seen that header refuses plain HTTP to this host for six months out of its own cache, whatever this server later says."
 msgstr ""
 
 #, fuzzy
@@ -7987,6 +7999,9 @@ msgid "Self-signed"
 msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
+
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"
@@ -10192,6 +10207,9 @@ msgstr ""
 msgid "Unclassified"
 msgstr "Aucun noeud associé"
 
+msgid "Under https, the netboot URL has to address this server by a name the served certificate actually carries, so FOG_WEB_HOST becomes a record rather than a control -- rewritten on every run, and an edit through FOG Settings will not survive."
+msgstr ""
+
 msgid "Unicast"
 msgstr "Unicast"
 
@@ -11254,6 +11272,12 @@ msgstr "1 heure"
 msgid "hr"
 msgstr "ici"
 
+msgid "http"
+msgstr ""
+
+msgid "https"
+msgstr ""
+
 #, fuzzy
 msgid "iPXE Config Update Fail"
 msgstr "mise à jour a échoué Snapin"
@@ -11295,6 +11319,9 @@ msgstr "iPXE nouvelle entrée de menu"
 #, fuzzy
 msgid "iPXE config successfully stored!"
 msgstr "a été mis à jour avec succès"
+
+msgid "iPXE validates TLS strictly, has no insecure mode, and will not chain a private CA it has never been given. So https netboot works only if the certificate is publicly trusted, or iPXE has been rebuilt with this server's CA embedded."
+msgstr ""
 
 msgid "iPrint Printer"
 msgstr "iPrint Printer"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -3603,6 +3603,9 @@ msgstr ""
 msgid "HTML Error Code"
 msgstr "Codice di errore"
 
+msgid "HTTPS netboot is one decision, not three."
+msgstr ""
+
 msgid "Hard - require a valid certificate"
 msgstr ""
 
@@ -4036,6 +4039,9 @@ msgid "If disabled, the client will not make changes until all users are logged 
 msgstr ""
 
 msgid "If that chain loads but the network never comes up, the firmware's own UEFI network stack is at fault. Point the boot filename at"
+msgstr ""
+
+msgid "If the served certificate carries no name the netboot URL could use, the install STOPS and prints the names it does carry, rather than writing a default.ipxe that cannot boot. Re-issue for the name you need, or set this back to http."
 msgstr ""
 
 msgid "If this is an upgrade"
@@ -5347,6 +5353,9 @@ msgstr "Immagine assegnata"
 msgid "Machines imaged"
 msgstr "Immagine assegnata"
 
+msgid "Machines that PXE boot cannot fix this themselves. That is the whole reason this is a deliberate setting rather than a default."
+msgstr ""
+
 msgid "Main Menu"
 msgstr "Menu principale"
 
@@ -5744,6 +5753,9 @@ msgstr "Nuova chiave deve essere una stringa"
 #, fuzzy
 msgid "Nested group search failed"
 msgstr "Aggiornamento utente non riuscita"
+
+msgid "Netboot fetches boot.php over"
+msgstr ""
 
 msgid "Network Information"
 msgstr "Informationi di rete"
@@ -6277,7 +6289,7 @@ msgstr "Indirizzo MAC"
 msgid "Off - direct membership only"
 msgstr ""
 
-msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place. It does NOT affect netboot -- that is the separate setting below. Turning it on is not fully reversible: it also sends HSTS, and a browser that has seen that header refuses plain HTTP to this host for six months out of its own cache, whatever this server later says."
 msgstr ""
 
 #, fuzzy
@@ -7764,6 +7776,9 @@ msgid "Self-signed"
 msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
+
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"
@@ -9897,6 +9912,9 @@ msgstr ""
 msgid "Unclassified"
 msgstr "Host associato"
 
+msgid "Under https, the netboot URL has to address this server by a name the served certificate actually carries, so FOG_WEB_HOST becomes a record rather than a control -- rewritten on every run, and an edit through FOG Settings will not survive."
+msgstr ""
+
 msgid "Unicast"
 msgstr "Unicast"
 
@@ -10921,6 +10939,12 @@ msgstr "ora"
 msgid "hr"
 msgstr "ore"
 
+msgid "http"
+msgstr ""
+
+msgid "https"
+msgstr ""
+
 #, fuzzy
 msgid "iPXE Config Update Fail"
 msgstr "Aggiornamento Snapin fallito"
@@ -10961,6 +10985,9 @@ msgstr "iPXE nuova voce di menu"
 #, fuzzy
 msgid "iPXE config successfully stored!"
 msgstr "Le impostazioni sono state memorizzate correttamente!"
+
+msgid "iPXE validates TLS strictly, has no insecure mode, and will not chain a private CA it has never been given. So https netboot works only if the certificate is publicly trusted, or iPXE has been rebuilt with this server's CA embedded."
+msgstr ""
 
 msgid "iPrint Printer"
 msgstr "iPrint stampante"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -3578,6 +3578,9 @@ msgstr ""
 msgid "HTML Error Code"
 msgstr "エラーコード"
 
+msgid "HTTPS netboot is one decision, not three."
+msgstr ""
+
 msgid "Hard - require a valid certificate"
 msgstr ""
 
@@ -4008,6 +4011,9 @@ msgid "If disabled, the client will not make changes until all users are logged 
 msgstr ""
 
 msgid "If that chain loads but the network never comes up, the firmware's own UEFI network stack is at fault. Point the boot filename at"
+msgstr ""
+
+msgid "If the served certificate carries no name the netboot URL could use, the install STOPS and prints the names it does carry, rather than writing a default.ipxe that cannot boot. Re-issue for the name you need, or set this back to http."
 msgstr ""
 
 msgid "If this is an upgrade"
@@ -5312,6 +5318,9 @@ msgstr "割り当てられたイメージ"
 msgid "Machines imaged"
 msgstr "割り当てられたイメージ"
 
+msgid "Machines that PXE boot cannot fix this themselves. That is the whole reason this is a deliberate setting rather than a default."
+msgstr ""
+
 msgid "Main Menu"
 msgstr "メインメニュー"
 
@@ -5710,6 +5719,9 @@ msgstr "ユーザー名は 41 文字未満で指定してください"
 #, fuzzy
 msgid "Nested group search failed"
 msgstr "ユーザーの更新に失敗しました！"
+
+msgid "Netboot fetches boot.php over"
+msgstr ""
 
 msgid "Network Information"
 msgstr "ネットワーク情報"
@@ -6244,7 +6256,7 @@ msgstr "MAC アドレス"
 msgid "Off - direct membership only"
 msgstr ""
 
-msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place. It does NOT affect netboot -- that is the separate setting below. Turning it on is not fully reversible: it also sends HSTS, and a browser that has seen that header refuses plain HTTP to this host for six months out of its own cache, whatever this server later says."
 msgstr ""
 
 #, fuzzy
@@ -7725,6 +7737,9 @@ msgid "Self-signed"
 msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
+
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"
@@ -9842,6 +9857,9 @@ msgstr "権限がありません"
 msgid "Unclassified"
 msgstr "関連付けられたホスト"
 
+msgid "Under https, the netboot URL has to address this server by a name the served certificate actually carries, so FOG_WEB_HOST becomes a record rather than a control -- rewritten on every run, and an edit through FOG Settings will not survive."
+msgstr ""
+
 #, fuzzy
 msgid "Unicast"
 msgstr "ユニキャスト"
@@ -10867,6 +10885,12 @@ msgstr "時間"
 msgid "hr"
 msgstr "時間"
 
+msgid "http"
+msgstr ""
+
+msgid "https"
+msgstr ""
+
 #, fuzzy
 msgid "iPXE Config Update Fail"
 msgstr "iPXE の更新に失敗しました"
@@ -10907,6 +10931,9 @@ msgstr "新しい iPXE メニューエントリ"
 #, fuzzy
 msgid "iPXE config successfully stored!"
 msgstr "設定を正常に保存しました！"
+
+msgid "iPXE validates TLS strictly, has no insecure mode, and will not chain a private CA it has never been given. So https netboot works only if the certificate is publicly trusted, or iPXE has been rebuilt with this server's CA embedded."
+msgstr ""
 
 msgid "iPrint Printer"
 msgstr "iPrint プリンター"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -3183,6 +3183,9 @@ msgstr ""
 msgid "HTML Error Code"
 msgstr ""
 
+msgid "HTTPS netboot is one decision, not three."
+msgstr ""
+
 msgid "Hard - require a valid certificate"
 msgstr ""
 
@@ -3559,6 +3562,9 @@ msgid "If disabled, the client will not make changes until all users are logged 
 msgstr ""
 
 msgid "If that chain loads but the network never comes up, the firmware's own UEFI network stack is at fault. Point the boot filename at"
+msgstr ""
+
+msgid "If the served certificate carries no name the netboot URL could use, the install STOPS and prints the names it does carry, rather than writing a default.ipxe that cannot boot. Re-issue for the name you need, or set this back to http."
 msgstr ""
 
 msgid "If this is an upgrade"
@@ -4712,6 +4718,9 @@ msgstr ""
 msgid "Machines imaged"
 msgstr ""
 
+msgid "Machines that PXE boot cannot fix this themselves. That is the whole reason this is a deliberate setting rather than a default."
+msgstr ""
+
 msgid "Main Menu"
 msgstr ""
 
@@ -5050,6 +5059,9 @@ msgid "Nested group depth must be between 1 and 100"
 msgstr ""
 
 msgid "Nested group search failed"
+msgstr ""
+
+msgid "Netboot fetches boot.php over"
 msgstr ""
 
 msgid "Network Information"
@@ -5526,7 +5538,7 @@ msgstr ""
 msgid "Off - direct membership only"
 msgstr ""
 
-msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place. It does NOT affect netboot -- that is the separate setting below. Turning it on is not fully reversible: it also sends HSTS, and a browser that has seen that header refuses plain HTTP to this host for six months out of its own cache, whatever this server later says."
 msgstr ""
 
 msgid "Offered to every user on this grid."
@@ -6844,6 +6856,9 @@ msgid "Self-signed"
 msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
+
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"
@@ -8752,6 +8767,9 @@ msgstr ""
 msgid "Unclassified"
 msgstr ""
 
+msgid "Under https, the netboot URL has to address this server by a name the served certificate actually carries, so FOG_WEB_HOST becomes a record rather than a control -- rewritten on every run, and an edit through FOG Settings will not survive."
+msgstr ""
+
 msgid "Unicast"
 msgstr ""
 
@@ -9676,6 +9694,12 @@ msgstr ""
 msgid "hr"
 msgstr ""
 
+msgid "http"
+msgstr ""
+
+msgid "https"
+msgstr ""
+
 msgid "iPXE Config Update Fail"
 msgstr ""
 
@@ -9707,6 +9731,9 @@ msgid "iPXE New Menu Entry"
 msgstr ""
 
 msgid "iPXE config successfully stored!"
+msgstr ""
+
+msgid "iPXE validates TLS strictly, has no insecure mode, and will not chain a private CA it has never been given. So https netboot works only if the certificate is publicly trusted, or iPXE has been rebuilt with this server's CA embedded."
 msgstr ""
 
 msgid "iPrint Printer"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -3698,6 +3698,9 @@ msgstr ""
 msgid "HTML Error Code"
 msgstr "Erro de código"
 
+msgid "HTTPS netboot is one decision, not three."
+msgstr ""
+
 msgid "Hard - require a valid certificate"
 msgstr ""
 
@@ -4142,6 +4145,9 @@ msgid "If disabled, the client will not make changes until all users are logged 
 msgstr ""
 
 msgid "If that chain loads but the network never comes up, the firmware's own UEFI network stack is at fault. Point the boot filename at"
+msgstr ""
+
+msgid "If the served certificate carries no name the netboot URL could use, the install STOPS and prints the names it does carry, rather than writing a default.ipxe that cannot boot. Re-issue for the name you need, or set this back to http."
 msgstr ""
 
 msgid "If this is an upgrade"
@@ -5514,6 +5520,9 @@ msgstr "imagem atribuída"
 msgid "Machines imaged"
 msgstr "imagem atribuída"
 
+msgid "Machines that PXE boot cannot fix this themselves. That is the whole reason this is a deliberate setting rather than a default."
+msgstr ""
+
 msgid "Main Menu"
 msgstr "Menu principal"
 
@@ -5915,6 +5924,9 @@ msgstr "Evento deve ser uma string"
 #, fuzzy
 msgid "Nested group search failed"
 msgstr "atualização do utilizador falhou"
+
+msgid "Netboot fetches boot.php over"
+msgstr ""
 
 msgid "Network Information"
 msgstr "Informações de rede"
@@ -6462,7 +6474,7 @@ msgstr "Lista de endereços MAC"
 msgid "Off - direct membership only"
 msgstr ""
 
-msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place. It does NOT affect netboot -- that is the separate setting below. Turning it on is not fully reversible: it also sends HSTS, and a browser that has seen that header refuses plain HTTP to this host for six months out of its own cache, whatever this server later says."
 msgstr ""
 
 #, fuzzy
@@ -7988,6 +8000,9 @@ msgid "Self-signed"
 msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
+
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"
@@ -10194,6 +10209,9 @@ msgstr ""
 msgid "Unclassified"
 msgstr "No nó associado"
 
+msgid "Under https, the netboot URL has to address this server by a name the served certificate actually carries, so FOG_WEB_HOST becomes a record rather than a control -- rewritten on every run, and an edit through FOG Settings will not survive."
+msgstr ""
+
 msgid "Unicast"
 msgstr "unicast"
 
@@ -11256,6 +11274,12 @@ msgstr "1 hora"
 msgid "hr"
 msgstr "Aqui"
 
+msgid "http"
+msgstr ""
+
+msgid "https"
+msgstr ""
+
 #, fuzzy
 msgid "iPXE Config Update Fail"
 msgstr "atualização Snapin falhou"
@@ -11297,6 +11321,9 @@ msgstr "gpxe nova opção no menu"
 #, fuzzy
 msgid "iPXE config successfully stored!"
 msgstr "foi atualizado com sucesso"
+
+msgid "iPXE validates TLS strictly, has no insecure mode, and will not chain a private CA it has never been given. So https netboot works only if the certificate is publicly trusted, or iPXE has been rebuilt with this server's CA embedded."
+msgstr ""
 
 msgid "iPrint Printer"
 msgstr "iPrint Printer"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -3698,6 +3698,9 @@ msgstr ""
 msgid "HTML Error Code"
 msgstr "错误代码"
 
+msgid "HTTPS netboot is one decision, not three."
+msgstr ""
+
 msgid "Hard - require a valid certificate"
 msgstr ""
 
@@ -4142,6 +4145,9 @@ msgid "If disabled, the client will not make changes until all users are logged 
 msgstr ""
 
 msgid "If that chain loads but the network never comes up, the firmware's own UEFI network stack is at fault. Point the boot filename at"
+msgstr ""
+
+msgid "If the served certificate carries no name the netboot URL could use, the install STOPS and prints the names it does carry, rather than writing a default.ipxe that cannot boot. Re-issue for the name you need, or set this back to http."
 msgstr ""
 
 msgid "If this is an upgrade"
@@ -5514,6 +5520,9 @@ msgstr "分配图像"
 msgid "Machines imaged"
 msgstr "分配图像"
 
+msgid "Machines that PXE boot cannot fix this themselves. That is the whole reason this is a deliberate setting rather than a default."
+msgstr ""
+
 msgid "Main Menu"
 msgstr "主菜单"
 
@@ -5915,6 +5924,9 @@ msgstr "事件必须是字符串"
 #, fuzzy
 msgid "Nested group search failed"
 msgstr "用户更新失败"
+
+msgid "Netboot fetches boot.php over"
+msgstr ""
 
 msgid "Network Information"
 msgstr "网络信息"
@@ -6462,7 +6474,7 @@ msgstr "MAC地址列表"
 msgid "Off - direct membership only"
 msgstr ""
 
-msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place."
+msgid "Off by default on purpose. Trust in FOG's CA reaches a client when fog-client installs it there, so on a server whose clients are not enrolled yet a forced redirect breaks exactly the machines that cannot fix themselves. Turn it on once trust is in place. It does NOT affect netboot -- that is the separate setting below. Turning it on is not fully reversible: it also sends HSTS, and a browser that has seen that header refuses plain HTTP to this host for six months out of its own cache, whatever this server later says."
 msgstr ""
 
 #, fuzzy
@@ -7988,6 +8000,9 @@ msgid "Self-signed"
 msgstr ""
 
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
+msgstr ""
+
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"
@@ -10194,6 +10209,9 @@ msgstr ""
 msgid "Unclassified"
 msgstr "无关联的节点"
 
+msgid "Under https, the netboot URL has to address this server by a name the served certificate actually carries, so FOG_WEB_HOST becomes a record rather than a control -- rewritten on every run, and an edit through FOG Settings will not survive."
+msgstr ""
+
 msgid "Unicast"
 msgstr "单播"
 
@@ -11256,6 +11274,12 @@ msgstr "1小时"
 msgid "hr"
 msgstr "这里"
 
+msgid "http"
+msgstr ""
+
+msgid "https"
+msgstr ""
+
 #, fuzzy
 msgid "iPXE Config Update Fail"
 msgstr "管理单元更新失败"
@@ -11297,6 +11321,9 @@ msgstr "iPXE新的菜单项"
 #, fuzzy
 msgid "iPXE config successfully stored!"
 msgstr "已成功更新"
+
+msgid "iPXE validates TLS strictly, has no insecure mode, and will not chain a private CA it has never been given. So https netboot works only if the certificate is publicly trusted, or iPXE has been rebuilt with this server's CA embedded."
+msgstr ""
 
 msgid "iPrint Printer"
 msgstr "iPrint的打印机"

--- a/packages/web/src/Pages/FOGConfigurationPage.php
+++ b/packages/web/src/Pages/FOGConfigurationPage.php
@@ -898,7 +898,12 @@ class FOGConfigurationPage extends FOGPage
                     . 'client when fog-client installs it there, so on a server '
                     . 'whose clients are not enrolled yet a forced redirect '
                     . 'breaks exactly the machines that cannot fix themselves. '
-                    . 'Turn it on once trust is in place.'
+                    . 'Turn it on once trust is in place. It does NOT affect '
+                    . 'netboot -- that is the separate setting below. Turning '
+                    . 'it on is not fully reversible: it also sends HSTS, and a '
+                    . 'browser that has seen that header refuses plain HTTP to '
+                    . 'this host for six months out of its own cache, whatever '
+                    . 'this server later says.'
                 )
             ],
             'BOOT_rebuild_ipxe_with_my_ca' => [
@@ -913,6 +918,37 @@ class FOGConfigurationPage extends FOGPage
                 )
             ]
         ];
+        // The netboot transport, rendered after the three switches and inside
+        // the same card, because it is not a fourth independent preference --
+        // it is the same decision the other two steer. Kept out of $meta
+        // because its domain is http|https, so it is a select rather than a
+        // switch, and a checkbox would have to invent which way is "on".
+        $proto = 'https' === (string) ($prefs['BOOT_url_proto'] ?? 'http')
+            ? 'https' : 'http';
+        $protoRow = '<tr><td class="text-nowrap">';
+        $protoRow .= '<select class="form-select form-select-sm pki-pref-select"'
+            . ' id="BOOT_url_proto" data-key="BOOT_url_proto"'
+            . ' data-action="' . \Initiator::e($this->formAction) . '"'
+            . ($mayEdit ? '' : ' disabled') . '>';
+        foreach (['http' => _('http'), 'https' => _('https')] as $val => $label) {
+            $protoRow .= '<option value="' . \Initiator::e($val) . '"'
+                . ($proto === $val ? ' selected' : '') . '>'
+                . \Initiator::e($label) . '</option>';
+        }
+        $protoRow .= '</select></td>';
+        $protoRow .= '<td><label class="form-check-label" for="BOOT_url_proto">'
+            . '<strong>' . _('Netboot fetches boot.php over') . '</strong>'
+            . '<br><code class="small">BOOT_url_proto</code></label></td>';
+        $protoRow .= '<td><small class="text-muted">' . _(
+            'Separate from the HTTP redirect above, which never applies to the '
+            . 'paths a bootloader fetches for itself. Choosing https here also '
+            . 'FORCES it: the installer stops deriving the transport and keeps '
+            . 'what you set. If iPXE cannot validate the certificate this '
+            . 'server serves, every netboot stops at boot.php and nothing '
+            . 'server-side says why -- so decide it together with the two '
+            . 'settings above, not on its own.'
+        ) . '</small></td></tr>';
+
         $rows = '';
         foreach ($meta as $key => $text) {
             $on = 'yes' === (string) ($prefs[$key] ?? 'no');
@@ -950,7 +986,37 @@ class FOGConfigurationPage extends FOGPage
             . '<table class="table table-sm align-middle">';
         $body .= '<thead><tr><th></th><th>' . _('Setting') . '</th><th>'
             . _('What it does') . '</th></tr></thead>';
-        $body .= '<tbody>' . $rows . '</tbody></table></div>';
+        $body .= '<tbody>' . $rows . $protoRow . '</tbody></table></div>';
+        // The two conditions ADR 0036's rejected alternative named, met here
+        // rather than in the helper: the transport is never offered alone, and
+        // the cost is stated at the point of change.
+        $body .= '<div class="alert alert-warning" role="alert">';
+        $body .= '<strong>' . _('HTTPS netboot is one decision, not three.')
+            . '</strong> ';
+        $body .= _(
+            'iPXE validates TLS strictly, has no insecure mode, and will not '
+            . 'chain a private CA it has never been given. So https netboot '
+            . 'works only if the certificate is publicly trusted, or iPXE has '
+            . 'been rebuilt with this server\'s CA embedded.'
+        );
+        $body .= '<ul class="mb-0 mt-2">';
+        $body .= '<li>' . _(
+            'Under https, the netboot URL has to address this server by a name '
+            . 'the served certificate actually carries, so FOG_WEB_HOST becomes '
+            . 'a record rather than a control -- rewritten on every run, and an '
+            . 'edit through FOG Settings will not survive.'
+        ) . '</li>';
+        $body .= '<li>' . _(
+            'If the served certificate carries no name the netboot URL could '
+            . 'use, the install STOPS and prints the names it does carry, '
+            . 'rather than writing a default.ipxe that cannot boot. Re-issue '
+            . 'for the name you need, or set this back to http.'
+        ) . '</li>';
+        $body .= '<li>' . _(
+            'Machines that PXE boot cannot fix this themselves. That is the '
+            . 'whole reason this is a deliberate setting rather than a default.'
+        ) . '</li>';
+        $body .= '</ul></div>';
         $body .= '<p class="form-text">' . sprintf(
             '%s <a href="%s" target="_blank" rel="noopener">%s</a>.',
             _('A worked example of the first one, end to end:'),
@@ -1239,7 +1305,18 @@ class FOGConfigurationPage extends FOGPage
     private function _pkiSetPreference()
     {
         $key = (string) filter_input(INPUT_POST, 'key');
-        $value = filter_input(INPUT_POST, 'value') ? 'yes' : 'no';
+        $raw = (string) filter_input(INPUT_POST, 'value');
+        // Mapped by KEY, not by inspecting the value: the three switches post a
+        // truthy flag and the netboot transport posts its own word, and keying
+        // off the value would let one be talked into posting the other's
+        // domain. This side deciding is a convenience either way -- the helper
+        // re-checks against that key's own literal pattern, and that check is
+        // the boundary, because .fogsettings is sourced as shell by root.
+        if ('BOOT_url_proto' === $key) {
+            $value = 'https' === $raw ? 'https' : 'http';
+        } else {
+            $value = $raw ? 'yes' : 'no';
+        }
         $res = self::_pkiRun(['set-preference', $key, $value]);
         if (!$res['ok']) {
             throw new \Exception(

--- a/tests/certificate-management-permission.test.php
+++ b/tests/certificate-management-permission.test.php
@@ -157,18 +157,55 @@ $results[] = pkiPermCheck(
  */
 $helper = (string) file_get_contents($root . '/packages/pki/fog-pki-admin');
 $results[] = pkiPermCheck(
-    'the helper constrains the preference value to yes or no',
-    1 === preg_match('#\[\[ \$value =~ \^\(yes\|no\)\$ \]\]#', $helper),
-    'the ^(yes|no)$ pattern is not in fog-pki-admin'
+    'the helper constrains the three switches to yes or no',
+    1 === preg_match("#\\*\\)\\s+printf '%s' '\\^\\(yes\\|no\\)\\$'#", $helper),
+    'the ^(yes|no)$ pattern is not the default in prefPattern()'
+);
+/*
+ * The netboot transport's domain is http|https, not yes|no, so the value check
+ * became per-key. That is not a relaxation -- every key still names a fixed
+ * set, which is what ADR 0036's rule requires -- but it has to be pinned in
+ * both directions, because a per-key lookup is exactly the shape that could
+ * quietly acquire a permissive default.
+ */
+$results[] = pkiPermCheck(
+    'the netboot transport is constrained to http or https',
+    1 === preg_match(
+        "#BOOT_url_proto\\)\\s+printf '%s' '\\^\\(http\\|https\\)\\$'#",
+        $helper
+    ),
+    'the ^(http|https)$ pattern is not bound to BOOT_url_proto'
 );
 $results[] = pkiPermCheck(
-    'the helper carries a key allowlist, and it is the three preferences',
+    'http is reachable through no key but BOOT_url_proto',
+    1 === preg_match_all("#'\\^\\(http\\|https\\)\\\$'#", $helper),
+    'the http|https domain appears more than once in fog-pki-admin'
+);
+$results[] = pkiPermCheck(
+    'the value is matched against a pattern the helper chose, not the caller',
+    1 === preg_match('#pattern=\$\(prefPattern "\$key"\)#', $helper)
+        && 1 === preg_match('#\[\[ \$value =~ \$pattern \]\]#', $helper),
+    'set-preference does not validate against prefPattern()'
+);
+$results[] = pkiPermCheck(
+    'the helper carries a key allowlist, and it is the four preferences',
     1 === preg_match(
         '#PREF_KEYS="PKI_web_cert_publicly_trusted WEB_https_redirect '
-        . 'BOOT_rebuild_ipxe_with_my_ca"#',
+        . 'BOOT_rebuild_ipxe_with_my_ca BOOT_url_proto"#',
         $helper
     ),
     'PREF_KEYS is missing or has gained an entry'
+);
+/*
+ * BOOT_url_proto_forced stays out. Setting BOOT_url_proto already forces the
+ * transport -- _resolveInstallMode() sets the flag whenever an explicit value
+ * is supplied -- so a separate settable flag would be a second way to say the
+ * same thing, and the one that carries no steering keys with it.
+ */
+$results[] = pkiPermCheck(
+    'the allowlist does not carry BOOT_url_proto_forced',
+    1 !== preg_match('#PREF_KEYS="[^"]*BOOT_url_proto_forced#', $helper),
+    'PREF_KEYS reaches BOOT_url_proto_forced'
 );
 /*
  * Neither secret in .fogsettings may be reachable, whatever else changes.

--- a/tests/pki-admin-helper.test.sh
+++ b/tests/pki-admin-helper.test.sh
@@ -11,8 +11,9 @@
 #
 # The .fogsettings half is the one worth stating plainly. Writing an
 # unvalidated value into a file root later sources is a root shell with extra
-# steps, so set-preference matches its value against ^(yes|no)$ and its key
-# against a three-entry allowlist. Both refusals are exercised here, and both
+# steps, so set-preference matches its value against that KEY'S OWN literal
+# pattern -- ^(yes|no)$ for the three switches, ^(http|https)$ for the netboot
+# transport -- and its key against a four-entry allowlist. Both refusals are exercised here, and both
 # are checked by "did the file change", not merely by "did the command exit
 # non-zero" -- a helper that rejected the argument after writing would pass the
 # weaker test.
@@ -170,6 +171,7 @@ WEB_https_redirect='no'
 
 ## BOOT
 BOOT_rebuild_ipxe_with_my_ca='no'
+BOOT_url_proto='http'
 BOOT_url_proto_forced='no'
 
 ## The two cleartext secrets, and a path key. Present in the fixture ON
@@ -403,6 +405,56 @@ done
 ( set +u; . "$SETTINGS" >/dev/null 2>&1 )
 [[ -e $CANARY ]] && bad "sourcing .fogsettings executed an injected payload" \
     || ok "sourcing .fogsettings after every refusal executes nothing"
+
+echo
+echo "== the value domain is PER KEY, and each one is still a fixed set =="
+# BOOT_url_proto's domain is http|https, so the single ^(yes|no)$ became a
+# per-key lookup. That is not a relaxation -- every key still names a literal
+# set -- but a per-key lookup is exactly the shape that can quietly acquire a
+# permissive default, so both directions are pinned.
+"$HELPER" set-preference BOOT_url_proto https >/dev/null 2>&1
+check "$?" "0" "set-preference accepts https for BOOT_url_proto"
+check "$(settingOf BOOT_url_proto)" "https" "and the value lands in the file"
+"$HELPER" set-preference BOOT_url_proto http >/dev/null 2>&1
+check "$?" "0" "and accepts http"
+check "$(settingOf BOOT_url_proto)" "http" "and back again"
+
+# The domains must not leak into one another. A switch that accepted a
+# transport, or a transport that accepted yes, would mean the per-key lookup
+# had collapsed back to one permissive pattern.
+before=$(sha256sum "$SETTINGS" | cut -d' ' -f1)
+"$HELPER" set-preference BOOT_url_proto yes >/dev/null 2>&1
+check "$?" "1" "BOOT_url_proto refuses yes -- its domain is not the switches'"
+"$HELPER" set-preference WEB_https_redirect https >/dev/null 2>&1
+check "$?" "1" "and WEB_https_redirect refuses https -- nor is the reverse true"
+check "$(sha256sum "$SETTINGS" | cut -d' ' -f1)" "$before" \
+    "neither refusal changed the file"
+
+# The same injection shapes as above, against the key whose domain is new.
+# .fogsettings is still sourced as shell by root, so a widened domain that
+# stopped matching a literal pattern would be a root shell with extra steps.
+CANARY2=/opt/fog/canary2
+for payload in "http'; touch ${CANARY2}; #" \
+               "\$(touch ${CANARY2})" \
+               "https"$'\n'"touch ${CANARY2}" \
+               "HTTPS" "httpss" "ftp" ""; do
+    before=$(sha256sum "$SETTINGS" | cut -d' ' -f1)
+    "$HELPER" set-preference BOOT_url_proto "$payload" >/dev/null 2>&1
+    st=$?
+    label=$(printf '%s' "$payload" | tr '\n' ' ')
+    check "$st" "1" "BOOT_url_proto refuses the value '${label:-<empty>}'"
+    check "$(sha256sum "$SETTINGS" | cut -d' ' -f1)" "$before" \
+        "refusing '${label:-<empty>}' changed nothing in the file"
+done
+( set +u; . "$SETTINGS" >/dev/null 2>&1 )
+[[ -e $CANARY2 ]] && bad "sourcing .fogsettings executed an injected transport" \
+    || ok "sourcing .fogsettings after every transport refusal executes nothing"
+
+# BOOT_url_proto_forced is still not settable. Writing BOOT_url_proto already
+# forces the transport, so a second settable flag would be another way to say
+# the same thing -- and the one that carries none of the steering keys with it.
+"$HELPER" set-preference BOOT_url_proto_forced yes >/dev/null 2>&1
+check "$?" "1" "BOOT_url_proto_forced is still not a settable preference"
 
 # A key the allowlist permits but the file does not carry. Appending it would
 # land it after "## End of FOG Settings", in the region the installer's merge


### PR DESCRIPTION
Closes the second half of ADR 0036's 2026-09-02 amendment (#1691). Two things the redirect switch was quietly implying, and one reversal recorded rather than smuggled in.

## The redirect never applied to netboot — now the page says so

The vhost already excludes `service/ipxe/`, `service/secureboot/` and `service/uboot/` whenever `BOOT_url_proto` is not `https`, and `management/other/ca.cert.der` unconditionally, since redirecting that would make fetching the CA require already trusting the CA. Nothing on the page said any of it, so the redirect and the netboot transport read as one setting. The redirect's description now says it does not affect netboot, and points at the setting that does.

## And it now says the redirect cannot be taken back

Turning it on also emits `Strict-Transport-Security max-age=15768000`. A browser that has seen that header refuses plain HTTP to this host **for six months out of its own cache**, whatever the server later says. The code has always gated HSTS correctly and `vhost-netboot-exclusion.test.sh` pins it; what was missing was telling the administrator at the point of change — which is this page's whole reason for existing over a command line.

## `BOOT_url_proto` becomes settable

A `<select>`, not a switch: its domain is `http|https` and a checkbox would have to invent which way is "on".

So `set-preference`'s value check is now **per key**. `prefPattern()` holds one literal pattern each — `^(yes|no)$` for the three switches, `^(http|https)$` for the transport. That is not a relaxation: every key still names a fixed set, which is what ADR 0036's rule requires, and it is the implementation that generalizes. But a per-key lookup is exactly the shape that can quietly acquire a permissive default, so it is pinned in **both** directions:

- the transport refuses `yes`; the switches refuse `https`
- the same injection payloads already run against a switch are run against the transport, and `.fogsettings` is sourced afterwards to prove nothing executed
- `^(http|https)$` is asserted to appear **exactly once** in the helper, and to be reachable through no key but `BOOT_url_proto`

## This reverses a rejected alternative

ADR 0036 refused **"`BOOT_url_proto_forced` in the allowlist"**, because forcing netboot to HTTPS with neither steering key set breaks PXE for machines that cannot fix themselves and is "not a thing a misclick should reach." Writing `BOOT_url_proto` achieves the same thing — `_resolveInstallMode()` sets the forced flag whenever an explicit value is supplied — and the helper's comment now says so in those words rather than leaving it to be discovered.

What answers the objection is its own two conditions, and both are met in the **page**, not the helper:

- **Never offered alone.** The transport sits in the same card as `PKI_web_cert_publicly_trusted` and `BOOT_rebuild_ipxe_with_my_ca`, under a notice saying https netboot is one decision and not three, because "can iPXE validate what this server serves" is one question.
- **Not a misclick.** The cost is stated where the change is made: iPXE validates strictly and cannot be told to trust a private CA; under https `FOG_WEB_HOST` becomes a record rather than a control, rewritten every run; and an install whose served certificate carries no usable name **stops** rather than writing a `default.ipxe` that cannot boot.

`BOOT_url_proto_forced` itself stays out of the allowlist, and is now asserted to stay out.

## Correction: the vhost test #1692 asked for already exists

I filed #1692 asking for a test that is already there, and [said so on the issue](https://github.com/FOGProject/fogproject/issues/1692). `tests/vhost-netboot-exclusion.test.sh` already pins both engines' exclusion sets (as *two* occurrences of one shared loop, so they cannot drift), the `^~` that makes nginx's beat `location /`, `ca.cert.der` in both, that nginx's redirect stays a `location` and never a server-level `return`, the `BOOT_url_proto != https` guard, and that HSTS has exactly two gated emissions.

`docs/PKI_ZONES.md`'s "Still unverified" line means the narrower thing: that branch has never run **on a real nginx server**. The test says as much itself — it asserts on the generator, "not on a running web server". That needs a machine, not a test, so the line stays and this PR does not touch it.

## Verification

- `tests/certificate-management-permission.test.php` — the two assertions pinning `PREF_KEYS` and `^(yes|no)$` are the privilege boundary (its own comment: a duplicate check in PHP is harmless, a missing one in the helper is "the whole boundary gone"), so they were **rewritten to be tighter**, not relaxed: four keys, both domains, the exactly-once count, that `set-preference` asks `prefPattern()` rather than inlining a pattern, and that `BOOT_url_proto_forced` is absent. This box has no `gettext` extension so the harness cannot boot here; all seven new assertions were validated directly against the helper instead, and they pass.
- `tests/pki-admin-helper.test.sh` gains the accept/refuse matrix and the injection set for the new domain. It needs uid 0 and `unshare`, so it first runs for real in CI — as it did for #1695, where it passed.
- `vhost-netboot-exclusion` (13/0), `netboot-not-redirected-to-https` (3/0), `install-settings-resolution` (50/0), `fogsettings-migration` (40/0) all green locally and unchanged.
- `phpstan` runs first in CI — no `composer`/`vendor` on this box.

## Ordering note

Independent of **#1695**, and both edit `packages/pki/fog-pki-admin` — #1695 adds verbs and config defaults, this one changes `PREF_KEYS` and the `set-preference` block. Different hunks, but close enough that whichever merges second may want a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
