### PR TITLE
Add bin/revertupdate.sh: a standalone way back from a 1.6 update (GH-1659)

### DIFF
--- a/bin/revertupdate.sh
+++ b/bin/revertupdate.sh
@@ -183,7 +183,7 @@ dumpdir="${DB_backup_path%/}/fogDBbackups"
 # ---------------------------------------------------------------------------
 # Report. This runs on every invocation, because a checkout or a restore that
 # does not first say what it found is a checkout or a restore nobody can
-# check afterwards.
+# check afterward.
 # ---------------------------------------------------------------------------
 echo " * Checkout: ${gitpath}"
 if [[ -z $recorded ]]; then

--- a/bin/revertupdate.sh
+++ b/bin/revertupdate.sh
@@ -1,0 +1,417 @@
+#!/bin/bash
+#
+#  FOG is a computer imaging solution.
+#  Copyright (C) 2007  Chuck Syperski & Jian Zhang
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#    any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# The way back from an update that stayed on this release line (GH-1659).
+#
+# An update records two things it can be undone from and, until this script,
+# surfaced neither on its own: FOG_last_good_commit in .fogsettings names the
+# commit the last COMPLETED install ran from, and backupDB() writes a dump of
+# the database immediately before the schema is migrated. offerRevert()
+# prints both -- but only from installfog.sh's EXIT trap, so only on a run
+# that failed, and never again. An update that succeeded and then turned out
+# to have broken something had no command to run at all.
+#
+# This script is that command, in two halves that are deliberately separate:
+#
+#   --checkout           moves the working copy back to FOG_last_good_commit
+#                        (git checkout --detach, as offerRevert suggests)
+#   --restore-db <dump>  puts a pre-migration dump back
+#
+# Run with neither and it only REPORTS: where the checkout is against where it
+# was, what schema the database is on against what the code expects, and
+# which of the dumps on disk could be restored. Nothing is changed.
+#
+# Why it is not bin/revertfog.sh: that script is the 1.6 -> 1.5 crossing. It
+# restores the pre-upgrade 1.5 web tree as well as the database, and its
+# _dumpNotFifteenReason() proof refuses any dump that reads as 1.6 -- which is
+# every dump this script exists to restore. The proof here is a different
+# question: not "is this dump 1.5" but "does this dump match the schema of
+# the code that is checked out". A dump's schemaVersion row and the checked-
+# out System.php's FOG_SCHEMA are both readable without touching the
+# database, so a mismatch is refused before anything is stopped or dropped.
+#
+# See docs/development/reverting-an-upgrade.md.
+bindir=$(dirname $(readlink -f "$BASH_SOURCE"))
+cd $bindir
+workingdir=$(pwd)
+
+if [[ ! $EUID -eq 0 ]]; then
+    echo "revertupdate.sh must be run as root user"
+    exit 1
+fi
+
+usage() {
+    echo -e "Usage: $0 [-h?] [--checkout] [--restore-db <dump>] [--yes]"
+    echo -e "\t-h -? --help\t\tDisplay this info"
+    echo -e "\t      --checkout\tMove the working copy back to the commit the"
+    echo -e "\t                \tlast completed install ran from"
+    echo -e "\t      --restore-db\tRestore a pre-migration database dump. Refused"
+    echo -e "\t                  \tunless its schema matches the checked-out code"
+    echo -e "\t-y    --yes\t\tSkip the confirmation prompt"
+    echo
+    echo -e "With no action, reports what could be reverted and changes nothing."
+    exit 0
+}
+
+shortopts="h?y"
+longopts="help,checkout,restore-db:,yes"
+optargs=$(getopt -o $shortopts -l $longopts -n "$0" -- "$@")
+[[ $? -ne 0 ]] && usage
+eval set -- "$optargs"
+
+doCheckout=0
+dumpfile=""
+autoYes=""
+while :; do
+    case $1 in
+        -h | -\? | --help)
+            usage
+            ;;
+        --checkout)
+            doCheckout=1
+            shift
+            ;;
+        --restore-db)
+            dumpfile="$2"
+            shift 2
+            ;;
+        -y | --yes)
+            autoYes=1
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            echo "Error: unhandled option '$1'."
+            exit 10
+            ;;
+    esac
+done
+
+[[ ! -d ./error_logs/ ]] && mkdir -p ./error_logs >/dev/null 2>&1
+error_log="${workingdir}/error_logs/fog_revertupdate_error.log"
+: > "$error_log"
+
+# exitFail so a failing errorStat inside the sourced functions returns control
+# here instead of killing the script mid-restore. Same reason restorekernel.sh
+# and revertfog.sh set it.
+exitFail=1
+. ../lib/common/functions.sh
+
+# Same resolution order as restorekernel.sh and revertfog.sh: the
+# /etc/fog/fog.conf pointer, then .fogsettings for what the last install
+# recorded, then config.sh for what it derives.
+[[ -z $fogprogramdir && -r /etc/fog/fog.conf ]] && . /etc/fog/fog.conf
+[[ -z $fogprogramdir ]] && fogprogramdir="/opt/fog"
+fogprogramdir="${fogprogramdir%/}"
+
+if [[ ! -r "$fogprogramdir/.fogsettings" ]]; then
+    echo " * No existing FOG install found at $fogprogramdir (.fogsettings missing)."
+    echo " * revertupdate.sh undoes an UPDATE -- there is no install here to go back from."
+    exit 1
+fi
+. "$fogprogramdir/.fogsettings"
+migrateDeprecatedKeys
+# Saved BEFORE config.sh, which overwrites FOG_git_path with the tree this
+# script runs from. That is right for the installer -- "the git path is
+# wherever you ran me" -- and wrong here: the recorded value is the tree the
+# last completed install ran from, which is the one FOG_last_good_commit is
+# a commit OF. An admin running this from a second clone still gets the
+# checkout the record names, and the fallback is config.sh's answer.
+settingsGitPath="${FOG_git_path:-}"
+linuxReleaseName_lower="${FOG_os_name,,}"
+. ../lib/common/config.sh
+[[ -n ${FOG_os_id} ]] && doOSSpecificIncludes >/dev/null
+
+gitpath="${settingsGitPath:-${FOG_git_path:-$(dirname "$bindir")}}"
+if [[ ! -d ${gitpath}/.git ]]; then
+    echo " * ${gitpath} is not a git checkout, so there is no commit to go back to."
+    echo " * FOG_git_path in ${fogprogramdir}/.fogsettings names the tree the installer ran from."
+    exit 1
+fi
+
+# Read the same way offerRevert() does: off disk, stripped of quoting.
+recorded=$(sed -n 's/^FOG_last_good_commit=//p' "${fogprogramdir}/.fogsettings" 2>/dev/null | tr -d "\"' " | tail -n1)
+head=$(git -C "$gitpath" rev-parse HEAD 2>/dev/null)
+
+# FOG_SCHEMA of the code at a given commit, read out of git rather than off
+# disk so it can be asked of a commit that is NOT checked out -- which is how
+# the report says "this dump would be restorable after --checkout" without
+# moving anything first. Empty for a commit with no 1.6 System.php, which is
+# how a 1.5 commit is told apart: that crossing belongs to revertfog.sh.
+schemaOfCommit() {
+    git -C "$gitpath" show "$1:packages/web/src/Base/System.php" 2>/dev/null \
+        | awk -F'[(),]' '/define\(.FOG_SCHEMA.,/ {gsub(/[[:space:]]/, "", $3); print $3; exit}'
+}
+# The schemaVersion row a dump would put back. mysqldump-php and the mysql
+# client both write it as INSERT INTO `schemaVersion` VALUES (1,'N').
+schemaOfDump() {
+    sed -n "s/^INSERT INTO \`schemaVersion\` VALUES (1,'\([0-9]*\)').*/\1/p" "$1" 2>/dev/null | head -n1
+}
+short() { echo "${1:0:12}"; }
+
+recordedSchema=""
+[[ -n $recorded ]] && recordedSchema=$(schemaOfCommit "$recorded")
+headSchema=$(schemaOfCommit "$head")
+
+[[ -n ${DB_host} ]] && host="--host=${DB_host}"
+sqloptionsuser="${host} -s --user=${DB_user}"
+liveSchema=""
+if [[ ${DB_external} != yes ]]; then
+    liveSchema=$(schemaVersionInDB 2>/dev/null)
+fi
+
+dumpdir="${DB_backup_path%/}/fogDBbackups"
+
+# ---------------------------------------------------------------------------
+# Report. This runs on every invocation, because a checkout or a restore that
+# does not first say what it found is a checkout or a restore nobody can
+# check afterwards.
+# ---------------------------------------------------------------------------
+echo " * Checkout: ${gitpath}"
+if [[ -z $recorded ]]; then
+    echo " |   last completed install: not recorded (FOG_last_good_commit is empty)"
+elif [[ $head == "$recorded" ]]; then
+    echo " |   at $(short "$head"), which is where the last completed install ran from"
+else
+    echo " |   now at:                $(short "$head")  (code expects schema ${headSchema:-unknown})"
+    echo " |   last completed install: $(short "$recorded")  (code expects schema ${recordedSchema:-unknown})"
+fi
+echo " * Database:"
+if [[ ${DB_external} == yes ]]; then
+    echo " |   external -- not read, and not restored by this script"
+elif [[ -n $liveSchema ]]; then
+    echo " |   schema ${liveSchema}"
+else
+    echo " |   could not read the schema version (is the database up?)"
+fi
+echo " * Dumps under ${dumpdir}:"
+dumps=()
+while IFS= read -r f; do
+    [[ -n $f ]] && dumps+=("$f")
+done < <(ls -t "${dumpdir}"/fog_sql_*.sql 2>/dev/null)
+if [[ ${#dumps[@]} -eq 0 ]]; then
+    echo " |   none"
+fi
+for f in "${dumps[@]}"; do
+    s=$(schemaOfDump "$f")
+    note=""
+    if [[ -z $s ]]; then
+        note="no schemaVersion row -- not restorable"
+    elif [[ -n $headSchema && $s == "$headSchema" ]]; then
+        note="matches the checked-out code -- restorable now"
+    elif [[ -n $recordedSchema && $s == "$recordedSchema" ]]; then
+        note="matches the last completed install -- restorable after --checkout"
+    else
+        note="matches neither"
+    fi
+    echo " |   $(basename "$f")  schema ${s:-?}  ($note)"
+done
+
+if [[ $doCheckout -eq 0 && -z $dumpfile ]]; then
+    echo
+    echo " * Nothing was changed. To go back:"
+    if [[ -n $recorded && $head != "$recorded" ]]; then
+        echo " |     $0 --checkout"
+    fi
+    echo " |     $0 --restore-db <dump>"
+    echo " |     cd ${gitpath}/bin && ./installfog.sh"
+    echo " | The installer run is what puts the checked-out code back in service;"
+    echo " | neither step above touches the deployed web tree."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# --checkout
+# ---------------------------------------------------------------------------
+if [[ $doCheckout -eq 1 ]]; then
+    echo
+    if [[ -z $recorded ]]; then
+        echo " * No commit is recorded to go back to. Nothing done."
+        exit 1
+    fi
+    if [[ $head == "$recorded" ]]; then
+        echo " * The checkout is already at $(short "$recorded"). Nothing done."
+        exit 0
+    fi
+    if [[ -z $recordedSchema ]]; then
+        echo " * $(short "$recorded") is not a 1.6 commit. Going back across the 1.5"
+        echo " * boundary restores a web tree as well, which is bin/revertfog.sh's job."
+        exit 1
+    fi
+    echo " * About to move ${gitpath} to $(short "$recorded") (detached HEAD)."
+    echo " * Local changes that conflict will make git refuse; nothing is discarded."
+    if [[ -z $autoYes ]]; then
+        echo -n " * Continue? (y/N) "
+        read -r reply
+        case $reply in
+            [Yy]|[Yy][Ee][Ss]) ;;
+            *) echo " * Aborted."; exit 0 ;;
+        esac
+    fi
+    # --detach, not reset --hard, for the reason offerRevert() gives: the
+    # checkout may be on a different branch than the recorded commit belongs
+    # to, and moving a branch ref at a foreign commit leaves a diverged branch
+    # behind. Detaching moves only HEAD.
+    dots "Checking out $(short "$recorded")"
+    if git -C "$gitpath" checkout --detach "$recorded" >>$error_log 2>&1; then
+        errorStat 0
+        head="$recorded"
+        headSchema="$recordedSchema"
+    else
+        echo "Failed"
+        echo " * git refused. See $error_log -- usually local changes in the way."
+        exit 1
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# --restore-db
+# ---------------------------------------------------------------------------
+if [[ -n $dumpfile ]]; then
+    echo
+    if [[ ${DB_external} == yes ]]; then
+        echo " * DB_external=yes: this server's database is not managed here, so this"
+        echo " * script will not restore into it. Restore the dump on that server."
+        exit 1
+    fi
+    [[ $dumpfile != /* ]] && dumpfile="${workingdir}/${dumpfile}"
+    if [[ ! -s $dumpfile ]]; then
+        echo " * ${dumpfile} does not exist or is empty. Nothing done."
+        exit 1
+    fi
+    dumpschema=$(schemaOfDump "$dumpfile")
+    if [[ -z $dumpschema ]]; then
+        echo " * ${dumpfile} carries no schemaVersion row, so there is no telling what"
+        echo " * code it belongs to. Nothing done."
+        exit 1
+    fi
+    # THE PROOF. The dump has to match the code that will run against it,
+    # which is whatever is checked out now -- after --checkout, that is the
+    # recorded commit. Old code at a newer schema, or new code at an older
+    # one, is the state this script exists to get people OUT of, so it will
+    # not create it.
+    if [[ -z $headSchema ]]; then
+        echo " * The checked-out commit has no 1.6 System.php. If you are going back to"
+        echo " * 1.5, bin/revertfog.sh restores the database AND the web tree; this"
+        echo " * script does neither for that crossing. Nothing done."
+        exit 1
+    fi
+    if [[ $dumpschema != "$headSchema" ]]; then
+        echo " * REFUSED: $(basename "$dumpfile") is schema ${dumpschema}, and the checked-out"
+        echo " * code at $(short "$head") expects schema ${headSchema}. Restoring it would leave the"
+        echo " * database and the code disagreeing, which is what you are trying to undo."
+        if [[ -n $recordedSchema && $dumpschema == "$recordedSchema" && $head != "$recorded" ]]; then
+            echo " * It does match the last completed install: run --checkout first, or"
+            echo " * pass both flags together."
+        fi
+        echo " * Nothing done."
+        exit 1
+    fi
+    if [[ -n $liveSchema && $liveSchema == "$dumpschema" ]]; then
+        echo " * Note: the database is already on schema ${liveSchema}. Restoring replaces"
+        echo " * its contents with the dump's all the same."
+    fi
+
+    # Credentials, proven before anything is stopped -- same shape as
+    # revertfog.sh, and for the same reason: a revert that cannot reach the
+    # database can only get halfway.
+    if ! mysql $sqloptionsuser --password="${DB_password}" --execute="quit" >/dev/null 2>&1; then
+        if detectMysqlSslOption $sqloptionsuser --password="${DB_password}"; then
+            sqloptionsuser="${sqloptionsuser} ${mysqlsslopt}"
+        else
+            echo " * Cannot connect to the database as '${DB_user}' with the credentials in"
+            echo " * ${fogprogramdir}/.fogsettings. Fix that first. Nothing done."
+            exit 1
+        fi
+    fi
+
+    predump="${dumpdir}/fog_sql_prerevert_$(date +"%Y%m%d_%H%M%S").sql"
+    echo " * About to:"
+    echo " |   dump the current database to ${predump}"
+    echo " |   stop the FOG daemons ($serviceList)"
+    echo " |   drop every table in \`${DB_name}\` and restore $(basename "$dumpfile") (schema ${dumpschema})"
+    echo " | Everything recorded since that dump was taken is lost. Then re-run"
+    echo " | installfog.sh to put the code back in service."
+    if [[ -z $autoYes ]]; then
+        echo -n " * Continue? (y/N) "
+        read -r reply
+        case $reply in
+            [Yy]|[Yy][Ee][Ss]) ;;
+            *) echo " * Aborted."; exit 0 ;;
+        esac
+    fi
+
+    dots "Dumping the current database first"
+    mkdir -p "$dumpdir" >>$error_log 2>&1
+    # Not $sqloptionsuser: it carries -s, which mysqldump rejects. Found by
+    # revertfog.sh's rehearsal, not by reading.
+    if command -v mysqldump >/dev/null 2>&1 \
+        && mysqldump ${host} --user="${DB_user}" ${mysqlsslopt:-} \
+            --password="${DB_password}" "${DB_name}" > "$predump" 2>>$error_log; then
+        chmod 600 "$predump" >>$error_log 2>&1
+        errorStat 0
+    else
+        echo "Failed"
+        echo " * Could not dump the current database. See $error_log."
+        echo " * Stopping here: nothing has been touched."
+        rm -f "$predump"
+        exit 1
+    fi
+
+    stopInitScript
+
+    dots "Dropping the current tables"
+    # By name rather than DROP DATABASE, so the database object and the FOG
+    # user's grants survive; FOREIGN_KEY_CHECKS off because 1.6 declares
+    # constraints (ADR 0031) and SHOW TABLES is not dependency order.
+    tables=$(mysql $sqloptionsuser --password="${DB_password}" -N -B --execute="SHOW TABLES" "${DB_name}" 2>>$error_log)
+    if [[ -n $tables ]]; then
+        droplist=$(printf '%s\n' "$tables" | sed 's/^/`/; s/$/`/' | paste -sd, -)
+        if ! mysql $sqloptionsuser --password="${DB_password}" \
+            --execute="SET FOREIGN_KEY_CHECKS=0; DROP TABLE IF EXISTS ${droplist}; SET FOREIGN_KEY_CHECKS=1;" \
+            "${DB_name}" >>$error_log 2>&1; then
+            echo "Failed"
+            echo " * Could not drop the existing tables. See $error_log."
+            echo " * The database is half-dropped at best. Restore from ${predump}"
+            echo " * or from ${dumpfile} by hand before doing anything else."
+            exit 1
+        fi
+    fi
+    errorStat 0
+
+    dots "Restoring $(basename "$dumpfile")"
+    if mysql $sqloptionsuser --password="${DB_password}" "${DB_name}" < "$dumpfile" >>$error_log 2>&1; then
+        errorStat 0
+    else
+        echo "Failed"
+        echo " * The restore did not complete. See $error_log."
+        echo " * \`${DB_name}\` now holds a PARTIAL restore. The dump is still at"
+        echo " * ${dumpfile} and the pre-revert state is at ${predump}."
+        exit 1
+    fi
+    echo " * Database restored to schema ${dumpschema}. The daemons are stopped."
+fi
+
+echo
+echo " * Now re-run the installer from the checked-out code:"
+echo " |     cd ${gitpath}/bin && ./installfog.sh"
+echo " | That redeploys the web tree to match, and starts the daemons again."
+exit 0

--- a/bin/updatefog.sh
+++ b/bin/updatefog.sh
@@ -373,4 +373,6 @@ fi
 echo " * installfog.sh failed (exit $installStatus)."
 echo " * The system has NOT been reverted. See $error_log -- if the checkout"
 echo " | moved, the installer named the commit to reset to at the end of it."
+echo " | bin/revertupdate.sh reports the same, and can do the checkout and the"
+echo " | database restore for you."
 exit $installStatus

--- a/docs/development/reverting-an-upgrade.md
+++ b/docs/development/reverting-an-upgrade.md
@@ -1,5 +1,8 @@
 # Reverting a 1.6 upgrade back to 1.5
 
+> For an update that stayed on 1.6, see **Going back from a 1.6 → 1.6 update**
+> at the end of this document; `revertfog.sh` refuses a 1.6-era dump by design.
+
 `bin/revertfog.sh` puts a server that upgraded to 1.6 back onto its pre-upgrade
 1.5 database, web tree and FOS kernels. It restores **data**, not code: the last
 thing it prints is a reminder to re-run `bin/installfog.sh` from a 1.5 checkout,
@@ -145,8 +148,45 @@ itself. Check these first, and stop if any is missing.
 5. **Take your own backup as well.** `DB_backup_path` defaults to `/home/`, on
    the same machine and often the same disk as the database it is protecting.
 
+## Going back from a 1.6 → 1.6 update: `bin/revertupdate.sh`
+
+`revertfog.sh` is the 1.5 crossing and refuses a 1.6-era dump on purpose.
+An update that stayed on 1.6 and then turned out to be broken -- or failed
+after `updateDB()` had already migrated the schema -- is `bin/revertupdate.sh`
+(GH-1659). It reads two things the update already recorded and surfaces them
+on demand rather than only from the installer's failure trap:
+
+| record | written by | used for |
+|---|---|---|
+| `FOG_last_good_commit` in `.fogsettings` | `markInstallCommit()`, on every completed install | `--checkout` |
+| `fog_sql_<ver>_<ts>.sql` under `${DB_backup_path}/fogDBbackups/` | `backupDB()`, immediately before the migration | `--restore-db` |
+
+Run with no action it **reports and changes nothing**: where the checkout is
+against where the last completed install ran from, what schema the database
+is on, and for each dump on disk whether it fits the code checked out now,
+the code the record names, or neither.
+
+The proof between a dump and the database is a different one from
+`_dumpNotFifteenReason()`: not "is this dump 1.5" but **"does this dump's
+`schemaVersion` row equal the `FOG_SCHEMA` of the code that is checked out"**.
+Both numbers are readable without touching the database -- the row from the
+dump, the constant from `git show <commit>:packages/web/src/Base/System.php` --
+so a mismatch is refused before anything is connected to, stopped or dropped.
+That is what stops the script creating the state it exists to undo: old code
+at a newer schema, or new code at an older one. `--checkout` first, then
+`--restore-db`, or both flags together, is the order that makes a
+pre-migration dump fit.
+
+`--restore-db` takes its own safety dump first (`fog_sql_prerevert_<ts>.sql`,
+beside the others), stops the daemons, drops the tables by name and restores.
+Neither action touches the deployed web tree: re-running `installfog.sh` from
+the checked-out code is what puts it back in service, and the script says so.
+`tests/revertupdate.test.sh` pins the refusals, the order, and that a refusal
+invokes nothing.
+
 ## Related
 
+- `bin/revertupdate.sh` — the 1.6 → 1.6 way back, above.
 - `bin/restorekernel.sh` — the FOS kernel/init generations, reused as step 6.
 - `docs/development/upgrade-rehearsal.md` — rehearsing the upgrade before you
   run it for real.

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -276,6 +276,9 @@ offerRevert() {
     echo " |     git -C ${FOG_git_path} checkout --detach ${recorded}"
     echo " |     cd ${FOG_git_path}/bin && ./installfog.sh"
     echo " |"
+    echo " | bin/revertupdate.sh does the same checkout for you, and it can be run"
+    echo " | later -- this message appears only now, the script reads the same record."
+    echo " |"
     echo " | Nothing has been reverted for you. Your customizations were already"
     echo " | restored by this run -- see docs/SUPPORTED_CUSTOMIZATIONS.md -- and"
     echo " | bin/restorekernel.sh --list will show the kernel sets kept for you."
@@ -295,7 +298,11 @@ offerRevert() {
     # bin/revertfog.sh is deliberately NOT offered here. It restores a
     # pre-upgrade 1.5 dump and _dumpNotFifteenReason() refuses anything that
     # looks like 1.6 -- so pointing at it would send someone to a tool that
-    # turns them away. A manual restore of the dump below is the way back.
+    # turns them away. bin/revertupdate.sh is the tool for this case (GH-1659):
+    # it restores a dump only when the dump's schema matches the checked-out
+    # code, which is the proof this situation needs. The manual command is
+    # still printed, because the dump path is the one thing worth having in
+    # the log if the script is never run.
     local nowSchema
     nowSchema=$(schemaVersionInDB 2>/dev/null)
     if [[ -n $fogPreUpgradeSchema && -n $nowSchema && $nowSchema != "$fogPreUpgradeSchema" ]]; then
@@ -305,9 +312,12 @@ offerRevert() {
         echo " | its own -- the older code would run against the newer schema."
         if [[ -n $fogPreUpgradeDump && -s $fogPreUpgradeDump ]]; then
             echo " |"
-            echo " | Restore the dump taken immediately before the migration:"
+            echo " | Restore the dump taken immediately before the migration, after"
+            echo " | the checkout above so the code matches it:"
             echo " |"
-            echo " |     mysql -u ${DB_user} -p ${DB_name} < ${fogPreUpgradeDump}"
+            echo " |     cd ${FOG_git_path}/bin && ./revertupdate.sh --checkout --restore-db ${fogPreUpgradeDump}"
+            echo " |"
+            echo " | or by hand:  mysql -u ${DB_user} -p ${DB_name} < ${fogPreUpgradeDump}"
         else
             echo " |"
             echo " | No pre-migration dump was written for this run, so there is"

--- a/tests/revertupdate.test.sh
+++ b/tests/revertupdate.test.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+#
+# Guards bin/revertupdate.sh (GH-1659).
+#
+#   tests/revertupdate.test.sh
+#
+# The script has two halves that must stay separate and one proof that must
+# stand between them and the database: a dump is restored only when its
+# schemaVersion row equals the FOG_SCHEMA of the code that is checked out.
+# Old code at a newer schema, or new code at an older one, is the state the
+# script exists to get an administrator OUT of, so the cases below pin that it
+# will not create it -- and that a refusal invokes nothing destructive at all.
+#
+# Fake install under a temporary directory: a real git repository standing in
+# for FOG_git_path with two commits carrying different FOG_SCHEMA values, two
+# dumps carrying the matching schemaVersion rows, and stub mysql / mysqldump /
+# systemctl on PATH that log their arguments. The mysql stub answers the one
+# read the script makes (the live schemaVersion) from $FAKE_LIVE_SCHEMA.
+#
+#   A  no action           -> reports, names which dump fits which commit,
+#                             runs nothing destructive
+#   B  --restore-db, dump behind the checkout  -> REFUSED, nothing invoked
+#   C  --checkout          -> HEAD moves to the recorded commit, nothing else
+#   D  --restore-db, dump ahead of the checkout -> REFUSED, nothing invoked
+#   E  --restore-db, dump matching the checkout -> safety dump, stop, drop,
+#                             restore, in that order
+#   F  --checkout at the recorded commit -> nothing to do, exit 0
+#
+# Root: the script refuses to run as anyone else, so this uses `unshare -r`.
+# If unprivileged user namespaces are unavailable the test SKIPS.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+SCRIPT="$REPO/bin/revertupdate.sh"
+
+[[ -f $SCRIPT ]] || { echo "ERROR: $SCRIPT not found" >&2; exit 1; }
+
+if ! unshare -r true >/dev/null 2>&1; then
+    echo "  SKIP  unprivileged user namespaces unavailable; cannot run revertupdate.sh as root"
+    exit 0
+fi
+command -v git >/dev/null 2>&1 || { echo "  SKIP  git not installed"; exit 0; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+check() { [[ $1 == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+has()   { [[ "$1" == *"$2"* ]] && ok "$3" || bad "$3 (missing: $2)"; }
+hasnt() { [[ "$1" != *"$2"* ]] && ok "$3" || bad "$3 (unexpectedly present: $2)"; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+STUB="$WORK/stub"
+LOG="$WORK/calls.log"
+PROG="$WORK/fog"
+GITREPO="$WORK/checkout"
+BACKUPS="$WORK/backups"
+DUMPS="$BACKUPS/fogDBbackups"
+mkdir -p "$STUB" "$PROG" "$DUMPS" "$GITREPO/packages/web/src/Base"
+
+# The mysql stub answers the schema read and logs everything else. It must
+# SUCCEED on the destructive calls, so that anything past a guard runs to
+# completion rather than being saved by a failing stub.
+cat > "$STUB/mysql" <<'EOF'
+#!/bin/bash
+echo "mysql $*" >> "$STUBLOG"
+case "$*" in
+    *"SELECT vValue"*) echo "$FAKE_LIVE_SCHEMA" ;;
+    *"SHOW TABLES"*)   printf 'hosts\nimages\n' ;;
+esac
+exit 0
+EOF
+for c in mysqldump systemctl; do
+    cat > "$STUB/$c" <<EOF
+#!/bin/bash
+echo "$c \$*" >> "\$STUBLOG"
+exit 0
+EOF
+done
+chmod +x "$STUB"/*
+
+# A checkout with two commits: OLD expects schema 410, NEW expects 415.
+export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@x GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@x
+git -C "$GITREPO" init -q -b working-1.6
+printf '<?php\n        define('"'"'FOG_SCHEMA'"'"', 410);\n' > "$GITREPO/packages/web/src/Base/System.php"
+git -C "$GITREPO" add -A && git -C "$GITREPO" commit -q -m old
+OLD=$(git -C "$GITREPO" rev-parse HEAD)
+printf '<?php\n        define('"'"'FOG_SCHEMA'"'"', 415);\n' > "$GITREPO/packages/web/src/Base/System.php"
+git -C "$GITREPO" commit -q -am new
+NEW=$(git -C "$GITREPO" rev-parse HEAD)
+
+cat > "$PROG/.fogsettings" <<EOF
+## Start of FOG Settings
+## Version: 1.6.0
+FOG_install_type='N'
+FOG_os_id='2'
+FOG_os_name='Debian'
+FOG_program_dir='$PROG'
+FOG_git_path='$GITREPO'
+FOG_last_good_commit='$OLD'
+DB_name='fog'
+DB_host='localhost'
+DB_user='fogmaster'
+DB_password='secret'
+DB_external='no'
+DB_backup_path='$BACKUPS/'
+WEB_docroot='$WORK/www/'
+WEB_root='/fog/'
+WEB_server_engine='apache2'
+SVC_user='fogproject'
+## End of FOG Settings
+EOF
+
+mkdump() { # <file> <schema>
+    cat > "$1" <<EOF
+-- mysqldump-php shaped
+CREATE TABLE \`schemaVersion\` (
+  \`vID\` int(11) NOT NULL,
+  \`vValue\` varchar(255) NOT NULL
+);
+INSERT INTO \`schemaVersion\` VALUES (1,'$2');
+SET SQL_NOTES=@OLD_SQL_NOTES;
+EOF
+}
+mkdump "$DUMPS/fog_sql_4600_20260901_120000.sql" 410
+sleep 1
+mkdump "$DUMPS/fog_sql_4650_20260902_120000.sql" 415
+
+run() {
+    : > "$LOG"
+    out=$(cd "$REPO/bin" && unshare -r env \
+        PATH="$STUB:$PATH" \
+        STUBLOG="$LOG" \
+        FAKE_LIVE_SCHEMA="${LIVE:-415}" \
+        GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.directory GIT_CONFIG_VALUE_0='*' \
+        fogprogramdir="$PROG" \
+        systemctl=yes \
+        bash ./revertupdate.sh "$@" 2>&1)
+    rc=$?
+    calls=$(cat "$LOG")
+}
+
+echo "== A: no action reports, and changes nothing =="
+run
+check "$rc" "0" "exits 0"
+has "$out" "last completed install: ${OLD:0:12}" "names the commit the last completed install ran from"
+has "$out" "now at:                ${NEW:0:12}" "and where the checkout is now"
+has "$out" "fog_sql_4600_20260901_120000.sql  schema 410  (matches the last completed install -- restorable after --checkout)" \
+    "says the older dump fits the recorded commit, after a checkout"
+has "$out" "fog_sql_4650_20260902_120000.sql  schema 415  (matches the checked-out code -- restorable now)" \
+    "and that the newer dump fits the code checked out now"
+has "$out" "Nothing was changed" "says nothing was changed"
+hasnt "$calls" "mysqldump" "took no safety dump"
+hasnt "$calls" "systemctl" "stopped nothing"
+hasnt "$calls" "DROP TABLE" "dropped nothing"
+check "$(git -C "$GITREPO" rev-parse HEAD)" "$NEW" "and moved the checkout nowhere"
+
+echo "== B: a dump behind the checked-out code is refused before anything runs =="
+run --restore-db "$DUMPS/fog_sql_4600_20260901_120000.sql" --yes
+check "$rc" "1" "exits non-zero"
+has "$out" "REFUSED" "says so"
+has "$out" "schema 410, and the checked-out" "names the dump's schema"
+has "$out" "expects schema 415" "and the code's"
+has "$out" "run --checkout first" "and points at the checkout that would make it fit"
+hasnt "$calls" "mysqldump" "no safety dump"
+hasnt "$calls" "systemctl" "nothing stopped"
+hasnt "$calls" "DROP TABLE" "nothing dropped"
+[[ $calls == *"--execute=quit"* ]] && bad "connected to the database before the proof" \
+    || ok "the proof runs before the database is even connected to"
+
+echo "== C: --checkout moves HEAD to the recorded commit and nothing else =="
+run --checkout --yes
+check "$rc" "0" "exits 0"
+check "$(git -C "$GITREPO" rev-parse HEAD)" "$OLD" "HEAD is the recorded commit"
+check "$(git -C "$GITREPO" rev-parse --abbrev-ref HEAD)" "HEAD" "detached, not a moved branch"
+check "$(git -C "$GITREPO" rev-parse working-1.6)" "$NEW" "the branch ref is where it was"
+hasnt "$calls" "mysqldump" "no safety dump"
+hasnt "$calls" "DROP TABLE" "nothing dropped"
+has "$out" "installfog.sh" "and says the installer run is what puts the code in service"
+
+echo "== D: a dump AHEAD of the checked-out code is refused too =="
+run --restore-db "$DUMPS/fog_sql_4650_20260902_120000.sql" --yes
+check "$rc" "1" "exits non-zero"
+has "$out" "REFUSED" "says so"
+hasnt "$out" "run --checkout first" "and does not suggest a checkout that would not help"
+hasnt "$calls" "DROP TABLE" "nothing dropped"
+
+echo "== E: the matching dump restores, in order, after a safety dump =="
+run --restore-db "$DUMPS/fog_sql_4600_20260901_120000.sql" --yes
+check "$rc" "0" "exits 0"
+seq=$(printf '%s\n' "$calls" | grep -oE '^(mysqldump|systemctl|mysql .*(DROP TABLE|SHOW TABLES)|mysql .* fog$)' | sed 's/ .*DROP TABLE.*/ DROP/; s/ .*SHOW TABLES.*/ SHOW/; s/^mysql .*fog$/mysql RESTORE/' | tr '\n' ' ')
+has "$seq" "mysqldump " "took the safety dump"
+case "$seq" in
+    "mysqldump systemctl "*"mysql SHOW mysql DROP mysql RESTORE ") ok "in the order dump, stop, list, drop, restore" ;;
+    *) bad "order was: $seq" ;;
+esac
+has "$out" "Database restored to schema 410" "says what schema the database is on now"
+ls "$DUMPS"/fog_sql_prerevert_*.sql >/dev/null 2>&1 && ok "the safety dump is named beside the others" \
+    || bad "no fog_sql_prerevert_*.sql was written"
+
+echo "== F: --checkout at the recorded commit has nothing to do =="
+run --checkout --yes
+check "$rc" "0" "exits 0"
+has "$out" "already at" "and says so"
+hasnt "$calls" "DROP TABLE" "nothing dropped"
+
+echo
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
Fixes both gaps in GH-1659 with one script, because after a failed update that migrated the schema an administrator needs both halves and should not have to know which tool owns which.

## What it does

`bin/revertupdate.sh`, beside `restorekernel.sh` and `revertfog.sh`, same bootstrap, same `--yes`.

| invocation | effect |
|---|---|
| no action | **reports and changes nothing**: checkout vs `FOG_last_good_commit`, live schema, and for every dump on disk whether it fits the code checked out now, the recorded commit, or neither |
| `--checkout` | `git checkout --detach <FOG_last_good_commit>`, the command `offerRevert()` already prints, now runnable any time |
| `--restore-db <dump>` | safety dump, stop daemons, drop tables by name, restore, in that order, then "re-run installfog.sh" |

## The proof, which is the part the issue said needed deciding

`revertfog.sh`'s `_dumpNotFifteenReason()` proves "this dump is 1.5". The intra-1.6 case needs a different proof, and the one used is: **the dump's `schemaVersion` row must equal the `FOG_SCHEMA` of the code that is checked out.** Both numbers are readable without the database, the constant via `git show <commit>:packages/web/src/Base/System.php`, so the check runs before the script connects to, stops, or drops anything. A dump that fits the *recorded* commit but not the current one is refused with "run `--checkout` first"; a dump that fits neither is just refused. A 1.5 commit (no `System.php`) is refused and pointed at `revertfog.sh`, because that crossing restores a web tree as well.

This is deliberately narrower than option 2 in the issue (teaching `revertfog.sh` an intra-1.6 mode): that script's whole shape is "restore the 1.5 tree too", and bolting a mode onto it would mean two proofs and two web-tree behaviours in one file.

## One thing worth a reviewer's attention

`config.sh` overwrites `FOG_git_path` with the tree the script runs from. Right for the installer, wrong here: the recorded value is the tree the last completed install ran from, which is what the recorded commit is a commit of. The script saves the `.fogsettings` value before sourcing `config.sh` and prefers it. The test's fixture would have failed silently without this, since the test harness runs the script from this repo and the fake install records a different checkout.

## Also

- `offerRevert()` now names the script in both branches; the manual `mysql` command stays, since the dump path is the thing worth having in the log if the script is never run.
- `updatefog.sh`'s failure message names it.
- `docs/development/reverting-an-upgrade.md` gains a section and a pointer at the top.

## Verification

- `tests/revertupdate.test.sh`: **38 passed, 0 failed** under `unshare -r`, against a real two-commit git repo and stub `mysql`/`mysqldump`/`systemctl`. Both refusals invoke *nothing*, asserted on the stub log; `--checkout` moves HEAD and not the branch ref; the matching restore runs dump, stop, list, drop, restore in that order and names the safety dump.
- Mutation: disabling the schema proof turns eleven assertions red across cases B and D, including "connected to the database before the proof". Restored from a copy.
- `revert-offer` 46/0 and `revert-refuses-without-dump` 31/0, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzmGoXrtPgYHz9mvYVCZt2
