### PR TITLE
Boot file records are read, so host and group pages stop re-hashing the boot directory

### DIFF
--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -6287,9 +6287,26 @@ abstract class FOGPage extends FOGBase
         if (null === self::$_bootFileRows) {
             self::$_bootFileRows = [];
             try {
-                $rows = self::getClass('BootFileManager')->find();
-                foreach ((array)$rows as $row) {
-                    if ($row && $row->isValid()) {
+                /**
+                 * Route::getIds(), which is how every other list-all in
+                 * this class is done. The first version called
+                 * BootFileManager->find(), a 1.5 method that does not exist
+                 * on the 1.6 manager, so it threw "undefined method" into
+                 * the catch below on every request and the map was never
+                 * populated. The cost of that was not one failed query: it
+                 * was every file in the boot directory re-read, re-hashed
+                 * (264MB on a stock install) and re-saved on every host
+                 * and group page, ~1.8s before the first byte.
+                 *
+                 * `false` for the filter, like HookManager's own lookup:
+                 * an empty array asks the request body for a filter, and a
+                 * host form POSTs a `name` field, which would filter the
+                 * rows down to the one boot file called after the host.
+                 */
+                $ids = Route::getIds('bootfile', false);
+                foreach ((array)$ids as $id) {
+                    $row = new \FOG\Items\BootFile((int)$id);
+                    if ($row->isValid()) {
                         self::$_bootFileRows[(string)$row->get('name')] = $row;
                     }
                 }

--- a/packages/web/src/Pages/StorageGroupManagement.php
+++ b/packages/web/src/Pages/StorageGroupManagement.php
@@ -796,7 +796,19 @@ class StorageGroupManagement extends FOGPage
      */
     public function edit()
     {
-        $master = $this->obj->getMasterStorageNode();
+        /**
+         * A group with no members has no master, and
+         * getMasterStorageNode() says so by throwing -- right for tasking,
+         * which cannot proceed without one, and fatal here, where the page
+         * is the only way to GIVE the group its first member. The list
+         * formatter in Route already catches this for the same reason; the
+         * note below already spells "None" for a master that is not a node.
+         */
+        try {
+            $master = $this->obj->getMasterStorageNode();
+        } catch (\Exception $e) {
+            $master = null;
+        }
         $this->notes = [
             _('Storage Group') => $this->obj->get('name'),
             _('Master Node') => (

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2325,7 +2325,7 @@ parameters:
 		-
 			message: '#^Parameter \#2 \$whereItems of static method FOG\\Router\\Route\:\:getIds\(\) expects array, false given\.$#'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: packages/web/src/Base/FOGPage.php
 
 		-

--- a/tests/boot-file-info.test.php
+++ b/tests/boot-file-info.test.php
@@ -184,6 +184,72 @@ $t->check(
     $page::bootFileInfo($dir . '/bzImage') == $info
 );
 
+// --- a stored record is USED, not re-derived -----------------------------
+
+/**
+ * The map of bootFile rows was never populated: the loader called a 1.5
+ * manager method that does not exist on 1.6, threw into its own catch, and
+ * every host and group page re-read, re-hashed and re-saved every file in
+ * the boot directory -- 264MB and ~1.8s on a stock install. The catch is
+ * there for an unreachable store, so nothing else could see the difference
+ * between "no rows" and "the query never ran".
+ *
+ * So answer the store here, with a row that is fresh for bzImage (same size,
+ * same mtime) and carries a checksum no hash could produce. A loader that
+ * reads the row serves that checksum; one that never gets the row re-hashes
+ * the file and reports the real digest. The row is deliberately NOT stale:
+ * a stale row is re-inspected by design, so it could not tell the two apart.
+ */
+$cached = 'served-from-the-record-not-the-file';
+$db->responder = function ($sql, $params) use ($dir, $cached) {
+    if (false !== stripos($sql, 'FROM `globalSettings`')) {
+        return [
+            [
+                'settingKey' => 'FOG_TFTP_PXE_KERNEL_DIR',
+                'settingValue' => $dir . '/'
+            ]
+        ];
+    }
+    if (false !== stripos($sql, 'FROM `bootFile`')) {
+        $row = [
+                'bfID' => 7,
+                'bfName' => 'bzImage',
+                'bfSize' => 4096,
+                'bfMtime' => gmdate('Y-m-d H:i:s', filemtime($dir . '/bzImage')),
+                'bfChecksum' => $cached,
+                'bfRole' => 'kernel',
+                'bfKernelVersion' => 'cached',
+                'bfReleaseTag' => 'cached-tag',
+                'bfInspected' => gmdate('Y-m-d H:i:s'),
+                'bfPinned' => 0
+        ];
+        // load() reads its by-id SELECT through fetch()->get() with no
+        // field -- ONE flat row -- where the id listing wants a list of
+        // rows. Same distinction tests/route-write-path-guards.test.php
+        // draws; a wrapped row here is not an error, it is an empty record.
+        return preg_match('/WHERE `bfID`=:id\b/', $sql) ? $row : [$row];
+    }
+
+    return null;
+};
+// The per-request map was filled (with nothing) by the calls above.
+FogTestHarness::setStatic($page, '_bootFileRows', null);
+$writesBefore = count(
+    preg_grep('/^\s*(INSERT|UPDATE)\b.*`bootFile`/i', $db->log)
+);
+$fromRow = $page::bootFileInfo($dir . '/bzImage');
+$writesAfter = count(
+    preg_grep('/^\s*(INSERT|UPDATE)\b.*`bootFile`/i', $db->log)
+);
+$t->check(
+    'a fresh record answers for the file: the checksum is the stored one',
+    $cached === $fromRow['checksum']
+);
+$t->check(
+    'a fresh record is not rewritten on read',
+    $writesBefore === $writesAfter
+);
+
 // --- the panel no longer hardcodes six names or drops stderr -------------
 
 $panel = file_get_contents(

--- a/tests/storagegroup-edit-without-members.test.php
+++ b/tests/storagegroup-edit-without-members.test.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * A storage group with no members can still be edited.
+ *
+ * Creating a group makes an empty one, and the edit page is the only place
+ * to give it its first member. That page opened by asking the group for its
+ * master node, and getMasterStorageNode() answers "no members" by throwing
+ * -- right for tasking, which cannot run without one, and a blank 500 here,
+ * on the one page that could have fixed it. On the lab, group 6 ("something")
+ * could be created and never opened again.
+ *
+ * DB-free: the fake DB has no nodes, so every group is an empty one, which is
+ * exactly the state under test.
+ *
+ * Usage: php tests/storagegroup-edit-without-members.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+use FOG\Items\StorageGroup;
+use FOG\Pages\StorageGroupManagement;
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('storagegroup-edit-without-members');
+FogTestHarness::fakeDb();
+
+$t = new FogChecks();
+
+$page = new StorageGroupManagement();
+$obj = new \ReflectionProperty($page, 'obj');
+$obj->setAccessible(true);
+$obj->setValue($page, new StorageGroup());
+
+$threw = '';
+try {
+    ob_start();
+    $page->edit();
+    ob_end_clean();
+} catch (\Throwable $e) {
+    ob_end_clean();
+    $threw = get_class($e) . ': ' . $e->getMessage();
+}
+$t->check(
+    'editing a group with no members does not throw' . ($threw ? " ($threw)" : ''),
+    '' === $threw
+);
+
+$t->finish();


### PR DESCRIPTION
## Host and group pages: ~1.8s → ~0.04s before first byte

Every host and group page (list, add, edit) took ~1.8s before the first byte on the lab; the home page takes 0.09s and the DataTables call answers in 24ms. `FOGPage::_bootFileRow()` calls `BootFileManager->find()`, a 1.5 method the 1.6 manager does not have, so it threw into the catch meant for an unreachable store and the record map was never populated. Every render then re-read, re-hashed (264MB) and re-saved every file in the boot directory. All 30 records were present and fresh the whole time.

Fix: `Route::getIds('bootfile', false)`, the same list-all form the rest of the class uses. `false` so the request body is not used as a filter (a host form POSTs `name`). Measured `kernelFileList()` 1.69s → 0.04s with the same result.

`phpstan-baseline.neon`: the FOGPage.php count for `getIds() expects array, false given` goes 1 → 2 (that is how HookManager, GroupManagement and ImageManagement carry the same call).

## Storage group edit fatals on an empty group

`StorageGroupManagement::edit()` let `getMasterStorageNode()` throw "No master nodes available" for a group with no members, which is the only page that can give it one (lab group 6 answered a blank 500). Caught; the note already prints "None". Route's list formatter already handles it the same way.

## Gates

- `tests/boot-file-info.test.php`: the fake store answers a fresh row with an impossible checksum; the listing must report it and write nothing. Red on the old call, green now.
- `tests/storagegroup-edit-without-members.test.php`: edit on a memberless group must not throw. Red without the catch.

Both phpstan passes green locally. `feat/agent-enroll` carries a different wrong form of the same loader call (`self::getIds`, undefined on FOGPage); that session has been told.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnyHvfCQWPMzFWRsyUQJKi