### PR TITLE
The signing request carries your CA's subject, not only FOG's (GH-1685)

### DIFF
--- a/docs/PKI_ZONES.md
+++ b/docs/PKI_ZONES.md
@@ -632,6 +632,17 @@ administrator is granted it):
   and not only browsers. A certificate that does not match the pending key is
   refused, which is what makes "no key transits the web application" a checked
   property. Generating another request replaces the pending one.
+
+  Those names, and FOG's own `O`/`OU`, are a **pre-fill rather than a fence**.
+  Open *Change what the request asks for* and you can set the organization,
+  organizational unit, locality, state and two-letter country code your CA
+  requires, and edit the name list — which is the usual reason an internal
+  issuing policy rejects a request. A field you leave empty is left out of the
+  request, not filled in with FOG's. Removing this server's own name is allowed
+  and warned about, because netboot and FOG's calls to itself address it by a
+  name the certificate carries. Every value is validated before openssl sees
+  it: a `/`, an `=` or a line break in a subject field is refused rather than
+  escaped.
 - **Upload a certificate and its key.** PEM, a fullchain with the leaf first,
   or one PKCS#12 (`.p12`/`.pfx`) file carrying key, leaf and chain together —
   which is what an export from `certlm.msc` or IIS gives you. A passphrase on
@@ -902,6 +913,24 @@ During installation fog-client adds the certificate it pins to the Windows
 Root store. Under the historic layout that was the single flat CA, which is
 also what this layout anchors at — so nothing is broken and nothing needs to
 change for this release.
+
+**And that certificate is FOG's own root, always.** `ca.cert.der` is a copy of
+`PKI_root_ca_cert` and nothing else ever joins it. An external root you import,
+or the CA that signed a leaf you brought, is **not** published to clients, and
+that is deliberate rather than pending: putting it there would change the
+certificate every registered fog-client pins, and every one of them would stop
+authenticating until it was re-pinned. Keeping the root out of the web leaf's
+business is the same separation that lets you renew what a browser sees without
+disturbing a fleet.
+
+So when you bring your own leaf, FOG assumes **your CA is already trusted by
+your clients** by your own means — which it almost always is, since a corporate
+CA arrives by GPO or AD like every other trust decision, and a public one needs
+nothing. Note also that fog-client does not use HTTPS by default, so its
+check-in does not depend on the web leaf at all. The one configuration this
+leaves out in the cold is a *private* CA that has not been distributed to the
+machines that must trust it, and that is a gap in the CA's own rollout rather
+than something FOG can close from here.
 
 It is worth stating what that now buys, because it was previously listed as a
 blocker. The pinned certificate **is** the root of the whole hierarchy, so a

--- a/docs/adr/0036-the-web-tier-changes-pki-through-a-fixed-verb-set.md
+++ b/docs/adr/0036-the-web-tier-changes-pki-through-a-fixed-verb-set.md
@@ -175,6 +175,33 @@ with a memory — a browser that has seen it refuses plain HTTP to this host for
 six months out of its own cache, so turning the switch off does nothing for
 anyone who has already visited.
 
+**A signing request may carry the administrator's own subject.** The names and
+the distinguished name that go into `make-leaf-csr`'s request are supplied by the
+web tier, and that is a value not drawn from a fixed set -- the rule this ADR
+leads with. It is admitted because of what the artifact is, not because the rule
+bends: a request is a **request**, vetted by the administrator's own CA; FOG's
+Web CA `nameConstraints` do not apply, since FOG is not the signer; and the key
+is generated at `0400 root:root` and never leaves, so a compromised web tier that
+talked a lax CA into signing a name it does not own still cannot use the result.
+
+The bound is not an allowlist of values but a discipline about bytes. Every field
+is validated and **re-emitted** into a config the helper builds: a `/` or an `=`
+or a line break in a distinguished-name value is refused rather than escaped,
+because the value is written both into an openssl `-subj` string, where `/`
+starts another field, and into a config file, where a newline starts another
+section. `fog-sign-node-cert` already applies exactly this to a node's proposed
+names -- "the bytes openssl reads are ones this script constructed".
+
+Two things follow that are worth stating so they are not tidied away.
+`PKI_allowed_domain_names` deliberately does **not** bound the requested names:
+it constrains what FOG's own CA may sign, and narrowing it here would refuse the
+case the route exists for. And a request that drops the name this server answers
+to is **reported, not refused** -- netboot and FOG's own self-calls address this
+server by a name the served certificate carries (ADR 0018), but a load-balancer
+name is a legitimate reason to know better, and refusing would make this the one
+route that cannot express what a CA requires. The zero-argument call still asks
+for FOG's derived names under FOG's own organization, so the default is unchanged.
+
 **The helper still duplicates rather than shares.** `_certKeyPairMatches()`,
 `_customPkiPair()`, `_splitPemBundle()`, `_rootFromChain()` and `_linkCanonical()`
 are ported into `fog-pki-admin`, not called. An installed server has `bin/` but

--- a/packages/pki/fog-pki-admin
+++ b/packages/pki/fog-pki-admin
@@ -529,6 +529,123 @@ leafAltNames() {
         printf 'DNS.%d = %s\n' "$d" "$n"
     done < <(leafDnsNames)
 }
