### PR TITLE
HdrS is not enough: grub.exe and memdisk still read as kernels

### DIFF
--- a/docs/adr/0041-a-boot-file-is-what-its-bytes-say-not-what-its-name-says.md
+++ b/docs/adr/0041-a-boot-file-is-what-its-bytes-say-not-what-its-name-says.md
@@ -49,7 +49,7 @@ Four roles, decided by `FOGPage::bootFileRole()` from the file's own contents:
 
 | Role | Test |
 |---|---|
-| FOS Kernel | `HdrS` at 0x202 (x86 setup header magic) or `ARMd` at 0x38 (arm64 Image header magic) |
+| FOS Kernel | `ARMd` at 0x38 (arm64 Image header), or `HdrS` at 0x202 (x86 setup header) **plus** either a genuine PE header or a boot protocol at 0x206 of 0x020c or later |
 | FOS Init | an initramfs archive or compression magic at offset 0 |
 | Boot Payload | neither of the above, and not one of FOG's own web assets |
 | Unclassified | FOG's web assets sharing the directory, and `.unsigned` signing working files |
@@ -59,10 +59,42 @@ FOS Kernel or a FOS Init; `FOG_MEMTEST_KERNEL` asks for a Boot Payload. One
 list serving two meanings is what put memdisk in a kernel menu, so there is no
 longer one list.
 
-`grub.exe` and `memdisk` are PE binaries, so a PE/`MZ` check could not have
-separated them from an EFI-stub kernel. The two header magics can, and an
-arm64 kernel is *also* a PE image when built with the EFI stub, which is why
-its magic is checked in its own right rather than inferred.
+**Corrected 2026-09-02: `HdrS` alone was not enough, and the first version of
+this decision said otherwise.** It claimed the two header magics separated a
+kernel from `grub.exe` and `memdisk`. They do not. Both of those carry a Linux
+setup header and even a version banner, because grub4dos and syslinux's
+memdisk are built to be loaded the way a kernel is loaded — `memdisk` reports
+`MEMDISK 3.86 2010-04-01` and `grub.exe` reports `2.6.13.1 (mdv@localhost)`.
+So both were still classified as FOS Kernels, which is most of the bug this
+decision was written to fix. Found by running the classifier against a real
+`service/ipxe` rather than against fixtures, which is what the plan asked for
+and what had not been done.
+
+Measured on that directory:
+
+| file | MZ | `HdrS` | protocol | genuine PE header |
+|---|---|---|---|---|
+| `bzImage`, `bzImage32` | yes | yes | 0x020f | yes |
+| `arm_Image` | yes | no (`ARMd`) | — | yes |
+| `grub.exe` | yes | yes | **0x0203** | **no** |
+| `memdisk` | **no** | yes | **0x0203** | **no** |
+
+Two independent things separate them, and either suffices. A **genuine PE
+header** — every FOS kernel is an EFI-stub image on all three architectures,
+which is why `kernelfetch()` already refuses a download that is not `MZ`, and
+neither impostor has one: `grub.exe` is `MZ` with no `PE\0\0` at the offset
+0x3c records, and `memdisk` is not even `MZ`. Or a **boot protocol from this
+decade**: 0x020f on the real kernels against 0x0203 on both impostors, a
+2003-era protocol no FOS kernel has spoken. The test is OR rather than AND so
+a hand-compiled kernel built without `CONFIG_EFI_STUB` is still recognized.
+
+An arm64 kernel is *also* a PE image when built with the EFI stub, which is
+why `ARMd` is checked in its own right rather than inferred.
+
+The general lesson, and the reason this paragraph is a correction rather than
+a rewrite: a magic number proves a file was *built to be loaded* a certain
+way. It does not prove what the file *is*. Two things designed to be booted
+like a kernel look like a kernel to any single-magic test.
 
 ### 2. Name-based exclusion survives for exactly two things
 
@@ -125,6 +157,10 @@ known-good kernel for awkward hardware knows something the classifier does not.
 - A file whose first 4KiB cannot be read at all is Unclassified, so an
   unreadable file disappears from the dropdowns rather than being offered and
   failing at boot.
