### PR TITLE
Let FOG correct a readme it wrote, and name the /opt tree's third direction

### DIFF
--- a/docs/SUPPORTED_CUSTOMIZATIONS.md
+++ b/docs/SUPPORTED_CUSTOMIZATIONS.md
@@ -45,22 +45,16 @@ fog-docs at `docs/1.6/management/server/supported-customizations.md`.
 
 ## The short version
 
-- **Preserved automatically**, on a bare `./installfog.sh` upgrade as much as
-  through `bin/updatefog.sh`: the iPXE boot menu background (under whatever
-  name `FOG_IPXE_BG_FILE` holds), custom-named kernels and inits, previous
-  kernel generations, Secure Boot keys, reports you have written, replaced
-  iPXE binaries in the TFTP tree, and anything in the vhost **outside** the
-  managed block.
-- **Yours to place**: files under names FOG does not ship. Nothing removes
-  them.
-- **Adopted**: a `web-leaf.pem`/`web-leaf.key` pair in
-  `/etc/fog/customizations/pki` is picked up on the next run and served, with
-  nothing to configure. That directory is the `/etc` counterpart of
-  `$fogprogramdir/customizations` and runs the other way round -- FOG writes the
-  `/opt` one, and only reads the `/etc` one. There is a `readme.txt` in each.
-- **Not preserved**: edits *inside* the managed block, direct edits to
-  `default.ipxe`, and anything under the web root that FOG does not ship — the
-  tree is rebuilt wholesale on every run.
+There isn't one here any more, and that is deliberate.
 
-Read the page above before relying on any of that; every entry has conditions
-this summary leaves out.
+A summary in this file is a second copy of the page above, which is the drift
+this file exists to prevent -- and it drifted: the summary described what FOG
+preserves without the condition the guarantee actually rests on, and went on
+saying so after `kernel-backups/keep/` gave the `/opt` tree a direction the
+summary did not know about.
+
+Read <https://docs.fogproject.org/supported-customizations>. Without network
+access, the two readmes on the server itself say what each tree is for --
+`/etc/fog/customizations/readme.txt` and
+`$fogprogramdir/customizations/readme.txt` -- and the full former text of this
+file is in `git log --follow -p docs/SUPPORTED_CUSTOMIZATIONS.md`.

--- a/docs/adr/0040-certificates-you-bring-live-in-a-customizations-tree.md
+++ b/docs/adr/0040-certificates-you-bring-live-in-a-customizations-tree.md
@@ -7,6 +7,57 @@ accepted, and implemented on `working-1.6` as `_customPkiDir()` /
 with `PKI_custom_dir` recorded in `.fogsettings` and signal 0 of
 `_detectExternalCertManagement()`.
 