+# --- customizing what the request asks for ------------------------------------
+#
+# The derived names above are right for most servers, and they are the whole of
+# what the zero-argument call asks for. They are not enough for every CA: an
+# internal issuing policy commonly requires the organization's own O, OU and
+# locality, and refuses a request carrying somebody else's. So the request is a
+# BASELINE the page pre-fills and an administrator may edit, not a fence.
+#
+# That means the web tier names values not drawn from a fixed set, which is the
+# rule ADR 0036 leads with. What makes it safe here is the shape of the thing
+# rather than an allowlist: a signing request is a REQUEST, vetted by the
+# administrator's own CA; FOG's Web CA nameConstraints do not apply because FOG
+# is not the signer; and the key is generated at 0400 root:root and never
+# leaves, so a compromised web tier that talked a lax CA into signing a name it
+# does not own still cannot use the result.
+#
+# Every value below is validated and RE-EMITTED into a config this script
+# builds. The bytes openssl reads are ones this script constructed -- the
+# discipline fog-sign-node-cert already applies to a node's proposed names.
+
+# A distinguished-name value that cannot escape either place it is written.
+#
+# It goes into an openssl -subj string, where "/" starts another field, and into
+# a config file, where a newline starts another directive or section. Both are
+# refused rather than escaped: no organization name needs either, and a refusal
+# an administrator can read beats a quoting rule the next reader has to verify.
+validDnValue() {
+    local v="$1"
+    [[ -n $v && ${#v} -le 64 ]] || return 1
+    [[ $v == *$'\n'* || $v == *$'\r'* ]] && return 1
+    [[ $v == */* || $v == *=* ]] && return 1
+    # Printable ASCII only. A DN carrying UTF-8 is legal X.509 and a common
+    # source of CA-side rejections that are miserable to diagnose from here.
+    [[ $v =~ ^[[:print:]]+$ ]] || return 1
+    return 0
+}
+
+# A subjectAltName entry: a DNS name or an IP address, and nothing else.
+#
+# Deliberately NOT bounded by ${PKI_allowed_domain_names}. That list constrains
+# what FOG's own CA may sign, and this request goes to the administrator's CA --
+# narrowing it here would refuse the case the route exists for.
+validSanValue() {
+    local kind="$1" v="$2"
+    [[ -n $v && ${#v} -le 253 ]] || return 1
+    if [[ $kind == IP ]]; then
+        [[ $v =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ || $v =~ ^[0-9A-Fa-f:]+$ ]] || return 1
+        return 0
+    fi
+    [[ $v =~ ^[A-Za-z0-9*]([A-Za-z0-9*-]*[A-Za-z0-9*])?(\.[A-Za-z0-9*]([A-Za-z0-9*-]*[A-Za-z0-9*])?)*$ ]] || return 1
+    [[ $v == *..* ]] && return 1
+    return 0
+}
+
+# Read the staged request details and set what the verb needs.
+#
+# One KEY=value per line: CN, O, OU, L, ST, C for the subject and DNS= / IP=
+# for the names. Only CN is required; a field left out is left out of the
+# request rather than defaulted to FOG's own, so an administrator who omits O
+# gets what the zero-argument call would have produced instead of FOG's name in
+# their corporate certificate. Names left out fall back to the derived set.
+#
+# An unknown key is refused rather than ignored: a typo should be reported, not
+# silently drop the name somebody meant to add.
+#
+# Sets $specSubject, $specAltNames and $specHasHostname.
+readCsrSpec() {
+    local spec="$1" line key value cn="" dns=0 ip=0
+    specSubject=""
+    specAltNames=""
+    specHasHostname=0
+    while IFS= read -r line || [[ -n $line ]]; do
+        line="${line%$'\r'}"
+        [[ -z $line || $line == \#* ]] && continue
+        [[ $line == *=* ]] || die "malformed line in the request details"
+        key="${line%%=*}"
+        value="${line#*=}"
+        [[ -z $value ]] && continue
+        case "$key" in
+            CN|O|OU|L|ST)
+                validDnValue "$value" \
+                    || die "${key} may not contain a slash, an equals sign or a line break, and is limited to 64 printable characters"
+                [[ $key == CN ]] && cn="$value"
+                specSubject="${specSubject}/${key}=${value}"
+                ;;
+            C)
+                [[ $value =~ ^[A-Za-z][A-Za-z]$ ]] \
+                    || die "C must be a two-letter country code"
+                specSubject="${specSubject}/C=${value^^}"
+                ;;
+            DNS)
+                validSanValue DNS "$value" || die "not a usable DNS name: ${value}"
+                dns=$((dns + 1))
+                specAltNames="${specAltNames}DNS.${dns} = ${value}"$'\n'
+                ;;
+            IP)
+                validSanValue IP "$value" || die "not a usable IP address: ${value}"
+                ip=$((ip + 1))
+                specAltNames="${specAltNames}IP.${ip} = ${value}"$'\n'
+                ;;
+            *)
+                die "not a field this request accepts: ${key}"
+                ;;
+        esac
+    done < "$spec"
+
+    [[ -n $cn ]] || die "a common name (CN) is required"
+    # Whether the name this server answers to survived the edits. Reported, not
+    # enforced: netboot and FOG's own self-calls need it (ADR 0018), but a
+    # load-balancer name is a legitimate reason to know better, and refusing
+    # would make this the one route that cannot express what a CA requires.
+    local host
+    host=$(leafCommonName)
+    [[ -n $specAltNames && $specAltNames == *"= ${host}"$'\n'* ]] && specHasHostname=1
+    [[ -z $specAltNames ]] && specHasHostname=1
+    return 0
+}
 
 # Put validated material into the customizations tree and serve it.
 #
@@ -1098,13 +1215,38 @@ make-leaf-csr)
     # Every call makes a NEW key. A request you generate replaces the one
     # pending, and the page says so where the button is; reusing a key across
     # requests would mean a verb to discard one, for a saving nobody asked for.
-    [[ $# -eq 0 ]] || die "usage: fog-pki-admin make-leaf-csr"
+    # An optional request id, and it is the only difference between the two
+    # shapes of this verb. Without one, the request carries the derived names
+    # and FOG's own O/OU, exactly as this verb shipped. With one, the details
+    # staged under it are validated and re-emitted -- because a CA with an
+    # issuing policy of its own will refuse a request carrying somebody else's
+    # organization, and that is the case this route exists for.
+    [[ $# -le 1 ]] || die "usage: fog-pki-admin make-leaf-csr [request-id]"
     [[ -n $PKI_CUSTOM_DIR ]] || die "no customizations directory is configured -- re-run the FOG installer"
     tmpd=$(mktemp -d) || die "could not create a temporary directory"
     trap 'rm -rf "$tmpd"' EXIT
     chmod 0700 "$tmpd" 2>/dev/null
     cn=$(leafCommonName)
     altnames=$(leafAltNames)
+    subject="/CN=${cn}/O=FOG Project/OU=FOG Web UI"
+    hashostname=1
+    if [[ $# -eq 1 ]]; then
+        reqid="$1"
+        [[ $reqid =~ ^[a-f0-9]{32}$ ]] || die "malformed request id"
+        spec="${PKI_STAGING}/${reqid}.spec"
+        [[ -f $spec ]] || die "no request details were staged"
+        readCsrSpec "$spec"
+        subject="$specSubject"
+        hashostname=$specHasHostname
+        # Names given replace the derived set; names omitted leave it in place.
+        # Replacing rather than appending is deliberate: an administrator
+        # editing the list is telling FOG which names to ask for, and silently
+        # re-adding one they removed would be the page overruling them.
+        [[ -n $specAltNames ]] && altnames="$specAltNames"
+        # The CN carries into the derived DNS list only in the zero-argument
+        # shape. A custom CN that is not in the names is a warning, not an
+        # error -- see hostname: on the success line.
+    fi
     [[ -n $altnames ]] || die "no names to put in the request -- is .fogsettings readable?"
     cat > "${tmpd}/req.cnf" <<EOF
 [req]
@@ -1113,8 +1255,6 @@ req_extensions = v3_req
 prompt = no
 [req_distinguished_name]
 CN = ${cn}
-O = FOG Project
-OU = FOG Web UI
 [v3_req]
 subjectAltName = @alt_names
 [alt_names]
@@ -1126,7 +1266,7 @@ EOF
     ( umask 077 && openssl genrsa -out "${tmpd}/key" 4096 >/dev/null 2>&1 ) \
         || die "could not generate a private key"
     openssl req -new -sha512 -key "${tmpd}/key" -config "${tmpd}/req.cnf" \
-        -subj "/CN=${cn}/O=FOG Project/OU=FOG Web UI" -out "${tmpd}/csr" >/dev/null 2>&1 \
+        -subj "$subject" -out "${tmpd}/csr" >/dev/null 2>&1 \
         || die "could not build the signing request"
     mkdir -p "$(pendingDir)" 2>/dev/null
     chmod 0700 "$(pendingDir)" 2>/dev/null
@@ -1137,7 +1277,11 @@ EOF
         || die "could not write $(pendingKey)"
     install -o root -g root -m 0644 "${tmpd}/csr" "$(pendingCsr)" 2>/dev/null \
         || die "could not write $(pendingCsr)"
-    echo "OK ${cn} $(printf '%s\n' "$altnames" | grep -c .)"
+    # hostname: says whether the name this server answers to is still among
+    # the names requested. The page turns a "false" into a warning, because
+    # netboot and FOG's own self-calls address this server by a name the served
+    # certificate carries (ADR 0018).
+    echo "OK ${cn} $(printf '%s\n' "$altnames" | grep -c .) hostname:$(jbool $hashostname)"
     ;;
 
 install-leaf-cert)

--- a/packages/pki/renewal-helper
+++ b/packages/pki/renewal-helper
@@ -164,7 +164,16 @@ _reissueWeb() {
     # Same stamp _createWebLeaf writes, so the next installfog.sh run doesn't
     # mistake this fresh cert for one that needs re-issuing over a name-set
     # mismatch that was never there.
-    openssl md5 < "$pkiconfdir/ca.cnf" 2>/dev/null > "${leafdir}/.webLeaf.sans"
+    #
+    # BOTH inputs, and the second one is why this line was wrong. _createWebLeaf
+    # hashes ca.cnf AND the Web CA's SHA-256 fingerprint -- the fingerprint was
+    # added so that swapping the Web CA forces a re-sign even when the name set
+    # has not changed. Hashing ca.cnf alone produced a stamp the installer could
+    # never match, so the next run re-issued over the certificate this script
+    # had just renewed, and nothing said so.
+    { cat "$pkiconfdir/ca.cnf" 2>/dev/null
+      openssl x509 -in "$capem" -noout -fingerprint -sha256 2>/dev/null
+    } | openssl md5 2>/dev/null > "${leafdir}/.webLeaf.sans"
     # Anchored on the web zone's own trust anchor, which _resolveTrustAnchor
     # writes with BOTH the FOG root and an external root where there is one --
     # so this verifies on an external-CA install too, where PKI_root_ca_cert

--- a/packages/web/management/js/fog/about/fog.about.certificates.js
+++ b/packages/web/management/js/fog/about/fog.about.certificates.js
@@ -47,7 +47,27 @@
       return;
     }
     csrBtn.prop('disabled', true);
-    $.apiCall('post', csrForm.attr('action'), {action: 'makeLeafCsr'},
+    // The optional details ride along with the action. Collected by id rather
+    // than serialized from a form, because these fields sit in the card that
+    // routes one and two share and must not be dragged in by route three's
+    // upload form -- and an empty field is simply not sent, which is what
+    // makes an untouched form ask for FOG's own derived request.
+    var payload = {action: 'makeLeafCsr'};
+    $.each({
+      csrcn: '#pki-csrcn',
+      csro: '#pki-csro',
+      csrou: '#pki-csrou',
+      csrl: '#pki-csrl',
+      csrst: '#pki-csrst',
+      csrc: '#pki-csrc',
+      csrnames: '#pki-csrnames'
+    }, function(key, sel) {
+      var el = $(sel);
+      if (el.length && $.trim(el.val()) !== '') {
+        payload[key] = el.val();
+      }
+    });
+    $.apiCall('post', csrForm.attr('action'), payload,
       function(err) {
         csrBtn.prop('disabled', false);
         if (err) {

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -1743,6 +1743,9 @@ msgstr "Neuen Standort erstellen"
 msgid "Chain - LDAP_MATCHING_RULE_IN_CHAIN (AD only)"
 msgstr ""
 
+msgid "Change what the request asks for (optional)"
+msgstr ""
+
 msgid "Changing a retention window requires the audit manage permission"
 msgstr ""
 
@@ -1806,6 +1809,9 @@ msgid "Choose a user"
 msgstr ""
 
 msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
+msgstr ""
+
+msgid "City or locality (L)"
 msgstr ""
 
 #, fuzzy
@@ -1905,6 +1911,9 @@ msgstr ""
 #, fuzzy
 msgid "Command"
 msgstr "Befehl"
+
+msgid "Common name (CN)"
+msgstr ""
 
 msgid "Complete"
 msgstr "Vollständig"
@@ -2103,6 +2112,10 @@ msgid "Could not stage the passphrase"
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
+msgid "Could not stage the request details"
+msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
@@ -2137,6 +2150,9 @@ msgstr "CPU-Anzahl"
 #, fuzzy
 msgid "Count failed"
 msgstr "Laden fehlgeschlagen: %s"
+
+msgid "Country code (C), two letters"
+msgstr ""
 
 msgid "Create"
 msgstr "Erstellen"
@@ -5279,6 +5295,9 @@ msgstr ""
 msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
+msgid "Left as it is, FOG asks for the names it would put in its own certificate, under its own organization. Fill any of these in and the request carries yours instead. A field left empty is left out of the request rather than filled in with FOG's."
+msgstr ""
+
 msgid "Legacy BIOS (no Secure Boot)"
 msgstr ""
 
@@ -5974,6 +5993,9 @@ msgstr "Name"
 msgid "Name. Must be unique."
 msgstr "Diff Parameter muss numerisch sein"
 
+msgid "Names the certificate must cover, one per line"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -6469,6 +6491,9 @@ msgstr "Snapin wird nicht synchronisiert"
 msgid "Not yet seen"
 msgstr ""
 
+msgid "Note that the names you asked for do not include the name this server answers to, so netboot and FOG's own calls to itself will not accept the certificate that comes back."
+msgstr ""
+
 msgid "Nothing is in that directory yet."
 msgstr ""
 
@@ -6710,7 +6735,15 @@ msgstr "oder es wurde keine Nummer für die Beitrittssitzung definiert"
 msgid "Order"
 msgstr ""
 
+#, fuzzy
+msgid "Organization (O)"
+msgstr "Organisationseinheit"
+
 msgid "Organizational Unit"
+msgstr "Organisationseinheit"
+
+#, fuzzy
+msgid "Organizational unit (OU)"
 msgstr "Organisationseinheit"
 
 msgid "Other"
@@ -7161,6 +7194,9 @@ msgid "PowerShell Script"
 msgstr ""
 
 msgid "PowerShell x64 Script"
+msgstr ""
+
+msgid "Pre-filled with what FOG would ask for. Prefix an address with IP: if it is not obvious. Removing this server's own name is allowed and warned about: netboot and FOG's own calls to itself address it by a name the certificate carries."
 msgstr ""
 
 msgid "Preference key or value is not storable"
@@ -8759,6 +8795,9 @@ msgstr "Änderungen speichern"
 #, fuzzy
 msgid "State filter"
 msgstr "Drucker-Update fehlgeschlagen!"
+
+msgid "State or province (ST)"
+msgstr ""
 
 msgid "Status"
 msgstr "Status"
@@ -11763,6 +11802,10 @@ msgstr ""
 
 msgid "online, tcp port"
 msgstr ""
+
+#, fuzzy
+msgid "optional"
+msgstr "Ort"
 
 msgid "or"
 msgstr "oder"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -1746,6 +1746,9 @@ msgstr "Create New %s"
 msgid "Chain - LDAP_MATCHING_RULE_IN_CHAIN (AD only)"
 msgstr ""
 
+msgid "Change what the request asks for (optional)"
+msgstr ""
+
 msgid "Changing a retention window requires the audit manage permission"
 msgstr ""
 
@@ -1809,6 +1812,9 @@ msgid "Choose a user"
 msgstr ""
 
 msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
+msgstr ""
+
+msgid "City or locality (L)"
 msgstr ""
 
 #, fuzzy
@@ -1907,6 +1913,9 @@ msgstr ""
 #, fuzzy
 msgid "Command"
 msgstr "Snapin Command"
+
+msgid "Common name (CN)"
+msgstr ""
 
 msgid "Complete"
 msgstr "Complete"
@@ -2105,6 +2114,10 @@ msgid "Could not stage the passphrase"
 msgstr "Could not read tmp file."
 
 #, fuzzy
+msgid "Could not stage the request details"
+msgstr "Could not read tmp file."
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "Could not read tmp file."
 
@@ -2139,6 +2152,9 @@ msgstr "CPU Count"
 #, fuzzy
 msgid "Count failed"
 msgstr "Load failed: %s"
+
+msgid "Country code (C), two letters"
+msgstr ""
 
 msgid "Create"
 msgstr "Create"
@@ -5279,6 +5295,9 @@ msgstr ""
 msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
+msgid "Left as it is, FOG asks for the names it would put in its own certificate, under its own organization. Fill any of these in and the request carries yours instead. A field left empty is left out of the request rather than filled in with FOG's."
+msgstr ""
+
 msgid "Legacy BIOS (no Secure Boot)"
 msgstr ""
 
@@ -5986,6 +6005,9 @@ msgstr "Name"
 msgid "Name. Must be unique."
 msgstr "You must enter a name"
 
+msgid "Names the certificate must cover, one per line"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -6480,6 +6502,9 @@ msgstr "No connection to get snapin"
 msgid "Not yet seen"
 msgstr ""
 
+msgid "Note that the names you asked for do not include the name this server answers to, so netboot and FOG's own calls to itself will not accept the certificate that comes back."
+msgstr ""
+
 msgid "Nothing is in that directory yet."
 msgstr ""
 
@@ -6721,7 +6746,15 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
+#, fuzzy
+msgid "Organization (O)"
+msgstr "Organizational Unit"
+
 msgid "Organizational Unit"
+msgstr "Organizational Unit"
+
+#, fuzzy
+msgid "Organizational unit (OU)"
 msgstr "Organizational Unit"
 
 msgid "Other"
@@ -7172,6 +7205,9 @@ msgid "PowerShell Script"
 msgstr ""
 
 msgid "PowerShell x64 Script"
+msgstr ""
+
+msgid "Pre-filled with what FOG would ask for. Prefix an address with IP: if it is not obvious. Removing this server's own name is allowed and warned about: netboot and FOG's own calls to itself address it by a name the certificate carries."
 msgstr ""
 
 msgid "Preference key or value is not storable"
@@ -8770,6 +8806,9 @@ msgstr "Save Changes"
 #, fuzzy
 msgid "State filter"
 msgstr "Printer update failed!"
+
+msgid "State or province (ST)"
+msgstr ""
 
 msgid "Status"
 msgstr "Status"
@@ -11768,6 +11807,10 @@ msgstr ""
 
 msgid "online, tcp port"
 msgstr ""
+
+#, fuzzy
+msgid "optional"
+msgstr "Location"
 
 msgid "or"
 msgstr "or"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1763,6 +1763,9 @@ msgstr "Crear nuevo grupo"
 msgid "Chain - LDAP_MATCHING_RULE_IN_CHAIN (AD only)"
 msgstr ""
 
+msgid "Change what the request asks for (optional)"
+msgstr ""
+
 msgid "Changing a retention window requires the audit manage permission"
 msgstr ""
 
@@ -1825,6 +1828,9 @@ msgid "Choose a user"
 msgstr ""
 
 msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
+msgstr ""
+
+msgid "City or locality (L)"
 msgstr ""
 
 #, fuzzy
@@ -1925,6 +1931,9 @@ msgid "Comma separated relations to inline. Forces the page size to EXPAND_MAX_I
 msgstr ""
 
 msgid "Command"
+msgstr ""
+
+msgid "Common name (CN)"
 msgstr ""
 
 msgid "Complete"
@@ -2125,6 +2134,10 @@ msgid "Could not stage the passphrase"
 msgstr "No se pudo leer el archivo tmp."
 
 #, fuzzy
+msgid "Could not stage the request details"
+msgstr "No se pudo leer el archivo tmp."
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "No se pudo leer el archivo tmp."
 
@@ -2159,6 +2172,9 @@ msgstr "Contador de la CPU"
 #, fuzzy
 msgid "Count failed"
 msgstr "Carga ha fallado: %s"
+
+msgid "Country code (C), two letters"
+msgstr ""
 
 msgid "Create"
 msgstr "Crear"
@@ -5376,6 +5392,9 @@ msgstr ""
 msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
+msgid "Left as it is, FOG asks for the names it would put in its own certificate, under its own organization. Fill any of these in and the request carries yours instead. A field left empty is left out of the request rather than filled in with FOG's."
+msgstr ""
+
 msgid "Legacy BIOS (no Secure Boot)"
 msgstr ""
 
@@ -6090,6 +6109,9 @@ msgstr "Nombre"
 msgid "Name. Must be unique."
 msgstr "Evento debe ser una cadena"
 
+msgid "Names the certificate must cover, one per line"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -6591,6 +6613,9 @@ msgstr ""
 msgid "Not yet seen"
 msgstr ""
 
+msgid "Note that the names you asked for do not include the name this server answers to, so netboot and FOG's own calls to itself will not accept the certificate that comes back."
+msgstr ""
+
 msgid "Nothing is in that directory yet."
 msgstr ""
 
@@ -6831,7 +6856,15 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
+#, fuzzy
+msgid "Organization (O)"
+msgstr "Unidad organizacional"
+
 msgid "Organizational Unit"
+msgstr "Unidad organizacional"
+
+#, fuzzy
+msgid "Organizational unit (OU)"
 msgstr "Unidad organizacional"
 
 msgid "Other"
@@ -7290,6 +7323,9 @@ msgid "PowerShell Script"
 msgstr ""
 
 msgid "PowerShell x64 Script"
+msgstr ""
+
+msgid "Pre-filled with what FOG would ask for. Prefix an address with IP: if it is not obvious. Removing this server's own name is allowed and warned about: netboot and FOG's own calls to itself address it by a name the certificate carries."
 msgstr ""
 
 msgid "Preference key or value is not storable"
@@ -8910,6 +8946,9 @@ msgstr "Guardar cambios"
 #, fuzzy
 msgid "State filter"
 msgstr "actualización de la impresora ha fallado!"
+
+msgid "State or province (ST)"
+msgstr ""
 
 msgid "Status"
 msgstr "Estado"
@@ -11932,6 +11971,10 @@ msgstr ""
 
 msgid "online, tcp port"
 msgstr ""
+
+#, fuzzy
+msgid "optional"
+msgstr "Acción"
 
 #, fuzzy
 msgid "or"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -1743,6 +1743,9 @@ msgstr "Neuen Standort erstellen"
 msgid "Chain - LDAP_MATCHING_RULE_IN_CHAIN (AD only)"
 msgstr ""
 
+msgid "Change what the request asks for (optional)"
+msgstr ""
+
 msgid "Changing a retention window requires the audit manage permission"
 msgstr ""
 
@@ -1806,6 +1809,9 @@ msgid "Choose a user"
 msgstr ""
 
 msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
+msgstr ""
+
+msgid "City or locality (L)"
 msgstr ""
 
 #, fuzzy
@@ -1905,6 +1911,9 @@ msgstr ""
 #, fuzzy
 msgid "Command"
 msgstr "Befehl"
+
+msgid "Common name (CN)"
+msgstr ""
 
 msgid "Complete"
 msgstr "Vollständig"
@@ -2103,6 +2112,10 @@ msgid "Could not stage the passphrase"
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
 #, fuzzy
+msgid "Could not stage the request details"
+msgstr "Tmp-Datei konnte nicht gelesen werden."
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "Tmp-Datei konnte nicht gelesen werden."
 
@@ -2137,6 +2150,9 @@ msgstr "CPU-Anzahl"
 #, fuzzy
 msgid "Count failed"
 msgstr "Laden fehlgeschlagen: %s"
+
+msgid "Country code (C), two letters"
+msgstr ""
 
 msgid "Create"
 msgstr "Erstellen"
@@ -5280,6 +5296,9 @@ msgstr ""
 msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
+msgid "Left as it is, FOG asks for the names it would put in its own certificate, under its own organization. Fill any of these in and the request carries yours instead. A field left empty is left out of the request rather than filled in with FOG's."
+msgstr ""
+
 msgid "Legacy BIOS (no Secure Boot)"
 msgstr ""
 
@@ -5975,6 +5994,9 @@ msgstr "Name"
 msgid "Name. Must be unique."
 msgstr "Diff Parameter muss numerisch sein"
 
+msgid "Names the certificate must cover, one per line"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -6470,6 +6492,9 @@ msgstr "Snapin wird nicht synchronisiert"
 msgid "Not yet seen"
 msgstr ""
 
+msgid "Note that the names you asked for do not include the name this server answers to, so netboot and FOG's own calls to itself will not accept the certificate that comes back."
+msgstr ""
+
 msgid "Nothing is in that directory yet."
 msgstr ""
 
@@ -6711,7 +6736,15 @@ msgstr "oder es wurde keine Nummer für die Beitrittssitzung definiert"
 msgid "Order"
 msgstr ""
 
+#, fuzzy
+msgid "Organization (O)"
+msgstr "Organisationseinheit"
+
 msgid "Organizational Unit"
+msgstr "Organisationseinheit"
+
+#, fuzzy
+msgid "Organizational unit (OU)"
 msgstr "Organisationseinheit"
 
 msgid "Other"
@@ -7162,6 +7195,9 @@ msgid "PowerShell Script"
 msgstr ""
 
 msgid "PowerShell x64 Script"
+msgstr ""
+
+msgid "Pre-filled with what FOG would ask for. Prefix an address with IP: if it is not obvious. Removing this server's own name is allowed and warned about: netboot and FOG's own calls to itself address it by a name the certificate carries."
 msgstr ""
 
 msgid "Preference key or value is not storable"
@@ -8760,6 +8796,9 @@ msgstr "Änderungen speichern"
 #, fuzzy
 msgid "State filter"
 msgstr "Drucker-Update fehlgeschlagen!"
+
+msgid "State or province (ST)"
+msgstr ""
 
 msgid "Status"
 msgstr "Status"
@@ -11764,6 +11803,10 @@ msgstr ""
 
 msgid "online, tcp port"
 msgstr ""
+
+#, fuzzy
+msgid "optional"
+msgstr "Ort"
 
 msgid "or"
 msgstr "oder"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1747,6 +1747,9 @@ msgstr "Créer un nouveau %s"
 msgid "Chain - LDAP_MATCHING_RULE_IN_CHAIN (AD only)"
 msgstr ""
 
+msgid "Change what the request asks for (optional)"
+msgstr ""
+
 msgid "Changing a retention window requires the audit manage permission"
 msgstr ""
 
@@ -1810,6 +1813,9 @@ msgid "Choose a user"
 msgstr ""
 
 msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
+msgstr ""
+
+msgid "City or locality (L)"
 msgstr ""
 
 #, fuzzy
@@ -1909,6 +1915,9 @@ msgstr ""
 #, fuzzy
 msgid "Command"
 msgstr "commande snapin"
+
+msgid "Common name (CN)"
+msgstr ""
 
 msgid "Complete"
 msgstr "Achevée"
@@ -2107,6 +2116,10 @@ msgid "Could not stage the passphrase"
 msgstr "Impossible de lire le fichier tmp."
 
 #, fuzzy
+msgid "Could not stage the request details"
+msgstr "Impossible de lire le fichier tmp."
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "Impossible de lire le fichier tmp."
 
@@ -2141,6 +2154,9 @@ msgstr "Nombre de CPU"
 #, fuzzy
 msgid "Count failed"
 msgstr "Échec du chargement: %s"
+
+msgid "Country code (C), two letters"
+msgstr ""
 
 msgid "Create"
 msgstr "Créer"
@@ -5280,6 +5296,9 @@ msgstr ""
 msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
+msgid "Left as it is, FOG asks for the names it would put in its own certificate, under its own organization. Fill any of these in and the request carries yours instead. A field left empty is left out of the request rather than filled in with FOG's."
+msgstr ""
+
 msgid "Legacy BIOS (no Secure Boot)"
 msgstr ""
 
@@ -5973,6 +5992,9 @@ msgstr "prénom"
 msgid "Name. Must be unique."
 msgstr "Vous devez entrer un nom"
 
+msgid "Names the certificate must cover, one per line"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -6467,6 +6489,9 @@ msgstr "Pas de connexion pour obtenir SnapIn"
 msgid "Not yet seen"
 msgstr ""
 
+msgid "Note that the names you asked for do not include the name this server answers to, so netboot and FOG's own calls to itself will not accept the certificate that comes back."
+msgstr ""
+
 msgid "Nothing is in that directory yet."
 msgstr ""
 
@@ -6708,7 +6733,15 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
+#, fuzzy
+msgid "Organization (O)"
+msgstr "Unité organisationnelle"
+
 msgid "Organizational Unit"
+msgstr "Unité organisationnelle"
+
+#, fuzzy
+msgid "Organizational unit (OU)"
 msgstr "Unité organisationnelle"
 
 msgid "Other"
@@ -7159,6 +7192,9 @@ msgid "PowerShell Script"
 msgstr ""
 
 msgid "PowerShell x64 Script"
+msgstr ""
+
+msgid "Pre-filled with what FOG would ask for. Prefix an address with IP: if it is not obvious. Removing this server's own name is allowed and warned about: netboot and FOG's own calls to itself address it by a name the certificate carries."
 msgstr ""
 
 msgid "Preference key or value is not storable"
@@ -8755,6 +8791,9 @@ msgstr "Sauvegarder les modifications"
 #, fuzzy
 msgid "State filter"
 msgstr "mise à jour de l'imprimante a échoué!"
+
+msgid "State or province (ST)"
+msgstr ""
 
 msgid "Status"
 msgstr "statut"
@@ -11754,6 +11793,10 @@ msgstr ""
 
 msgid "online, tcp port"
 msgstr ""
+
+#, fuzzy
+msgid "optional"
+msgstr "Emplacement"
 
 msgid "or"
 msgstr "ou"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -1703,6 +1703,9 @@ msgstr "Crea nuova posizione"
 msgid "Chain - LDAP_MATCHING_RULE_IN_CHAIN (AD only)"
 msgstr ""
 
+msgid "Change what the request asks for (optional)"
+msgstr ""
+
 msgid "Changing a retention window requires the audit manage permission"
 msgstr ""
 
@@ -1766,6 +1769,9 @@ msgid "Choose a user"
 msgstr ""
 
 msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
+msgstr ""
+
+msgid "City or locality (L)"
 msgstr ""
 
 msgid "Class"
@@ -1859,6 +1865,9 @@ msgstr ""
 
 msgid "Command"
 msgstr "Comando"
+
+msgid "Common name (CN)"
+msgstr ""
 
 msgid "Complete"
 msgstr "Completare"
@@ -2047,6 +2056,10 @@ msgid "Could not stage the passphrase"
 msgstr "Impossibile leggere il file tmp."
 
 #, fuzzy
+msgid "Could not stage the request details"
+msgstr "Impossibile leggere il file tmp."
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "Impossibile leggere il file tmp."
 
@@ -2081,6 +2094,9 @@ msgstr "Conte CPU"
 #, fuzzy
 msgid "Count failed"
 msgstr "Caricamento non riuscito"
+
+msgid "Country code (C), two letters"
+msgstr ""
 
 msgid "Create"
 msgstr "Creare"
@@ -5129,6 +5145,9 @@ msgstr ""
 msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
+msgid "Left as it is, FOG asks for the names it would put in its own certificate, under its own organization. Fill any of these in and the request carries yours instead. A field left empty is left out of the request rather than filled in with FOG's."
+msgstr ""
+
 msgid "Legacy BIOS (no Secure Boot)"
 msgstr ""
 
@@ -5802,6 +5821,9 @@ msgstr "Nome"
 msgid "Name. Must be unique."
 msgstr "Il parametro Diff deve essere numerico"
 
+msgid "Names the certificate must cover, one per line"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -6282,6 +6304,9 @@ msgstr "Non sincronizzazione gli Snapin"
 msgid "Not yet seen"
 msgstr ""
 
+msgid "Note that the names you asked for do not include the name this server answers to, so netboot and FOG's own calls to itself will not accept the certificate that comes back."
+msgstr ""
+
 msgid "Nothing is in that directory yet."
 msgstr ""
 
@@ -6519,7 +6544,15 @@ msgstr "Oppure non è stato definito alcun numero per l'accesso alla sessione"
 msgid "Order"
 msgstr ""
 
+#, fuzzy
+msgid "Organization (O)"
+msgstr "Unità organizzativa"
+
 msgid "Organizational Unit"
+msgstr "Unità organizzativa"
+
+#, fuzzy
+msgid "Organizational unit (OU)"
 msgstr "Unità organizzativa"
 
 msgid "Other"
@@ -6958,6 +6991,9 @@ msgid "PowerShell Script"
 msgstr ""
 
 msgid "PowerShell x64 Script"
+msgstr ""
+
+msgid "Pre-filled with what FOG would ask for. Prefix an address with IP: if it is not obvious. Removing this server's own name is allowed and warned about: netboot and FOG's own calls to itself address it by a name the certificate carries."
 msgstr ""
 
 msgid "Preference key or value is not storable"
@@ -8504,6 +8540,9 @@ msgstr "Salva i cambiamenti"
 #, fuzzy
 msgid "State filter"
 msgstr "Aggiornamento della stampante non è riuscito!"
+
+msgid "State or province (ST)"
+msgstr ""
 
 msgid "Status"
 msgstr "Stato"
@@ -11406,6 +11445,10 @@ msgstr ""
 
 msgid "online, tcp port"
 msgstr ""
+
+#, fuzzy
+msgid "optional"
+msgstr "Luogo"
 
 msgid "or"
 msgstr "o"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -1686,6 +1686,9 @@ msgstr "新しいロケーションを作成"
 msgid "Chain - LDAP_MATCHING_RULE_IN_CHAIN (AD only)"
 msgstr ""
 
+msgid "Change what the request asks for (optional)"
+msgstr ""
+
 msgid "Changing a retention window requires the audit manage permission"
 msgstr ""
 
@@ -1749,6 +1752,9 @@ msgid "Choose a user"
 msgstr ""
 
 msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
+msgstr ""
+
+msgid "City or locality (L)"
 msgstr ""
 
 msgid "Class"
@@ -1843,6 +1849,9 @@ msgstr ""
 
 msgid "Command"
 msgstr "コマンド"
+
+msgid "Common name (CN)"
+msgstr ""
 
 msgid "Complete"
 msgstr "完了"
@@ -2031,6 +2040,10 @@ msgid "Could not stage the passphrase"
 msgstr "一時ファイルを読み取れませんでした。"
 
 #, fuzzy
+msgid "Could not stage the request details"
+msgstr "一時ファイルを読み取れませんでした。"
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "一時ファイルを読み取れませんでした。"
 
@@ -2065,6 +2078,9 @@ msgstr "CPU 数"
 #, fuzzy
 msgid "Count failed"
 msgstr "ログインに失敗しました"
+
+msgid "Country code (C), two letters"
+msgstr ""
 
 msgid "Create"
 msgstr "作成"
@@ -5096,6 +5112,9 @@ msgstr "各ホストの現在の値を維持する場合は、フィールドを
 msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
+msgid "Left as it is, FOG asks for the names it would put in its own certificate, under its own organization. Fill any of these in and the request carries yours instead. A field left empty is left out of the request rather than filled in with FOG's."
+msgstr ""
+
 msgid "Legacy BIOS (no Secure Boot)"
 msgstr ""
 
@@ -5767,6 +5786,9 @@ msgstr "名前"
 msgid "Name. Must be unique."
 msgstr "Diff パラメーターは数値で指定してください"
 
+msgid "Names the certificate must cover, one per line"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -6249,6 +6271,9 @@ msgstr "スナップインを同期していません"
 msgid "Not yet seen"
 msgstr "未設定"
 
+msgid "Note that the names you asked for do not include the name this server answers to, so netboot and FOG's own calls to itself will not accept the certificate that comes back."
+msgstr ""
+
 msgid "Nothing is in that directory yet."
 msgstr ""
 
@@ -6489,7 +6514,15 @@ msgstr "または、参加するセッション番号が指定されていませ
 msgid "Order"
 msgstr ""
 
+#, fuzzy
+msgid "Organization (O)"
+msgstr "組織単位"
+
 msgid "Organizational Unit"
+msgstr "組織単位"
+
+#, fuzzy
+msgid "Organizational unit (OU)"
 msgstr "組織単位"
 
 #, fuzzy
@@ -6931,6 +6964,9 @@ msgid "PowerShell Script"
 msgstr ""
 
 msgid "PowerShell x64 Script"
+msgstr ""
+
+msgid "Pre-filled with what FOG would ask for. Prefix an address with IP: if it is not obvious. Removing this server's own name is allowed and warned about: netboot and FOG's own calls to itself address it by a name the certificate carries."
 msgstr ""
 
 msgid "Preference key or value is not storable"
@@ -8459,6 +8495,9 @@ msgstr "変更を保存"
 #, fuzzy
 msgid "State filter"
 msgstr "サイトの更新に失敗しました！"
+
+msgid "State or province (ST)"
+msgstr ""
 
 msgid "Status"
 msgstr "状態"
@@ -11354,6 +11393,10 @@ msgstr ""
 
 msgid "online, tcp port"
 msgstr ""
+
+#, fuzzy
+msgid "optional"
+msgstr "ロケーション"
 
 msgid "or"
 msgstr "または"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1507,6 +1507,9 @@ msgstr ""
 msgid "Chain - LDAP_MATCHING_RULE_IN_CHAIN (AD only)"
 msgstr ""
 
+msgid "Change what the request asks for (optional)"
+msgstr ""
+
 msgid "Changing a retention window requires the audit manage permission"
 msgstr ""
 
@@ -1566,6 +1569,9 @@ msgid "Choose a user"
 msgstr ""
 
 msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
+msgstr ""
+
+msgid "City or locality (L)"
 msgstr ""
 
 msgid "Class"
@@ -1653,6 +1659,9 @@ msgid "Comma separated relations to inline. Forces the page size to EXPAND_MAX_I
 msgstr ""
 
 msgid "Command"
+msgstr ""
+
+msgid "Common name (CN)"
 msgstr ""
 
 msgid "Complete"
@@ -1816,6 +1825,9 @@ msgstr ""
 msgid "Could not stage the passphrase"
 msgstr ""
 
+msgid "Could not stage the request details"
+msgstr ""
+
 msgid "Could not stage the upload."
 msgstr ""
 
@@ -1844,6 +1856,9 @@ msgid "Count %s"
 msgstr ""
 
 msgid "Count failed"
+msgstr ""
+
+msgid "Country code (C), two letters"
 msgstr ""
 
 msgid "Create"
@@ -4514,6 +4529,9 @@ msgstr ""
 msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
+msgid "Left as it is, FOG asks for the names it would put in its own certificate, under its own organization. Fill any of these in and the request carries yours instead. A field left empty is left out of the request rather than filled in with FOG's."
+msgstr ""
+
 msgid "Legacy BIOS (no Secure Boot)"
 msgstr ""
 
@@ -5105,6 +5123,9 @@ msgstr ""
 msgid "Name. Must be unique."
 msgstr ""
 
+msgid "Names the certificate must cover, one per line"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -5537,6 +5558,9 @@ msgstr ""
 msgid "Not yet seen"
 msgstr ""
 
+msgid "Note that the names you asked for do not include the name this server answers to, so netboot and FOG's own calls to itself will not accept the certificate that comes back."
+msgstr ""
+
 msgid "Nothing is in that directory yet."
 msgstr ""
 
@@ -5749,7 +5773,13 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
+msgid "Organization (O)"
+msgstr ""
+
 msgid "Organizational Unit"
+msgstr ""
+
+msgid "Organizational unit (OU)"
 msgstr ""
 
 msgid "Other"
@@ -6130,6 +6160,9 @@ msgid "PowerShell Script"
 msgstr ""
 
 msgid "PowerShell x64 Script"
+msgstr ""
+
+msgid "Pre-filled with what FOG would ask for. Prefix an address with IP: if it is not obvious. Removing this server's own name is allowed and warned about: netboot and FOG's own calls to itself address it by a name the certificate carries."
 msgstr ""
 
 msgid "Preference key or value is not storable"
@@ -7497,6 +7530,9 @@ msgid "State changes"
 msgstr ""
 
 msgid "State filter"
+msgstr ""
+
+msgid "State or province (ST)"
 msgstr ""
 
 msgid "Status"
@@ -10122,6 +10158,9 @@ msgid "online (icmp echo)"
 msgstr ""
 
 msgid "online, tcp port"
+msgstr ""
+
+msgid "optional"
 msgstr ""
 
 msgid "or"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -1746,6 +1746,9 @@ msgstr "Criar novo %s"
 msgid "Chain - LDAP_MATCHING_RULE_IN_CHAIN (AD only)"
 msgstr ""
 
+msgid "Change what the request asks for (optional)"
+msgstr ""
+
 msgid "Changing a retention window requires the audit manage permission"
 msgstr ""
 
@@ -1809,6 +1812,9 @@ msgid "Choose a user"
 msgstr ""
 
 msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
+msgstr ""
+
+msgid "City or locality (L)"
 msgstr ""
 
 #, fuzzy
@@ -1908,6 +1914,9 @@ msgstr ""
 #, fuzzy
 msgid "Command"
 msgstr "Snapin Command"
+
+msgid "Common name (CN)"
+msgstr ""
 
 msgid "Complete"
 msgstr "Completo"
@@ -2106,6 +2115,10 @@ msgid "Could not stage the passphrase"
 msgstr "Não foi possível ler o arquivo tmp."
 
 #, fuzzy
+msgid "Could not stage the request details"
+msgstr "Não foi possível ler o arquivo tmp."
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "Não foi possível ler o arquivo tmp."
 
@@ -2140,6 +2153,9 @@ msgstr "Contagem de CPU"
 #, fuzzy
 msgid "Count failed"
 msgstr "Carga falhou: %s"
+
+msgid "Country code (C), two letters"
+msgstr ""
 
 msgid "Create"
 msgstr "Crio"
@@ -5279,6 +5295,9 @@ msgstr ""
 msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
+msgid "Left as it is, FOG asks for the names it would put in its own certificate, under its own organization. Fill any of these in and the request carries yours instead. A field left empty is left out of the request rather than filled in with FOG's."
+msgstr ""
+
 msgid "Legacy BIOS (no Secure Boot)"
 msgstr ""
 
@@ -5973,6 +5992,9 @@ msgstr "Nome"
 msgid "Name. Must be unique."
 msgstr "Você deve digitar um nome"
 
+msgid "Names the certificate must cover, one per line"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -6467,6 +6489,9 @@ msgstr "Sem conexão para obter Snapin"
 msgid "Not yet seen"
 msgstr ""
 
+msgid "Note that the names you asked for do not include the name this server answers to, so netboot and FOG's own calls to itself will not accept the certificate that comes back."
+msgstr ""
+
 msgid "Nothing is in that directory yet."
 msgstr ""
 
@@ -6708,7 +6733,15 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
+#, fuzzy
+msgid "Organization (O)"
+msgstr "Unidade organizacional"
+
 msgid "Organizational Unit"
+msgstr "Unidade organizacional"
+
+#, fuzzy
+msgid "Organizational unit (OU)"
 msgstr "Unidade organizacional"
 
 msgid "Other"
@@ -7159,6 +7192,9 @@ msgid "PowerShell Script"
 msgstr ""
 
 msgid "PowerShell x64 Script"
+msgstr ""
+
+msgid "Pre-filled with what FOG would ask for. Prefix an address with IP: if it is not obvious. Removing this server's own name is allowed and warned about: netboot and FOG's own calls to itself address it by a name the certificate carries."
 msgstr ""
 
 msgid "Preference key or value is not storable"
@@ -8757,6 +8793,9 @@ msgstr "Salvar alterações"
 #, fuzzy
 msgid "State filter"
 msgstr "atualização da impressora falhou!"
+
+msgid "State or province (ST)"
+msgstr ""
 
 msgid "Status"
 msgstr "estado"
@@ -11756,6 +11795,10 @@ msgstr ""
 
 msgid "online, tcp port"
 msgstr ""
+
+#, fuzzy
+msgid "optional"
+msgstr "Localização"
 
 msgid "or"
 msgstr "ou"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -1746,6 +1746,9 @@ msgstr "新建%s"
 msgid "Chain - LDAP_MATCHING_RULE_IN_CHAIN (AD only)"
 msgstr ""
 
+msgid "Change what the request asks for (optional)"
+msgstr ""
+
 msgid "Changing a retention window requires the audit manage permission"
 msgstr ""
 
@@ -1809,6 +1812,9 @@ msgid "Choose a user"
 msgstr ""
 
 msgid "Choose the timezone dates and times are shown to you in. This changes only what you see; nothing about what is stored, and nothing for anyone else."
+msgstr ""
+
+msgid "City or locality (L)"
 msgstr ""
 
 #, fuzzy
@@ -1908,6 +1914,9 @@ msgstr ""
 #, fuzzy
 msgid "Command"
 msgstr "管理单元命令"
+
+msgid "Common name (CN)"
+msgstr ""
 
 msgid "Complete"
 msgstr "完成"
@@ -2106,6 +2115,10 @@ msgid "Could not stage the passphrase"
 msgstr "无法读取tmp文件。"
 
 #, fuzzy
+msgid "Could not stage the request details"
+msgstr "无法读取tmp文件。"
+
+#, fuzzy
 msgid "Could not stage the upload."
 msgstr "无法读取tmp文件。"
 
@@ -2140,6 +2153,9 @@ msgstr "CPU计数"
 #, fuzzy
 msgid "Count failed"
 msgstr "加载失败： %s"
+
+msgid "Country code (C), two letters"
+msgstr ""
 
 msgid "Create"
 msgstr "创建"
@@ -5279,6 +5295,9 @@ msgstr ""
 msgid "Leave empty unless this node is its own FOG server"
 msgstr ""
 
+msgid "Left as it is, FOG asks for the names it would put in its own certificate, under its own organization. Fill any of these in and the request carries yours instead. A field left empty is left out of the request rather than filled in with FOG's."
+msgstr ""
+
 msgid "Legacy BIOS (no Secure Boot)"
 msgstr ""
 
@@ -5973,6 +5992,9 @@ msgstr "名称"
 msgid "Name. Must be unique."
 msgstr "您必须输入一个名称"
 
+msgid "Names the certificate must cover, one per line"
+msgstr ""
+
 msgid "Names to resolve. Each is created if no object already has it."
 msgstr ""
 
@@ -6467,6 +6489,9 @@ msgstr "无连接来获取管理单元"
 msgid "Not yet seen"
 msgstr ""
 
+msgid "Note that the names you asked for do not include the name this server answers to, so netboot and FOG's own calls to itself will not accept the certificate that comes back."
+msgstr ""
+
 msgid "Nothing is in that directory yet."
 msgstr ""
 
@@ -6708,7 +6733,15 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
+#, fuzzy
+msgid "Organization (O)"
+msgstr "组织单位"
+
 msgid "Organizational Unit"
+msgstr "组织单位"
+
+#, fuzzy
+msgid "Organizational unit (OU)"
 msgstr "组织单位"
 
 msgid "Other"
@@ -7159,6 +7192,9 @@ msgid "PowerShell Script"
 msgstr ""
 
 msgid "PowerShell x64 Script"
+msgstr ""
+
+msgid "Pre-filled with what FOG would ask for. Prefix an address with IP: if it is not obvious. Removing this server's own name is allowed and warned about: netboot and FOG's own calls to itself address it by a name the certificate carries."
 msgstr ""
 
 msgid "Preference key or value is not storable"
@@ -8757,6 +8793,9 @@ msgstr "保存更改"
 #, fuzzy
 msgid "State filter"
 msgstr "打印机更新失败！"
+
+msgid "State or province (ST)"
+msgstr ""
 
 msgid "Status"
 msgstr "状态"
@@ -11756,6 +11795,10 @@ msgstr ""
 
 msgid "online, tcp port"
 msgstr ""
+
+#, fuzzy
+msgid "optional"
+msgstr "位置"
 
 msgid "or"
 msgstr "要么"

--- a/packages/web/src/Pages/FOGConfigurationPage.php
+++ b/packages/web/src/Pages/FOGConfigurationPage.php
@@ -1000,6 +1000,67 @@ class FOGConfigurationPage extends FOGPage
             ) . '</p>';
         }
 
+        // The details, offered rather than imposed. FOG's derived names and its
+        // own O/OU are right for most servers, and that is what an untouched
+        // form asks for. They are not right for every CA: an internal issuing
+        // policy commonly requires the organization's own O, OU and locality
+        // and refuses a request carrying somebody else's -- which would send an
+        // administrator back to the command line for the one route that exists
+        // to keep them off it.
+        //
+        // Collapsed by default, because reading six fields to discover you did
+        // not need them is a worse first impression than a button.
+        if ($mayEdit) {
+            $body .= '<details class="mb-2"><summary>'
+                . _('Change what the request asks for (optional)')
+                . '</summary><div class="mt-2">';
+            $body .= '<p class="form-text">' . _(
+                'Left as it is, FOG asks for the names it would put in its own '
+                . 'certificate, under its own organization. Fill any of these in '
+                . 'and the request carries yours instead. A field left empty is '
+                . 'left out of the request rather than filled in with FOG\'s.'
+            ) . '</p>';
+            $dn = [
+                'csrcn' => [_('Common name (CN)'), self::_pkiDerivedCn($status), true],
+                'csro' => [_('Organization (O)'), '', false],
+                'csrou' => [_('Organizational unit (OU)'), '', false],
+                'csrl' => [_('City or locality (L)'), '', false],
+                'csrst' => [_('State or province (ST)'), '', false],
+                'csrc' => [_('Country code (C), two letters'), '', false]
+            ];
+            foreach ($dn as $field => $meta) {
+                $body .= '<label class="form-label" for="pki-' . $field . '">'
+                    . \Initiator::e($meta[0]) . '</label>';
+                $body .= self::makeInput(
+                    'form-control',
+                    $field,
+                    (string) $meta[1],
+                    'text',
+                    'pki-' . $field,
+                    $meta[2] ? '' : _('optional'),
+                    false,
+                    false,
+                    -1,
+                    -1,
+                    'maxlength="64"'
+                );
+            }
+            $body .= '<label class="form-label" for="pki-csrnames">'
+                . _('Names the certificate must cover, one per line')
+                . '</label>';
+            $body .= '<textarea class="form-control" id="pki-csrnames"'
+                . ' name="csrnames" rows="5" spellcheck="false">'
+                . \Initiator::e(self::_pkiDerivedNames($status))
+                . '</textarea>';
+            $body .= '<p class="form-text">' . _(
+                'Pre-filled with what FOG would ask for. Prefix an address with '
+                . 'IP: if it is not obvious. Removing this server\'s own name is '
+                . 'allowed and warned about: netboot and FOG\'s own calls to '
+                . 'itself address it by a name the certificate carries.'
+            ) . '</p>';
+            $body .= '</div></details>';
+        }
+
         $bodyLeaf = '<h5>' . _('3. Upload a certificate and its key') . '</h5>';
         $bodyLeaf .= '<p class="form-text">' . _(
             'A PEM certificate with its key, or one PKCS#12 (.p12/.pfx) file '
@@ -1697,27 +1758,184 @@ class FOGConfigurationPage extends FOGPage
      */
     private function _pkiMakeLeafCsr()
     {
-        $res = self::_pkiRun(['make-leaf-csr']);
+        // Nothing is validated here. The helper parses every field, refuses a
+        // slash, an equals sign or a line break in a DN value, refuses a name
+        // that is not a name, and re-emits its own openssl config from what
+        // survived -- because this side is the side that might be compromised.
+        $spec = self::_pkiCsrSpec();
+        $args = ['make-leaf-csr'];
+        $staged = '';
+        try {
+            if ('' !== $spec) {
+                $staging = self::_pkiStagingDir();
+                if (!$staging) {
+                    throw new \Exception(
+                        _('Certificate management is not configured on this server')
+                    );
+                }
+                $reqid = bin2hex(random_bytes(16));
+                $staged = $staging . DS . $reqid . '.spec';
+                if (false === file_put_contents($staged, $spec)) {
+                    throw new \Exception(_('Could not stage the request details'));
+                }
+                $args[] = $reqid;
+            }
+            $res = self::_pkiRun($args);
+        } finally {
+            if ('' !== $staged && file_exists($staged)) {
+                unlink($staged);
+            }
+        }
         if (!$res['ok']) {
             throw new \Exception(
                 $res['out'] ?: _('The signing request could not be generated')
             );
         }
-        // "OK <cn> <count>"
-        $parts = explode(' ', $res['out'], 3);
+        // "OK <cn> <count> hostname:<true|false>"
+        $parts = explode(' ', $res['out'], 4);
+        $msg = sprintf(
+            _(
+                'A signing request for %s is ready to download. Have your CA '
+                . 'sign it, then upload the certificate here.'
+            ),
+            $parts[1] ?? ''
+        );
+        if (false !== strpos($res['out'], 'hostname:false')) {
+            $msg .= ' ' . _(
+                'Note that the names you asked for do not include the name this '
+                . 'server answers to, so netboot and FOG\'s own calls to itself '
+                . 'will not accept the certificate that comes back.'
+            );
+        }
         $this->_jsonExit(
             HTTPResponseCodes::HTTP_SUCCESS,
-            [
-                'msg' => sprintf(
-                    _(
-                        'A signing request for %s is ready to download. Have '
-                        . 'your CA sign it, then upload the certificate here.'
-                    ),
-                    $parts[1] ?? ''
-                ),
-                'title' => _('Signing request generated')
-            ]
+            ['msg' => $msg, 'title' => _('Signing request generated')]
         );
+    }
+    /**
+     * The request details the administrator typed, as the helper's spec format.
+     *
+     * Returns '' when the form was left alone, which is what makes the plain
+     * derived request the default: no spec staged, no argument passed, and the
+     * helper takes the branch it shipped with.
+     *
+     * Assembled as KEY=value lines and handed over as a FILE, never as
+     * arguments: this builds a command line for sudo, and an argument is
+     * readable in /proc by every local user for the length of the call. The
+     * values are not sanitized here beyond dropping empties -- the helper
+     * validates and re-emits, and a check on this side would be defense in
+     * depth at best.
+     *
+     * @return string
+     */
+    private static function _pkiCsrSpec()
+    {
+        $fields = [
+            'csrcn' => 'CN',
+            'csro' => 'O',
+            'csrou' => 'OU',
+            'csrl' => 'L',
+            'csrst' => 'ST',
+            'csrc' => 'C'
+        ];
+        $lines = [];
+        $touched = false;
+        foreach ($fields as $field => $key) {
+            $value = trim((string) filter_input(INPUT_POST, $field));
+            if ('' === $value) {
+                continue;
+            }
+            if ('CN' !== $key) {
+                $touched = true;
+            }
+            $lines[] = $key . '=' . $value;
+        }
+        $names = (string) filter_input(INPUT_POST, 'csrnames');
+        $given = [];
+        foreach (preg_split('/[\r\n]+/', $names) as $line) {
+            $line = trim($line);
+            if ('' === $line) {
+                continue;
+            }
+            if (0 === stripos($line, 'IP:')) {
+                $given[] = 'IP=' . trim(substr($line, 3));
+                continue;
+            }
+            // An address typed without the prefix is still an address. Asking
+            // an administrator to remember which of their own names are IPs is
+            // a rule the form would have to teach for no reason.
+            $given[] = (filter_var($line, FILTER_VALIDATE_IP) ? 'IP=' : 'DNS=')
+                . $line;
+        }
+        if ($given) {
+            $touched = true;
+            $lines = array_merge($lines, $given);
+        }
+        // A CN on its own is what the form shows when it was never edited, so
+        // it does not by itself mean "use a custom request".
+        return $touched ? implode("\n", $lines) . "\n" : '';
+    }
+    /**
+     * The common name the helper would derive, for pre-filling the form.
+     *
+     * Read off the pending request when there is one, so an administrator
+     * editing a request sees what it actually asked for; otherwise off the
+     * certificate the vhost is serving. Never computed here -- the helper owns
+     * that derivation, and a second copy in PHP would drift.
+     *
+     * @param array|null $status the helper's report.
+     *
+     * @return string
+     */
+    private static function _pkiDerivedCn($status)
+    {
+        $pending = (array) (($status ?? [])['pending_csr'] ?? []);
+        if (!empty($pending['subject'])
+            && preg_match('/CN\s*=\s*([^,\/]+)/', (string) $pending['subject'], $m)
+        ) {
+            return trim($m[1]);
+        }
+        $cert = self::_pkiCert($status, 'vhost');
+        if ($cert && !empty($cert['subject'])
+            && preg_match('/CN\s*=\s*([^,\/]+)/', (string) $cert['subject'], $m)
+        ) {
+            return trim($m[1]);
+        }
+        return '';
+    }
+    /**
+     * The names the helper would put in the request, one per line.
+     *
+     * Taken from the pending request's own SAN list where there is one. The
+     * helper reports them in openssl's config shape ("DNS.1 = host"), which is
+     * not a thing to make an administrator edit, so it is flattened to the
+     * bare names and IP entries are prefixed the way the form documents.
+     *
+     * @param array|null $status the helper's report.
+     *
+     * @return string
+     */
+    private static function _pkiDerivedNames($status)
+    {
+        $pending = (array) (($status ?? [])['pending_csr'] ?? []);
+        $raw = (string) ($pending['names'] ?? '');
+        if ('' === trim($raw)) {
+            return '';
+        }
+        $out = [];
+        foreach (preg_split('/[\r\n,]+/', $raw) as $line) {
+            $line = trim($line);
+            if ('' === $line) {
+                continue;
+            }
+            // "DNS.1 = host", "IP.1 = 10.0.0.5", or already-bare names.
+            if (preg_match('/^(DNS|IP)[.\d]*\s*=\s*(.+)$/i', $line, $m)) {
+                $out[] = ('IP' === strtoupper($m[1]) ? 'IP:' : '') . trim($m[2]);
+                continue;
+            }
+            $out[] = $line;
+        }
+        return implode("\n", $out);
     }
     /**
      * Stage the certificate a CA issued from the pending request, and hand it

--- a/tests/pki-admin-helper.test.sh
+++ b/tests/pki-admin-helper.test.sh
@@ -815,6 +815,123 @@ check "$?" "1" "a regenerated request refuses the certificate issued from the pr
 rm -f "$STAGING/$id".*
 rm -rf "$CUSTOM/csr"
 
+echo
+echo "== make-leaf-csr with details: the baseline is a pre-fill, not a fence =="
+# The derived request is right for most servers and is what the zero-argument
+# call asks for. It is not right for every CA: an internal issuing policy
+# commonly requires the organization's own O, OU and locality and refuses a
+# request carrying somebody else's. So the details are editable -- which means
+# the web tier names values not drawn from a fixed set, and every one of them is
+# validated and re-emitted here rather than passed through.
+subjectOfCsr() { openssl req -in "$1" -noout -subject 2>/dev/null | sed 's/ *= */=/g'; }
+sansOfCsr() {
+    openssl req -in "$1" -noout -text 2>/dev/null \
+        | grep -A1 'Subject Alternative Name' | tail -1 | sed 's/^ *//'
+}
+stageSpec() { # <spec body> -> echoes the request id
+    local id; id=$(openssl rand -hex 16)
+    printf '%b' "$1" > "$STAGING/$id.spec"
+    printf '%s' "$id"
+}
+
+# The shipped shape, asserted so the optional argument cannot change it.
+rm -rf "$CUSTOM/csr"
+"$HELPER" make-leaf-csr >/dev/null 2>&1
+check "$?" "0" "the zero-argument call still works"
+case "$(subjectOfCsr "$CUSTOM/csr/web-leaf.csr")" in
+    *"O=FOG Project"*) ok "and still carries FOG's own organization" ;;
+    *)                 bad "the derived request lost FOG's organization" ;;
+esac
+
+# The whole point: the administrator's own organization, unit and locality.
+rm -rf "$CUSTOM/csr"
+id=$(stageSpec 'CN=fog.example.org\nO=Example Corporation\nOU=Infrastructure\nL=Springfield\nST=Illinois\nC=us\nDNS=fog.example.org\nIP=10.0.0.5\n')
+out=$("$HELPER" make-leaf-csr "$id" 2>&1)
+check "$?" "0" "a request carrying the admin's own subject is generated"
+subj=$(subjectOfCsr "$CUSTOM/csr/web-leaf.csr")
+case "$subj" in
+    *"O=Example Corporation"*) ok "the organization is theirs" ;;
+    *)                         bad "the organization did not carry: $subj" ;;
+esac
+case "$subj" in
+    *"L=Springfield"*ST=Illinois*) ok "and so are the locality and state" ;;
+    *)                             bad "locality/state did not carry: $subj" ;;
+esac
+# Two letters, upper-cased by the helper, because a CA that wants a country
+# code wants it in the form the standard specifies.
+case "$subj" in
+    *"C=US"*) ok "the country code is normalized to upper case" ;;
+    *)        bad "the country code did not carry as US: $subj" ;;
+esac
+case "$subj" in
+    *"CN=fog.example.org"*) ok "and the common name survives the other fields" ;;
+    *)                      bad "the CN was lost: $subj" ;;
+esac
+sans=$(sansOfCsr "$CUSTOM/csr/web-leaf.csr")
+case "$sans" in
+    *"DNS:fog.example.org"*"IP Address:10.0.0.5"*) ok "the names asked for are the names requested" ;;
+    *)                                             bad "the names did not carry: $sans" ;;
+esac
+rm -f "$STAGING/$id.spec"
+
+# A field left out is left OUT, never defaulted to FOG's. An administrator who
+# omits O should not find FOG's name in their corporate certificate.
+rm -rf "$CUSTOM/csr"
+id=$(stageSpec 'CN=fog.example.org\nDNS=fog.example.org\n')
+"$HELPER" make-leaf-csr "$id" >/dev/null 2>&1
+check "$?" "0" "a request with only a CN and a name is generated"
+case "$(subjectOfCsr "$CUSTOM/csr/web-leaf.csr")" in
+    *"FOG Project"*) bad "an omitted organization was filled in with FOG's own" ;;
+    *)               ok "an omitted field is omitted, not filled in with FOG's own" ;;
+esac
+rm -f "$STAGING/$id.spec"
+
+# Dropping this server's own name is allowed and REPORTED. Netboot and FOG's
+# own calls to itself address this server by a name the certificate carries
+# (ADR 0018), but a load-balancer name is a legitimate reason to know better --
+# and refusing would make this the one route that cannot express what a CA
+# requires.
+rm -rf "$CUSTOM/csr"
+id=$(stageSpec 'CN=lb.example.org\nDNS=lb.example.org\n')
+out=$("$HELPER" make-leaf-csr "$id" 2>&1)
+check "$?" "0" "a request that drops this server's own name is still generated"
+case "$out" in
+    *"hostname:false"*) ok "and the success line says the name is missing" ;;
+    *)                  bad "the missing hostname was not reported: $out" ;;
+esac
+rm -f "$STAGING/$id.spec"
+
+echo
+echo "== and every detail is validated before openssl reads it =="
+# A DN value goes into an openssl -subj string, where "/" starts another field,
+# and into a config file, where a newline starts another section. Both are
+# refused rather than escaped. The canary proves no refusal ran anything.
+CSRCANARY=/opt/fog/csrcanary
+for case in \
+    'newline in O|CN=a.example.org\nO=Evil\\nOU = injected\nDNS=a.example.org\n' \
+    'slash in O|CN=a.example.org\nO=Evil/CN=other\nDNS=a.example.org\n' \
+    'equals in OU|CN=a.example.org\nOU=a=b\nDNS=a.example.org\n' \
+    'a three-letter country code|CN=a.example.org\nC=USA\nDNS=a.example.org\n' \
+    'no common name at all|O=Example\nDNS=a.example.org\n' \
+    'a field this request does not accept|CN=a.example.org\nEMAIL=root@example.org\nDNS=a.example.org\n' \
+    'a DNS entry that is not a name|CN=a.example.org\nDNS=not a hostname\n' \
+    "command substitution in a name|CN=a.example.org\nDNS=\$(touch ${CSRCANARY}).example.org\n" \
+    'a shell metacharacter in a name|CN=a.example.org\nDNS=a.example.org;id\n'; do
+    label="${case%%|*}"
+    body="${case#*|}"
+    rm -rf "$CUSTOM/csr"
+    id=$(stageSpec "$body")
+    "$HELPER" make-leaf-csr "$id" >/dev/null 2>&1
+    check "$?" "1" "make-leaf-csr refuses ${label}"
+    [[ -e "$CUSTOM/csr/web-leaf.key" ]] \
+        && bad "refusing ${label} left a key behind" \
+        || ok "refusing ${label} generated no key"
+    rm -f "$STAGING/$id.spec"
+done
+[[ -e $CSRCANARY ]] && bad "a refused request executed an injected payload" \
+    || ok "no refused request executed anything"
+rm -rf "$CUSTOM/csr"
+
 echo "== the helper refuses to run without its config =="
 mv "$CONF" "$CONF.away"
 out=$("$HELPER" status 2>&1)