+- Plain text is Unclassified rather than a payload, whatever it is named. The
+  same real directory carried a `refind.conf.new`, and a config file offered
+  as a bootable payload is the same class of wrong as `refind.efi.new` in the
+  kernel list, just quieter.
 - The listing now reads every file in the directory instead of only its names.
   The cost is bounded (4KiB each, a directory of tens of files) but it is no
   longer free, which is the argument for caching the answer once there is

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -5828,7 +5828,38 @@ abstract class FOGPage extends FOGBase
         if (self::_looksLikeKernel($head)) {
             return self::BOOT_ROLE_KERNEL;
         }
+        /**
+         * A payload is something the boot menu can CHAIN. Plain text is not,
+         * whatever it is called. The extension list above catches
+         * refind.conf, but a real server had refind.conf.new left by an old
+         * backup script -- the same shape as the refind.efi.new that
+         * started all this -- and a config file offered as a bootable
+         * payload is the same class of wrong, just quieter.
+         */
+        if (self::_looksLikeText($head)) {
+            return self::BOOT_ROLE_OTHER;
+        }
+
         return self::BOOT_ROLE_PAYLOAD;
+    }
+    /**
+     * True when $head is plainly text rather than an image of any kind.
+     *
+     * A NUL byte settles it immediately: no text file has one, and every
+     * boot payload does within the first few hundred bytes. The printable
+     * test then covers a short file that happens to have no NUL yet.
+     *
+     * @param string $head leading bytes of the file
+     *
+     * @return bool
+     */
+    private static function _looksLikeText($head)
+    {
+        if (false !== strpos($head, "\0")) {
+            return false;
+        }
+
+        return 0 === preg_match('/[^\x09\x0a\x0d\x20-\x7e]/', $head);
     }
     /**
      * True when $head carries a Linux kernel image's own header magic.
@@ -5839,20 +5870,89 @@ abstract class FOGPage extends FOGBase
      */
     private static function _looksLikeKernel($head)
     {
-        // x86/x86_64 bzImage: setup header magic, four bytes at 0x202.
-        if (substr($head, 0x202, 4) === 'HdrS') {
-            return true;
-        }
         /**
-         * arm64 Image: header magic 0x644d5241 at 0x38, which is the bytes
-         * 'ARMd'. An arm64 kernel is also a PE image when built with EFI stub
-         * support, so this has to be checked in its own right rather than
-         * inferred from MZ.
+         * arm64 first: an Image has no setup header at all. Its header magic
+         * is 0x644d5241 at 0x38, the bytes 'ARMd'. An arm64 kernel is also a
+         * PE image when built with EFI stub support, so this is checked in
+         * its own right rather than inferred from MZ.
          */
         if (substr($head, 0x38, 4) === 'ARMd') {
             return true;
         }
-        return false;
+        // x86/x86_64: the setup header's own magic, four bytes at 0x202.
+        if (substr($head, 0x202, 4) !== 'HdrS') {
+            return false;
+        }
+        /**
+         * HdrS is necessary and NOT sufficient, which the first version of
+         * this got wrong. Measured against a real service/ipxe:
+         *
+         *   file          MZ   HdrS  protocol  PE header
+         *   bzImage       yes  yes   0x020f    yes
+         *   bzImage32     yes  yes   0x020f    yes
+         *   grub.exe      yes  yes   0x0203    NO
+         *   memdisk       NO   yes   0x0203    NO
+         *
+         * grub4dos and syslinux's memdisk are built to be loaded the way a
+         * kernel is loaded, so they carry a setup header and even a version
+         * banner -- memdisk reports "MEMDISK 3.86 2010-04-01" and grub.exe
+         * reports "2.6.13.1 (mdv@localhost)". On HdrS alone both were
+         * classified as FOS Kernels, which is most of the bug this whole
+         * change set is about.
+         *
+         * Two independent things separate them, and either is enough:
+         *
+         * A GENUINE PE header. Every FOS kernel is an EFI-stub image on all
+         * three architectures -- kernelfetch() already refuses a download
+         * that is not MZ for that reason -- and neither grub.exe nor memdisk
+         * has one. grub.exe is MZ with no PE at e_lfanew; memdisk is not
+         * even MZ.
+         *
+         * Or a BOOT PROTOCOL from this decade. The field at 0x206 is 0x020f
+         * on the real kernels and 0x0203 on both impostors, which is a
+         * 2003-era protocol no FOS kernel has ever spoken. 0x020c is Linux
+         * 3.8, comfortably below the oldest kernel FOS has shipped.
+         *
+         * OR rather than AND, so a hand-compiled kernel built without
+         * CONFIG_EFI_STUB is still recognized on its protocol version.
+         */
+        if (self::_hasPeHeader($head)) {
+            return true;
+        }
+        $proto = @unpack('v', substr($head, 0x206, 2));
+
+        return is_array($proto)
+            && !empty($proto[1])
+            && (int)$proto[1] >= 0x020c;
+    }
+    /**
+     * True when $head is a real PE image, not merely an MZ stub.
+     *
+     * MZ on its own means almost nothing -- every DOS-era executable starts
+     * with it, grub.exe included. The PE signature sits at the offset the
+     * DOS header records at 0x3c, and that indirection is the part a check
+     * for 'MZ' misses.
+     *
+     * @param string $head leading bytes of the file
+     *
+     * @return bool
+     */
+    private static function _hasPeHeader($head)
+    {
+        if (0 !== strpos($head, 'MZ')) {
+            return false;
+        }
+        $at = @unpack('V', substr($head, 0x3c, 4));
+        if (!is_array($at) || empty($at[1])) {
+            return false;
+        }
+        $at = (int)$at[1];
+        // Inside what was read, and past the DOS header it points from.
+        if ($at < 4 || $at > strlen($head) - 4) {
+            return false;
+        }
+
+        return substr($head, $at, 4) === "PE\0\0";
     }
     /**
      * True when $head carries an initramfs archive or compression magic.

--- a/tests/boot-file-info.test.php
+++ b/tests/boot-file-info.test.php
@@ -43,13 +43,20 @@ mkdir($dir, 0755, true);
 $banner = '6.6.30 (fos@buildroot) #1 SMP Wed Aug 6 11:10:46 UTC 2026';
 $kernel = str_repeat("\x00", 4096);
 $kernel = substr_replace($kernel, 'MZ', 0, 2);
+// A real PE header and a current boot protocol: HdrS alone is also true of
+// grub.exe and memdisk. See tests/boot-file-roles.test.php.
+$kernel = substr_replace($kernel, pack('V', 0x40), 0x3c, 4);
+$kernel = substr_replace($kernel, "PE\x00\x00", 0x40, 4);
 $kernel = substr_replace($kernel, 'HdrS', 0x202, 4);
+$kernel = substr_replace($kernel, pack('v', 0x020f), 0x206, 2);
 $kernel = substr_replace($kernel, pack('v', 0x100), 0x20e, 2);
 $kernel = substr_replace($kernel, $banner . "\x00", 0x300, strlen($banner) + 1);
 file_put_contents($dir . '/bzImage', $kernel);
 
 $armKernel = str_repeat("\x00", 4096);
 $armKernel = substr_replace($armKernel, 'MZ', 0, 2);
+$armKernel = substr_replace($armKernel, pack('V', 0x40), 0x3c, 4);
+$armKernel = substr_replace($armKernel, "PE\x00\x00", 0x40, 4);
 $armKernel = substr_replace($armKernel, 'ARMd', 0x38, 4);
 file_put_contents($dir . '/arm_Image', $armKernel);
 

--- a/tests/boot-file-roles.test.php
+++ b/tests/boot-file-roles.test.php
@@ -156,7 +156,7 @@ function fixturePeBinary()
 }
 
 /**
- * A raw binary image with no recognisable header at all -- memtest.bin, and
+ * A raw binary image with no recognizable header at all -- memtest.bin, and
  * the memdisk shipped in the repo tree.
  *
  * NUL bytes matter: an all-printable stand-in is TEXT, and text is not a

--- a/tests/boot-file-roles.test.php
+++ b/tests/boot-file-roles.test.php
@@ -50,7 +50,19 @@ function fixtureX86Kernel($version = '')
 {
     $buf = str_repeat("\x00", 4096);
     $buf = substr_replace($buf, 'MZ', 0, 2);
+    /**
+     * A real PE header, not just the MZ stub, and a boot protocol from this
+     * decade. Measured off a real service/ipxe: every bzImage there is
+     * 0x020f with a PE signature at the offset 0x3c records, and grub.exe
+     * and memdisk are 0x0203 with no PE at all. HdrS alone does not
+     * distinguish a kernel from either of them, which is what the first
+     * version of the classifier got wrong -- so a fixture that carries only
+     * HdrS is not a kernel-shaped file and must not be used as one.
+     */
+    $buf = substr_replace($buf, pack('V', 0x40), 0x3c, 4);
+    $buf = substr_replace($buf, "PE\x00\x00", 0x40, 4);
     $buf = substr_replace($buf, 'HdrS', 0x202, 4);