+## Amended 2026-09-02 — the /opt tree has a third direction, and the readmes can be corrected
+
+Two corrections to the amendment below, both found by reading the merged code
+rather than the issue.
+
+**"The two readmes already say exactly that" is no longer true.** The `/opt`
+readme says *"This directory is written BY FOG. You do not need to put anything
+here."* Then `kernel-backups/keep/` arrived — `2775`, group-owned by the web
+user, and by its own comment *"the one directory under here the WEB TIER
+writes."* Marking a boot file to keep copies it in on the administrator's
+instruction. That is a third direction, and it is neither of the two this ADR
+names: not FOG's own backup taken before a rebuild, and not an administrator's
+drop-in that FOG only reads. It is FOG acting on a recorded intention.
+
+It does not reopen the split. `keep/` is written by FOG, restored by FOG, and
+removed by FOG when the mark is cleared; an administrator never places a file
+there by hand, and the tree stays output-only in the sense that matters — the
+conflict rule below is unchanged, because nothing in `keep/` competes with a
+file the administrator put somewhere. What it does reopen is the *description*,
+and the readme is where that lives.
+
+**`keep/` is the effect of a pin, not a record of one.** Worth stating because
+it looks like a manifest at a glance, and ADR 0042's *"Existence is read, never
+recorded"* would rule against a manifest. `bfPinned` holds the judgment; the
+copy is what the judgment does. A manifest is data *about* files and can drift
+from them — a copy is a second set of the same bytes and cannot. The comments
+in `_ensureCustomizationsTree()` and `FOGPage::_bootFileKeepCopy()` said "the
+copy IS the record" and now say this instead.
+
+**So "never overwrite a readme" is narrowed to "never overwrite an *edited*
+readme."** The original rule was written to protect the note somebody left for
+the next person, which is right. But it also froze FOG's own text, and a server
+installed before `keep/` existed had a readme that was wrong with no run able to
+correct it — the rule was defending FOG's prose from FOG.
+
+`_ensureCustomizationsTree()` now replaces a readme while it is still
+byte-identical to a revision FOG shipped, and leaves anything else alone
+permanently. `_fogShippedReadmeSums()` holds the sums, appended to and never
+replaced; adding a revision means adding its sum. Where `sha256sum` is missing
+the question cannot be answered, and the file is kept: there is no run in which
+discarding somebody's note is the better mistake. Both arms are executed by
+`tests/customizations-readme-refresh.test.sh`, because a too-eager version and a
+too-timid one fail in opposite directions and a textual check cannot tell an
+inverted comparison from a working one.
+
+One consequence outside this ADR: `docs/SUPPORTED_CUSTOMIZATIONS.md` carried a
+`## The short version` summary, which is the duplication that file's own text
+warns against, and it had drifted the same way — stating the preservation
+guarantee without the condition it rests on, and predating `keep/`. It is now a
+pure pointer.
+
 ## Amended 2026-09-02 — two trees, by direction, is the design
 
 FOGProject/fogproject#1684 asked the question "One unified tree" below

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,62 @@
+# Architecture decision records
+
+One decision per file, numbered in the order they were taken. A record is
+written when a decision is **hard to reverse**, **surprising without context**,
+and **the result of a real trade-off** — if any of the three is missing, the
+reasoning belongs in a comment beside the code instead.
+
+This index exists because forty-two records with no way in is forty-two records
+nobody reads. GH-1684 asked a question ADR 0040 had already answered and
+rejected by name; that is the failure mode a list of titles prevents.
+
+**Amendments are part of the record.** Several ADRs here carry a
+`## Amended <date>` section that narrows or reverses something in the body
+below it — 0036 and 0040 both do. Read the amendments first; the body is what
+was decided originally, not necessarily what stands.
+
+Status is summarized here and stated in full in each file.
+
+| # | Decision | Status |
+|---|---|---|
+| 0001 | [Group association state is a derived tri-state; modules count only *enabled* hosts](0001-group-association-state.md) | superseded |
+| 0002 | [DHCP engine: detect-and-prefer Kea, fall back to ISC, never auto-switch an existing install](0002-kea-dhcp-engine-selection.md) | accepted |
+| 0003 | [The settings-cache flush dir is sticky world-writable, not owned by one web user](0003-settings-cache-flush-dir-perms.md) | accepted |
+| 0004 | [Server-rendered chrome is refreshed via a second fragment request, not rebuilt in-place](0004-ajax-refresh-server-chrome.md) | accepted |
+| 0005 | [Role-based permissions are native; the accesscontrol plugin is retired](0005-native-rbac-retires-accesscontrol-plugin.md) | accepted |
+| 0006 | [Per-object scoping is a plugin boundary layered on native RBAC](0006-site-object-scope-boundary.md) | accepted |
+| 0007 | [External identity is provenance; authority comes from roles, mapped per directory group](0007-external-identity-provenance-and-directory-group-mapping.md) | accepted |
+| 0008 | [The Secure Boot enrollment task type, and the narrow case it is actually for](0008-secure-boot-enrolment-task-type.md) | accepted |
+| 0009 | [Plugins become installable artifacts with a lifecycle of their own](0009-plugins-become-installable-artifacts.md) | accepted |
+| 0010 | [A single core daemon runs plugin-declared background work](0010-plugin-background-work.md) | accepted |
+| 0011 | [Route hands results back as values, and raises instead of exiting](0011-route-result-wrappers.md) | accepted |
+| 0012 | [A self-rescheduling poll guards on its own widget](0012-self-rescheduling-polls-guard-on-their-own-widget.md) | accepted |
+| 0013 | [A flat `FOG\` namespace, and the reverse alias as the 1.6 plugin ABI](0013-flat-fog-namespace-and-the-reverse-alias-abi.md) | accepted |
+| 0014 | [Authentication seams live in core; identity providers are plugins](0014-authentication-seams-in-core-identity-providers-as-plugins.md) | accepted |
+| 0015 | [The install settings are independent keys, not one compound value](0015-install-settings-are-independent-keys.md) | accepted |
+| 0016 | [iPXE enforces X.509 name constraints, rather than FOG weakening them](0016-ipxe-enforces-x509-name-constraints.md) | accepted |
+| 0017 | [The hook dispatch contract](0017-hook-dispatch-contract.md) | accepted |
+| 0018 | [Netboot addresses this server by the name in its certificate](0018-netboot-addresses-this-server-by-its-certificate-name.md) | accepted |
+| 0019 | [Object scope is a property of the request, and it lives in the query](0019-object-scope-is-a-property-of-the-request-and-lives-in-the-query.md) | accepted |
+| 0020 | [Event logs share a record shape, not a table](0020-event-logs-share-a-record-shape-not-a-table.md) | accepted, implemented |
+| 0021 | [The audit trail: a header at the authorization seam, changes beside it](0021-the-audit-trail.md) | accepted, implemented |
+| 0022 | [Spans and work items are different things; only one of these tables is a span](0022-spans-and-work-items.md) | accepted |
+| 0023 | [Activity is a filtered view of one log; retention is a registry, not a page](0023-activity-is-a-view-and-retention-is-a-registry.md) | accepted |
+| 0024 | [`.fogsettings` keys are namespaced by the subsystem that owns them](0024-fogsettings-unified-key-model.md) | accepted |
+| 0025 | [One boolean encoding in `.fogsettings`, normalized on load](0025-one-boolean-encoding-normalised-on-load.md) | accepted |
+| 0026 | [Retention runs in a daemon named for retention](0026-retention-runs-in-a-daemon-named-for-retention.md) | accepted |
+| 0027 | [API tokens are a separate, hashed credential](0027-api-tokens-are-a-separate-hashed-credential.md) | proposed |
+| 0028 | [A boolean column is `TINYINT(1)`, not `enum('0','1')`](0028-booleans-are-tinyint-not-enum.md) | accepted |
+| 0029 | [The Secure Boot ledger is one observed half and one asserted half, and neither is a security control](0029-the-secure-boot-ledger-is-observed-and-asserted-and-neither-is-a-control.md) | accepted |
+| 0030 | [A report is an aggregation over a window, not a grid over a table](0030-a-report-is-an-aggregation-over-a-window.md) | accepted |
+| 0031 | [Referential integrity is declared in the database, not remembered in PHP](0031-referential-integrity-is-declared-in-the-database.md) | accepted, implemented |
+| 0032 | [A saved filter is shared by grant, and a grant is a row per target kind](0032-a-saved-filter-is-shared-by-grant-not-by-visibility.md) | accepted, implemented |
+| 0033 | [Impersonation is a second identity, not a replaced one](0033-impersonation-is-a-second-identity-not-a-replaced-one.md) | accepted, implemented |
+| 0034 | [One authority decides whether a node exists](0034-one-authority-decides-whether-a-node-exists.md) | accepted, implemented |
+| 0035 | [A plugin is laid out like core](0035-a-plugin-is-laid-out-like-core.md) | accepted, implemented |
+| 0036 | [The web tier changes PKI through a fixed verb set, never through a path](0036-the-web-tier-changes-pki-through-a-fixed-verb-set.md) | accepted, implemented |
+| 0037 | [The PKI tree lives in /etc/fog/pki, reached at its old name by a symlink](0037-the-pki-tree-lives-in-etc.md) | accepted, implemented |
+| 0038 | [A group grants snapins and printers; it copies nothing](0038-a-group-grants-it-does-not-copy.md) | accepted, implemented |
+| 0039 | [A booting machine is identified by its MAC first and its firmware second, and the firmware ships in log mode](0039-a-booting-machine-is-identified-by-firmware-second.md) | accepted |
+| 0040 | [Certificates you bring live in /etc/fog/customizations/pki](0040-certificates-you-bring-live-in-a-customizations-tree.md) | accepted, implemented |
+| 0041 | [A boot file is what its bytes say, not what its name says](0041-a-boot-file-is-what-its-bytes-say-not-what-its-name-says.md) | accepted |
+| 0042 | [The filesystem is the inventory; the database records judgments about it](0042-the-filesystem-is-the-inventory-the-database-records-judgments.md) | accepted |

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -750,8 +750,8 @@ restorePreservedCustomizations() {
     # the sibling or a custom name, which is what the tab steers toward.
     #
     # ORDER DEPENDENCY, and it fails silently if broken: the directory is
-    # created by _ensureCustomizationsTree(), which runs inside
-    # configureHttpd() -- installfog.sh calls that BEFORE this function
+    # created by _ensureCustomizationsTree(), which configureHttpd() calls
+    # first thing -- installfog.sh calls that BEFORE this function
     # (backup, then configureHttpd, then restore). Moving either past the
     # other leaves this reading a directory that does not exist yet, which
     # the -d guard turns into "nothing was kept" rather than an error, and
@@ -8264,12 +8264,53 @@ _customPkiDir() {
     [[ -n $root ]] || root="$(dirname "$(_pkiRootDir)")/customizations/pki"
     echo "${root%/}"
 }
+# Sums of every readme revision FOG has shipped, one per line, oldest first.
+#
+# Adding a revision means appending its sum here, never replacing the list. The
+# question each entry answers is "did FOG write this exact file", not "is this
+# the current text" -- a server installed before a revision has an untouched
+# readme whose text is now wrong, and that is precisely the file that should be
+# replaced.
+_fogShippedReadmeSums() {
+    case "$1" in
+        etc)
+            # GH-1681, the first revision
+            echo a469b039e3bb37e8353b9726b8dd0deae6165fd1d49e77e5657d4376be4f9bf9
+            # GH-1684, adds the note that FOG may rewrite this file
+            echo 02fa0e9953a72b7de62aa59dbcf3dad48b99c90d4070187c25b2f6c8f130ff85
+            ;;
+        opt)
+            # GH-1681, the first revision
+            echo b6c5abd15b7bf6120005fa32b346d07df4ce9259ba6922613d5677b85fffd736
+            # GH-1684, adds kernel-backups/keep/ and the rewrite note
+            echo 521105edd799740d61d5d138df5cec37576c42e0693c238d474186d0b9b9edcc
+            ;;
+    esac
+}
+# Whether $1 is a readme FOG may write: absent, or still byte-identical to a
+# revision FOG shipped. $2 is the readme kind, etc or opt.
+#
+# Returns 1 -- leave it alone -- for anything else, which is an admin's edit,
+# and for the case where sha256sum is missing and the question cannot be
+# answered at all. Keeping somebody's note is the safe direction; there is no
+# run in which discarding it is the better mistake.
+_readmeIsFogsOwn() {
+    local f="$1" kind="$2" cur
+    [[ -f $f ]] || return 0
+    command -v sha256sum >/dev/null 2>&1 || return 1
+    cur=$(sha256sum "$f" 2>/dev/null | cut -d' ' -f1)
+    [[ -n $cur ]] || return 1
+    _fogShippedReadmeSums "$kind" | grep -qxF "$cur"
+}
 # The two readme files, and the directories that hold them.
 #
-# Idempotent, and it does NOT overwrite a readme an admin has edited: the file is
-# written only when absent. A run that rewrote it would be a run that discards
-# the note somebody left for the next person, which is the opposite of what a
-# directory for the admin's own files should do.
+# Idempotent, and it does NOT overwrite a readme an admin has edited -- but it
+# does replace one FOG wrote itself and has since outgrown. "Written only when
+# absent" was the first shape of that rule and it was too crude: it also froze
+# FOG's own text, so a server installed before kernel-backups/keep/ existed kept
+# a readme saying nothing is written here on your instruction, with no run that
+# could ever correct it. The property worth keeping is "never discard the note
+# somebody left for the next person", and a checksum tells the two apart.
 #
 # Both readmes are written, not just the /etc one, because the pair only makes
 # sense read together -- "why are there two of these" is the question the files
@@ -8295,8 +8336,12 @@ _ensureCustomizationsTree() {
     [[ -n $optdir ]] && mkdir -p "$optdir" >>$error_log 2>&1
     # kernel-backups/keep is the one directory under here the WEB TIER writes.
     # Marking a boot file to be kept copies it in from service/ipxe, and the
-    # copy is the record: the pruner tests for its existence with no manifest
-    # to read and nothing to drift.
+    # copy is the EFFECT of that mark rather than a record of it: bfPinned
+    # holds the judgment, per ADR 0042, and this is what the judgment does. The
+    # distinction is the whole reason it survives that ADR's no-manifest rule --
+    # a manifest is data ABOUT files and can drift from them, while this is a
+    # second copy of the bytes and cannot. The pruner tests for its existence
+    # with nothing to parse.
     #
     # No sudo helper and no privileged path. The alternative was to follow
     # packages/secureboot/fog-sign-kernel, but that helper's whole security
@@ -8313,7 +8358,7 @@ _ensureCustomizationsTree() {
         chown "${SVC_user}:${apacheuser}" "$optdir/kernel-backups/keep" >>$error_log 2>&1
         chmod 2775 "$optdir/kernel-backups/keep" >>$error_log 2>&1
     fi
-    if [[ ! -f "$etcdir/readme.txt" ]]; then
+    if _readmeIsFogsOwn "$etcdir/readme.txt" etc; then
         cat > "$etcdir/readme.txt" <<'ETCREADME'
 This directory is for configuration you supply yourself.
 
@@ -8347,12 +8392,15 @@ to /etc/fog/pki for the same reason.
 Note that pki/ here sits BESIDE /etc/fog/pki, not inside it. That is what makes
 FOG treat what you put here as yours: anything under /etc/fog/pki is read as a
 certificate FOG issued and manages, and would be regenerated over.
+
+This file is FOG's own note, and a later version of FOG may rewrite it. Edit it
+and FOG leaves it alone from then on -- your version stays for good.
 ETCREADME
         chmod 0644 "$etcdir/readme.txt" >>$error_log 2>&1
     fi
-    if [[ -n $optdir && ! -f "$optdir/readme.txt" ]]; then
+    if [[ -n $optdir ]] && _readmeIsFogsOwn "$optdir/readme.txt" opt; then
         cat > "$optdir/readme.txt" <<'OPTREADME'
-This directory is written BY FOG. You do not need to put anything here.
+This directory is written BY FOG. Almost nothing here needs your hand.
 
 Before a run rebuilds a tree that might hold something of yours, FOG copies
 what it finds into here, and restores it afterward:
@@ -8361,6 +8409,15 @@ what it finds into here, and restores it afterward:
   ipxe-legacy/      iPXE binaries you replaced in the TFTP tree
   kernel-backups/   previous kernel and init generations, newest kept first.
                     bin/restorekernel.sh restores from these.
+
+One directory here is different, because it is written on YOUR instruction
+rather than as part of a rebuild:
+
+  kernel-backups/keep/
+                    boot files you marked to keep, from the kernel and init
+                    pages in the web interface. Marking one copies it in here;
+                    a later run puts it back if it is missing from the live
+                    tree. Unmark it there and the copy goes away.
 
 If a restore ever fails, your files are still here -- nothing is deleted on the
 way through.
@@ -8375,6 +8432,9 @@ Why two: keys and certificates are small, secret and irreplaceable, so they
 belong under /etc, which is what a backup policy already captures. Kernels and
 boot images are large, rebuildable binaries, and the filesystem standard does
 not put binaries under /etc.
+
+This file is FOG's own note, and a later version of FOG may rewrite it. Edit it
+and FOG leaves it alone from then on -- your version stays for good.
 OPTREADME
         chmod 0644 "$optdir/readme.txt" >>$error_log 2>&1
     fi
@@ -10418,7 +10478,6 @@ createSSLCA() {
     # that used to do the damage silently, so the safe behavior has to be the
     # DEFAULT rather than an answer. Everything needed is already on disk: the
     # vhost names the files and the certificate names itself.
-    _ensureCustomizationsTree
     if ! _externallyManagedLeaf; then
         local extReason="" extCert="" extKey="" customPair="" customChain=""
         if extReason=$(_detectExternalCertManagement); then
@@ -11737,6 +11796,14 @@ _warnUnrecognizedPlugins() {
 }
 configureHttpd() {
     normalizeWebroot
+    # Both customizations trees, before anything below needs either of them.
+    #
+    # This used to sit inside createSSLCA(), which this function calls further
+    # down, so it ran late and it made the PKI routine responsible for creating
+    # kernel-backups/keep/ -- a boot-file directory that has nothing to do with
+    # certificates. Same run, same order relative to the restore below; only the
+    # function that owns the call changes.
+    _ensureCustomizationsTree
     dots "Stopping web service"
     case $systemctl in
         yes)

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -6302,12 +6302,17 @@ abstract class FOGPage extends FOGBase
     /**
      * Puts a copy of a boot file where an upgrade will find it, or removes it.
      *
-     * `customizations/kernel-backups/keep/` -- and the copy IS the record.
-     * The pruner and the restore are shell functions running while the web
-     * root is being rebuilt, with no database in reach, so the alternative
-     * was a manifest for them to read. A copy needs no parsing and cannot
-     * drift from what it describes, which is the same reasoning
-     * restorekernel.sh gives for using xattrs instead of a manifest.
+     * `customizations/kernel-backups/keep/` -- and the copy is the EFFECT of
+     * the pin, not a record of it. `bfPinned` holds the judgment, per ADR
+     * 0042; this is what the judgment does.
+     *
+     * That distinction is what keeps it on the right side of the same ADR's
+     * no-manifest rule. The pruner and the restore are shell functions running
+     * while the web root is being rebuilt, with no database in reach, so the
+     * alternative was a manifest for them to read -- and a manifest is data
+     * ABOUT files, which can drift from them. A copy is a second set of the
+     * same bytes: it needs no parsing and cannot drift, which is the same
+     * reasoning restorekernel.sh gives for using xattrs instead of a manifest.
      *
      * It also earns its space: the web root is deleted and rebuilt on every
      * install, and a per-release sibling is deliberately not part of a

--- a/tests/customizations-readme-refresh.test.sh
+++ b/tests/customizations-readme-refresh.test.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+#
+# FOG replaces a readme it wrote itself, and never one an admin edited.
+#
+#   tests/customizations-readme-refresh.test.sh
+#
+# _ensureCustomizationsTree() used to write each readme only when absent. That
+# kept the admin's edits, which was the point, but it also froze FOG's own
+# text: a server installed before kernel-backups/keep/ existed keeps a readme
+# saying nothing under /opt/fog/customizations is written on your instruction,
+# and no later run can correct it.
+#
+# The rule is now "replace it while it is still byte-identical to something FOG
+# shipped". That is two behaviors in one branch and they fail in opposite
+# directions -- a too-eager version destroys somebody's note, a too-timid one
+# leaves the stale text in place forever -- so BOTH arms are executed here
+# against a fixture rather than read.
+#
+# The function is EXECUTED, not grepped. A textual check cannot tell a working
+# checksum comparison from an inverted one.
+#
+# No root, no network, no FOG install, no openssl.
+#
+# Usage: bash tests/customizations-readme-refresh.test.sh
+# Exit status 0 = pass, 1 = fail.
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+functions="$root/lib/common/functions.sh"
+
+pass=0
+fail=0
+
+check() {
+    if [[ $2 -eq 0 ]]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        printf '  FAIL  %s\n' "$1"
+    fi
+}
+
+if [[ ! -r $functions ]]; then
+    echo "FAIL: cannot read $functions" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# The functions under test, lifted out rather than sourcing the whole library.
+# Each closes on a column-0 brace, which nothing inside a readme heredoc does.
+# ---------------------------------------------------------------------------
+for fn in _fogShippedReadmeSums _readmeIsFogsOwn _resolveCustomizationsDir \
+          _customPkiDir _ensureCustomizationsTree; do
+    body=$(sed -n "/^${fn}() {/,/^}/p" "$functions")
+    if [[ -z $body ]]; then
+        echo "FAIL: could not find ${fn}() in lib/common/functions.sh." >&2
+        echo "  If it moved or was renamed, point this test at it -- do not" >&2
+        echo "  delete the assertion." >&2
+        exit 1
+    fi
+    eval "$body"
+done
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+error_log="$work/error.log"
+SVC_user="$(id -un)"
+apacheuser="$(id -un)"
+
+etcroot="$work/etc/customizations"
+optroot="$work/opt/customizations"
+PKI_custom_dir="$etcroot/pki"
+
+# _resolveCustomizationsDir() is idempotent on $customizationsDir, so setting it
+# here keeps every run in this test pointed at the scratch tree.
+customizationsDir="$optroot"
+
+etcreadme="$etcroot/readme.txt"
+optreadme="$optroot/readme.txt"
+
+# ---------------------------------------------------------------------------
+# The first shipped revision of the /opt readme, verbatim (GH-1681).
+#
+# Embedded rather than fetched from git history: the point of the test is that
+# a server still carrying THESE bytes gets them replaced, so the bytes are the
+# fixture. Its checksum is asserted against the registered list below, so
+# editing this block fails loudly instead of silently testing nothing.
+# ---------------------------------------------------------------------------
+cat > "$work/opt-v1.txt" <<'OPTV1'
+This directory is written BY FOG. You do not need to put anything here.
+
+Before a run rebuilds a tree that might hold something of yours, FOG copies
+what it finds into here, and restores it afterward:
+
+  ipxe-bg/          the iPXE boot menu background image
+  ipxe-legacy/      iPXE binaries you replaced in the TFTP tree
+  kernel-backups/   previous kernel and init generations, newest kept first.
+                    bin/restorekernel.sh restores from these.
+
+If a restore ever fails, your files are still here -- nothing is deleted on the
+way through.
+
+There is a second customizations directory, and it works the other way round:
+
+  /etc/fog/customizations   written by YOU, only read by FOG. That is where
+                            certificates and private keys you supply go, under
+                            pki/.
+
+Why two: keys and certificates are small, secret and irreplaceable, so they
+belong under /etc, which is what a backup policy already captures. Kernels and
+boot images are large, rebuildable binaries, and the filesystem standard does
+not put binaries under /etc.
+OPTV1
+
+v1sum=$(sha256sum "$work/opt-v1.txt" | cut -d' ' -f1)
+_fogShippedReadmeSums opt | grep -qxF "$v1sum"
+check "the embedded first revision is one of the registered opt sums" $?
+
+# ---------------------------------------------------------------------------
+# 1. Nothing there yet: both readmes are written.
+# ---------------------------------------------------------------------------
+_ensureCustomizationsTree >/dev/null 2>&1
+
+[[ -f $etcreadme ]]
+check "a fresh tree gets an /etc readme" $?
+[[ -f $optreadme ]]
+check "a fresh tree gets an /opt readme" $?
+
+grep -q 'kernel-backups/keep/' "$optreadme"
+check "the /opt readme documents kernel-backups/keep/" $?
+grep -q 'written on YOUR instruction' "$optreadme"
+check "the /opt readme names the third direction" $?
+[[ -d $optroot/kernel-backups/keep ]]
+check "kernel-backups/keep is created" $?
+
+current=$(sha256sum "$optreadme" | cut -d' ' -f1)
+
+# ---------------------------------------------------------------------------
+# 2. Idempotent: a second run over FOG's current text leaves it current.
+# ---------------------------------------------------------------------------
+_ensureCustomizationsTree >/dev/null 2>&1
+[[ "$(sha256sum "$optreadme" | cut -d' ' -f1)" == "$current" ]]
+check "a second run leaves the current readme current" $?
+
+# ---------------------------------------------------------------------------
+# 3. THE STALE ARM. A server carrying the first shipped revision is upgraded.
+# ---------------------------------------------------------------------------
+cp -f "$work/opt-v1.txt" "$optreadme"
+_ensureCustomizationsTree >/dev/null 2>&1
+
+[[ "$(sha256sum "$optreadme" | cut -d' ' -f1)" == "$current" ]]
+check "a readme FOG shipped earlier is replaced with the current text" $?
+grep -q 'kernel-backups/keep/' "$optreadme"
+check "the replaced readme now documents keep/" $?
+
+# ---------------------------------------------------------------------------
+# 4. THE ADMIN ARM. An edited readme is never touched, on this run or any
+#    later one -- including one that only appended a line to FOG's own text.
+# ---------------------------------------------------------------------------
+printf '%s\n' "Note to whoever is next: ask Dave before touching ipxe-legacy." \
+    > "$optreadme"
+edited=$(sha256sum "$optreadme" | cut -d' ' -f1)
+_ensureCustomizationsTree >/dev/null 2>&1
+[[ "$(sha256sum "$optreadme" | cut -d' ' -f1)" == "$edited" ]]
+check "a readme the admin wrote is left alone" $?
+
+_ensureCustomizationsTree >/dev/null 2>&1
+_ensureCustomizationsTree >/dev/null 2>&1
+[[ "$(sha256sum "$optreadme" | cut -d' ' -f1)" == "$edited" ]]
+check "and is still left alone on every later run" $?
+
+cp -f "$work/opt-v1.txt" "$optreadme"
+printf '%s\n' "" "One more thing: the background lives in ipxe-bg." >> "$optreadme"
+appended=$(sha256sum "$optreadme" | cut -d' ' -f1)
+_ensureCustomizationsTree >/dev/null 2>&1
+[[ "$(sha256sum "$optreadme" | cut -d' ' -f1)" == "$appended" ]]
+check "appending to FOG's own text makes it the admin's, and it is kept" $?
+
+# The same rule has to hold on the /etc side, which is the tree whose whole
+# purpose is that FOG only reads it.
+printf '%s\n' "Our wildcard renews every March. -- ops" > "$etcreadme"
+etcedited=$(sha256sum "$etcreadme" | cut -d' ' -f1)
+_ensureCustomizationsTree >/dev/null 2>&1
+[[ "$(sha256sum "$etcreadme" | cut -d' ' -f1)" == "$etcedited" ]]
+check "an edited /etc readme is left alone too" $?
+
+# ---------------------------------------------------------------------------
+# 5. No sha256sum: the question cannot be answered, so nothing is overwritten.
+#    That is the safe direction -- there is no run in which discarding
+#    somebody's note is the better mistake.
+# ---------------------------------------------------------------------------
+cp -f "$work/opt-v1.txt" "$optreadme"
+stale=$(sha256sum "$optreadme" | cut -d' ' -f1)
+command() {
+    if [[ $1 == -v && $2 == sha256sum ]]; then
+        return 1
+    fi
+    builtin command "$@"
+}
+_ensureCustomizationsTree >/dev/null 2>&1
+unset -f command
+[[ "$(sha256sum "$optreadme" | cut -d' ' -f1)" == "$stale" ]]
+check "without sha256sum a stale readme is kept rather than guessed at" $?
+
+# ---------------------------------------------------------------------------
+printf '\n%s\n' "customizations-readme-refresh: $pass passed, $fail failed"
+[[ $fail -eq 0 ]]

--- a/tests/install-settings-resolution.test.sh
+++ b/tests/install-settings-resolution.test.sh
@@ -296,7 +296,7 @@ for key in WEB_https_redirect PKI_web_cert_publicly_trusted \
     fi
 done
 
-# All 70 keys of the model are managed, and NOTHING ELSE is: adding a key to
+# All 71 keys of the model are managed, and NOTHING ELSE is: adding a key to
 # this array turns a hand-set key into a managed one, and the admin's value
 # starts being overwritten. That is a behavior change even though it looks
 # like documentation, so the count is asserted as well as the membership.

--- a/tests/kernel-keep-survives-upgrade.test.sh
+++ b/tests/kernel-keep-survives-upgrade.test.sh
@@ -14,8 +14,9 @@
 # So "keep this kernel" applied to a sibling would have survived exactly until
 # the next upgrade, with nothing reporting that it had gone. The copy in
 # customizations/kernel-backups/keep/ is what makes the promise real, and the
-# copy IS the record: the restore is a shell function running while the web
-# root is being rebuilt, with no database in reach.
+# copy is the EFFECT of the pin rather than a record of it: bfPinned holds the
+# judgment (ADR 0042), and the restore is a shell function running while the
+# web root is being rebuilt, with no database in reach.
 #
 # The restore is EXECUTED against a fixture, not read. The interesting cases
 # are the two exclusions -- a fresh file of the same name must win, and the six


### PR DESCRIPTION
Follow-through on GH-1684 after #1700 recorded the decision. #1700 answered the design question — two trees, split by direction — and this fixes the things that reading the merged code turned up, which the issue did not know about.

## The defect

`_ensureCustomizationsTree()` wrote each readme **only when absent**. That protected an admin's edits, which was the point. But it also froze FOG's own text, and the text has since gone stale:

`/opt/fog/customizations/readme.txt` says

> This directory is written BY FOG. You do not need to put anything here.

Then `kernel-backups/keep/` arrived — `2775`, group-owned by the web user, and by its own comment *"the one directory under here the WEB TIER writes."* Marking a boot file to keep copies it in on the administrator's instruction.

So the `/opt` tree has a **third direction** — not FOG's rebuild backup, not an admin drop-in that FOG only reads, but FOG acting on a recorded intention — and on every already-installed server the readme says otherwise, with no run able to correct it. ADR 0040's new amendment states *"The two readmes already say exactly that"*, which is no longer true.

## What this does

**Replaces a readme while it is still byte-identical to a revision FOG shipped**, and leaves anything else alone permanently. `_fogShippedReadmeSums()` holds the sums, appended to and never replaced. Where `sha256sum` is missing the question cannot be answered and the file is kept — there is no run in which discarding somebody's note is the better mistake.

The rule "never overwrite a readme" was a crude proxy for "never discard the note somebody left for the next person". A checksum tells the two apart, so FOG can fix its own prose without touching yours.

The `/opt` readme now documents `keep/` and the third direction; both readmes say FOG may rewrite them and that editing one stops that for good.

## Also, from the same read

- **`keep/` is the *effect* of a pin, not a record of one.** `bfPinned` holds the judgment per ADR 0042, and the comments said *"the copy IS the record"* — the one word that ADR forbids (*"Existence is read, never recorded"*), which invites a future reader to rule it a manifest. A manifest is data *about* files and can drift from them; a copy is a second set of the same bytes and cannot.
- **`_ensureCustomizationsTree()` moves out of `createSSLCA()`** to the top of `configureHttpd()`. Not a bug — it was reached unconditionally either way — but it made the PKI routine responsible for creating a boot-file directory. Same run, same order relative to the restore.
- **`SUPPORTED_CUSTOMIZATIONS.md` loses its `## The short version`.** That section is the duplication the file's own text warns against (*"A second copy in the code repository is exactly how the two would drift"*), and it had drifted — stating the preservation guarantee without the condition it rests on, and predating `keep/`. Now a pure pointer. The path stays, since the frozen vhost marker names it.
- **`docs/adr/README.md` indexes all 42 records.** There was no index, no status table, and nothing cross-referenced 0042. GH-1684 asked a question ADR 0040 had already answered *and rejected by name* — that is the failure mode a list of titles prevents.
- **`tests/install-settings-resolution.test.sh:299`** said "All 70 keys" and there are 71 since `PKI_custom_dir`. The assertion is count-*equality* between two lists, so CI was green and only the prose was wrong.

ADR 0040 gets a further amendment recording the third direction, the effect-not-record distinction, and the narrowed readme rule.

## Verification

`tests/customizations-readme-refresh.test.sh` — 14 cases, executed against a fixture rather than grepped, because a textual check cannot tell an inverted comparison from a working one. Both arms are covered: the stale readme must be replaced, the edited one must never be.

Verified by mutation:

| Mutation | Result |
|---|---|
| restore the old `! -f` never-overwrite behavior | 2 failures — the stale arm |
| make the checksum test always return true | 4 failures — every admin-edit case |
| unmodified | 14 passed |

Picked up automatically by `tests/run-all.sh`'s `*.test.sh` glob.

Existing suites re-run locally: `kernel-keep-survives-upgrade` 12/12, `kernel-backup-rotation` 26/26, `install-settings-resolution` 50/50, `fogsettings-migration` 40/40.

`external-cert-detection` reports 26 passed / 5 failed here — **identical on a stashed baseline**, so those are this Windows box's openssl-fixture problem, not this change. The PKI shell suites cannot run here; CI is the first place they run for real.

`tests/us-spelling.test.php` cannot run on this box either (it fails on git enumeration under Windows), so the word list was checked by hand. The only two hits are `enrolment` and `normalised` inside existing ADR *filenames* in the new index's link targets, and both strings are already in that test's `$allowed` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNj39e7pDke6Rr6Whxin9U