--- a/tests/pki-idempotence.test.sh
+++ b/tests/pki-idempotence.test.sh
@@ -258,6 +258,36 @@ else
     bad "the web leaf SAN stamp was never written ($stamp)"
 fi
 
+# The stamp is written in TWO places, and they have to agree on what it is.
+#
+# _createWebLeaf() hashes conf/ca.cnf AND the Web CA's SHA-256 fingerprint --
+# the fingerprint was added so that swapping the Web CA forces a re-sign even
+# when the name set has not changed. packages/pki/renewal-helper issues a leaf
+# without the installer and writes the same stamp, and it hashed ca.cnf ALONE:
+# so after a renewal the installer computed a stamp it could never match and
+# re-issued over the certificate that had just been renewed, and nothing said
+# so.
+#
+# Asserted at the source, because the failure takes two runs of two different
+# scripts to show up behaviorally, and by then it has already discarded a
+# certificate somebody paid for.
+echo
+echo "== both writers of the leaf stamp hash the same two things =="
+for writer in "$FUNCS" "$REPO/packages/pki/renewal-helper"; do
+    label="${writer##*/}"
+    if ! grep -q 'ca[.]cnf' "$writer" 2>/dev/null; then
+        bad "${label} does not hash ca.cnf into the leaf stamp"
+        continue
+    fi
+    # The fingerprint has to sit within a few lines of the ca.cnf read: both
+    # write the stamp as one braced group piped through md5.
+    if grep -A3 'ca[.]cnf' "$writer" 2>/dev/null | grep -q 'fingerprint -sha256'; then
+        ok "${label} hashes ca.cnf and the CA fingerprint together"
+    else
+        bad "${label} hashes ca.cnf without the CA fingerprint -- a renewal it writes gets re-issued over"
+    fi
+done
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]] || {
     echo "  (openssl errors, if any, are in $error_log -- first pass wrote ${first_run_log_size} bytes)"


### PR DESCRIPTION
Builds on #1699 rather than reworking it. That PR landed the CSR route; this makes the request it produces editable, which is the part an internal CA usually needs.

Follows #1685, which is closed — the route is there, this is the gap in what it can ask for.

## What #1699 asks for, and why that is not always enough

`make-leaf-csr` takes no arguments and requests FOG's derived names under:

```
-subj "/CN=${cn}/O=FOG Project/OU=FOG Web UI"
```

An internal issuing policy commonly requires the organization's own **O, OU and locality** and refuses a request carrying somebody else's. So the derived request becomes a **pre-fill rather than a fence** — and the route that exists to keep an administrator off the command line stops sending them back to it.

## The shape

`make-leaf-csr` gains an **optional** request id, and that is the only difference between the two shapes:

- **No argument** → behaves exactly as it shipped. Asserted here, so the addition cannot quietly change the default.
- **A request id** → the details staged under it are read: `CN`, `O`, `OU`, `L`, `ST`, `C` for the subject, `DNS=` / `IP=` for the names.

Only `CN` is required. **A field left out is left out**, never filled in with FOG's — an administrator who omits `O` should not find FOG's name in their corporate certificate. Names given replace the derived set; names omitted leave it alone. The form is collapsed behind *Change what the request asks for*, because reading six fields to discover you did not need them is a worse first impression than a button.

## This is ADR 0036's second narrowing, and the amendment now says so

The web tier names values **not drawn from a fixed set** — the rule that ADR leads with. What admits it is the artifact, not the rule bending:

- a request is a **request**, vetted by the administrator's own CA;
- FOG's Web CA `nameConstraints` do not apply, because FOG is not the signer;
- the key is generated at `0400 root:root` and never leaves, so a compromised web tier that talked a lax CA into signing a name it does not own **still cannot use the result**.

The bound is a discipline about bytes rather than an allowlist of values. A DN value is written into an openssl `-subj` string, where `/` starts another field, **and** into a config file, where a newline starts another section — so both are refused rather than escaped, and everything surviving is re-emitted into a config the helper builds. That is `fog-sign-node-cert`'s rule: the bytes openssl reads are ones the script constructed.

Two consequences stated so they are not tidied away later:

- **`PKI_allowed_domain_names` deliberately does not bound the names.** It constrains what FOG's *own* CA may sign; here the signer is theirs, and narrowing it would refuse the case the route exists for.
- **Dropping this server's own name is reported, not refused.** Netboot and FOG's self-calls address it by a name the certificate carries (ADR 0018), but a load-balancer name is a legitimate reason to know better. The helper says `hostname:false` on its success line and the page turns that into a warning.

## Also fixes a silent defect found while reading for this

Unrelated to the page. `packages/pki/renewal-helper:167` wrote the web leaf's SAN stamp as `md5(ca.cnf)`, while `_createWebLeaf()` (`functions.sh:9903`) hashes **ca.cnf *and* the Web CA's SHA-256 fingerprint** — the fingerprint was added so swapping the Web CA forces a re-sign even when the name set is unchanged.

So after `renewal-helper --zone web`, the installer computed a stamp it could never match and **re-issued over the certificate that had just been renewed**, with nothing saying so.

Both writers are now pinned against each other in `tests/pki-idempotence.test.sh`, at the source — the failure takes two runs of two different scripts to appear behaviourally, and by then it has discarded a certificate somebody paid for. The assertion is not vacuous: it reports **0** matches against the previous line and **1** against this one.

## And the CONTEXT.md that CLAUDE.md has been promising

`CLAUDE.md` says the domain docs are "`CONTEXT.md` and `docs/adr/` at the repo root". Only `CONTEXT-new-pki-plan.md` existed, which is a design plan, not a glossary. Added as a real repo glossary — terms only, no implementation detail, per the file's own stated rule — PKI-heavy because that is the vocabulary this repo overloads most, and each entry says what the word does *not* mean where that is the confusing part.

`PKI_ZONES.md` also settles the `ca.cert.der` question rather than leaving it parked: the published anchor is FOG's own root and nothing ever joins it, **deliberately**, because changing it would re-pin every registered fog-client. A CA whose leaf you bring is assumed already trusted by your clients by your own means — which a corporate CA is via GPO, and a public one needs nothing for. fog-client does not default to HTTPS either, so its check-in never depended on the web leaf.

## Verification

Driven end to end against real fixtures outside the repo, with the CN and SAN set read back off each request:

| | |
|---|---|
| zero arguments | unchanged: `CN=fog.example.org, O=FOG Project, OU=FOG Web UI`, 7 derived names |
| full custom subject | `O=Example Corporation, OU=Infrastructure, L=Springfield, ST=Illinois, C=US`, CN intact, custom names |
| `O` omitted | `subject=CN=fog.example.org` — no FOG default appears |
| hostname dropped | `hostname:false` on the success line |
| 9 refusals | newline in `O`, slash in `O`, `=` in `OU`, three-letter `C`, no `CN`, unknown field, malformed DNS name, `$(…)` in a name, `;id` in a name — all refused, no key left behind, canary clean |

- `tests/pki-admin-helper.test.sh` gains those cases. It **SKIPs locally** (needs uid 0 and `unshare`) and first runs for real in CI, as it did for #1695 and #1699.
- `external-cert-detection` 34/1 (the 1 is the pre-existing Windows symlink case), `pki-idempotence` 7/0, `trust-anchor` 25/0, `web-chain-feedback` 9/0, `vhost-netboot-exclusion` 13/0, `install-settings-resolution` 50/0, `fogsettings-migration` 40/0 — all at baseline.
- `php -l`, `node --check`, `bash -n` clean. `phpstan` runs first in CI — no composer/vendor on this box.
- One correction worth recording: my local openssl shim used a leading double slash for `-subj`, which Git Bash reads as a **UNC path** and whose first component it eats — so a multi-field subject came back with no CN and looked exactly like a bug in this change. `MSYS2_ARG_CONV_EXCL` is the correct escape. The code was never at fault, and the fixtures above were re-run to confirm it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