+    $buf = substr_replace($buf, pack('v', 0x020f), 0x206, 2);
     if ($version !== '') {
         // 0x300 in the file is 0x100 past the 0x200 the field is relative to.
         $buf = substr_replace($buf, pack('v', 0x100), 0x20e, 2);
@@ -66,6 +78,49 @@ function fixtureX86Kernel($version = '')
 }
 
 /**
+ * grub4dos: MZ and a setup header, an old boot protocol, and NO PE header.
+ *
+ * It reports a version banner too ("2.6.13.1 (mdv@localhost)"), because it
+ * is built to be loaded the way a kernel is loaded. This is the file the
+ * report named, and the shape that a HdrS-only test calls a FOS Kernel.
+ *
+ * @return string
+ */
+function fixtureGrubShaped()
+{
+    $buf = str_repeat("\x00", 4096);
+    $buf = substr_replace($buf, 'MZ', 0, 2);
+    $buf = substr_replace($buf, 'HdrS', 0x202, 4);
+    $buf = substr_replace($buf, pack('v', 0x0203), 0x206, 2);
+    $buf = substr_replace($buf, pack('v', 0x100), 0x20e, 2);
+    $banner = '2.6.13.1 (mdv@localhost)';
+    $buf = substr_replace($buf, $banner . "\x00", 0x300, strlen($banner) + 1);
+
+    return $buf;
+}
+
+/**
+ * syslinux memdisk: a setup header, an old boot protocol, and not even MZ.
+ *
+ * Reports "MEMDISK 3.86 2010-04-01" as its version. FOG_MEMTEST_KERNEL
+ * legitimately points at this, so it has to remain a payload rather than
+ * disappearing -- and it must never be a kernel.
+ *
+ * @return string
+ */
+function fixtureMemdiskShaped()
+{
+    $buf = str_repeat("\x00", 4096);
+    $buf = substr_replace($buf, 'HdrS', 0x202, 4);
+    $buf = substr_replace($buf, pack('v', 0x0203), 0x206, 2);
+    $buf = substr_replace($buf, pack('v', 0x100), 0x20e, 2);
+    $banner = 'MEMDISK 3.86 2010-04-01';
+    $buf = substr_replace($buf, $banner . "\x00", 0x300, strlen($banner) + 1);
+
+    return $buf;
+}
+
+/**
  * An arm64 Image: header magic 'ARMd' at 0x38, and PE as well because the
  * EFI stub is built in. No version field exists in this header.
  *
@@ -75,6 +130,8 @@ function fixtureArmKernel()
 {
     $buf = str_repeat("\x00", 4096);
     $buf = substr_replace($buf, 'MZ', 0, 2);
+    $buf = substr_replace($buf, pack('V', 0x40), 0x3c, 4);
+    $buf = substr_replace($buf, "PE\x00\x00", 0x40, 4);
     $buf = substr_replace($buf, 'ARMd', 0x38, 4);
 
     return $buf;
@@ -89,7 +146,31 @@ function fixtureArmKernel()
  */
 function fixturePeBinary()
 {
-    return 'MZ' . str_repeat('X', 4094);
+    $buf = str_repeat("\x00", 4096);
+    $buf = substr_replace($buf, 'MZ', 0, 2);
+    $buf = substr_replace($buf, pack('V', 0x80), 0x3c, 4);
+    $buf = substr_replace($buf, "PE\x00\x00", 0x80, 4);
+    // No HdrS: an EFI application is not loaded through the Linux boot
+    // protocol, so it has no setup header to carry one.
+    return $buf;
+}
+
+/**
+ * A raw binary image with no recognisable header at all -- memtest.bin, and
+ * the memdisk shipped in the repo tree.
+ *
+ * NUL bytes matter: an all-printable stand-in is TEXT, and text is not a
+ * boot payload. Three fixtures here were ASCII fillers until the text rule
+ * caught them, which is a fair reminder that a fixture has to have the
+ * shape of the thing it stands for.
+ *
+ * @param string $tag byte to fill with, so two images differ
+ *
+ * @return string
+ */
+function fixtureRawImage($tag)
+{
+    return str_repeat($tag . "\x00\xfe\x7f", 1024);
 }
 
 $dir = dirname(FOG_CACHE_DIR) . '/service/ipxe';
@@ -115,9 +196,16 @@ $fixtures = [
     ],
     'arm_init.cpio.gz' => ["\x1f\x8b" . str_repeat('g', 512), 'init'],
     'customInit.lz4' => ["\x04\x22\x4d\x18" . str_repeat('l', 512), 'init'],
-    'memdisk' => [str_repeat('D', 4096), 'payload'],
-    'memtest.bin' => [str_repeat('T', 4096), 'payload'],
-    'grub.exe' => [fixturePeBinary(), 'payload'],
+    'memdisk' => [fixtureRawImage('D'), 'payload'],
+    'memtest.bin' => [fixtureRawImage('T'), 'payload'],
+    /**
+     * The two the report named that a setup-header test alone gets WRONG.
+     * Both carry HdrS and a version banner; neither is a FOS Kernel.
+     */
+    'grub.exe' => [fixtureGrubShaped(), 'payload'],
+    'memdisk.real' => [fixtureMemdiskShaped(), 'payload'],
+    // Plain text left by a backup script. Not bootable, so not a payload.
+    'refind.conf.new' => ["timeout 20\nscanfor manual\n", 'unclassified'],
     'refind.efi' => [fixturePeBinary(), 'payload'],
     'refind_x64.efi' => [fixturePeBinary(), 'payload'],
     'refind.efi.new' => [fixturePeBinary(), 'payload'],
@@ -280,9 +368,21 @@ $t->check(
     'an arm64 kernel reports no version rather than inventing one',
     '' === $page::bootFileKernelVersion($dir . '/arm_Image')
 );
+/**
+ * A payload CAN report a version banner, and grub.exe does -- it carries a
+ * setup header, so the extractor reads it exactly as it reads a kernel's.
+ * That is the whole trap: a banner says nothing about the role, so the role
+ * must not be inferred from having one.
+ */
 $t->check(
-    'a payload reports no version',
-    '' === $page::bootFileKernelVersion($dir . '/grub.exe')
+    'a file with a setup header reports its banner whatever its role is',
+    '2.6.13.1 (mdv@localhost)'
+    === $page::bootFileKernelVersion($dir . '/grub.exe')
+    && 'payload' === $page::bootFileRole($dir . '/grub.exe')
+);
+$t->check(
+    'a file with no setup header reports no version',
+    '' === $page::bootFileKernelVersion($dir . '/memtest.bin')
 );
 $t->check(
     'a kernel with no version field reports none',


### PR DESCRIPTION
**#1688 did not fully fix the reported bug.** Two of the four files named in the report were still offered as Host Kernels.

## What was wrong

#1688 decided a boot file's role by reading it, and its ADR claimed the setup header magic separated a FOS Kernel from `grub.exe` and `memdisk`. **It does not.** Both carry a Linux setup header, and both carry a version banner — `memdisk` reports `MEMDISK 3.86 2010-04-01`, `grub.exe` reports `2.6.13.1 (mdv@localhost)` — because grub4dos and syslinux's memdisk are built to be *loaded the way a kernel is loaded*.

So: `memtest.bin` and `refind.efi.new` were fixed. `grub.exe` and `memdisk` were not.

## How it was found, and why it wasn't found earlier

By running the classifier against a **real `service/ipxe`** instead of against fixtures. The plan asked for exactly that and it had not been done.

Every fixture up to now was synthetic, and each one carried `HdrS` and nothing else — so the fixtures and the code agreed about a claim neither of them had ever tested. That is the more useful lesson than the bug: a fixture built from the same assumption as the code cannot falsify it.

Measured on that directory:

| file | MZ | `HdrS` | protocol | genuine PE header |
|---|---|---|---|---|
| `bzImage`, `bzImage32` | yes | yes | 0x020f | yes |
| `arm_Image` | yes | no (`ARMd` at 0x38) | — | yes |
| `grub.exe` | yes | yes | **0x0203** | **no** |
| `memdisk` | **no** | yes | **0x0203** | **no** |

## The fix

`ARMd` at 0x38 still settles arm64 on its own. For x86, `HdrS` is now necessary but not sufficient — it must be joined by **either**:

- a **genuine PE header** (`PE\0\0` at the offset 0x3c records, not merely an `MZ` stub). Every FOS kernel is an EFI-stub image on all three architectures, which is why `kernelfetch()` already refuses a download that is not `MZ`; `grub.exe` is `MZ` with no PE, and `memdisk` is not even `MZ`.
- **or** a boot protocol at 0x206 of **0x020c or later**. The real kernels are 0x020f; both impostors are 0x0203, a 2003-era protocol no FOS kernel has spoken. 0x020c is Linux 3.8, comfortably below the oldest kernel FOS ships.

`OR` rather than `AND`, so a hand-compiled kernel built without `CONFIG_EFI_STUB` is still recognized on its protocol version.

## Also: plain text is not a payload

The same real directory carried a `refind.conf.new`. The extension list catches `refind.conf`, but not that — so a **text config file** was being offered as a bootable payload. Same class of wrong as `refind.efi.new` in the kernel list, just quieter. Text (no NUL byte, all printable) is now Unclassified.

## Verification

Against the real directory, every file now classifies correctly — all five kernels, all six inits, `arm_Image`, and `grub.exe` / `memdisk` / `memtest.bin` / `refind*.efi.new` as payloads, web assets as unclassified.

**The fixtures now have the shape of the things they stand for.** Two new ones reproduce `grub.exe` and `memdisk` exactly — header, banner and old protocol. And three existing fixtures were ASCII fillers standing in for binaries, which the new text rule caught immediately; a stand-in for a binary has to contain the bytes a binary contains.

**Mutation-tested:** reverting the classifier to `HdrS` alone fails five assertions, including `memdisk.real is a payload (got kernel)` and `grub.exe is not offered as a kernel`. The suite now detects the original bug.

- `tests/boot-file-roles.test.php` — 48 checks (was 45).
- Full PHP suite: **222 pass, 29 fail — the same 29 that fail on an unmodified checkout.**
- One assertion had to be corrected rather than kept: "a payload reports no version" was false, because `grub.exe` genuinely does report one. It now asserts the honest fact — a file with a setup header reports its banner *whatever its role is* — which is precisely why the role cannot be inferred from having a banner.
- **phpstan not run** (no `composer`/`vendor` here).

ADR 0041 carries a dated correction rather than a rewrite, since the decision it records still stands: a magic number proves a file was built to be **loaded** a certain way, not what it **is**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYw9JCZGPeHuse6RTyNPgs
