### PR TITLE
Name the class at the call site instead of fetching it by string

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -483,10 +483,11 @@ reasoning and the rejected alternatives:
 - **PHPDoc**: present on classes and methods (`@category`, `@package`, `@author`, `@license`, `@link`)
 - **Static globals**: `FOGBase::$HookManager`, `FOGBase::$DB`, etc. — set once, shared everywhere
 - **Method chaining**: `Page` and `FOGPage` use fluent interface
-- **Class instantiation**: use `FOGBase::getClass('ClassName')` factory, not `new ClassName()` directly
+- **Class instantiation**: `new ClassName()` with a `use` import. `getClass()` is
+  only for a class named by a **variable** (see below)
 - **Translation**: `_('string')` for inline gettext; `$foglang['Key']` for pre-defined strings from `text.php`
 - **Newer files**: `declare(strict_types=1)` at top; older files do not have this — don't add it retroactively
-- **Avoid `new` directly**: use `FOGBase::getClass()` or `FOGBase::getManager()` as appropriate
+- **`getManager()`**: still the way to reach a model's manager, unchanged
 
 ### Button color and alignment
 
@@ -596,7 +597,7 @@ badly — `ou` and `windowskey` become "Ou" and "Windowskey" without it.
 ## What NOT to Do
 
 - Do not add `declare(strict_types=1)` to files that don't already have it
-- Do not instantiate classes with `new ClassName()` where `FOGBase::getClass()` is the established pattern
+- Do not call `getClass()` with a string literal -- write `new ClassName()`; `tests/getclass-literals.test.php` refuses it
 - Do not use raw `$_GET`/`$_POST` — use `filter_input()` or the already-sanitized values
 - Do not echo user data without `Initiator::e()`
 - Do not remove hooks, events, or plugin integration points without explicit confirmation

--- a/bin/getclass-to-new.php
+++ b/bin/getclass-to-new.php
@@ -1,0 +1,569 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Rewrite `getClass('Literal', ...)` into a plain `new` expression.
+ *
+ * `FOGBase::getClass()` exists as the chokepoint the Phase 3 namespacing
+ * migration needed (docs/refactor-brief.md): one function that turned a bare
+ * short name into an FQCN, so ~500 call sites never had to be edited while
+ * 226 files were renamed underneath them. That migration is finished, and
+ * what the literal call sites are left paying for is real -- `getClass()` is
+ * documented `@return object|mixed`, so PHPStan cannot type a single one of
+ * them and no editor can follow one to its definition.
+ *
+ * It is NOT a substitution seam: `FOGBase::qualify()` consults the core map
+ * before the plugin map deliberately (ADR 0013), so nothing can ever answer a
+ * core name with a different class. There is therefore no behavior to
+ * preserve beyond name resolution itself.
+ *
+ * What this rewrites, and only this:
+ *
+ *   - the first argument is a single quoted string naming a plain identifier;
+ *   - there is no third argument (the `$props = true` mode returns
+ *     ReflectionClass::getDefaultProperties() and has no `new` equivalent);
+ *   - the name is not 'ReflectionClass' (getClass() special-cases it).
+ *
+ * A call whose first argument is a variable is the one shape `new` cannot
+ * express, and is left alone -- that is what getClass() keeps existing for.
+ *
+ * Resolution mirrors FOGBase::qualify() exactly, including its order: core's
+ * short-name map first, then the plugins', then unchanged. Getting that order
+ * wrong here would silently repoint a call at a plugin class.
+ *
+ * Two output styles, matching where the code lives:
+ *
+ *   --style=import  a `use` line and a bare `new Host()`. The house style in
+ *                   packages/web/src (255 of 289 files already carry a use
+ *                   block) and what ADR 0013 chose for volume reasons.
+ *   --style=fqcn    inline `new \FOG\Items\Host()`. Required in fog-plugins,
+ *                   whose tests/core-references-are-qualified.test.php refuses
+ *                   a bare core name, and used here for files that declare no
+ *                   namespace.
+ *
+ * Usage:
+ *   php bin/getclass-to-new.php [options] [file ...]
+ *
+ * Options:
+ *   --core-src=DIR    core PSR-4 root (default: packages/web/src)
+ *   --plugin-root=DIR plugin root to add to the short map; repeatable
+ *   --style=STYLE     import (default) or fqcn
+ *   --dry-run         report only, write nothing
+ *   --quiet           suppress the per-site listing
+ *
+ * With no file arguments it rewrites every `*.php` tracked by git under the
+ * current directory.
+ *
+ * Exit status 0 = every site either rewritten or deliberately skipped,
+ * 1 = at least one site could not be resolved and needs a human.
+ */
+
+$opts = [
+    'core-src' => 'packages/web/src',
+    'style' => 'import',
+    'dry-run' => false,
+    'quiet' => false,
+];
+$pluginRoots = [];
+$argFiles = [];
+foreach (array_slice($argv, 1) as $arg) {
+    if ($arg === '--dry-run' || $arg === '--quiet') {
+        $opts[substr($arg, 2)] = true;
+    } elseif (strpos($arg, '--plugin-root=') === 0) {
+        $pluginRoots[] = rtrim(substr($arg, 14), '/');
+    } elseif (preg_match('#^--(core-src|style)=(.*)$#', $arg, $m)) {
+        $opts[$m[1]] = $m[2];
+    } elseif (strpos($arg, '--') === 0) {
+        fwrite(STDERR, "unknown option: $arg\n");
+        exit(2);
+    } else {
+        $argFiles[] = $arg;
+    }
+}
+if (!in_array($opts['style'], ['import', 'fqcn'], true)) {
+    fwrite(STDERR, "--style must be import or fqcn\n");
+    exit(2);
+}
+
+/**
+ * The namespace a file declares, or '' for the global namespace.
+ *
+ * @param array $tokens token_get_all output
+ *
+ * @return string
+ */
+function nsOf(array $tokens)
+{
+    $count = count($tokens);
+    for ($i = 0; $i < $count; $i++) {
+        if (!is_array($tokens[$i]) || $tokens[$i][0] !== T_NAMESPACE) {
+            continue;
+        }
+        $ns = '';
+        for ($j = $i + 1; $j < $count; $j++) {
+            $t = $tokens[$j];
+            if (is_string($t)) {
+                if ($t === ';' || $t === '{') {
+                    break 2;
+                }
+                continue;
+            }
+            if ($t[0] === T_WHITESPACE) {
+                continue;
+            }
+            $ns .= $t[1];
+        }
+        break;
+    }
+    return trim($ns ?? '', '\\');
+}
+
+/**
+ * Core's short-name map, derived exactly as Initiator::srcClassMap() does:
+ * the bucket directory and the file basename, never the declared namespace.
+ *
+ * @param string $dir the src root
+ *
+ * @return array lowercased short name => FQCN
+ */
+function coreMap($dir)
+{
+    $map = [];
+    if (!is_dir($dir)) {
+        return $map;
+    }
+    $walk = new \RecursiveIteratorIterator(
+        new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+    );
+    foreach ($walk as $file) {
+        if (!$file->isFile() || $file->getExtension() !== 'php') {
+            continue;
+        }
+        $path = $file->getPathname();
+        $map[strtolower($file->getBasename('.php'))] = 'FOG\\'
+            . basename(dirname($path)) . '\\' . $file->getBasename('.php');
+    }
+    return $map;
+}
+
+/**
+ * A plugin tree's short-name map.
+ *
+ * The namespace is READ from each file rather than derived from the directory
+ * name: Initiator::pluginSegment() reads it too, and the casing differs
+ * (ldap/ declares FOG\Plugins\LDAP). Deriving it would produce a name that
+ * only resolves because PHP is case-insensitive, which is the drift
+ * tests/getclass-literals.test.php was written to stop.
+ *
+ * @param array $roots plugin roots
+ *
+ * @return array lowercased short name => FQCN
+ */
+function pluginMap(array $roots)
+{
+    $map = [];
+    foreach ($roots as $root) {
+        if (!is_dir($root)) {
+            continue;
+        }
+        foreach (glob($root . '/*/src/*/*.php') ?: [] as $path) {
+            $tokens = token_get_all(file_get_contents($path));
+            $ns = nsOf($tokens);
+            if ($ns === '') {
+                continue;
+            }
+            $class = basename($path, '.php');
+            $short = strtolower($class);
+            if (isset($map[$short])) {
+                continue;
+            }
+            $map[$short] = $ns . '\\' . $class;
+        }
+    }
+    return $map;
+}
+
+$core = coreMap($opts['core-src']);
+$plugins = pluginMap($pluginRoots);
+
+if ($core === [] && $plugins === []) {
+    fwrite(STDERR, "no classes found -- check --core-src / --plugin-root\n");
+    exit(2);
+}
+
+$files = $argFiles;
+if ($files === []) {
+    $files = array_values(array_filter(
+        explode("\n", (string) shell_exec('git ls-files "*.php"')),
+        function ($f) {
+            return '' !== $f && is_readable($f)
+                && 0 !== strpos($f, 'packages/web/vendor/');
+        }
+    ));
+}
+
+$rewritten = 0;
+$skipped = [];
+$unresolved = [];
+$touched = 0;
+
+foreach ($files as $file) {
+    $src = file_get_contents($file);
+    if (strpos($src, 'getClass') === false) {
+        continue;
+    }
+    $tokens = token_get_all($src);
+    $count = count($tokens);
+
+    // Offsets, so replacements can be spliced back into the original bytes.
+    $offset = 0;
+    $offsets = [];
+    foreach ($tokens as $i => $t) {
+        $offsets[$i] = $offset;
+        $offset += strlen(is_array($t) ? $t[1] : $t);
+    }
+
+    $ns = nsOf($tokens);
+    // A file in the GLOBAL namespace may still carry an import block --
+    // commons/schema.php does -- and mixing an inline FQCN in beside an
+    // already-bare `Schema::` reads as two conventions in one file. Follow
+    // whichever the file already demonstrates; fall back to inline FQCN only
+    // when it demonstrates neither, which is also the only case addImports()
+    // has nowhere to put a `use` line.
+    $hasImports = (bool) preg_match('/^use\s+[^;(]+;/m', $src);
+    $style = ($ns === '' && !$hasImports) ? 'fqcn' : $opts['style'];
+
+    // What short names this file already binds, and to what.
+    $bound = [];
+    for ($i = 0; $i < $count; $i++) {
+        $t = $tokens[$i];
+        if (is_array($t) && $t[0] === T_CLASS
+            && ($i < 1 || !is_array($tokens[$i - 1])
+                || $tokens[$i - 1][0] !== T_DOUBLE_COLON)
+        ) {
+            for ($j = $i + 1; $j < $count; $j++) {
+                if (is_array($tokens[$j]) && $tokens[$j][0] === T_STRING) {
+                    $bound[strtolower($tokens[$j][1])] = ($ns === '' ? '' : $ns . '\\')
+                        . $tokens[$j][1];
+                    break;
+                }
+            }
+        }
+        if (!is_array($t) || $t[0] !== T_USE) {
+            continue;
+        }
+        // Only top-level imports; a closure's `use (...)` is followed by '('.
+        $clause = '';
+        for ($j = $i + 1; $j < $count; $j++) {
+            $u = $tokens[$j];
+            if (is_string($u)) {
+                if ($u === ';') {
+                    break;
+                }
+                if ($u === '(' || $u === '{') {
+                    $clause = '';
+                    break;
+                }
+                $clause .= $u;
+                continue;
+            }
+            if ($u[0] === T_WHITESPACE) {
+                $clause .= ' ';
+                continue;
+            }
+            $clause .= $u[1];
+        }
+        $clause = trim($clause);
+        if ($clause === '' || stripos($clause, 'function ') === 0
+            || stripos($clause, 'const ') === 0
+        ) {
+            continue;
+        }
+        if (preg_match('/^(\S+)\s+as\s+(\S+)$/i', $clause, $m)) {
+            $bound[strtolower($m[2])] = ltrim($m[1], '\\');
+        } else {
+            $short = substr($clause, strrpos('\\' . $clause, '\\'));
+            $bound[strtolower($short)] = ltrim($clause, '\\');
+        }
+    }
+
+    $edits = [];
+    $needImports = [];
+
+    for ($i = 0; $i < $count; $i++) {
+        $t = $tokens[$i];
+        if (!is_array($t) || $t[0] !== T_STRING
+            || strtolower($t[1]) !== 'getclass'
+        ) {
+            continue;
+        }
+        // Preceding significant token must be `::`; `getClass` appearing as a
+        // method name in a declaration or inside a string is not a call site.
+        $p = $i - 1;
+        while ($p >= 0 && is_array($tokens[$p]) && $tokens[$p][0] === T_WHITESPACE) {
+            $p--;
+        }
+        if ($p < 0 || !is_array($tokens[$p]) || $tokens[$p][0] !== T_DOUBLE_COLON) {
+            continue;
+        }
+        $n = $i + 1;
+        while ($n < $count && is_array($tokens[$n]) && $tokens[$n][0] === T_WHITESPACE) {
+            $n++;
+        }
+        if ($n >= $count || $tokens[$n] !== '(') {
+            continue;
+        }
+
+        // Walk the argument list, splitting on depth-1 commas.
+        $depth = 0;
+        $args = [];
+        $curStart = null;
+        $curEnd = null;
+        $curToks = [];
+        $close = null;
+        for ($j = $n; $j < $count; $j++) {
+            $tok = $tokens[$j];
+            $text = is_array($tok) ? $tok[1] : $tok;
+            $opens = is_string($tok) && strpos('([{', $tok) !== false;
+            if (!$opens && is_array($tok)
+                && in_array($tok[0], [T_CURLY_OPEN, T_DOLLAR_OPEN_CURLY_BRACES], true)
+            ) {
+                // `"{$x}"` opens with an ARRAY token and closes with a plain
+                // '}' string token. Counting only the close takes the depth
+                // negative and truncates the argument list.
+                $opens = true;
+            }
+            if ($opens) {
+                $depth++;
+                if ($depth === 1) {
+                    continue;
+                }
+            } elseif (is_string($tok) && strpos(')]}', $tok) !== false) {
+                $depth--;
+                if ($depth === 0) {
+                    $close = $j;
+                    if ($curToks !== []) {
+                        $args[] = [$curStart, $curEnd, $curToks];
+                    }
+                    break;
+                }
+            } elseif ($depth === 1 && $tok === ',') {
+                $args[] = [$curStart, $curEnd, $curToks];
+                $curStart = $curEnd = null;
+                $curToks = [];
+                continue;
+            }
+            if (is_array($tok) && $tok[0] === T_WHITESPACE && $curToks === []) {
+                continue;
+            }
+            if (is_array($tok) && $tok[0] === T_WHITESPACE) {
+                continue;
+            }
+            if ($curStart === null) {
+                $curStart = $offsets[$j];
+            }
+            $curEnd = $offsets[$j] + strlen($text);
+            $curToks[] = $tok;
+        }
+        if ($close === null || $args === []) {
+            continue;
+        }
+
+        $where = $file . ':' . $t[2];
+
+        // First argument must be exactly one quoted string.
+        $first = $args[0][2];
+        if (count($first) !== 1 || !is_array($first[0])
+            || $first[0][0] !== T_CONSTANT_ENCAPSED_STRING
+        ) {
+            $skipped[] = [$where, 'dynamic class name'];
+            continue;
+        }
+        $name = substr($first[0][1], 1, -1);
+        if (!preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $name)) {
+            $skipped[] = [$where, 'non-identifier literal'];
+            continue;
+        }
+        if (strtolower($name) === 'reflectionclass') {
+            $skipped[] = [$where, 'ReflectionClass special case'];
+            continue;
+        }
+        if (count($args) > 2) {
+            $skipped[] = [$where, 'props/3-arg form'];
+            continue;
+        }
+
+        $lower = strtolower($name);
+        if (isset($core[$lower])) {
+            $fqcn = $core[$lower];
+        } elseif (isset($plugins[$lower])) {
+            $fqcn = $plugins[$lower];
+        } elseif (class_exists($name) || interface_exists($name)) {
+            // A PHP built-in. tests/global-class-prefix.test.php requires
+            // every global class reference to carry its leading backslash,
+            // so these are always spelled inline and never imported.
+            $edits[] = [
+                $offsets[$p - 1],
+                $offsets[$close] + 1,
+                'new \\' . $name . '('
+                . (count($args) > 1
+                    ? substr($src, $args[1][0], $args[1][1] - $args[1][0])
+                    : '')
+                . ')',
+            ];
+            $rewritten++;
+            continue;
+        } else {
+            $unresolved[] = [$where, $name];
+            continue;
+        }
+
+        $short = substr($fqcn, strrpos('\\' . $fqcn, '\\'));
+        $shortLower = strtolower($short);
+        $ref = '\\' . $fqcn;
+        if ($style === 'import') {
+            if (isset($bound[$shortLower])) {
+                // Already bound here: bare only if it means the same class.
+                if ($bound[$shortLower] === $fqcn) {
+                    $ref = $short;
+                }
+            } elseif ($ns !== '' && $ns . '\\' . $short === $fqcn) {
+                $ref = $short;  // same namespace; an import would be noise
+            } else {
+                $needImports[$fqcn] = true;
+                $bound[$shortLower] = $fqcn;
+                $ref = $short;
+            }
+        }
+
+        $inner = '';
+        if (count($args) > 1) {
+            $inner = substr($src, $args[1][0], $args[1][1] - $args[1][0]);
+        }
+        $expr = 'new ' . $ref . '(' . $inner . ')';
+
+        // PHP's floor here is 7.4, so `new X()->y()` is a parse error.
+        $after = $close + 1;
+        while ($after < $count && is_array($tokens[$after])
+            && $tokens[$after][0] === T_WHITESPACE
+        ) {
+            $after++;
+        }
+        $next = $after < $count ? $tokens[$after] : null;
+        $chained = $next === '[' || $next === '{'
+            || (is_array($next)
+                && in_array($next[0], [T_OBJECT_OPERATOR, T_DOUBLE_COLON], true))
+            || (defined('T_NULLSAFE_OBJECT_OPERATOR') && is_array($next)
+                && $next[0] === T_NULLSAFE_OBJECT_OPERATOR);
+        if ($chained) {
+            $expr = '(' . $expr . ')';
+        }
+
+        // Replace from the class-reference prefix (`self`) through `)`.
+        $start = $offsets[$p - 1];
+        $q = $p - 1;
+        while ($q > 0 && is_array($tokens[$q])
+            && in_array($tokens[$q][0], [T_STRING, T_NS_SEPARATOR, T_STATIC], true)
+        ) {
+            $start = $offsets[$q];
+            $q--;
+        }
+        $end = $offsets[$close] + 1;
+        $edits[] = [$start, $end, $expr];
+        $rewritten++;
+    }
+
+    if ($edits === [] && $needImports === []) {
+        continue;
+    }
+
+    usort($edits, function ($a, $b) {
+        return $b[0] - $a[0];
+    });
+    foreach ($edits as list($start, $end, $expr)) {
+        $src = substr($src, 0, $start) . $expr . substr($src, $end);
+    }
+
+    if ($needImports !== []) {
+        $src = addImports($src, array_keys($needImports));
+    }
+
+    $touched++;
+    if (!$opts['dry-run']) {
+        file_put_contents($file, $src);
+    }
+}
+
+/**
+ * Splice `use` lines into a file's existing import block, alphabetically.
+ *
+ * When the file has no import block yet the lines go after the namespace
+ * declaration, separated by a blank line -- the shape every already-converted
+ * file in packages/web/src carries.
+ *
+ * @param string $src   file contents
+ * @param array  $fqcns fully qualified names to import
+ *
+ * @return string
+ */
+function addImports($src, array $fqcns)
+{
+    $lines = explode("\n", $src);
+    $existing = [];
+    $first = null;
+    $last = null;
+    $nsLine = null;
+    foreach ($lines as $i => $line) {
+        if ($nsLine === null && preg_match('/^namespace\s+/', $line)) {
+            $nsLine = $i;
+        }
+        if (preg_match('/^use\s+([^;]+);/', $line, $m)
+            && stripos($m[1], 'function ') !== 0
+            && stripos($m[1], 'const ') !== 0
+        ) {
+            $existing[$i] = trim($m[1]);
+            $first = $first ?? $i;
+            $last = $i;
+        }
+    }
+    $all = array_values($existing);
+    foreach ($fqcns as $f) {
+        $all[] = $f;
+    }
+    $all = array_unique($all);
+    usort($all, 'strcasecmp');
+    $block = array_map(function ($f) {
+        return 'use ' . $f . ';';
+    }, $all);
+
+    if ($first !== null) {
+        array_splice($lines, $first, $last - $first + 1, $block);
+        return implode("\n", $lines);
+    }
+    if ($nsLine === null) {
+        // No namespace and no existing import block: the caller is supposed
+        // to have chosen fqcn style, so reaching here means a bug rather
+        // than a file to guess at.
+        fwrite(STDERR, "no place to add imports: " . implode(', ', $fqcns) . "\n");
+        exit(2);
+    }
+    array_splice($lines, $nsLine + 1, 0, array_merge([''], $block));
+    return implode("\n", $lines);
+}
+
+if (!$opts['quiet']) {
+    foreach ($skipped as list($where, $why)) {
+        echo "skip  $where  ($why)\n";
+    }
+}
+foreach ($unresolved as list($where, $name)) {
+    fwrite(STDERR, "UNRESOLVED  $where  '$name'\n");
+}
+printf(
+    "%s%d site(s) rewritten across %d file(s); %d skipped; %d unresolved\n",
+    $opts['dry-run'] ? '[dry-run] ' : '',
+    $rewritten,
+    $touched,
+    count($skipped),
+    count($unresolved)
+);
+exit($unresolved === [] ? 0 : 1);

--- a/bin/getclass-to-new.php
+++ b/bin/getclass-to-new.php
@@ -387,9 +387,19 @@ foreach ($files as $file) {
             $skipped[] = [$where, 'ReflectionClass special case'];
             continue;
         }
-        if (count($args) > 2) {
-            $skipped[] = [$where, 'props/3-arg form'];
-            continue;
+        // getClass()'s THIRD named parameter is $props, so `('X', '', true)`
+        // asks for the default properties and has no `new` equivalent. Any
+        // other arity is an ordinary constructor call, however many arguments
+        // it carries -- NtfyHandler takes three.
+        if (count($args) >= 3) {
+            $third = '';
+            foreach ($args[2][2] as $t) {
+                $third .= is_array($t) ? $t[1] : $t;
+            }
+            if ('true' === strtolower(trim($third))) {
+                $skipped[] = [$where, 'props form'];
+                continue;
+            }
         }
 
         $lower = strtolower($name);
@@ -406,7 +416,11 @@ foreach ($files as $file) {
                 $offsets[$close] + 1,
                 'new \\' . $name . '('
                 . (count($args) > 1
-                    ? substr($src, $args[1][0], $args[1][1] - $args[1][0])
+                    ? substr(
+                        $src,
+                        $args[1][0],
+                        $args[count($args) - 1][1] - $args[1][0]
+                    )
                     : '')
                 . ')',
             ];
@@ -437,7 +451,8 @@ foreach ($files as $file) {
 
         $inner = '';
         if (count($args) > 1) {
-            $inner = substr($src, $args[1][0], $args[1][1] - $args[1][0]);
+            $last = $args[count($args) - 1];
+            $inner = substr($src, $args[1][0], $last[1] - $args[1][0]);
         }
         $expr = 'new ' . $ref . '(' . $inner . ')';
 

--- a/docs/adr/0043-a-class-is-named-at-the-call-site-not-fetched-by-string.md
+++ b/docs/adr/0043-a-class-is-named-at-the-call-site-not-fetched-by-string.md
@@ -1,0 +1,124 @@
+# A class is named at the call site, not fetched by string
+
+## Status
+
+accepted
+
+## Context
+
+`FOGBase::getClass('Host')` was how core instantiated almost everything: 459
+call sites across 120 files spelled every model, manager, hook and page as a
+quoted string handed to a factory. The factory ran the name through
+`FOGBase::qualify()` and then `ReflectionClass::newInstance()`.
+
+That existed for a reason, and the reason is written down in
+`docs/refactor-brief.md`:
+
+> **`getClass()` has 491 call sites and 136 distinct names.** Convert it to a
+> short-name-to-FQCN map so those call sites never need editing. This is the
+> whole reason the migration is tractable: one chokepoint controls the
+> overwhelming majority of class references.
+
+Phase 3 renamed 226 files into `FOG\<Bucket>\<Class>` and needed the tree to
+keep working after every commit. One function that translated a bare name into
+whatever the namespace happened to be that week is exactly the right tool for
+that, and it worked — the migration landed without touching those 459 sites.
+
+The migration is finished. What the literal call sites are left paying is a
+standing cost with nothing on the other side of it.
+
+**The type is erased.** `getClass()` is declared `@return object|mixed`, so
+PHPStan cannot check anything done to the result and no editor can follow one
+to a definition. That is not theoretical: converting the tree turned up **90
+PHPStan errors on a baseline that reports zero**, every one of them
+pre-existing and previously unreachable. Among them —
+
+| Found | What it was |
+|---|---|
+| `Schema::dropDuplicateData()` | `@return void` on a method whose body ends `return $queries;`, and `@param string $table` on one that is indexed `$table[0]`, `$table[1]`, `$table[2]`. 74 of the 90. |
+| `FOGController::destroy()`, `Module::save()` | `@return object` on methods that `return false;`, so every `if (!$x->destroy())` guard in the tree read as dead code |
+| `StorageNode::get()` | `@return object` on a method that returns trimmed **strings**, which is why four `trim()` calls looked like `trim(object)` |
+| `HostManagement::pendingMacsAjax()` | `$errt` assigned only inside two branches of a `try`, then read unconditionally in the `catch` |
+
+None of those are new defects. They are what a decade of annotations drifting
+behind their bodies looks like when something finally reads them.
+
+**It is not a substitution seam.** That is the usual argument for a factory,
+and it does not hold here. `qualify()` consults the core map *before* the
+plugin map, and ADR 0013 says that ordering is load-bearing: "it is what stops
+a plugin answering a core name." Nothing can ever answer `getClass('Host')`
+with a different class. There is no behavior to preserve beyond resolving the
+name — which `use FOG\Items\Host;` already does, at compile time, checkably.
+
+The one exception is the **test harnesses**, which do substitute through it:
+`tests/lib/bootmenu-harness.php` declares a stub `FOGBase` whose `getClass()`
+returns cut-down stand-ins. That seam is real, but it is not the factory's — it
+is the harness replacing `FOGBase` wholesale, and `tests/lib/stub-buckets.php`
+already re-exports flat stubs under their bucketed names precisely so a direct
+`new` finds them. Two of them (`KeySequence`, `Ipxe`) existed only as arms of
+the harness's `getClass()` switch and needed promoting to classes; the golden
+iPXE output is byte-identical either way.
+
+## Decision
+
+**A class named by a literal is instantiated with `new`.** In `packages/web/src`
+that means a `use` import and a bare `new Host()` — the house style already, 255
+of 289 files carry an import block. In files that declare no namespace, and
+throughout `fog-plugins` (whose own
+`tests/core-references-are-qualified.test.php` refuses a bare core name), it
+means an inline `new \FOG\Items\Host()`.
+
+**`getClass()` stays, for the shape `new` cannot express: a class named by a
+variable.** 56 sites, and they are the ones that matter — `Route`,
+`Authorization::_scopeClassVars()`, `OpenAPI::_entitySchema()` and
+`FOGPage::$childClass` hold a lowercase string that arrived over the API or in
+a URL and turn it into a class through `qualify()`. Nothing else can do that,
+and narrowing the function to that job is what makes the job legible.
+
+Two literal forms survive because they have no `new` equivalent at all:
+
+- `getClass('X', '', true)` returns `ReflectionClass::getDefaultProperties()`
+  rather than an instance. Three sites.
+- `getClass('ReflectionClass', ...)`, which the factory special-cases.
+
+`tests/getclass-literals.test.php` enforces this. It already checked that a
+literal names a class spelled exactly as declared; it now also refuses a
+literal `getClass()` that is neither of the two forms above, and its
+scan-sanity anchor moved from counting literals to counting declarations —
+counting literals would have made the gate weaker every time it succeeded.
+
+## Consequences
+
+**The 90 findings had to be dealt with rather than deferred**, because the
+`phpstan` check is required and the baseline was zero. Seven were corrected
+annotations that now match their bodies, one was the undefined `$errt`, and one
+— a `!$StorageNode` guard after a method that throws instead of returning null
+— is genuinely dead and was left in place with a baseline entry saying why.
+Deleting defensive code on the strength of a docblock, in a tree where this
+change just proved the docblocks unreliable, is the wrong direction.
+
+**Eight tests read the source as text and pinned the old spelling** —
+`strpos($post, "getClass('GroupPowerManagement')")` and similar. They were
+updated to the new spelling, not loosened to accept both; accepting both would
+let the old form back in through the gate's own blind spot.
+
+**Plugin authors are affected**, and `docs/plugin-development.md` says so. A
+bare `getClass('LDAPGroupManager')` inside a plugin used to be the documented
+way to reach a class without spelling its namespace. It still resolves — the
+function is unchanged — but the documented advice is now `new
+\FOG\Plugins\LDAP\Managers\LDAPGroupManager()`, and fog-plugins was converted
+in the same sweep.
+
+**The rewrite was mechanical and is reproducible.** `bin/getclass-to-new.php`
+is the tool, kept for the same reason fog-plugins keeps
+`bin/qualify-core-references.php`: it is how the sweep was done, it can be
+re-run against a plugin tree or a long-lived branch, and it resolves names
+through the same core-then-plugins order `qualify()` does, so it cannot
+silently repoint a call at a plugin class. It is token-based rather than
+regex-based, which is what keeps it off the `getClass(` occurrences inside
+strings, docblocks and commented-out code — of which this tree has 30.
+
+**What this does not do is make the tree type-safe.** It makes 459 call sites
+*visible* to a checker that was previously blind to them. The 90 errors are the
+first instalment of that, not the last: every future change to a method these
+call sites touch is now checked, which is the point.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,3 +60,4 @@ Status is summarized here and stated in full in each file.
 | 0040 | [Certificates you bring live in /etc/fog/customizations/pki](0040-certificates-you-bring-live-in-a-customizations-tree.md) | accepted, implemented |
 | 0041 | [A boot file is what its bytes say, not what its name says](0041-a-boot-file-is-what-its-bytes-say-not-what-its-name-says.md) | accepted |
 | 0042 | [The filesystem is the inventory; the database records judgments about it](0042-the-filesystem-is-the-inventory-the-database-records-judgments.md) | accepted |
+| 0043 | [A class is named at the call site, not fetched by string](0043-a-class-is-named-at-the-call-site-not-fetched-by-string.md) | accepted |

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -621,11 +621,15 @@ A page is a page because it is in `src/Pages/`; core lists that directory —
 buckets. Anything else you ship is simply autoloaded when something names it.
 
 Bare spellings still work wherever **core** does the resolving:
-`getClass('HelloWorld')`, `FOGController::getManager()`, `FOGPage::$childClass`,
-`Route::_newEntity()` and `Authorization`'s object-scope lookup all take a
-short name. Core builds that map from the file *paths* now rather than by
-reading every plugin file, so you never spell the namespace out anywhere except
-the `namespace` declaration itself.
+`FOGController::getManager()`, `FOGPage::$childClass`, `Route::_newEntity()`,
+`Authorization`'s object-scope lookup and a variable handed to `getClass()` all
+take a short name. Core builds that map from the file *paths* now rather than
+by reading every plugin file, so you never spell the namespace out anywhere
+except the `namespace` declaration itself.
+
+That is about names core is *given*. Names **you** write are a different
+question: spell those fully qualified rather than routing them through
+`getClass()`, per ADR 0043 and the section below.
 
 **`class_alias()` is not needed and should not be used.** It was the workaround
 for a gap that no longer exists — discovery once derived a bare class name from
@@ -659,17 +663,36 @@ friends. Core wins it: a plugin class whose short name matches a core class is
 reachable only by its FQCN. Pick a distinctive name and the question never
 arises.
 
+### Name the class, do not fetch it by string
+
+**Write `new \FOG\Plugins\LDAP\Managers\LDAPGroupManager()`, not
+`self::getClass('LDAPGroupManager')`** (ADR 0043). The factory erased the
+type — it is declared `@return object|mixed` — so nothing could check what you
+then did with the result, and it was never a substitution seam: `qualify()`
+consults core's map before the plugins', so a bare name can only ever resolve
+to one class. Core was converted in the same sweep, and
+`tests/getclass-literals.test.php` there refuses a literal `getClass()`.
+
+Fully qualified rather than imported, because this repository's
+`tests/core-references-are-qualified.test.php` refuses a bare core name
+outright — a plugin tree is fetched on its own and cannot assume core's
+class list is anywhere nearby.
+
+`getClass()` itself has not gone and still resolves a bare name through
+`FOGBase::qualify()`. Reach for it when the class is named by a **variable**,
+which is the one thing `new` cannot express, and for
+`getClass('X', '', true)`, which returns the default properties rather than an
+instance.
+
 ### The one place a bare name still bites
 
-Core resolves a bare name wherever *it* does the resolving: `getClass()`,
-`getManager()`, discovery, `$childClass`, `Route::_newEntity()`,
+Core resolves a bare name wherever *it* does the resolving: `getClass()` with a
+variable, `getManager()`, discovery, `$childClass`, `Route::_newEntity()`,
 `Authorization`. A class name **your own code** holds in a plain string is
-resolved exactly as written, with no such mapping behind it. So
-`self::getClass('LDAPGroupManager')` inside a plugin is fine — core resolves
-it — but a raw `new $someString` or `is_subclass_of($x, 'SomeClass')` naming
-a bare plugin class in your own code is not. Spell those fully qualified
-(`\FOG\Plugins\LDAP\Managers\LDAPGroupManager`) or route them through
-`self::getClass()` instead.
+resolved exactly as written, with no such mapping behind it — so a raw
+`new $someString` or `is_subclass_of($x, 'SomeClass')` naming a bare plugin
+class is not. Spell those fully qualified
+(`\FOG\Plugins\LDAP\Managers\LDAPGroupManager`).
 
 ### What the failure looks like
 
@@ -929,8 +952,8 @@ just-provisioned account has no id before then.
   superglobals) — never raw `$_POST`/`$_GET`.
 - **CSRF/auth:** call `self::checkAuthAndCSRF()` at the top of every state‑
   changing POST handler.
-- **Instantiation:** prefer `self::getClass('HelloWorld')` /
-  `self::getClass('HelloWorldManager')` over `new`.
+- **Instantiation:** `new \FOG\Plugins\HelloWorld\Items\HelloWorld()`, fully
+  qualified. Not `self::getClass('HelloWorld')` — see ADR 0043.
 - **Translation:** wrap UI strings in `_('…')`.
 - **Secrets in your table:** if a column holds a credential — an API token, a
   webhook URL, a bind password — declare it through `API_SENSITIVE_FIELDS` or

--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -13,6 +13,8 @@
 
 use FOG\Audit\Audit;
 use FOG\Db\DatabaseManager;
+use FOG\Items\Image;
+use FOG\Items\OS;
 use FOG\Items\Schema;
 use FOG\Items\TaskLog;
 
@@ -25,7 +27,7 @@ use FOG\Items\TaskLog;
  * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
  * @link     https://fogproject.org
  */
-$tmpSchema = self::getClass('Schema');
+$tmpSchema = new Schema();
 self::$DB->query(Schema::useDatabaseQuery());
 /**
  * GH-529: FOG_WEB_ROOT used to be seeded with a literal '/fog/' regardless of
@@ -1143,11 +1145,11 @@ if (FOG_SCHEMA < $tmpSchema->get('value')) {
         $allImageID[$Host['hostImage']] = $Host['hostOS'];
     }
     foreach ((array)$allImageID as $imageID => $osID) {
-        $Image = self::getClass('Image', $imageID);
+        $Image = new Image($imageID);
         if (!$Image->isValid()) {
             continue;
         }
-        $OS = self::getClass('OS', $osID);
+        $OS = new OS($osID);
         if (!$OS->isValid()) {
             continue;
         }

--- a/packages/web/maintenance/backup_db.php
+++ b/packages/web/maintenance/backup_db.php
@@ -12,6 +12,7 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Db\Mysqldump;
 
 /**
  * Backs up the db for us
@@ -49,7 +50,7 @@ if (false === $tmpfile) {
 }
 chmod($tmpfile, 0600);
 $data = '';
-FOGCore::getClass('Mysqldump')->start($tmpfile);
+(new Mysqldump())->start($tmpfile);
 if (!file_exists($tmpfile) || !is_readable($tmpfile)) {
     throw new \Exception(_('Could not read file from tmp folder.'));
 }

--- a/packages/web/maintenance/check_node_exists.php
+++ b/packages/web/maintenance/check_node_exists.php
@@ -12,6 +12,7 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Managers\StorageNodeManager;
 
 /**
  * Check if the node exists and return it
@@ -52,7 +53,7 @@ if (!$ip) {
 }
 
 $val = '';
-$exists = FOGCore::getClass('StorageNodeManager')
+$exists = (new StorageNodeManager())
     ->exists($ip, '', 'ip');
 if ($exists) {
     $val = 'exists';

--- a/packages/web/maintenance/create_update_node.php
+++ b/packages/web/maintenance/create_update_node.php
@@ -12,6 +12,8 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Items\StorageNode;
+use FOG\Managers\StorageNodeManager;
 use FOG\Router\Route;
 
 /**
@@ -89,7 +91,7 @@ function nodeRegistrationName($posted, $ip)
     ) {
         return $ip;
     }
-    if (FOGCore::getClass('StorageNodeManager')->exists($posted, 0, 'name')) {
+    if ((new StorageNodeManager())->exists($posted, 0, 'name')) {
         return $ip;
     }
     return $posted;
@@ -108,12 +110,12 @@ if (isset($_POST['newNode'])) {
     $interface  = $stripped['interface'] ?? '';
     $bandwidth  = $stripped['bandwidth'] ?? 1;
     $webroot    = $stripped['webroot'] ?? '/';
-    $exists = FOGCore::getClass('StorageNodeManager')
+    $exists = (new StorageNodeManager())
         ->exists($ip, '', 'ip');
     if ($exists) {
         return;
     }
-    FOGCore::getClass('StorageNode')
+    (new StorageNode())
         ->set('name', $name)
         ->set('path', $path)
         ->set('ftppath', $ftppath)
@@ -141,7 +143,7 @@ if (isset($_POST['newNode'])) {
         ) {
             continue;
         }
-        FOGCore::getClass('StorageNode', $StorageNode->id)
+        (new StorageNode($StorageNode->id))
             ->set('user', $user)
             ->set('pass', $pass)
             ->save();

--- a/packages/web/management/index.php
+++ b/packages/web/management/index.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 use FOG\Auth\Identity;
 use FOG\Base\FOGCore;
+use FOG\Base\FOGPageManager;
+use FOG\Base\Page;
+use FOG\Pages\ProcessLogin;
 use FOG\Router\HTTPResponseCodes;
 
 /*
@@ -30,15 +33,15 @@ define('FOG_WANTS_SESSION', true);
 require '../commons/base.inc.php';
 
 // Initialize required classes
-$FOGPageManager = FOGCore::getClass('FOGPageManager');
+$FOGPageManager = new FOGPageManager();
 
 // Capture login process output
 ob_start();
-FOGCore::getClass('ProcessLogin')->processMainLogin();
+(new ProcessLogin())->processMainLogin();
 $login = ob_get_clean();
 
 require '../commons/text.php';
-$Page = FOGCore::getClass('Page');
+$Page = new Page();
 
 // Define allowed nodes
 $nodes = [

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -5602,6 +5602,10 @@ msgid "MAC Format is invalid"
 msgstr "MAC-Format ist ungültig"
 
 #, fuzzy
+msgid "MAC Update Fail"
+msgstr "Modulupdate fehlgeschlagen"
+
+#, fuzzy
 msgid "MAC address is already in use by another host"
 msgstr "Die MAC-Adresse wird bereits von einem andern Host verwendet"
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -5614,6 +5614,10 @@ msgid "MAC Format is invalid"
 msgstr "MAC Format is invalid"
 
 #, fuzzy
+msgid "MAC Update Fail"
+msgstr "Group create failed"
+
+#, fuzzy
 msgid "MAC address is already in use by another host"
 msgstr "MAC address is already in use by another host"
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5707,6 +5707,10 @@ msgid "MAC Format is invalid"
 msgstr "Dirección MAC de lista de origen: "
 
 #, fuzzy
+msgid "MAC Update Fail"
+msgstr "Grupo Error de creación"
+
+#, fuzzy
 msgid "MAC address is already in use by another host"
 msgstr "La dirección MAC ya está en uso por otro host"
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5603,6 +5603,10 @@ msgid "MAC Format is invalid"
 msgstr "MAC-Format ist ungültig"
 
 #, fuzzy
+msgid "MAC Update Fail"
+msgstr "Modulupdate fehlgeschlagen"
+
+#, fuzzy
 msgid "MAC address is already in use by another host"
 msgstr "Liste der MAC-Adressen"
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -5602,6 +5602,10 @@ msgid "MAC Format is invalid"
 msgstr "MAC Format est invalide"
 
 #, fuzzy
+msgid "MAC Update Fail"
+msgstr "Groupe create a échoué"
+
+#, fuzzy
 msgid "MAC address is already in use by another host"
 msgstr "L'adresse MAC est déjà utilisée par un autre hôte"
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -5435,6 +5435,10 @@ msgid "MAC Format is invalid"
 msgstr "MAC Format non è valido"
 
 #, fuzzy
+msgid "MAC Update Fail"
+msgstr "Aggiornamento modulo non riuscito"
+
+#, fuzzy
 msgid "MAC address is already in use by another host"
 msgstr "L'indirizzo MAC è già in uso da un altro host"
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -5400,6 +5400,10 @@ msgstr "承認に成功しました"
 msgid "MAC Format is invalid"
 msgstr "MAC アドレス形式が無効です"
 
+#, fuzzy
+msgid "MAC Update Fail"
+msgstr "モジュールの更新に失敗しました"
+
 msgid "MAC address is already in use by another host"
 msgstr "MAC アドレスは別のホストで既に使用されています"
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -4792,6 +4792,9 @@ msgstr ""
 msgid "MAC Format is invalid"
 msgstr ""
 
+msgid "MAC Update Fail"
+msgstr ""
+
 msgid "MAC address is already in use by another host"
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -5601,6 +5601,10 @@ msgid "MAC Format is invalid"
 msgstr "Formato MAC é inválido"
 
 #, fuzzy
+msgid "MAC Update Fail"
+msgstr "Grupo Criar falhou"
+
+#, fuzzy
 msgid "MAC address is already in use by another host"
 msgstr "O endereço MAC já está sendo usado por outro host"
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -5601,6 +5601,10 @@ msgid "MAC Format is invalid"
 msgstr "MAC格式无效"
 
 #, fuzzy
+msgid "MAC Update Fail"
+msgstr "集团创建失败"
+
+#, fuzzy
 msgid "MAC address is already in use by another host"
 msgstr "MAC地址已被其他主机使用"
 

--- a/packages/web/management/other/index.php
+++ b/packages/web/management/other/index.php
@@ -18,6 +18,7 @@ use FOG\Auth\Authorization;
 use FOG\Auth\CSRF;
 use FOG\Base\FOGPage;
 use FOG\Base\Page;
+use FOG\Items\Setting;
 
 // Not an entry point: this is the page shell, included by Page::render()
 // with the application already booted, which is what makes the self::
@@ -458,7 +459,7 @@ if ($isLoggedIn && \FOG\Auth\Identity::canStart()) : ?>
             $pageLength = self::getSetting('FOG_VIEW_DEFAULT_SCREEN');
 if (in_array(strtolower($pageLength), ['search', 'list'])) {
     $pageLength = 10;
-    $Setting = self::getClass('Setting')
+    $Setting = (new Setting())
         ->set('name', 'FOG_VIEW_DEFAULT_SCREEN')
         ->load('name')
         ->set(

--- a/packages/web/service/Post_Stage2.php
+++ b/packages/web/service/Post_Stage2.php
@@ -34,5 +34,5 @@ define('FOG_MACHINE_REQUEST', true);
 
 require '../commons/base.inc.php';
 TaskQueue::ackIfAlreadyComplete();
-FOGCore::getClass('TaskQueue')
+(new TaskQueue())
     ->checkout();

--- a/packages/web/service/Post_Stage3.php
+++ b/packages/web/service/Post_Stage3.php
@@ -34,5 +34,5 @@ define('FOG_MACHINE_REQUEST', true);
 
 require '../commons/base.inc.php';
 TaskQueue::ackIfAlreadyComplete();
-FOGCore::getClass('TaskQueue')
+(new TaskQueue())
     ->checkout();

--- a/packages/web/service/Post_Wipe.php
+++ b/packages/web/service/Post_Wipe.php
@@ -12,6 +12,7 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\TaskHandling\TaskQueue;
 
 /**
  * Check out other tasks.
@@ -32,5 +33,5 @@ use FOG\Base\FOGCore;
 define('FOG_MACHINE_REQUEST', true);
 
 require '../commons/base.inc.php';
-FOGCore::getClass('TaskQueue')
+(new TaskQueue())
     ->checkout();

--- a/packages/web/service/Pre_Stage1.php
+++ b/packages/web/service/Pre_Stage1.php
@@ -12,6 +12,7 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\TaskHandling\TaskQueue;
 
 /**
  * Check in tasks.
@@ -32,5 +33,5 @@ use FOG\Base\FOGCore;
 define('FOG_MACHINE_REQUEST', true);
 
 require '../commons/base.inc.php';
-FOGCore::getClass('TaskQueue')
+(new TaskQueue())
     ->checkIn();

--- a/packages/web/service/Printers.php
+++ b/packages/web/service/Printers.php
@@ -12,6 +12,7 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Client\PrinterClient;
 
 /**
  * Printer client script
@@ -32,4 +33,4 @@ use FOG\Base\FOGCore;
 define('FOG_MACHINE_REQUEST', true);
 
 require '../commons/base.inc.php';
-FOGCore::getClass('PrinterClient');
+new PrinterClient();

--- a/packages/web/service/checkcredentials.php
+++ b/packages/web/service/checkcredentials.php
@@ -13,6 +13,7 @@
 
 use FOG\Audit\Audit;
 use FOG\Base\FOGCore;
+use FOG\Items\User;
 
 /**
  * Checks credentials for init based calls
@@ -136,7 +137,7 @@ try {
     if (false === $password) {
         throw new \Exception('#!il');
     }
-    $userTest = FOGCore::getClass('User')
+    $userTest = (new User())
         ->passwordValidate($username, $password);
     if (!$userTest) {
         $recordBadAttempt();

--- a/packages/web/service/hostinfo.php
+++ b/packages/web/service/hostinfo.php
@@ -13,6 +13,7 @@
 
 use FOG\Base\FOGCore;
 use FOG\Items\Image;
+use FOG\Items\MulticastSession;
 use FOG\Router\Route;
 
 /**
@@ -70,10 +71,7 @@ try {
                 $msIDs[] = $id->msID;
             }
 
-            $MulticastSession = FOGCore::getClass(
-                'MulticastSession',
-                FOGCore::maxId($msIDs)
-            );
+            $MulticastSession = new MulticastSession(FOGCore::maxId($msIDs));
             if (!$MulticastSession->isValid()) {
                 throw new \Exception(_('Invalid Multicast Session'));
             }

--- a/packages/web/service/hostnameloop.php
+++ b/packages/web/service/hostnameloop.php
@@ -13,6 +13,7 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Items\Host;
 
 /**
  * Hostname loop simply checks the host doesn't
@@ -39,7 +40,7 @@ try {
     $host = trim($host);
     $host = base64_decode($host);
     $host = trim($host);
-    $Host = FOGCore::getClass('Host')
+    $Host = (new Host())
         ->set('name', $host)
         ->load('name');
     if ($Host->isValid()) {

--- a/packages/web/service/inventory.php
+++ b/packages/web/service/inventory.php
@@ -67,7 +67,7 @@ try {
     if (!$Inventory instanceof Inventory
         || !$Inventory->isValid()
     ) {
-        $Inventory = FOGCore::getClass('Inventory')
+        $Inventory = (new Inventory())
             ->set('hostID', FOGCore::$Host->get('id'));
     }
     // Explicit allowlist of fields a client is permitted to write. Server

--- a/packages/web/service/mc_checkin.php
+++ b/packages/web/service/mc_checkin.php
@@ -12,6 +12,7 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\TaskHandling\TaskQueue;
 
 /**
  * Multicast check in
@@ -32,5 +33,5 @@ use FOG\Base\FOGCore;
 define('FOG_MACHINE_REQUEST', true);
 
 require '../commons/base.inc.php';
-FOGCore::getClass('TaskQueue')
+(new TaskQueue())
     ->checkIn();

--- a/packages/web/service/secureboot.report.php
+++ b/packages/web/service/secureboot.report.php
@@ -15,6 +15,7 @@ use FOG\Base\FOGBase;
 use FOG\Base\FOGCore;
 use FOG\Boot\SecureBootState;
 use FOG\Items\TaskType;
+use FOG\Managers\HostManager;
 use FOG\Router\Route;
 
 /**
@@ -139,7 +140,7 @@ if ('' === $cert) {
     $done('badcert');
 }
 
-FOGCore::getClass('HostManager')->update(
+(new HostManager())->update(
     ['id' => $Host->get('id')],
     '',
     [
@@ -159,7 +160,7 @@ $state = strtolower(trim((string)filter_input(INPUT_POST, 'sbstate')));
 if (SecureBootState::isKnown($state)
     && SecureBootState::UNKNOWN !== $state
 ) {
-    FOGCore::getClass('HostManager')->update(
+    (new HostManager())->update(
         ['id' => $Host->get('id')],
         '',
         [

--- a/packages/web/src/Audit/Audit.php
+++ b/packages/web/src/Audit/Audit.php
@@ -16,6 +16,7 @@ namespace FOG\Audit;
 use FOG\Auth\Identity;
 use FOG\Auth\Redaction;
 use FOG\Base\FOGBase;
+use FOG\Items\AuditChange;
 use FOG\Items\AuditLog;
 use FOG\Items\User;
 
@@ -179,7 +180,7 @@ class Audit extends FOGBase
     public static function record(array $row)
     {
         try {
-            $audit = self::getClass('AuditLog')
+            $audit = (new AuditLog())
                 ->set('correlationID', self::correlationID())
                 ->set('createdBy', $row['createdBy'] ?? self::_actor())
                 ->set('ip', (string)self::$remoteaddr)
@@ -407,7 +408,7 @@ class Audit extends FOGBase
                 $pair[1] ?? null
             );
             try {
-                $change = self::getClass('AuditChange')
+                $change = (new AuditChange())
                     ->set('auditID', (int)$audit->get('id'))
                     ->set('subjectType', $subjectType)
                     ->set('subjectID', (int)$subjectID)

--- a/packages/web/src/Audit/Blame.php
+++ b/packages/web/src/Audit/Blame.php
@@ -14,6 +14,7 @@
 
 namespace FOG\Audit;
 
+use FOG\Items\NodeFailure;
 use FOG\TaskHandling\TaskingElement;
 
 /**
@@ -46,7 +47,7 @@ class Blame extends TaskingElement
                 self::getAllBlamedNodes(self::$Host)
             )
         ) {
-            self::getClass('NodeFailure')
+            (new NodeFailure())
                 ->set('storagegroupID', $taskStorageGroupID)
                 ->set('storagenodeID', $taskStorageNodeID)
                 ->set('failureTime', $failtime)

--- a/packages/web/src/Audit/Retention.php
+++ b/packages/web/src/Audit/Retention.php
@@ -15,6 +15,7 @@ namespace FOG\Audit;
 
 use FOG\Base\FOGBase;
 use FOG\Base\HookManager;
+use FOG\Items\Setting;
 
 /**
  * Ages rows out of the tables that record what happened.
@@ -259,7 +260,7 @@ class Retention extends FOGBase
     private static function _settingID($key)
     {
         try {
-            $setting = self::getClass('Setting')
+            $setting = (new Setting())
                 ->set('name', $key)
                 ->load('name');
 

--- a/packages/web/src/Base/EventManager.php
+++ b/packages/web/src/Base/EventManager.php
@@ -14,6 +14,7 @@
 
 namespace FOG\Base;
 
+use FOG\Items\NotifyEvent;
 use FOG\Router\Route;
 
 /**
@@ -145,7 +146,7 @@ class EventManager extends FOGBase
         // inside save() could never recurse into saving the same name again.
         // Matches HookManager::processEvent().
         self::$knownNotifyEvents[$event] = true;
-        self::getClass('NotifyEvent')
+        (new NotifyEvent())
             ->set('name', $event)
             ->save();
     }

--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -22,8 +22,13 @@ use FOG\Db\SchemaReconciler;
 use FOG\Items\History;
 use FOG\Items\Host;
 use FOG\Items\MACAddress;
+use FOG\Items\Plugin;
+use FOG\Items\Setting;
 use FOG\Items\TaskState;
 use FOG\Items\User;
+use FOG\Managers\HostManager;
+use FOG\Managers\SettingManager;
+use FOG\Managers\UserPrefManager;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 
@@ -810,7 +815,7 @@ abstract class FOGBase
             unset($mac);
         }
         // Get the host element based on the mac address
-        self::getClass('HostManager')->getHostByMacAddresses($macs);
+        (new HostManager())->getHostByMacAddresses($macs);
         // If no macs are returned and the host is not required,
         // throw message that it's an invalid mac.
         if (count($macs ?: []) < 1 && $hostnotrequired === false) {
@@ -910,7 +915,7 @@ abstract class FOGBase
         if (!self::getSetting('FOG_PLUGINSYS_ENABLED')) {
             return [];
         }
-        self::getClass('Plugin')->getPlugins();
+        (new Plugin())->getPlugins();
         $find = [
             'installed' => 1,
             'state' => 1,
@@ -1941,7 +1946,7 @@ abstract class FOGBase
         }
         self::$_displayTimeZone = $storage;
         try {
-            $pref = self::getClass('UserPrefManager')
+            $pref = (new UserPrefManager())
                 ->fetch((int)$user->get('id'), self::TIMEZONE_PREF);
         } catch (\Exception $e) {
             // A preference store that cannot be read is not a reason to stop
@@ -2155,7 +2160,7 @@ abstract class FOGBase
             return self::$_displayTheme;
         }
         try {
-            $pref = self::getClass('UserPrefManager')
+            $pref = (new UserPrefManager())
                 ->fetch((int)$user->get('id'), self::THEME_PREF);
         } catch (\Exception $e) {
             // A preference store that cannot be read is not a reason to fail
@@ -3163,7 +3168,7 @@ abstract class FOGBase
         // Validate remaining MACs
         $validMACs = [];
         foreach ($MACs as $MAC) {
-            $MACObject = self::getClass('MACAddress', $MAC);
+            $MACObject = new MACAddress($MAC);
             if ($MACObject->isValid()) {
                 $validMACs[] = $MACObject;
             }
@@ -3377,7 +3382,7 @@ abstract class FOGBase
             return;
         }
         if (self::$DB) {
-            $History = self::getClass('History')
+            $History = (new History())
                 ->set('info', $string)
                 ->set('ip', self::$remoteaddr);
             foreach (['type', 'subjectType', 'subjectID', 'subjectLabel'] as $k) {
@@ -3740,11 +3745,11 @@ abstract class FOGBase
      *
      * @throws Exception
      *
-     * @return this
+     * @return bool true when the write reached the database
      */
     public static function setSetting($key, $value)
     {
-        $result = self::getClass('SettingManager')->update(
+        $result = (new SettingManager())->update(
             ['name' => $key],
             '',
             ['value' => trim($value)]
@@ -4343,7 +4348,7 @@ abstract class FOGBase
         $secret = self::getSetting('FOG_NODE_SECRET');
         if (empty($secret)) {
             $secret = bin2hex(random_bytes(32));
-            self::getClass('Setting')
+            (new Setting())
                 ->set('name', 'FOG_NODE_SECRET')
                 ->set('description', 'Auto-generated shared secret used to authenticate inter-node requests (e.g. the Wake-on-LAN relay). Do not edit.')
                 ->set('value', $secret)
@@ -4481,7 +4486,7 @@ abstract class FOGBase
         $password,
         $remember = false
     ) {
-        return self::getClass('User')
+        return (new User())
             ->validatePw($username, $password, $remember);
     }
     /**
@@ -4502,7 +4507,7 @@ abstract class FOGBase
      */
     public static function authenticateOnly($username, $password)
     {
-        return self::getClass('User')
+        return (new User())
             ->authenticate($username, $password);
     }
     /**
@@ -4761,7 +4766,7 @@ abstract class FOGBase
             // present; it is not a second authorization step. Whether this
             // deletion is allowed was already decided by the node's delete
             // permission before we got here.
-            $validate = self::getClass('User')
+            $validate = (new User())
                 ->passwordValidate(
                     $user,
                     $pass

--- a/packages/web/src/Base/FOGController.php
+++ b/packages/web/src/Base/FOGController.php
@@ -1296,7 +1296,7 @@ abstract class FOGController extends FOGBase
      *
      * @throws Exception
      *
-     * @return object
+     * @return bool|object false when the delete failed, $this otherwise
      */
     public function destroy($key = 'id')
     {

--- a/packages/web/src/Base/FOGManagerController.php
+++ b/packages/web/src/Base/FOGManagerController.php
@@ -2353,7 +2353,7 @@ abstract class FOGManagerController extends FOGBase
      * @param mixed  $matchID     select the matching id
      * @param string $elementName the name for the select box
      * @param string $orderBy     how to order
-     * @param string $filter      should we filter existing
+     * @param array|string $filter        ids to restrict the list to
      * @param mixed  $template    should we include a template element
      * @param string $useKey      id for storage.
      *
@@ -2462,7 +2462,7 @@ abstract class FOGManagerController extends FOGBase
      * Checks if item already exists or not.
      *
      * @param string $val     the value to test
-     * @param string $id      an ID if already exists
+     * @param int|string $id  an ID if already exists
      * @param string $idField the id field to scan
      *
      * @return bool

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -15,11 +15,17 @@
 namespace FOG\Base;
 
 use FOG\Auth\Authorization;
+use FOG\Boot\WakeOnLan;
+use FOG\Client\RegisterClient;
+use FOG\Items\BootFile;
 use FOG\Items\Group;
 use FOG\Items\Host;
 use FOG\Items\Image;
 use FOG\Items\Site;
 use FOG\Items\Snapin;
+use FOG\Managers\FileDeleteQueueManager;
+use FOG\Managers\HostManager;
+use FOG\Managers\PowerManagementManager;
 use FOG\Pages\ReportManagement;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
@@ -2333,7 +2339,7 @@ abstract class FOGPage extends FOGBase
                         ];
                     }
                 }
-                self::getClass('FileDeleteQueueManager')
+                (new FileDeleteQueueManager())
                     ->insertBatch(
                         $insert_fields,
                         $insert_values
@@ -3637,7 +3643,7 @@ abstract class FOGPage extends FOGBase
         }
         // Handles adding additional system macs for us.
         ob_start();
-        self::getClass('RegisterClient')->json();
+        (new RegisterClient())->json();
         ob_end_clean();
         try {
             $igMods = [
@@ -3774,10 +3780,10 @@ abstract class FOGPage extends FOGBase
         if ($groupid < 1) {
             $hosts = $id;
         } else {
-            $hosts = self::getClass('Group', $groupid)
+            $hosts = (new Group($groupid))
                 ->get('hosts');
         }
-        self::getClass('HostManager')
+        (new HostManager())
             ->update(
                 ['id' => $hosts],
                 '',
@@ -3813,7 +3819,7 @@ abstract class FOGPage extends FOGBase
         if ($groupid < 1) {
             return;
         }
-        $hosts = self::getClass('Group', $groupid)
+        $hosts = (new Group($groupid))
             ->get('hosts');
         if (count($hosts ?: [])) {
             Route::deletemass(
@@ -3960,7 +3966,7 @@ abstract class FOGPage extends FOGBase
         if (count($macs ?: []) < 1) {
             return;
         }
-        self::getClass('WakeOnLan', implode('|', $macs))->send();
+        (new WakeOnLan(implode('|', $macs)))->send();
     }
     /**
      * Presents the importer elements
@@ -5033,7 +5039,7 @@ abstract class FOGPage extends FOGBase
                     if ($isHost) {
                         $macs = self::parseMacList($rowVals['primac']);
                         self::$Host = $Item;
-                        self::getClass('HostManager')
+                        (new HostManager())
                             ->getHostByMacAddresses($macs);
                         if (self::$Host->isValid()) {
                             throw new \Exception(
@@ -5330,7 +5336,7 @@ abstract class FOGPage extends FOGBase
 
         $labelClass = 'col-sm-3 col-form-label';
 
-        $actionSelector = self::getClass('PowerManagementManager')->getActionSelect(
+        $actionSelector = (new PowerManagementManager())->getActionSelect(
             $action,
             false,
             'action'
@@ -6335,7 +6341,7 @@ abstract class FOGPage extends FOGBase
     private static function _bootFileStore($row, array $data)
     {
         try {
-            $obj = $row ?: self::getClass('BootFile');
+            $obj = $row ?: new BootFile();
             foreach ($data as $field => $value) {
                 $obj->set($field, $value);
             }
@@ -6403,7 +6409,7 @@ abstract class FOGPage extends FOGBase
             return false;
         }
         try {
-            $row = self::_bootFileRow($name) ?: self::getClass('BootFile');
+            $row = self::_bootFileRow($name) ?: new BootFile();
             $row->set('name', $name)
                 ->set('pinned', $keep ? 1 : 0);
             $row->save();

--- a/packages/web/src/Base/FOGPageManager.php
+++ b/packages/web/src/Base/FOGPageManager.php
@@ -162,7 +162,7 @@ class FOGPageManager extends FOGBase
                 || empty($method)
             ) {
                 $method = 'index';
-                self::getClass('Page')
+                (new Page())
                     ->addJavascript("js/fog/{$node}/fog.{$node}.list.js");
             }
             // The schema deploy endpoint must run before any user/session or

--- a/packages/web/src/Base/FOGPagePost.php
+++ b/packages/web/src/Base/FOGPagePost.php
@@ -24,6 +24,7 @@
 
 namespace FOG\Base;
 
+use FOG\Items\Site;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 use FOG\Util\FOGCron;
@@ -619,7 +620,7 @@ trait FOGPagePost
         // membership tables carry no foreign keys, and a stale row would
         // otherwise sit there granting scope for an id that could later be
         // reused by a different site.
-        $site = self::getClass('Site', $siteID);
+        $site = new Site($siteID);
         if (!$site->isValid()) {
             throw new \Exception(_('The selected site no longer exists'));
         }

--- a/packages/web/src/Base/FOGPageRender.php
+++ b/packages/web/src/Base/FOGPageRender.php
@@ -26,7 +26,10 @@ namespace FOG\Base;
 
 use FOG\Auth\Authorization;
 use FOG\Auth\SiteScope;
+use FOG\Items\Site;
 use FOG\Items\TaskType;
+use FOG\Managers\SiteManager;
+use FOG\Managers\SnapinManager;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 
@@ -1038,7 +1041,7 @@ trait FOGPageRender
      */
     protected function taskingOptionFields($type, $labelClass)
     {
-        $TaskType = self::getClass('TaskType', $type);
+        $TaskType = new TaskType($type);
         $issnapintask = $TaskType->isSnapinTasking();
         $isinitneeded = $TaskType->isInitNeededTasking();
         $iscapturetask = $TaskType->isCapture();
@@ -1055,7 +1058,7 @@ trait FOGPageRender
                     'snapin',
                     _('Select Snapin to run')
                 )
-            ] = self::getClass('SnapinManager')
+            ] = (new SnapinManager())
                 ->buildSelectBox('', 'snapin');
         } elseif (TaskType::PASSWORD_RESET == $type) {
             $fields[
@@ -1427,7 +1430,7 @@ trait FOGPageRender
                 $labelClass,
                 'site',
                 _('Site')
-            ) => self::getClass('SiteManager')->buildSelectBox($siteID, 'site')
+            ) => (new SiteManager())->buildSelectBox($siteID, 'site')
         ];
     }
     /**
@@ -1465,7 +1468,7 @@ trait FOGPageRender
                 'col-sm-3 col-form-label',
                 'site',
                 _('Site')
-            ) => self::getClass('SiteManager')->buildSelectBox($siteID, 'site')
+            ) => (new SiteManager())->buildSelectBox($siteID, 'site')
         ];
 
         $buttons = self::makeButton(
@@ -1512,7 +1515,7 @@ trait FOGPageRender
         if (count($current) > 1) {
             $names = [];
             foreach ($current as $sid) {
-                $site = self::getClass('Site', $sid);
+                $site = new Site($sid);
                 if ($site->isValid()) {
                     $names[] = $site->get('name');
                 }

--- a/packages/web/src/Base/HookManager.php
+++ b/packages/web/src/Base/HookManager.php
@@ -14,6 +14,7 @@
 
 namespace FOG\Base;
 
+use FOG\Items\HookEvent;
 use FOG\Router\Route;
 
 /**
@@ -175,7 +176,7 @@ class HookManager extends EventManager
             // inside save() could never recurse into saving the same name
             // again. Matches the dev-branch port (e827fd1bd).
             self::$knownEvents[$event] = true;
-            self::getClass('HookEvent')
+            (new HookEvent())
                 ->set('name', $event)
                 ->save();
         }

--- a/packages/web/src/Base/LoadGlobals.php
+++ b/packages/web/src/Base/LoadGlobals.php
@@ -18,6 +18,7 @@ use FOG\Db\DatabaseManager;
 use FOG\Items\User;
 use FOG\Net\FOGFTP;
 use FOG\Net\FOGSSH;
+use FOG\Net\FOGURLRequests;
 
 /**
  * Loads our global values
@@ -54,9 +55,9 @@ class LoadGlobals extends FOGBase
         if (!$GLOBALS['DB']) {
             return;
         }
-        $GLOBALS['HookManager'] = FOGCore::getClass('HookManager');
-        $GLOBALS['EventManager'] = FOGCore::getClass('EventManager');
-        $GLOBALS['FOGURLRequests'] = FOGCore::getClass('FOGURLRequests');
+        $GLOBALS['HookManager'] = new HookManager();
+        $GLOBALS['EventManager'] = new EventManager();
+        $GLOBALS['FOGURLRequests'] = new FOGURLRequests();
         FOGCore::setEnv();
         $userID = 0;
         if (session_status() === PHP_SESSION_ACTIVE) {

--- a/packages/web/src/Boot/IpxeBootMenu.php
+++ b/packages/web/src/Boot/IpxeBootMenu.php
@@ -17,13 +17,16 @@ use FOG\Base\FOGBase;
 use FOG\Base\SmbiosIdentity;
 use FOG\Items\Architecture;
 use FOG\Items\Host;
-use FOG\Managers\HostManager;
 use FOG\Items\Image;
+use FOG\Items\Inventory;
+use FOG\Items\Ipxe;
+use FOG\Items\KeySequence;
 use FOG\Items\MulticastSession;
 use FOG\Items\MulticastSessionAssociation;
 use FOG\Items\PXEMenuOptions;
 use FOG\Items\StorageNode;
 use FOG\Items\TaskType;
+use FOG\Managers\HostManager;
 use FOG\Router\Route;
 
 /**
@@ -211,7 +214,7 @@ class IpxeBootMenu extends BootMenuBase
         if ($archID === (int)self::$Host->get('archID')) {
             return;
         }
-        self::getClass('HostManager')->update(
+        (new HostManager())->update(
             ['id' => self::$Host->get('id')],
             '',
             ['archID' => $archID]
@@ -269,7 +272,7 @@ class IpxeBootMenu extends BootMenuBase
             return;
         }
         $now = self::niceDate()->format('Y-m-d H:i:s');
-        self::getClass('HostManager')->update(
+        (new HostManager())->update(
             ['id' => self::$Host->get('id')],
             '',
             ['sbstate' => $state, 'sbstatetime' => $now]
@@ -929,7 +932,7 @@ class IpxeBootMenu extends BootMenuBase
         $this->_hiddenmenu = ($hiddenmenu && empty($_REQUEST['menuAccess']));
         $this->_bootexittype = self::$_exitTypes[$exit];
         $this->_loglevel = "loglevel=$loglevel";
-        $this->_KS = self::getClass('KeySequence', $keySequence);
+        $this->_KS = new KeySequence($keySequence);
         $this->_booturl = self::$httpproto
             . "://{$webserver}/fog/service";
         $this->_memdisk = "kernel $memdisk initrd=$memtest";
@@ -949,7 +952,7 @@ class IpxeBootMenu extends BootMenuBase
                 if ($hostname == $webserver
                     || $hostname == self::resolveHostname($webserver)
                 ) {
-                    $StorageNode = self::getClass('StorageNode', $StorageNode->id);
+                    $StorageNode = new StorageNode($StorageNode->id);
                     break;
                 }
                 $StorageNode = new StorageNode(0);
@@ -1235,7 +1238,7 @@ class IpxeBootMenu extends BootMenuBase
             $findWhere
         );
         $id = count($id ?: []) ? max($id) : 0;
-        self::getClass('Ipxe', $id)
+        (new Ipxe($id))
             ->set('product', $findWhere['product'])
             ->set('manufacturer', $findWhere['manufacturer'])
             ->set('mac', $findWhere['mac'])
@@ -2105,7 +2108,7 @@ class IpxeBootMenu extends BootMenuBase
             return;
         }
         if (!self::$Host->isValid()) {
-            $this->falseTasking('', self::getClass('Image', $imgID));
+            $this->falseTasking('', new Image($imgID));
             return;
         }
         if (self::$Host->getImage()->get('id') != $imgID) {
@@ -2798,7 +2801,7 @@ class IpxeBootMenu extends BootMenuBase
             if (empty($usable)) {
                 return;
             }
-            $New = self::getClass('Inventory')->set('hostID', $hostID);
+            $New = (new Inventory())->set('hostID', $hostID);
             foreach ($usable as $field => $value) {
                 if ($field === 'sysuuid' ? $uuidOk : $textOk($value)) {
                     $New->set($field, $value);

--- a/packages/web/src/Boot/Registration.php
+++ b/packages/web/src/Boot/Registration.php
@@ -17,8 +17,11 @@ use FOG\Audit\Audit;
 use FOG\Base\FOGBase;
 use FOG\Base\SmbiosIdentity;
 use FOG\Items\Host;
-use FOG\Managers\HostManager;
+use FOG\Items\Image;
+use FOG\Items\Inventory;
 use FOG\Items\TaskType;
+use FOG\Items\User;
+use FOG\Managers\HostManager;
 use FOG\Router\Route;
 
 /**
@@ -147,9 +150,9 @@ class Registration extends FOGBase
             $smbiosID = (int)HostManager::resolveHostBySmbios($smbios);
         }
         try {
-            self::getClass('HostManager')->getHostByMacAddresses($this->PriMAC);
+            (new HostManager())->getHostByMacAddresses($this->PriMAC);
             if (!self::$Host->isValid()) {
-                self::getClass('HostManager')->getHostByMacAddresses($this->MACs);
+                (new HostManager())->getHostByMacAddresses($this->MACs);
             }
             if (self::$Host->isValid()) {
                 $this->_smbiosOutcome(
@@ -286,7 +289,7 @@ class Registration extends FOGBase
                 throw new \Exception(_('Invalid product key supplied'));
             }
             $host = filter_var($stripped['host'] ?? '');
-            $hostnameSafe = self::getClass('Host')->isHostnameSafe($host);
+            $hostnameSafe = (new Host())->isHostnameSafe($host);
             if (!$hostnameSafe) {
                 throw new \Exception(
                     sprintf(
@@ -295,7 +298,7 @@ class Registration extends FOGBase
                     )
                 );
             }
-            $hostnameExists = self::getClass('HostManager')->exists($host);
+            $hostnameExists = (new HostManager())->exists($host);
             if ($hostnameExists) {
                 throw new \Exception(
                     _(
@@ -305,7 +308,7 @@ class Registration extends FOGBase
             }
             $imageid = filter_var($stripped['imageid'] ?? '');
             $imageid = (
-                self::getClass('Image', $imageid)->isValid() ?
+                (new Image($imageid))->isValid() ?
                 $imageid :
                 0
             );
@@ -359,7 +362,7 @@ class Registration extends FOGBase
             $groupsToJoin = explode(',', $gID);
             $sID = filter_var($stripped['snapinid'] ?? '');
             $snapinsToJoin = explode(',', $sID);
-            self::$Host = self::getClass('Host')
+            self::$Host = (new Host())
                 ->set('name', $host)
                 ->set('description', $this->description)
                 ->set('imageID', $imageid)
@@ -409,7 +412,7 @@ class Registration extends FOGBase
             } catch (\Exception $e) {
                 echo $e->getMessage();
             }
-            self::getClass('Inventory')
+            (new Inventory())
                 ->set('hostID', self::$Host->get('id'))
                 ->set('primaryUser', $primaryuser)
                 ->set('other1', $other1)
@@ -448,7 +451,7 @@ class Registration extends FOGBase
         $password = self::decodeCredential($readCred('password'));
         $username = (false === $username) ? '' : $username;
         $password = (false === $password) ? '' : $password;
-        $userTest = self::getClass('User')->passwordValidate($username, $password);
+        $userTest = (new User())->passwordValidate($username, $password);
         if (!$userTest && !$quickReg) {
             throw new \Exception(
                 _('Done, without imaging: Invalid Login.')
@@ -544,7 +547,7 @@ class Registration extends FOGBase
                 $hostname = str_replace('{SYSSERIAL}', $sysserial, $hostname);
             }
             $hostname = trim($hostname);
-            if (!self::getClass('Host')->isHostnameSafe($hostname)) {
+            if (!(new Host())->isHostnameSafe($hostname)) {
                 $hostname = $this->macsimple;
             }
             $paddingLen = substr_count(
@@ -571,7 +574,7 @@ class Registration extends FOGBase
                         $paddedInsert,
                         $autoRegSysName
                     );
-                    while (self::getClass('HostManager')->exists($hostname)) {
+                    while ((new HostManager())->exists($hostname)) {
                         $paddingString = str_repeat(
                             '*',
                             $paddingLen
@@ -596,10 +599,10 @@ class Registration extends FOGBase
                     self::setSetting('FOG_QUICKREG_SYS_NUMBER', ++$autoRegSysNumber);
                 }
             }
-            if (!self::getClass('Host')->isHostnameSafe($hostname)) {
+            if (!(new Host())->isHostnameSafe($hostname)) {
                 $hostname = $this->macsimple;
             }
-            self::$Host = self::getClass('Host')
+            self::$Host = (new Host())
                 ->set('name', $hostname)
                 ->set('description', $this->description)
                 ->set('imageID', $imageid)
@@ -657,7 +660,7 @@ class Registration extends FOGBase
         try {
             $stripped = self::stripAndDecode($_POST);
             $prodkeyget = self::getSetting('FOG_QUICKREG_PROD_KEY_BIOS');
-            self::$Host = self::getClass('Host')
+            self::$Host = (new Host())
                 ->set('name', $this->macsimple)
                 ->set('description', $this->description)
                 ->set('modules', $this->modulesToJoin)

--- a/packages/web/src/Client/FOGClient.php
+++ b/packages/web/src/Client/FOGClient.php
@@ -15,6 +15,7 @@ namespace FOG\Client;
 
 use FOG\Base\FOGBase;
 use FOG\Items\Host;
+use FOG\Managers\HostManager;
 use FOG\Router\Route;
 
 /**
@@ -117,7 +118,7 @@ abstract class FOGClient extends FOGBase
                 if (false !== $peer) {
                     $update['ip'] = $peer;
                 }
-                self::getClass('HostManager')->update(
+                (new HostManager())->update(
                     ['id' => self::$Host->get('id')],
                     '',
                     $update

--- a/packages/web/src/Client/RegisterClient.php
+++ b/packages/web/src/Client/RegisterClient.php
@@ -15,6 +15,7 @@
 
 namespace FOG\Client;
 
+use FOG\Items\Host;
 use FOG\Router\Route;
 
 /**
@@ -69,12 +70,9 @@ class RegisterClient extends FOGClient
         ];
         $pendingMACcount = count(Route::getIds('macaddressassociation', $find, 'mac') ?: []);
         if (!self::$Host->isValid()) {
-            self::$Host = self::getClass(
-                'Host',
-                ['name' => $hostname]
-            )->load('name');
+            self::$Host = (new Host(['name' => $hostname]))->load('name');
             if (!(self::$Host->isValid() && !self::$Host->get('pending'))) {
-                if (!self::getClass('Host')->isHostnameSafe($hostname)) {
+                if (!(new Host())->isHostnameSafe($hostname)) {
                     if (!self::$json) {
                         echo '#!ih';
                         exit;
@@ -87,7 +85,7 @@ class RegisterClient extends FOGClient
                     'module',
                     $find
                 );
-                self::$Host = self::getClass('Host')
+                self::$Host = (new Host())
                     ->set('name', $hostname)
                     ->set(
                         'description',

--- a/packages/web/src/Client/SnapinClient.php
+++ b/packages/web/src/Client/SnapinClient.php
@@ -16,6 +16,7 @@ namespace FOG\Client;
 use FOG\Items\SnapinTask;
 use FOG\Items\StorageGroup;
 use FOG\Items\StorageNode;
+use FOG\Managers\SnapinTaskManager;
 use FOG\Router\Route;
 
 /**
@@ -335,7 +336,7 @@ class SnapinClient extends FOGClient
         $abortedOnFailure = false;
         if ($SnapinJob->get('abortOnFail') && $exitcode !== 0) {
             $abortedOnFailure = true;
-            self::getClass('SnapinTaskManager')
+            (new SnapinTaskManager())
                 ->update(
                     [
                         'jobID' => $SnapinJob->get('id'),

--- a/packages/web/src/Client/UserTrack.php
+++ b/packages/web/src/Client/UserTrack.php
@@ -93,7 +93,7 @@ class UserTrack extends FOGClient
         if ($user == null) {
             return ['error' => 'us'];
         }
-        self::getClass('UserTracking')
+        (new UserTracking())
             ->set('hostID', self::$Host->get('id'))
             ->set('username', $user)
             ->set('action', $this->actions[$action])

--- a/packages/web/src/Hooks/BootTask.php
+++ b/packages/web/src/Hooks/BootTask.php
@@ -14,6 +14,7 @@
 namespace FOG\Hooks;
 
 use FOG\Base\Hook;
+use FOG\Items\TaskType;
 
 /**
  * Alters the boot task to make a custom entry.
@@ -71,7 +72,7 @@ class BootTask extends Hook
         if (!isset($arguments['ipxe']['task'])) {
             return;
         }
-        $TaskType = self::getClass('TaskType')
+        $TaskType = (new TaskType())
             ->set('name', 'trusty-install')
             ->load('name');
         if (!$TaskType->isValid()) {

--- a/packages/web/src/Items/APIToken.php
+++ b/packages/web/src/Items/APIToken.php
@@ -193,7 +193,7 @@ class APIToken extends FOGController
         // 512 bits, the same generator users.uAPIToken uses. The prefix is
         // part of the token and therefore part of what gets hashed.
         $token = self::PREFIX . bin2hex(random_bytes(64));
-        $row = self::getClass('APIToken')
+        $row = (new APIToken())
             ->set('userID', $userID)
             ->set('name', $name)
             ->set('hash', self::hashToken($token))
@@ -322,7 +322,7 @@ class APIToken extends FOGController
     public function audit($type, $permission)
     {
         $ownerID = (int)$this->get('userID');
-        $owner = self::getClass('User', $ownerID);
+        $owner = new User($ownerID);
         Audit::record(
             [
                 'type' => $type,
@@ -357,7 +357,7 @@ class APIToken extends FOGController
         if ('' === $token) {
             return null;
         }
-        $row = self::getClass('APIToken')
+        $row = (new APIToken())
             ->set('hash', self::hashToken($token))
             ->load('hash');
         if (!$row->isValid()) {
@@ -368,7 +368,7 @@ class APIToken extends FOGController
         if ('1' !== (string)$row->get('enabled')) {
             return null;
         }
-        $user = self::getClass('User', (int)$row->get('userID'));
+        $user = new User((int)$row->get('userID'));
         if (!$user->isValid()) {
             // The owner is gone but the token is not. Destroying a user is
             // supposed to destroy its tokens; refuse rather than authenticate

--- a/packages/web/src/Items/Architecture.php
+++ b/packages/web/src/Items/Architecture.php
@@ -193,7 +193,7 @@ class Architecture extends FOGController
             return '';
         }
         if (!array_key_exists($id, self::$_names)) {
-            $Arch = self::getClass('Architecture', $id);
+            $Arch = new Architecture($id);
             self::$_names[$id] = $Arch->isValid()
                 ? (string)$Arch->get('name')
                 : '';

--- a/packages/web/src/Items/Group.php
+++ b/packages/web/src/Items/Group.php
@@ -17,6 +17,16 @@ use FOG\Assign\Resolver;
 use FOG\Base\FOGController;
 use FOG\Boot\SecureBootState;
 use FOG\Boot\UbootTftpSync;
+use FOG\Managers\GroupModuleAssociationManager;
+use FOG\Managers\GroupPrinterAssociationManager;
+use FOG\Managers\GroupSnapinAssociationManager;
+use FOG\Managers\HostAutoLogoutManager;
+use FOG\Managers\HostManager;
+use FOG\Managers\HostScreenSettingManager;
+use FOG\Managers\MulticastSessionAssociationManager;
+use FOG\Managers\SnapinJobManager;
+use FOG\Managers\SnapinTaskManager;
+use FOG\Managers\TaskManager;
 use FOG\Router\Route;
 
 /**
@@ -165,7 +175,7 @@ class Group extends FOGController
         // upserts on the (gpaGroupID, gpaPrinterID) unique key and sets every
         // column it is given, so naming it would reset a default the admin
         // had already chosen every time the printer was re-sent.
-        self::getClass('GroupPrinterAssociationManager')
+        (new GroupPrinterAssociationManager())
             ->insertBatch(
                 ['groupID', 'printerID'],
                 $insert_values
@@ -212,14 +222,14 @@ class Group extends FOGController
         $printerid = (int)$printerid;
         // Clear first, unconditionally: passing 0 is how the page says "no
         // default", and that has to be expressible.
-        self::getClass('GroupPrinterAssociationManager')
+        (new GroupPrinterAssociationManager())
             ->update(
                 ['groupID' => $groupID],
                 '',
                 ['isDefault' => 0]
             );
         if ($printerid > 0) {
-            self::getClass('GroupPrinterAssociationManager')
+            (new GroupPrinterAssociationManager())
                 ->update(
                     [
                         'groupID' => $groupID,
@@ -259,7 +269,7 @@ class Group extends FOGController
         // unique key and would overwrite the run order the admin set on the
         // Snapin Run Order card. New rows therefore land at the column
         // default of 0, and the sweep below numbers them.
-        self::getClass('GroupSnapinAssociationManager')
+        (new GroupSnapinAssociationManager())
             ->insertBatch(
                 ['groupID', 'snapinID'],
                 $insert_values
@@ -320,7 +330,7 @@ class Group extends FOGController
             }
         }
         foreach ($unsequenced as $snapinID) {
-            self::getClass('GroupSnapinAssociationManager')
+            (new GroupSnapinAssociationManager())
                 ->update(
                     [
                         'groupID' => $groupID,
@@ -357,7 +367,7 @@ class Group extends FOGController
                 continue;
             }
             ++$sequence;
-            self::getClass('GroupSnapinAssociationManager')
+            (new GroupSnapinAssociationManager())
                 ->update(
                     [
                         'groupID' => $groupID,
@@ -393,7 +403,7 @@ class Group extends FOGController
         foreach ($addArray as $moduleID) {
             $insert_values[] = [$groupID, $moduleID];
         }
-        self::getClass('GroupModuleAssociationManager')
+        (new GroupModuleAssociationManager())
             ->insertBatch(
                 ['groupID', 'moduleID'],
                 $insert_values
@@ -453,7 +463,7 @@ class Group extends FOGController
             $insert_items[] = [$hostID, $x, $y, $r];
             unset($hostID);
         }
-        self::getClass('HostScreenSettingManager')
+        (new HostScreenSettingManager())
             ->insertBatch(
                 $insert_fields,
                 $insert_items
@@ -486,7 +496,7 @@ class Group extends FOGController
             ];
             unset($hostID);
         }
-        self::getClass('HostAutoLogoutManager')
+        (new HostAutoLogoutManager())
             ->insertBatch(
                 $insert_fields,
                 $insert_items
@@ -553,7 +563,7 @@ class Group extends FOGController
         if ($TaskCount > 0) {
             throw new \Exception(_('There is a host in a tasking'));
         }
-        self::getClass('HostManager')
+        (new HostManager())
             ->update(
                 ['id' => $this->get('hosts')],
                 '',
@@ -650,7 +660,7 @@ class Group extends FOGController
             }
             if ($TaskType->isMulticast) {
                 MulticastSession::assertCapacity();
-                $MulticastSession = self::getClass('MulticastSession')
+                $MulticastSession = (new MulticastSession())
                     ->set('name', $taskName)
                     ->set('port', MulticastSession::allocatePort())
                     ->set('logpath', $Image->get('path'))
@@ -716,7 +726,7 @@ class Group extends FOGController
                     list(
                         $first_id,
                         $affected_rows
-                    ) = self::getClass('TaskManager')
+                    ) = (new TaskManager())
                     ->insertBatch(
                         $batchFields,
                         $batchTask
@@ -731,7 +741,7 @@ class Group extends FOGController
                         unset($val);
                     }
                     if (count($multicastsessionassocs ?: []) > 0) {
-                        self::getClass('MulticastSessionAssociationManager')
+                        (new MulticastSessionAssociationManager())
                             ->insertBatch(
                                 [
                                     'msID',
@@ -822,7 +832,7 @@ class Group extends FOGController
                     ];
                 }
                 if (count($batchTask ?: []) > 0) {
-                    $stat = self::getClass('TaskManager')
+                    $stat = (new TaskManager())
                         ->insertBatch(
                             $batchFields,
                             $batchTask
@@ -873,7 +883,7 @@ class Group extends FOGController
                 ];
             }
             if (count($batchTask ?: []) > 0) {
-                $stat = self::getClass('TaskManager')
+                $stat = (new TaskManager())
                     ->insertBatch($batchFields, $batchTask);
             }
         } else {
@@ -956,7 +966,7 @@ class Group extends FOGController
                     ];
                 }
                 if (count($batchTask ?: []) > 0) {
-                    $stat = self::getClass('TaskManager')
+                    $stat = (new TaskManager())
                         ->insertBatch($batchFields, $batchTask);
                 }
             }
@@ -1084,7 +1094,7 @@ class Group extends FOGController
             list(
                 $first_id,
                 $affected_rows
-            ) = self::getClass('SnapinJobManager')
+            ) = (new SnapinJobManager())
             ->insertBatch(
                 [
                     'hostID',
@@ -1133,7 +1143,7 @@ class Group extends FOGController
                 }
             }
             if (count($snapinTasks ?: []) > 0) {
-                self::getClass('SnapinTaskManager')
+                (new SnapinTaskManager())
                     ->insertBatch(
                         [
                             'jobID',
@@ -1186,7 +1196,7 @@ class Group extends FOGController
             $update['ADPass'] = $pass;
         }
         if (count($update) > 0) {
-            self::getClass('HostManager')
+            (new HostManager())
                 ->update(
                     ['id' => $this->get('hosts')],
                     '',
@@ -1203,7 +1213,7 @@ class Group extends FOGController
      */
     public function doMembersHaveUniformImages()
     {
-        $test = self::getClass('HostManager')
+        $test = (new HostManager())
             ->distinct(
                 'imageID',
                 ['id' => $this->get('hosts')]

--- a/packages/web/src/Items/Host.php
+++ b/packages/web/src/Items/Host.php
@@ -17,6 +17,12 @@ use FOG\Assign\Resolver;
 use FOG\Base\FOGController;
 use FOG\Boot\SecureBootState;
 use FOG\Boot\UbootTftpSync;
+use FOG\Managers\MACAddressAssociationManager;
+use FOG\Managers\PrinterAssociationManager;
+use FOG\Managers\SnapinAssociationManager;
+use FOG\Managers\SnapinJobManager;
+use FOG\Managers\SnapinTaskManager;
+use FOG\Managers\TaskManager;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 
@@ -305,7 +311,7 @@ class Host extends FOGController
             return false;
         }
         if (array_key_exists('mac', $this->data)) {
-            self::getClass('MACAddressAssociation')
+            (new MACAddressAssociation())
                 ->set('mac', $this->get('mac'))
                 ->set('primary', '1')
                 ->set('hostID', $this->get('id'))
@@ -413,7 +419,7 @@ class Host extends FOGController
                     'mac'
                 );
                 if (count((array)$approvedMacs) > 0) {
-                    self::getClass('MACAddressAssociationManager')
+                    (new MACAddressAssociationManager())
                         ->update(
                             [
                                 'hostID' => $hostID,
@@ -482,7 +488,7 @@ class Host extends FOGController
             $this->get('printers'),
             [$printerid]
         );
-        self::getClass('PrinterAssociationManager')
+        (new PrinterAssociationManager())
             ->update(
                 [
                     'printerID' => $printers,
@@ -493,7 +499,7 @@ class Host extends FOGController
                 ['isDefault' => 0]
             );
         if ($printerid) {
-            self::getClass('PrinterAssociationManager')
+            (new PrinterAssociationManager())
                 ->update(
                     [
                         'printerID' => $printerid,
@@ -918,7 +924,7 @@ class Host extends FOGController
         $wol = false,
         $bypassbitlocker = false
     ) {
-        $Task = self::getClass('Task')
+        $Task = (new Task())
             ->set('name', $taskName)
             ->set('createdBy', $username)
             ->set('hostID', $this->get('id'))
@@ -968,7 +974,7 @@ class Host extends FOGController
             'snapinjob',
             $find
         );
-        self::getClass('SnapinTaskManager')
+        (new SnapinTaskManager())
             ->update(
                 [
                     'jobID' => $SnapinJobs,
@@ -984,7 +990,7 @@ class Host extends FOGController
                     'stateID' => self::getCancelledState()
                 ]
             );
-        self::getClass('SnapinJobManager')
+        (new SnapinJobManager())
             ->update(
                 ['id' => $SnapinJobs],
                 '',
@@ -995,7 +1001,7 @@ class Host extends FOGController
             $find
         );
         $MyTask = $this->get('task')->get('id');
-        self::getClass('TaskManager')
+        (new TaskManager())
             ->update(
                 [
                     'id' => array_diff(
@@ -1114,7 +1120,7 @@ class Host extends FOGController
                 unset($snapinID);
             }
             if (count($insert_values) > 0) {
-                self::getClass('SnapinTaskManager')
+                (new SnapinTaskManager())
                     ->insertBatch(
                         $insert_fields,
                         $insert_values
@@ -1183,7 +1189,7 @@ class Host extends FOGController
                 && !$Task->getTaskType()->isImagingTask()
             ) {
                 $Task->cancel();
-                $Task = self::getClass('Task');
+                $Task = new Task();
             }
             // Block only if the host is already in an imaging task.
             if ($Task->isValid() && $TaskType->isImagingTask) {
@@ -1549,7 +1555,7 @@ class Host extends FOGController
                     $assoc = true;
                 } else {
                     MulticastSession::assertCapacity();
-                    $MulticastSession = self::getClass('MulticastSession')
+                    $MulticastSession = (new MulticastSession())
                         ->set('name', $taskName)
                         ->set('port', MulticastSession::allocatePort())
                         ->set('logpath', $this->getImage()->get('path'))
@@ -1583,7 +1589,7 @@ class Host extends FOGController
                     $assoc = true;
                 }
                 if ($assoc) {
-                    $stat = self::getClass('MulticastSessionAssociation')
+                    $stat = (new MulticastSessionAssociation())
                         ->set('msID', $MulticastSession->get('id'))
                         ->set('taskID', $Task->get('id'))
                         ->save();
@@ -1689,7 +1695,7 @@ class Host extends FOGController
             unset($mac);
         }
         if (count($insert_values) > 0) {
-            self::getClass('MACAddressAssociationManager')
+            (new MACAddressAssociationManager())
                 ->insertBatch(
                     $insert_fields,
                     $insert_values
@@ -1767,7 +1773,7 @@ class Host extends FOGController
             unset($m);
         }
         if (count($insert_values) > 0) {
-            self::getClass('MACAddressAssociationManager')
+            (new MACAddressAssociationManager())
                 ->insertBatch(
                     $insert_fields,
                     $insert_values
@@ -1902,7 +1908,7 @@ class Host extends FOGController
             }
         }
         foreach ($unsequenced as $snapinID) {
-            self::getClass('SnapinAssociationManager')
+            (new SnapinAssociationManager())
                 ->update(
                     [
                         'hostID' => $hostID,
@@ -1930,7 +1936,7 @@ class Host extends FOGController
                 continue;
             }
             ++$sequence;
-            self::getClass('SnapinAssociationManager')
+            (new SnapinAssociationManager())
                 ->update(
                     [
                         'hostID' => $this->get('id'),
@@ -2020,7 +2026,7 @@ class Host extends FOGController
         // turning ON to OFF is the same statement as stating it for the
         // first time, and no read is needed to tell the two apart.
         foreach ($ids as $id) {
-            self::getClass('ModuleAssociation')
+            (new ModuleAssociation())
                 ->set('hostID', $hostID)
                 ->set('moduleID', $id)
                 ->set('state', $state)
@@ -2134,7 +2140,7 @@ class Host extends FOGController
         $myMACs = array_unique($myMACs);
         $igMACs = array_unique($igMACs);
         $cgMACs = array_unique($cgMACs);
-        self::getClass('MACAddressAssociationManager')
+        (new MACAddressAssociationManager())
             ->update(
                 [
                     'mac' => array_diff(
@@ -2146,7 +2152,7 @@ class Host extends FOGController
                 '',
                 ['imageIgnore' => 0]
             );
-        self::getClass('MACAddressAssociationManager')
+        (new MACAddressAssociationManager())
             ->update(
                 [
                     'mac' => array_diff(
@@ -2159,7 +2165,7 @@ class Host extends FOGController
                 ['clientIgnore' => 0]
             );
         if (count($igMACs) > 0) {
-            self::getClass('MACAddressAssociationManager')
+            (new MACAddressAssociationManager())
                 ->update(
                     [
                         'mac' => $igMACs,
@@ -2170,7 +2176,7 @@ class Host extends FOGController
                 );
         }
         if (count($cgMACs) > 0) {
-            self::getClass('MACAddressAssociationManager')
+            (new MACAddressAssociationManager())
                 ->update(
                     [
                         'mac' => $cgMACs,

--- a/packages/web/src/Items/Image.php
+++ b/packages/web/src/Items/Image.php
@@ -14,6 +14,7 @@
 namespace FOG\Items;
 
 use FOG\Base\FOGController;
+use FOG\Managers\HostManager;
 use FOG\Router\Route;
 
 /**
@@ -247,7 +248,7 @@ class Image extends FOGController
             }
             $RemIDs = array_filter($RemIDs ?? []);
             if (count($RemIDs) > 0) {
-                self::getClass('HostManager')->update(
+                (new HostManager())->update(
                     [
                         'imageID' => $this->get('id'),
                         'id' => $RemIDs
@@ -262,7 +263,7 @@ class Image extends FOGController
             if (count($this->get('hosts')) < 1) {
                 return $this;
             }
-            self::getClass('HostManager')
+            (new HostManager())
                 ->update(
                     ['id' => $this->get('hosts')],
                     '',
@@ -296,7 +297,7 @@ class Image extends FOGController
             throw new \Exception(self::$foglang['ProtectedImage']);
         }
         foreach ($this->get('storagegroups') as $storagegroupID) {
-            self::getClass('FileDeleteQueue')
+            (new FileDeleteQueue())
                 ->set('path', $this->get('path'))
                 ->set('pathtype', 'Image')
                 ->set('createdTime', self::storageNow())
@@ -524,7 +525,7 @@ class Image extends FOGController
         );
         $assocID = self::minId($assocID);
 
-        return self::getClass('ImageAssociation', $assocID)->isPrimary();
+        return (new ImageAssociation($assocID))->isPrimary();
     }
     /**
      * Gets the primary storage group.

--- a/packages/web/src/Items/MACAddress.php
+++ b/packages/web/src/Items/MACAddress.php
@@ -95,7 +95,7 @@ class MACAddress extends FOGBase
          * If the mac is already registered, sets our
          * MAC Variable to the instance of the db item.
          */
-        $this->_MAC = self::getClass('MACAddressAssociation')
+        $this->_MAC = (new MACAddressAssociation())
             ->set('mac', $this->__toString())
             ->load('mac');
     }
@@ -265,7 +265,7 @@ class MACAddress extends FOGBase
             return self::$_vendorCache[$prefix];
         }
         $name = '';
-        $oui = self::getClass('OUI')
+        $oui = (new OUI())
             ->set('prefix', $prefix)
             ->load('prefix');
         if ($oui instanceof OUI && $oui->isValid()) {
@@ -340,7 +340,7 @@ class MACAddress extends FOGBase
         }
         // Keyed by the prefix column value, the same shape primeRel() relies
         // on for its id-keyed relations.
-        $ouis = self::getClass('OUI')->loadMany(
+        $ouis = (new OUI())->loadMany(
             array_values($prefixes),
             'prefix'
         );

--- a/packages/web/src/Items/Module.php
+++ b/packages/web/src/Items/Module.php
@@ -134,7 +134,7 @@ class Module extends FOGController
     /**
      * Saves the group elements.
      *
-     * @return object
+     * @return bool|object false when the save failed, $this otherwise
      */
     public function save()
     {

--- a/packages/web/src/Items/MulticastSession.php
+++ b/packages/web/src/Items/MulticastSession.php
@@ -14,6 +14,7 @@
 namespace FOG\Items;
 
 use FOG\Base\FOGController;
+use FOG\Managers\TaskManager;
 use FOG\Router\Route;
 
 /**
@@ -348,7 +349,7 @@ class MulticastSession extends FOGController
             $find,
             'taskID'
         );
-        self::getClass('TaskManager')->update(
+        (new TaskManager())->update(
             ['id' => $taskIDs],
             '',
             [
@@ -404,7 +405,7 @@ class MulticastSession extends FOGController
                 array_diff($taskIDs, $neverStarted)
             );
             if (count($received)) {
-                self::getClass('TaskManager')->update(
+                (new TaskManager())->update(
                     ['id' => $received],
                     '',
                     [
@@ -414,7 +415,7 @@ class MulticastSession extends FOGController
                 );
             }
             if (count($neverStarted)) {
-                self::getClass('TaskManager')->update(
+                (new TaskManager())->update(
                     ['id' => $neverStarted],
                     '',
                     [

--- a/packages/web/src/Items/Plugin.php
+++ b/packages/web/src/Items/Plugin.php
@@ -1147,7 +1147,7 @@ class Plugin extends FOGController
                 // set -- state, installed, version, pSchema -- silently
                 // uninstalling every plugin. The load costs a query, which is
                 // why it is on this branch and not the common one.
-                $plugin = self::getClass('Plugin', $id);
+                $plugin = new Plugin($id);
                 foreach ($fields as $field => $value) {
                     $plugin->set($field, $value);
                 }
@@ -1156,7 +1156,7 @@ class Plugin extends FOGController
                 // Nothing to write, so skip the load entirely and hydrate
                 // from the row already in hand. Keeps steady-state discovery
                 // at the single listem() above.
-                $plugin = self::getClass('Plugin');
+                $plugin = new Plugin();
                 $plugin->set('id', $id);
                 foreach ($fields as $field => $value) {
                     $plugin->set($field, $value);

--- a/packages/web/src/Items/Printer.php
+++ b/packages/web/src/Items/Printer.php
@@ -14,6 +14,7 @@
 namespace FOG\Items;
 
 use FOG\Base\FOGController;
+use FOG\Managers\PrinterAssociationManager;
 use FOG\Router\Route;
 
 /**
@@ -144,14 +145,14 @@ class Printer extends FOGController
             'printerassociation',
             $find
         );
-        self::getClass('PrinterAssociationManager')
+        (new PrinterAssociationManager())
             ->update(
                 [
                     'id' => $AllHostsPrinter,
                     'isDefault' => 0
                 ]
             );
-        self::getClass('PrinterAssociationManager')
+        (new PrinterAssociationManager())
             ->update(
                 [
                     'hostID' => $onoff,

--- a/packages/web/src/Items/Role.php
+++ b/packages/web/src/Items/Role.php
@@ -15,6 +15,7 @@ namespace FOG\Items;
 
 use FOG\Auth\Authorization;
 use FOG\Base\FOGController;
+use FOG\Managers\RolePermissionManager;
 use FOG\Router\Route;
 
 /**
@@ -312,7 +313,7 @@ class Role extends FOGController
                     $permission
                 ];
             }
-            self::getClass('RolePermissionManager')->insertBatch(
+            (new RolePermissionManager())->insertBatch(
                 ['roleID', 'name'],
                 $insert_values
             );

--- a/packages/web/src/Items/ScheduledTask.php
+++ b/packages/web/src/Items/ScheduledTask.php
@@ -124,7 +124,7 @@ class ScheduledTask extends FOGController
      */
     public function isMulticast()
     {
-        return (bool)self::getClass('TaskType', $this->get('taskTypeID'))
+        return (bool)(new TaskType($this->get('taskTypeID')))
             ->isMulticast();
     }
     /**

--- a/packages/web/src/Items/Schema.php
+++ b/packages/web/src/Items/Schema.php
@@ -14,6 +14,7 @@
 namespace FOG\Items;
 
 use FOG\Base\FOGController;
+use FOG\Db\Mysqldump;
 
 /**
  * Handles the database insert/export
@@ -88,11 +89,17 @@ class Schema extends FOGController
      * Recreates the database passed and removes
      * duplicate data
      *
+     * $table is a positional tuple, not a name: [0] the table, [1] the
+     * column or columns the uniqueness is over, and optionally [2] an index
+     * to drop afterward. The queries are RETURNED for the caller to fold
+     * into its own upgrade step -- commons/schema.php fastmerge()s them --
+     * and are not executed here.
+     *
      * @param string $dbname      the database name
-     * @param string $table       the table name
+     * @param array  $table       [tablename, indexes, dropIndex]
      * @param bool   $indexNeeded index is needed
      *
-     * @return void
+     * @return array the queries to run, empty when there is nothing to do
      */
     public function dropDuplicateData(
         $dbname,
@@ -100,10 +107,10 @@ class Schema extends FOGController
         $indexNeeded = false
     ) {
         if (empty($dbname)) {
-            return;
+            return [];
         }
         if (count($table) < 1) {
-            return;
+            return [];
         }
         $queries = [];
         $tablename = $table[0];
@@ -114,7 +121,7 @@ class Schema extends FOGController
         }
         if ($indexNeeded) {
             if (count($indexes) < 1) {
-                return;
+                return [];
             } elseif (count($indexes) === 1) {
                 $ending = sprintf(
                     'INDEX (`%s`)',
@@ -216,7 +223,7 @@ class Schema extends FOGController
                 self::formatTime('now', 'Ymd_His')
             );
         }
-        $dump = self::getClass('Mysqldump');
+        $dump = new Mysqldump();
         $dump->start($file);
         if (!file_exists($file) || !is_readable($file)) {
             throw new \Exception(_('Could not read tmp file.'));

--- a/packages/web/src/Items/Site.php
+++ b/packages/web/src/Items/Site.php
@@ -514,7 +514,7 @@ class Site extends FOGController
     {
         $names = [];
         foreach (self::hostSiteIDs($host->get('id')) as $siteID) {
-            $site = self::getClass('Site', $siteID);
+            $site = new Site($siteID);
             if ($site->isValid()) {
                 $names[] = $site->get('name');
             }
@@ -550,9 +550,9 @@ class Site extends FOGController
             if ($current === $wanted) {
                 return;
             }
-            self::getClass('Site', $current)->removeHost([$hostID])->save();
+            (new Site($current))->removeHost([$hostID])->save();
         }
-        $site = self::getClass('Site', $wanted);
+        $site = new Site($wanted);
         if ($site->isValid()) {
             $site->addHost([$hostID])->save();
         }

--- a/packages/web/src/Items/Snapin.php
+++ b/packages/web/src/Items/Snapin.php
@@ -16,6 +16,8 @@ namespace FOG\Items;
 use FOG\Base\FOGController;
 use FOG\Exception\SnapinSaveException;
 use FOG\Exception\UploadException;
+use FOG\Managers\SnapinJobManager;
+use FOG\Managers\SnapinManager;
 use FOG\Router\Route;
 
 /**
@@ -124,7 +126,7 @@ class Snapin extends FOGController
             $sjIDs[] = $sjID;
         }
         if (count($sjIDs ?: [])) {
-            self::getClass('SnapinJobManager')->cancel($sjIDs);
+            (new SnapinJobManager())->cancel($sjIDs);
         }
         Route::deletemass(
             'snapingroupassociation',
@@ -179,7 +181,7 @@ class Snapin extends FOGController
             throw new \Exception(self::$foglang['ProtectedSnapin']);
         }
         foreach ($this->get('storagegroups') as $storagegroupID) {
-            self::getClass('FileDeleteQueue')
+            (new FileDeleteQueue())
                 ->set('path', $this->get('file'))
                 ->set('pathtype', 'Snapin')
                 ->set('createdTime', self::storageNow())
@@ -357,7 +359,7 @@ class Snapin extends FOGController
         );
         $assocID = self::minId($assocID);
 
-        return self::getClass('SnapinGroupAssociation', $assocID)->isPrimary();
+        return (new SnapinGroupAssociation($assocID))->isPrimary();
     }
     /**
      * Sets the primary group for the snapin.
@@ -452,7 +454,7 @@ class Snapin extends FOGController
         $args = trim((string)($post['args'] ?? ''));
         $timeout = trim((string)($post['timeout'] ?? ''));
 
-        if (self::getClass('SnapinManager')->exists($snapin)) {
+        if ((new SnapinManager())->exists($snapin)) {
             throw new \InvalidArgumentException(
                 _('A snapin already exists with this name!')
             );
@@ -534,7 +536,7 @@ class Snapin extends FOGController
             self::$FOGSSH->put($src, $dest);
             self::$FOGSSH->disconnect();
         }
-        $Snapin = self::getClass('Snapin')
+        $Snapin = (new Snapin())
             ->set('name', $snapin)
             ->set('description', $description)
             ->set('packtype', $packtype)

--- a/packages/web/src/Items/StorageGroup.php
+++ b/packages/web/src/Items/StorageGroup.php
@@ -14,6 +14,7 @@
 namespace FOG\Items;
 
 use FOG\Base\FOGController;
+use FOG\Managers\StorageNodeManager;
 use FOG\Router\Route;
 
 /**
@@ -457,7 +458,7 @@ class StorageGroup extends FOGController
      */
     public function addNode($addArray)
     {
-        self::getClass('StorageNodeManager')
+        (new StorageNodeManager())
             ->update(
                 ['id' => $addArray],
                 '',

--- a/packages/web/src/Items/StorageNode.php
+++ b/packages/web/src/Items/StorageNode.php
@@ -140,7 +140,7 @@ class StorageNode extends FOGController
      *
      * @param mixed $key the key to get
      *
-     * @return object
+     * @return mixed the field value; the path keys return trimmed strings
      */
     public function get($key = '')
     {

--- a/packages/web/src/Items/Task.php
+++ b/packages/web/src/Items/Task.php
@@ -14,6 +14,8 @@
 namespace FOG\Items;
 
 use FOG\Boot\UbootTftpSync;
+use FOG\Managers\MulticastSessionManager;
+use FOG\Managers\SnapinTaskManager;
 use FOG\Router\Route;
 
 /**
@@ -253,7 +255,7 @@ class Task extends TaskType
 
             // Liveness: if expired, it's getting re-queued to the back. Don't count
             if (self::isExpired($Task->checkInTime ?? '')) {
-                self::getClass('Task', $tid)->expireTaskCheckin();
+                (new Task($tid))->expireTaskCheckin();
                 continue;
             }
 
@@ -285,7 +287,7 @@ class Task extends TaskType
         if ($SnapinJob instanceof SnapinJob
             && $SnapinJob->isValid()
         ) {
-            self::getClass('SnapinTaskManager')->update(
+            (new SnapinTaskManager())->update(
                 ['jobID' => $SnapinJob->get('id')],
                 '',
                 [
@@ -305,7 +307,7 @@ class Task extends TaskType
                 $find,
                 'msID'
             );
-            self::getClass('MulticastSessionManager')
+            (new MulticastSessionManager())
                 ->update(
                     ['id' => $msIDs],
                     '',

--- a/packages/web/src/Items/TaskLog.php
+++ b/packages/web/src/Items/TaskLog.php
@@ -14,6 +14,7 @@
 namespace FOG\Items;
 
 use FOG\Base\FOGController;
+use FOG\Managers\TaskLogManager;
 
 /**
  * Task log class.
@@ -210,7 +211,7 @@ class TaskLog extends FOGController
             }
         }
 
-        return self::getClass('TaskLog')
+        return (new TaskLog())
             ->set('taskID', $Task->get('id'))
             ->set('taskStateID', $Task->get('stateID'))
             ->set('createdTime', self::niceDate()->format('Y-m-d H:i:s'))
@@ -297,7 +298,7 @@ class TaskLog extends FOGController
         // the image name on isImagingTask(), and two definitions of "imaging"
         // that can drift is exactly the kind of thing that makes one row
         // disagree with another.
-        $TaskType = self::getClass('TaskType');
+        $TaskType = new TaskType();
         $imagingTypes = self::fastmerge(
             (array)$TaskType->isDeploy(true),
             (array)$TaskType->isCapture(true)
@@ -358,7 +359,7 @@ class TaskLog extends FOGController
          * signed in gets written, exactly as save()'s own catch does with it.
          */
         try {
-            list($insertID, $affected) = self::getClass('TaskLogManager')
+            list($insertID, $affected) = (new TaskLogManager())
                 ->insertBatch($fields, $values);
             unset($insertID);
         } catch (\Exception $e) {

--- a/packages/web/src/Items/User.php
+++ b/packages/web/src/Items/User.php
@@ -254,7 +254,7 @@ class User extends FOGController
         $typeIsValid = true;
         $ident = (int)$tmpUser->get('id');
         if (!$tmpUser->isValid()) {
-            $tmpUser = self::getClass('User')
+            $tmpUser = (new User())
                 ->set('name', $username)
                 ->load('name');
         }
@@ -358,7 +358,7 @@ class User extends FOGController
             // Build and create authorization/authentication system.
             $password_hash = UserAuth::generateHash($password);
             $selector_hash = UserAuth::generateHash($selector);
-            $auth = self::getClass('UserAuth')
+            $auth = (new UserAuth())
                 ->set('userID', $this->get('id'))
                 ->set('expire', $expire)
                 ->set('selector', $selector_hash)

--- a/packages/web/src/Managers/APITokenManager.php
+++ b/packages/web/src/Managers/APITokenManager.php
@@ -15,6 +15,7 @@ namespace FOG\Managers;
 
 use FOG\Auth\Authorization;
 use FOG\Base\FOGManagerController;
+use FOG\Items\APIToken;
 
 /**
  * API token manager.
@@ -70,7 +71,7 @@ class APITokenManager extends FOGManagerController
 
         $tokens = [];
         foreach ((array)$rows as $row) {
-            $token = self::getClass('APIToken', (int)$row['atID']);
+            $token = new APIToken((int)$row['atID']);
             // A row that will not load is skipped rather than returned
             // half-built: every caller reads get('enabled') off these and an
             // invalid object answers '' to everything, which would render as
@@ -188,7 +189,7 @@ class APITokenManager extends FOGManagerController
         if ($tokenID < 1) {
             return null;
         }
-        $token = self::getClass('APIToken', $tokenID);
+        $token = new APIToken($tokenID);
         if (!$token->isValid()) {
             return null;
         }

--- a/packages/web/src/Managers/GroupPowerManagementManager.php
+++ b/packages/web/src/Managers/GroupPowerManagementManager.php
@@ -14,6 +14,7 @@
 namespace FOG\Managers;
 
 use FOG\Base\FOGManagerController;
+use FOG\Items\GroupPowerManagement;
 
 /**
  * The group power-management grant manager class.
@@ -66,7 +67,7 @@ class GroupPowerManagementManager extends FOGManagerController
         $rows = (array)$res->fetch(\PDO::FETCH_ASSOC, 'fetch_all')->get();
         $grants = [];
         foreach ($rows as $row) {
-            $grants[] = self::getClass('GroupPowerManagement', $row['gpmID']);
+            $grants[] = new GroupPowerManagement($row['gpmID']);
         }
 
         return $grants;

--- a/packages/web/src/Managers/HostManager.php
+++ b/packages/web/src/Managers/HostManager.php
@@ -99,7 +99,8 @@ class HostManager extends FOGManagerController
     /**
      * Returns a single host object based on the passed MACs.
      *
-     * @param array $macs the macs to search for the host
+     * @param array|string $macs the macs to search for the host; a bare
+     *                            string or a stringable is wrapped
      *
      * @throws Exception
      *
@@ -170,7 +171,7 @@ class HostManager extends FOGManagerController
                             _('Host ID'),
                             $hostID,
                             _('Hostname'),
-                            self::getClass('Host', $hostID)->get('name')
+                            (new Host($hostID))->get('name')
                         );
                         // Print it in the error log.
                         error_log($err);
@@ -201,7 +202,7 @@ class HostManager extends FOGManagerController
                         _('Found the most used ID'),
                         $mostFrequentHostIDs[0],
                         _('Hostname'),
-                        self::getClass('Host', $mostFrequentHostIDs[0])->get('name'),
+                        (new Host($mostFrequentHostIDs[0]))->get('name'),
                         _('Assuming this is the intended host to resolve the MAC conflict'),
                         _('List of MACs'),
                         implode(', ', $macs)

--- a/packages/web/src/Managers/MulticastSessionManager.php
+++ b/packages/web/src/Managers/MulticastSessionManager.php
@@ -55,7 +55,7 @@ class MulticastSessionManager extends FOGManagerController
         /**
          * Set tasks to canceled as the main session was canceled.
          */
-        self::getClass('TaskManager')
+        (new TaskManager())
             ->update(
                 ['id' => $taskIDs],
                 '',

--- a/packages/web/src/Managers/PluginManager.php
+++ b/packages/web/src/Managers/PluginManager.php
@@ -14,6 +14,7 @@
 namespace FOG\Managers;
 
 use FOG\Base\FOGManagerController;
+use FOG\Items\Plugin;
 use FOG\Router\Route;
 
 /**
@@ -45,7 +46,7 @@ class PluginManager extends FOGManagerController
         // damaged row, but it is the same mistake.
         $plugins = Route::getList('plugin', ['installed' => 1]);
         foreach ($plugins as $row) {
-            $plugin = self::getClass('Plugin', $row->id);
+            $plugin = new Plugin($row->id);
             if ($plugin->needsSchemaUpdate()) {
                 $needing[] = $plugin;
             }

--- a/packages/web/src/Managers/SnapinJobManager.php
+++ b/packages/web/src/Managers/SnapinJobManager.php
@@ -14,6 +14,7 @@
 namespace FOG\Managers;
 
 use FOG\Base\FOGManagerController;
+use FOG\Items\SnapinJob;
 use FOG\Items\TaskType;
 use FOG\Router\Route;
 
@@ -80,7 +81,7 @@ class SnapinJobManager extends FOGManagerController
             ['jobID' => $snapinjobids]
         );
         if (count($snapintaskids ?: [])) {
-            self::getClass('SnapinTaskManager')
+            (new SnapinTaskManager())
                 ->cancel($snapintaskids);
         }
         // Only jobs still queued or running, so a job that already finished is
@@ -121,7 +122,7 @@ class SnapinJobManager extends FOGManagerController
             if ($left > 0) {
                 continue;
             }
-            $Host = self::getClass('SnapinJob', $jobID)->get('host');
+            $Host = (new SnapinJob($jobID))->get('host');
             if (!is_object($Host) || !$Host->isValid()) {
                 continue;
             }
@@ -134,7 +135,7 @@ class SnapinJobManager extends FOGManagerController
             }
         }
         if (count($hostTasks ?: [])) {
-            self::getClass('TaskManager')
+            (new TaskManager())
                 ->update(
                     ['id' => $hostTasks],
                     '',

--- a/packages/web/src/Managers/SnapinTaskManager.php
+++ b/packages/web/src/Managers/SnapinTaskManager.php
@@ -14,6 +14,7 @@
 namespace FOG\Managers;
 
 use FOG\Base\FOGManagerController;
+use FOG\Items\SnapinJob;
 use FOG\Items\TaskType;
 use FOG\Router\Route;
 
@@ -96,7 +97,7 @@ class SnapinTaskManager extends FOGManagerController
                 unset($snapinJobIDs[$i]);
                 continue;
             }
-            $Host = self::getClass('SnapinJob', $jobID)
+            $Host = (new SnapinJob($jobID))
                 ->get('host');
             $Task = $Host->get('task');
             if (in_array($Task->get('typeID'), TaskType::SNAPINTASKS)) {
@@ -108,7 +109,7 @@ class SnapinTaskManager extends FOGManagerController
          * Only remove snapin jobs if we have any to remove
          */
         if (count($snapinJobIDs ?: []) > 0) {
-            self::getClass('SnapinJobManager')
+            (new SnapinJobManager())
                 ->update(
                     ['id' => (array)$snapinJobIDs],
                     '',
@@ -119,7 +120,7 @@ class SnapinTaskManager extends FOGManagerController
          * Cancel tasks if they are snapin only tasks
          */
         if (count($hostTasksToCancel ?: []) > 0) {
-            self::getClass('TaskManager')
+            (new TaskManager())
                 ->update(
                     ['id' => (array)$hostTasksToCancel],
                     '',

--- a/packages/web/src/Managers/TaskManager.php
+++ b/packages/web/src/Managers/TaskManager.php
@@ -16,6 +16,7 @@ namespace FOG\Managers;
 use FOG\Base\FOGManagerController;
 use FOG\Boot\UbootTftpSync;
 use FOG\Items\TaskLog;
+use FOG\Items\TaskState;
 use FOG\Items\TaskType;
 use FOG\Router\Route;
 
@@ -61,7 +62,7 @@ class TaskManager extends FOGManagerController
             ];
         }
         // Reset token and lock on hosts from task cancel
-        self::getClass('HostManager')->update(
+        (new HostManager())->update(
             ['id' => $hostIDs],
             '',
             $updateFields
@@ -140,13 +141,13 @@ class TaskManager extends FOGManagerController
             ['msID' => $MulticastSessionIDs]
         );
         if (count($SnapinTaskIDs ?: [])) {
-            self::getClass('SnapinTaskManager')->cancel($SnapinTaskIDs);
+            (new SnapinTaskManager())->cancel($SnapinTaskIDs);
         }
         if (count($SnapinJobIDs ?: [])) {
-            self::getClass('SnapinJobManager')->cancel($SnapinJobIDs);
+            (new SnapinJobManager())->cancel($SnapinJobIDs);
         }
         if ($StillLeft < 1 && count($MulticastSessionIDs ?: [])) {
-            self::getClass('MulticastSessionManager')->cancel($MulticastSessionIDs);
+            (new MulticastSessionManager())->cancel($MulticastSessionIDs);
         }
     }
     /**
@@ -208,7 +209,7 @@ class TaskManager extends FOGManagerController
          * leaving it where it was for a few minutes.
          */
         $failed = (int)self::getFailedState();
-        if (!self::getClass('TaskState', $failed)->isValid()) {
+        if (!(new TaskState($failed))->isValid()) {
             return [];
         }
         $active = self::fastmerge(
@@ -352,7 +353,7 @@ class TaskManager extends FOGManagerController
          * moved -- the same call recordStates() makes for the same reason.
          */
         try {
-            self::getClass('TaskLogManager')->insertBatch(
+            (new TaskLogManager())->insertBatch(
                 [
                     'taskID',
                     'stateID',

--- a/packages/web/src/Pages/DashboardPage.php
+++ b/packages/web/src/Pages/DashboardPage.php
@@ -19,6 +19,7 @@ use FOG\Base\FOGPage;
 use FOG\Db\DatabaseManager;
 use FOG\Items\StorageGroup;
 use FOG\Items\StorageNode;
+use FOG\Managers\PluginManager;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 
@@ -199,7 +200,7 @@ class DashboardPage extends FOGPage
             $title = $pendingMACs . ' ' . _('Pending macs');
             self::displayAlert($title, $macPend, 'warning', true, true);
         }
-        $pluginsNeedingUpdate = self::getClass('PluginManager')
+        $pluginsNeedingUpdate = (new PluginManager())
             ->getPluginsNeedingUpdate();
         $pluginUpdateCount = count($pluginsNeedingUpdate);
         if ($pluginUpdateCount > 0) {

--- a/packages/web/src/Pages/FOGConfigurationPage.php
+++ b/packages/web/src/Pages/FOGConfigurationPage.php
@@ -20,11 +20,18 @@ use FOG\Base\FOGBase;
 use FOG\Base\FOGManagerController;
 use FOG\Base\FOGPage;
 use FOG\Boot\SecureBootState;
+use FOG\Db\Mysqldump;
 use FOG\Exception\UploadException;
 use FOG\Items\APIToken;
 use FOG\Items\Image;
+use FOG\Items\Schema;
 use FOG\Items\Setting;
+use FOG\Items\User;
+use FOG\Managers\APITokenManager;
+use FOG\Managers\KeySequenceManager;
+use FOG\Managers\OUIManager;
 use FOG\Managers\SettingManager;
+use FOG\Managers\UserManager;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 
@@ -3383,7 +3390,7 @@ class FOGConfigurationPage extends FOGPage
         $where = "`settingKey` IN ('"
             . implode("','", $ServicesToSee)
             . "')";
-        $settingMan = self::getClass('SettingManager');
+        $settingMan = new SettingManager();
         $table = $settingMan->getTable();
         $dbcolumns = $settingMan->getColumns();
         $sqlStr = $settingMan->getQueryStr();
@@ -3410,7 +3417,7 @@ class FOGConfigurationPage extends FOGPage
                 ) {
                     switch ($row['settingKey']) {
                         case 'FOG_KEY_SEQUENCE':
-                            $input = self::getClass('KeySequenceManager')
+                            $input = (new KeySequenceManager())
                                 ->buildSelectBox(
                                     $row['settingValue'],
                                     $row['settingID']
@@ -3788,7 +3795,7 @@ class FOGConfigurationPage extends FOGPage
                 _('User')
             );
             $issueBody .= '<div class="col-sm-9">'
-                . self::getClass('UserManager')
+                . (new UserManager())
                     ->buildSelectBox('', 'issuefor', 'name')
                 . '</div>';
             $issueBody .= '</div>';
@@ -3979,7 +3986,7 @@ class FOGConfigurationPage extends FOGPage
         $uid = (int)self::$FOGUser->get('id');
         $rows = [];
         foreach (
-            self::getClass('APITokenManager')->visibleTo($uid) as $token
+            (new APITokenManager())->visibleTo($uid) as $token
         ) {
             $rows[] = [
                 'id' => $token['id'],
@@ -4043,7 +4050,7 @@ class FOGConfigurationPage extends FOGPage
 
         // null owner: spanning users is this pane's whole job. The
         // per-user tab passes its own id here instead.
-        $deleted = self::getClass('APITokenManager')->revokeMany(
+        $deleted = (new APITokenManager())->revokeMany(
             array_map('intval', (array)($_POST['remitems'] ?? [])),
             (int)self::$FOGUser->get('id')
         );
@@ -4086,7 +4093,7 @@ class FOGConfigurationPage extends FOGPage
         }
 
         $enabled = (int)filter_input(INPUT_POST, 'enabled') === 1;
-        $changed = self::getClass('APITokenManager')->setEnabledMany(
+        $changed = (new APITokenManager())->setEnabledMany(
             array_map('intval', (array)($_POST['remitems'] ?? [])),
             $enabled,
             (int)self::$FOGUser->get('id')
@@ -4154,8 +4161,8 @@ class FOGConfigurationPage extends FOGPage
         // could mint a working credential for an account they are not
         // allowed to see, which is a privilege escalation dressed up as a
         // convenience feature.
-        $user = self::getClass('User', $forUserID);
-        $inScope = self::getClass('APITokenManager')
+        $user = new User($forUserID);
+        $inScope = (new APITokenManager())
             ->userInScope($forUserID, (int)self::$FOGUser->get('id'));
 
         if (!$user->isValid() || !$inScope) {
@@ -4338,7 +4345,7 @@ class FOGConfigurationPage extends FOGPage
                 list(
                     $first_id,
                     $affected_rows
-                ) = self::getClass('OUIManager')
+                ) = (new OUIManager())
                 ->insertBatch(
                     [
                         'prefix',
@@ -4378,10 +4385,7 @@ class FOGConfigurationPage extends FOGPage
     public function getOSID()
     {
         $imageid = (int)filter_input(INPUT_POST, 'image_id');
-        $osname = self::getClass(
-            'Image',
-            $imageid
-        )->getOS()->get('name');
+        $osname = (new Image($imageid))->getOS()->get('name');
         $this->jsonSend(HTTPResponseCodes::HTTP_SUCCESS, json_encode($osname ? $osname : _('No Image specified')));
     }
     /**
@@ -4847,7 +4851,7 @@ class FOGConfigurationPage extends FOGPage
                     . $row['settingKey']
                     . '">';
                 foreach ((array)$tzIDs as $i => &$tz) {
-                    $current_tz = self::getClass('DateTimeZone', $tz);
+                    $current_tz = new \DateTimeZone($tz);
                     $offset = $current_tz->getOffset($dt);
                     $transition = $current_tz->getTransitions(
                         $dt->getTimestamp(),
@@ -5350,7 +5354,7 @@ class FOGConfigurationPage extends FOGPage
                 unset($Setting);
             }
             if (count($items) > 0) {
-                $SettingMan = self::getClass('SettingManager');
+                $SettingMan = new SettingManager();
                 /*
                  * settingDesc and settingCategory are named even though this
                  * saver never changes them, and the values are the ones just
@@ -5595,7 +5599,7 @@ class FOGConfigurationPage extends FOGPage
             . 'A hard refresh (Ctrl+F5, or Cmd+Shift+R) may be required.'
         );
 
-        $table = self::getClass('SettingManager')->getTable();
+        $table = (new SettingManager())->getTable();
         $sql = 'SELECT `settingID`, `settingKey`, `settingDesc`, '
             . '`settingValue`, `settingCategory` FROM `' . $table . '` '
             . 'ORDER BY `settingCategory` ASC, `settingKey` ASC';
@@ -5850,7 +5854,7 @@ class FOGConfigurationPage extends FOGPage
         self::checkAuthAndCSRF();
         header('Content-type: application/json');
         self::$HookManager->processEvent('IMPORT_POST');
-        $Schema = self::getClass('Schema');
+        $Schema = new Schema();
         $serverFault = false;
         try {
             if (isset($_POST['toExport'])) {
@@ -5884,7 +5888,7 @@ class FOGConfigurationPage extends FOGPage
                 }
                 chmod($tmpfile, 0600);
                 $data = '';
-                self::getClass('Mysqldump')->start($tmpfile);
+                (new Mysqldump())->start($tmpfile);
                 if (!file_exists($tmpfile) || !is_readable($tmpfile)) {
                     throw new \Exception(_('Could not read file from tmp folder.'));
                 }
@@ -5934,7 +5938,7 @@ class FOGConfigurationPage extends FOGPage
 
                 // Now import
                 try {
-                    $result = self::getClass('Schema')->importdb($dest);
+                    $result = (new Schema())->importdb($dest);
                 } finally {
                     @unlink($dest); // cleanup regardless
                 }
@@ -5983,7 +5987,7 @@ class FOGConfigurationPage extends FOGPage
         $meta = $this->_settingsMeta();
         $needstobecheckbox = $meta['checkbox'];
         $needstobenumeric = $meta['numeric'];
-        $settingMan = self::getClass('SettingManager');
+        $settingMan = new SettingManager();
         $table = $settingMan->getTable();
         $dbcolumns = $settingMan->getColumns();
         $sqlStr = $settingMan->getQueryStr();

--- a/packages/web/src/Pages/GroupManagement.php
+++ b/packages/web/src/Pages/GroupManagement.php
@@ -17,8 +17,13 @@ namespace FOG\Pages;
 
 use FOG\Auth\Authorization;
 use FOG\Base\FOGPage;
+use FOG\Items\Group;
+use FOG\Items\GroupPowerManagement;
+use FOG\Items\ScheduledTask;
 use FOG\Items\Setting;
 use FOG\Items\TaskType;
+use FOG\Managers\GroupManager;
+use FOG\Managers\PowerManagementManager;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 use FOG\Util\FOGCron;
@@ -252,14 +257,14 @@ class GroupManagement extends FOGPage
                     0,
                     (int)filter_input(INPUT_POST, 'order')
                 );
-                $exists = self::getClass('GroupManager')
+                $exists = (new GroupManager())
                     ->exists($group);
                 if ($exists) {
                     throw new \Exception(
                         _('A group already exists with this name!')
                     );
                 }
-                $Group = self::getClass('Group')
+                $Group = (new Group())
                     ->set('name', $group)
                     ->set('description', $description)
                     ->set('order', $order)
@@ -907,7 +912,7 @@ class GroupManagement extends FOGPage
                     ];
                 }
                 if (count($items) > 0) {
-                    self::getClass('PowerManagementManager')
+                    (new PowerManagementManager())
                         ->insertBatch(
                             [
                                 'hostID',
@@ -925,7 +930,7 @@ class GroupManagement extends FOGPage
                 return;
             }
             // ONE ROW, ABOUT THE GROUP. Not one per member.
-            self::getClass('GroupPowerManagement')
+            (new GroupPowerManagement())
                 ->set('groupID', $groupID)
                 ->set('min', FOGCron::_sanitizeCronField($min))
                 ->set('hour', FOGCron::_sanitizeCronField($hour))
@@ -2259,7 +2264,7 @@ class GroupManagement extends FOGPage
                 $type = 1;
             }
 
-            $TaskType = self::getClass('TaskType', $type);
+            $TaskType = new TaskType($type);
 
             $this->title = $TaskType->get('name')
                 . ' '
@@ -2400,7 +2405,7 @@ class GroupManagement extends FOGPage
             }
 
             // Task Type setup
-            $TaskType = self::getClass('TaskType', $type);
+            $TaskType = new TaskType($type);
             if (!$TaskType->isValid()) {
                 throw new \Exception(_('Task Type is invalid'));
             }
@@ -2496,7 +2501,7 @@ class GroupManagement extends FOGPage
                     $snapinAbortOnFailure
                 );
             } else {
-                $ScheduledTask = self::getClass('ScheduledTask')
+                $ScheduledTask = (new ScheduledTask())
                     ->set('taskTypeID', $type)
                     ->set('name', $taskName)
                     ->set('hostID', $this->obj->get('id'))

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -24,8 +24,17 @@ use FOG\Items\Group;
 use FOG\Items\Host;
 use FOG\Items\HostAutoLogout;
 use FOG\Items\MACAddress;
+use FOG\Items\PowerManagement;
+use FOG\Items\ScheduledTask;
 use FOG\Items\Setting;
 use FOG\Items\TaskType;
+use FOG\Managers\ArchitectureManager;
+use FOG\Managers\HostAutoLogoutManager;
+use FOG\Managers\HostManager;
+use FOG\Managers\HostScreenSettingManager;
+use FOG\Managers\ImageManager;
+use FOG\Managers\MACAddressAssociationManager;
+use FOG\Managers\PowerManagementManager;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 use FOG\Util\FOGCron;
@@ -77,7 +86,7 @@ class HostManagement extends FOGPage
                     && !$this->obj->get('task')->isValid()
                 )
             ) {
-                self::getClass('HostManager')->update(
+                (new HostManager())->update(
                     ['id' => $this->obj->get('id')],
                     '',
                     [
@@ -327,7 +336,7 @@ class HostManagement extends FOGPage
             );
         }
         if (isset($_POST['approvepending'])) {
-            self::getClass('HostManager')->update(
+            (new HostManager())->update(
                 [
                     'id' => $pending,
                     'pending' => 1
@@ -482,6 +491,10 @@ class HostManagement extends FOGPage
         $remitems = $items['remitems'];
         $pending = $items['pending'];
         $serverFault = false;
+        // Set before the try: both branches assign it, but a throw from
+        // anywhere else reaches the catch with it undefined and puts null
+        // in the response title.
+        $errt = _('MAC Update Fail');
         try {
             if (isset($_POST['confirmdel'])) {
                 $errt = _('Delete MAC Fail');
@@ -507,7 +520,7 @@ class HostManagement extends FOGPage
             }
             if (isset($_POST['approvepending'])) {
                 $errt = _('Approve MAC Fail');
-                self::getClass('MACAddressAssociationManager')->update(
+                (new MACAddressAssociationManager())->update(
                     [
                         'id' => $pending,
                         'pending' => 1
@@ -609,7 +622,7 @@ class HostManagement extends FOGPage
         $enforce = isset($_POST['enforce']) ?: self::getSetting(
             'FOG_ENFORCE_HOST_CHANGES'
         );
-        $imageSelector = self::getClass('ImageManager')
+        $imageSelector = (new ImageManager())
             ->buildSelectBox($image, '', 'id');
 
         $labelClass = 'col-sm-3 col-form-label';
@@ -757,7 +770,7 @@ class HostManagement extends FOGPage
             [
                 'fields' => &$fields,
                 'buttons' => &$buttons,
-                'Host' => self::getClass('Host')
+                'Host' => new Host()
             ]
         );
         $rendered = self::formFields($fields);
@@ -777,7 +790,7 @@ class HostManagement extends FOGPage
             'HOST_ADD_AD_FIELDS',
             [
                 'fields' => &$fieldads,
-                'Host' => self::getClass('Host')
+                'Host' => new Host()
             ]
         );
         $renderedad = self::formFields($fieldads);
@@ -825,7 +838,7 @@ class HostManagement extends FOGPage
                     'HOST_ADD_AD_FIELDS',
                     [
                         'fields' => &$fieldads,
-                        'Host' => self::getClass('Host')
+                        'Host' => new Host()
                     ]
                 );
                 $renderedad = self::formFields($fieldads);
@@ -859,7 +872,7 @@ class HostManagement extends FOGPage
         $enforce = isset($_POST['enforce']) ?: self::getSetting(
             'FOG_ENFORCE_HOST_CHANGES'
         );
-        $imageSelector = self::getClass('ImageManager')
+        $imageSelector = (new ImageManager())
             ->buildSelectBox($image, '', 'id');
 
         $labelClass = 'col-sm-3 col-form-label';
@@ -1058,7 +1071,7 @@ class HostManagement extends FOGPage
                     (string)filter_input(INPUT_POST, 'efiBootTypeExit')
                 );
 
-                $exists = self::getClass('HostManager')
+                $exists = (new HostManager())
                     ->exists($host);
                 if ($exists) {
                     throw new \Exception(
@@ -1069,7 +1082,7 @@ class HostManagement extends FOGPage
                 if (!$MAC->isValid()) {
                     throw new \Exception(_('MAC Format is invalid'));
                 }
-                self::getClass('HostManager')->getHostByMacAddresses(
+                (new HostManager())->getHostByMacAddresses(
                     $MAC->__toString()
                 );
                 if (self::$Host->isValid()) {
@@ -1128,7 +1141,7 @@ class HostManagement extends FOGPage
             filter_input(INPUT_POST, 'image') ?:
             ($this->obj->get('imageID') ?: '')
         );
-        $imageSelector = self::getClass('ImageManager')
+        $imageSelector = (new ImageManager())
             ->buildSelectBox($image);
         // The architectures an admin may pick on a HOST, which is what
         // `architectures.archIsAccess` is for -- the same flag taskTypes uses
@@ -1146,7 +1159,7 @@ class HostManagement extends FOGPage
         if (count($archIds) < 1) {
             $archIds = [0];
         }
-        $archSelector = self::getClass('ArchitectureManager')
+        $archSelector = (new ArchitectureManager())
             ->buildSelectBox($archID, 'archID', 'name', $archIds);
         // Either use the passed in or get the objects info.
         $host = (
@@ -2004,7 +2017,7 @@ class HostManagement extends FOGPage
             if (!$mact->isValid()) {
                 throw new \Exception(_('MAC Address is invalid!'));
             }
-            $mace = self::getClass('MACAddressAssociationManager')
+            $mace = (new MACAddressAssociationManager())
                 ->exists($mac, '', 'mac');
             if ($mace) {
                 throw new \Exception(
@@ -2018,14 +2031,14 @@ class HostManagement extends FOGPage
                 INPUT_POST,
                 'primary'
             );
-            self::getClass('MACAddressAssociationManager')
+            (new MACAddressAssociationManager())
                 ->update(
                     ['hostID' => $this->obj->get('id')],
                     '',
                     ['primary' => 0]
                 );
             if ($primary) {
-                self::getClass('MACAddressAssociationManager')
+                (new MACAddressAssociationManager())
                     ->update(
                         [
                             'id' => $primary,
@@ -2049,7 +2062,7 @@ class HostManagement extends FOGPage
             $imageIgnore = $items['imageIgnore'];
             $clientIgnore = $items['clientIgnore'];
             $pending = $items['pending'];
-            self::getClass('MACAddressAssociationManager')
+            (new MACAddressAssociationManager())
                 ->update(
                     ['hostID' => $this->obj->get('id')],
                     '',
@@ -2060,7 +2073,7 @@ class HostManagement extends FOGPage
                     ]
                 );
             if (count($imageIgnore ?: []) > 0) {
-                self::getClass('MACAddressAssociationManager')
+                (new MACAddressAssociationManager())
                     ->update(
                         [
                             'id' => $imageIgnore,
@@ -2071,7 +2084,7 @@ class HostManagement extends FOGPage
                     );
             }
             if (count($clientIgnore ?: []) > 0) {
-                self::getClass('MACAddressAssociationManager')
+                (new MACAddressAssociationManager())
                     ->update(
                         [
                             'id' => $clientIgnore,
@@ -2082,7 +2095,7 @@ class HostManagement extends FOGPage
                     );
             }
             if (count($pending ?: []) > 0) {
-                self::getClass('MACAddressAssociationManager')
+                (new MACAddressAssociationManager())
                     ->update(
                         [
                             'id' => $pending,
@@ -2151,7 +2164,7 @@ class HostManagement extends FOGPage
             );
             $imageIgnore = $items['imageIgnore'];
             if (count($imageIgnore ?: []) > 0) {
-                self::getClass('MACAddressAssociationManager')
+                (new MACAddressAssociationManager())
                     ->update(
                         [
                             'id' => $imageIgnore,
@@ -2169,7 +2182,7 @@ class HostManagement extends FOGPage
             );
             $imageIgnore = $items['imageIgnore'];
             if (count($imageIgnore ?: []) > 0) {
-                self::getClass('MACAddressAssociationManager')
+                (new MACAddressAssociationManager())
                     ->update(
                         [
                             'id' => $imageIgnore,
@@ -2187,7 +2200,7 @@ class HostManagement extends FOGPage
             );
             $clientIgnore = $items['clientIgnore'];
             if (count($clientIgnore ?: []) > 0) {
-                self::getClass('MACAddressAssociationManager')
+                (new MACAddressAssociationManager())
                     ->update(
                         [
                             'id' => $clientIgnore,
@@ -2205,7 +2218,7 @@ class HostManagement extends FOGPage
             );
             $clientIgnore = $items['clientIgnore'];
             if (count($clientIgnore ?: []) > 0) {
-                self::getClass('MACAddressAssociationManager')
+                (new MACAddressAssociationManager())
                     ->update(
                         [
                             'id' => $clientIgnore,
@@ -2223,7 +2236,7 @@ class HostManagement extends FOGPage
             );
             $pending = $items['pending'];
             if (count($pending ?: []) > 0) {
-                self::getClass('MACAddressAssociationManager')
+                (new MACAddressAssociationManager())
                     ->update(
                         [
                             'id' => $pending,
@@ -2241,7 +2254,7 @@ class HostManagement extends FOGPage
             );
             $pending = $items['pending'];
             if (count($pending ?: []) > 0) {
-                self::getClass('MACAddressAssociationManager')
+                (new MACAddressAssociationManager())
                     ->update(
                         [
                             'id' => $pending,
@@ -3031,7 +3044,7 @@ class HostManagement extends FOGPage
             $dom = FOGCron::_sanitizeCronField($dom);
             $month = FOGCron::_sanitizeCronField($month);
             $dow = FOGCron::_sanitizeCronField($dow);
-            self::getClass('PowerManagement')
+            (new PowerManagement())
                 ->set('hostID', $this->obj->get('id'))
                 ->set('min', $min)
                 ->set('hour', $hour)
@@ -4383,7 +4396,7 @@ class HostManagement extends FOGPage
                 foreach ($hostIDs as $hostID) {
                     $rows[] = [$hostID, $minutes];
                 }
-                self::getClass('HostAutoLogoutManager')
+                (new HostAutoLogoutManager())
                     ->insertBatch(['hostID', 'time'], $rows);
             }
             $wrote = count($hostIDs);
@@ -4400,7 +4413,7 @@ class HostManagement extends FOGPage
                 foreach ($hostIDs as $hostID) {
                     $rows[] = [$hostID, $x, $y, $r];
                 }
-                self::getClass('HostScreenSettingManager')
+                (new HostScreenSettingManager())
                     ->insertBatch(
                         ['hostID', 'width', 'height', 'refresh'],
                         $rows
@@ -4533,7 +4546,7 @@ class HostManagement extends FOGPage
      */
     private function massEditColumnMap(array $spec)
     {
-        $map = self::getClass('HostManager')->getColumns();
+        $map = (new HostManager())->getColumns();
         $columns = [];
         foreach ($spec as $key => $entry) {
             $field = $entry['field'] ?? '';
@@ -4607,7 +4620,7 @@ class HostManagement extends FOGPage
         $kind = $spec['kind'] ?? 'text';
         switch ($kind) {
             case 'image':
-                return self::getClass('ImageManager')
+                return (new ImageManager())
                     ->buildSelectBox('', $name, 'name', '', false, 'id', $id);
                 /**
                  * The same picker the single-host form uses. Mass edit was left on
@@ -5136,7 +5149,7 @@ class HostManagement extends FOGPage
                 // it reported "Updated 1 field(s) on 86 host(s)" for a write
                 // the database had refused -- which is how a clear that
                 // never landed reads as a clear that did.
-                if (!self::getClass('HostManager')
+                if (!(new HostManager())
                     ->update(['id' => $hosts], '', $updates)
                 ) {
                     throw new \Exception(
@@ -5390,7 +5403,7 @@ class HostManagement extends FOGPage
                 // success while inserting nothing -- see the resolution above
                 // for the case that made it, and tests/save-propagates-
                 // failure.test.php for why this tree treats it as a rule.
-                $New = self::getClass('Group')
+                $New = (new Group())
                     ->set('name', $group)
                     ->addHost($hosts);
                 if (!$New->save()) {
@@ -5966,7 +5979,7 @@ class HostManagement extends FOGPage
 
             if ('wol' === $action) {
                 foreach (Route::getList('host', ['id' => $hosts]) as $Host) {
-                    self::getClass('Host', $Host->id)->wakeOnLAN();
+                    (new Host($Host->id))->wakeOnLAN();
                 }
             } else {
                 // insertBatch UPSERTS against `powerManagement`.`cron`, so
@@ -5977,7 +5990,7 @@ class HostManagement extends FOGPage
                 foreach ($hosts as $hostID) {
                     $items[] = [$hostID, '', '', '', '', '', 1, $action];
                 }
-                self::getClass('PowerManagementManager')
+                (new PowerManagementManager())
                     ->insertBatch(
                         [
                             'hostID',
@@ -6053,7 +6066,7 @@ class HostManagement extends FOGPage
         $items = '';
         $types = [TaskType::DEPLOY, TaskType::CAPTURE, TaskType::MULTICAST];
         foreach ($types as $typeId) {
-            $TaskType = self::getClass('TaskType', $typeId);
+            $TaskType = new TaskType($typeId);
             // A server whose taskTypes row was deleted simply loses that
             // button, the same way the accordion loses the entry.
             if (!$TaskType->isValid()) {
@@ -6111,7 +6124,7 @@ class HostManagement extends FOGPage
                 throw new \Exception(_('No hosts are selected'));
             }
 
-            $TaskType = self::getClass('TaskType', $type);
+            $TaskType = new TaskType($type);
             if (!$TaskType->isValid()) {
                 throw new \Exception(
                     sprintf(
@@ -6256,7 +6269,7 @@ class HostManagement extends FOGPage
             // bounded.
             Authorization::requirePageObjectScopeMass('host', $hosts);
 
-            $TaskType = self::getClass('TaskType', $type);
+            $TaskType = new TaskType($type);
             if (!$TaskType->isValid()) {
                 throw new \Exception(
                     sprintf(
@@ -6336,7 +6349,7 @@ class HostManagement extends FOGPage
             // back and a groups row would outlive the tasking it exists for.
             // Group::loadHosts() short circuits on an unsaved group, so the
             // ids set here are the ids used.
-            $Selection = self::getClass('Group')
+            $Selection = (new Group())
                 ->set(
                     'name',
                     sprintf(
@@ -6673,7 +6686,7 @@ class HostManagement extends FOGPage
                     $snapinAbortOnFailure
                 );
             } else {
-                $ScheduledTask = self::getClass('ScheduledTask')
+                $ScheduledTask = (new ScheduledTask())
                     ->set('taskTypeID', $TaskType->id)
                     ->set('name', $taskName)
                     ->set('hostID', $this->obj->get('id'))

--- a/packages/web/src/Pages/ImageManagement.php
+++ b/packages/web/src/Pages/ImageManagement.php
@@ -19,6 +19,15 @@ use FOG\Items\Architecture;
 use FOG\Items\Image;
 use FOG\Items\MulticastSession;
 use FOG\Items\StorageGroup;
+use FOG\Items\StorageNode;
+use FOG\Managers\ArchitectureManager;
+use FOG\Managers\ImageAssociationManager;
+use FOG\Managers\ImageManager;
+use FOG\Managers\ImagePartitionTypeManager;
+use FOG\Managers\ImageTypeManager;
+use FOG\Managers\MulticastSessionManager;
+use FOG\Managers\OSManager;
+use FOG\Managers\StorageGroupManager;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 
@@ -111,7 +120,7 @@ class ImageManagement extends FOGPage
             if (count($masterIds) < 1) {
                 $masterIds = $ids;
             }
-            $StorageNode = self::getClass('StorageNode', array_shift($masterIds));
+            $StorageNode = new StorageNode(array_shift($masterIds));
             return $StorageNode->isValid() ? $StorageNode : null;
         }
     }
@@ -137,20 +146,20 @@ class ImageManagement extends FOGPage
             $sgID = @min(Route::getIds('storagegroup', false));
         }
         $StorageGroup = new StorageGroup($sgID);
-        $StorageGroups = self::getClass('StorageGroupManager')
+        $StorageGroups = (new StorageGroupManager())
             ->buildSelectBox(
                 $sgID,
                 '',
                 'id'
             );
         $StorageNode = $this->_displayStorageNode($StorageGroup);
-        $OSs = self::getClass('OSManager')
+        $OSs = (new OSManager())
             ->buildSelectBox($os);
         $itID = 1;
         if ($imagetype > 0) {
             $itID = $imagetype;
         }
-        $ImageTypes = self::getClass('ImageTypeManager')
+        $ImageTypes = (new ImageTypeManager())
             ->buildSelectBox(
                 $itID,
                 '',
@@ -162,7 +171,7 @@ class ImageManagement extends FOGPage
         } else {
             $iptID = 1;
         }
-        $ImagePartitionTypes = self::getClass('ImagePartitionTypeManager')
+        $ImagePartitionTypes = (new ImagePartitionTypeManager())
             ->buildSelectBox(
                 $iptID,
                 '',
@@ -457,7 +466,7 @@ class ImageManagement extends FOGPage
                 $imagemanage = (int)trim(
                     (string)filter_input(INPUT_POST, 'imagemanage')
                 );
-                $exists = self::getClass('ImageManager')
+                $exists = (new ImageManager())
                     ->exists($image);
                 if ($exists) {
                     throw new \Exception(
@@ -469,14 +478,14 @@ class ImageManagement extends FOGPage
                         _('Please choose a different filename/path as this is reserved')
                     );
                 }
-                $exists = self::getClass('ImageManager')
+                $exists = (new ImageManager())
                     ->exists($path, '', 'path');
                 if ($exists) {
                     throw new \Exception(
                         _('The path requested is already in use by another image!')
                     );
                 }
-                $Image = self::getClass('Image')
+                $Image = (new Image())
                     ->set('name', $image)
                     ->set('description', $description)
                     ->set('osID', $os)
@@ -521,7 +530,7 @@ class ImageManagement extends FOGPage
             filter_input(INPUT_POST, 'os') ?:
             ($this->obj->get('osID') ?: '')
         );
-        $OSs = self::getClass('OSManager')
+        $OSs = (new OSManager())
             ->buildSelectBox($osID, '', 'id');
         $path = (
             filter_input(INPUT_POST, 'path') ?:
@@ -531,13 +540,13 @@ class ImageManagement extends FOGPage
             filter_input(INPUT_POST, 'imagetype') ?:
             ($this->obj->get('imageTypeID') ?: '')
         );
-        $ImageTypes = self::getClass('ImageTypeManager')
+        $ImageTypes = (new ImageTypeManager())
             ->buildSelectBox($itID, '', 'id');
         $iptID = (int)(
             filter_input(INPUT_POST, 'imagepartitiontype') ?:
             ($this->obj->get('imagePartitionTypeID') ?: '')
         );
-        $ImagePartitionTypes = self::getClass('ImagePartitionTypeManager')
+        $ImagePartitionTypes = (new ImagePartitionTypeManager())
             ->buildSelectBox($iptID, '', 'id');
         // The architectures an admin may pick on an IMAGE, which is what
         // `architectures.archIsAccess` is for -- the same flag taskTypes uses
@@ -566,7 +575,7 @@ class ImageManagement extends FOGPage
         if (count($archIds) < 1) {
             $archIds = [0];
         }
-        $Architectures = self::getClass('ArchitectureManager')
+        $Architectures = (new ArchitectureManager())
             ->buildSelectBox($archID, 'archID', 'name', $archIds);
         $isprot = (
             isset($_POST['isProtected']) ? 'checked' :
@@ -874,7 +883,7 @@ class ImageManagement extends FOGPage
         $protected = (int)isset($_POST['isProtected']);
         $isEnabled = (int)isset($_POST['isEnabled']);
         $toReplicate = (int)isset($_POST['toReplicate']);
-        $exists = self::getClass('ImageManager')->exists($image);
+        $exists = (new ImageManager())->exists($image);
         $compress = (int)trim(
             (string)filter_input(INPUT_POST, 'compression')
         );
@@ -987,7 +996,7 @@ class ImageManagement extends FOGPage
                 $this->obj->get('storagegroups'),
                 [$primary]
             );
-            self::getClass('ImageAssociationManager')->update(
+            (new ImageAssociationManager())->update(
                 [
                     'imageID' => $this->obj->get('id'),
                     'storagegroupID' => $storagegroups,
@@ -997,7 +1006,7 @@ class ImageManagement extends FOGPage
                 ['primary' => '0']
             );
             if ($primary) {
-                self::getClass('ImageAssociationManager')->update(
+                (new ImageAssociationManager())->update(
                     [
                         'imageID' => $this->obj->get('id'),
                         'storagegroupID' => $primary,
@@ -1278,7 +1287,7 @@ class ImageManagement extends FOGPage
         );
         $image = filter_input(INPUT_POST, 'image');
 
-        $images = self::getClass('ImageManager')->buildSelectBox(
+        $images = (new ImageManager())->buildSelectBox(
             $image
         );
 
@@ -1710,7 +1719,7 @@ class ImageManagement extends FOGPage
             if ($id < 1 || !in_array($value, $valid, true)) {
                 continue;
             }
-            $Arch = self::getClass('Architecture', $id);
+            $Arch = new Architecture($id);
             if (!$Arch->isValid()) {
                 continue;
             }
@@ -1929,7 +1938,7 @@ class ImageManagement extends FOGPage
                 _('Please select a valid image')
             );
         }
-        if (self::getClass('MulticastSessionManager')->exists($sessionname)) {
+        if ((new MulticastSessionManager())->exists($sessionname)) {
             throw new \Exception(_('Session with that name already exists!'));
         }
         if ($sessioncount < 1) {
@@ -1941,7 +1950,7 @@ class ImageManagement extends FOGPage
         MulticastSession::assertCapacity();
         $StorageGroup = $Image->getStorageGroup();
         $StorageNode = $StorageGroup->getMasterStorageNode();
-        return self::getClass('MulticastSession')
+        return (new MulticastSession())
             ->set('name', $sessionname)
             ->set('port', MulticastSession::allocatePort())
             ->set('image', $Image->get('id'))
@@ -1980,7 +1989,7 @@ class ImageManagement extends FOGPage
                 ]
             );
             $tasks = $tasks['tasks'];
-            self::getClass('MulticastSessionManager')->cancel(
+            (new MulticastSessionManager())->cancel(
                 $tasks
             );
         }

--- a/packages/web/src/Pages/IpxeManagement.php
+++ b/packages/web/src/Pages/IpxeManagement.php
@@ -14,6 +14,8 @@
 namespace FOG\Pages;
 
 use FOG\Base\FOGPage;
+use FOG\Items\PXEMenuOptions;
+use FOG\Managers\PXEMenuOptionsManager;
 
 /**
  * The Bootmenu Management Page
@@ -130,7 +132,7 @@ class IpxeManagement extends FOGPage
                 $labelClass,
                 'regmenu',
                 _('Show with')
-            ) => self::getClass('PXEMenuOptionsManager')->regSelect(
+            ) => (new PXEMenuOptionsManager())->regSelect(
                 $regmenu,
                 'regmenu'
             ),
@@ -202,7 +204,7 @@ class IpxeManagement extends FOGPage
             [
                 'fields' => &$fields,
                 'buttons' => &$buttons,
-                'Ipxe' => self::getClass('PXEMenuOptions')
+                'Ipxe' => new PXEMenuOptions()
             ]
         );
         $rendered = self::formFields($fields);
@@ -262,14 +264,14 @@ class IpxeManagement extends FOGPage
                 $keysequence = trim(
                     (string)filter_input(INPUT_POST, 'keysequence')
                 );
-                $exists = self::getClass('PXEMenuOptionsManager')
+                $exists = (new PXEMenuOptionsManager())
                     ->exists($ipxe);
                 if ($exists) {
                     throw new \Exception(
                         _('A menu entry already exists with this name!')
                     );
                 }
-                $iPXE = self::getClass('PXEMenuOptions')
+                $iPXE = (new PXEMenuOptions())
                     ->set('name', $ipxe)
                     ->set('description', $description)
                     ->set('params', $params)
@@ -387,7 +389,7 @@ class IpxeManagement extends FOGPage
                 $labelClass,
                 'regmenu',
                 _('Show with')
-            ) => self::getClass('PXEMenuOptionsManager')->regSelect(
+            ) => (new PXEMenuOptionsManager())->regSelect(
                 $regmenu,
                 'regmenu'
             ),
@@ -491,7 +493,7 @@ class IpxeManagement extends FOGPage
         $keysequence = trim(
             (string)filter_input(INPUT_POST, 'keysequence')
         );
-        $exists = self::getClass('PXEMenuOptionsManager')
+        $exists = (new PXEMenuOptionsManager())
             ->exists($ipxe);
         if ($this->obj->get('name') != $ipxe && $exists) {
             throw new \Exception(

--- a/packages/web/src/Pages/ModuleManagement.php
+++ b/packages/web/src/Pages/ModuleManagement.php
@@ -16,6 +16,8 @@
 namespace FOG\Pages;
 
 use FOG\Base\FOGPage;
+use FOG\Items\Module;
+use FOG\Managers\ModuleManager;
 
 /**
  * Module management page
@@ -178,14 +180,14 @@ class ModuleManagement extends FOGPage
                     (string)filter_input(INPUT_POST, 'shortname')
                 );
                 $isDefault = (int)isset($_POST['isDefault']);
-                $exists = self::getClass('ModuleManager')
+                $exists = (new ModuleManager())
                     ->exists($module);
                 if ($exists) {
                     throw new \Exception(
                         _('A module already exists with this name!')
                     );
                 }
-                $Module = self::getClass('Module')
+                $Module = (new Module())
                     ->set('name', $module)
                     ->set('description', $description)
                     ->set('shortName', $shortname)

--- a/packages/web/src/Pages/PluginManagement.php
+++ b/packages/web/src/Pages/PluginManagement.php
@@ -16,6 +16,7 @@ namespace FOG\Pages;
 use FOG\Auth\Authorization;
 use FOG\Base\FOGPage;
 use FOG\Items\Plugin;
+use FOG\Managers\PluginManager;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 
@@ -88,7 +89,7 @@ class PluginManagement extends FOGPage
             Route::listem('plugin');
             $data = json_decode(Route::getData());
             foreach ((array)$data->data as &$row) {
-                $plugin = self::getClass('Plugin', $row->id);
+                $plugin = new Plugin($row->id);
                 $row->needsupdate = $plugin->needsSchemaUpdate() ? 1 : 0;
                 // Why a plugin can't be turned on, rendered on the row rather
                 // than only raised when the activate button is pressed. The
@@ -551,7 +552,7 @@ class PluginManagement extends FOGPage
             $this->_refuseBlocked($plugins);
             $ids = ['id' => $plugins];
             $state = ['state' => 1];
-            $PluginManager = self::getClass('PluginManager');
+            $PluginManager = new PluginManager();
             if (!$PluginManager->update($ids, '', $state)) {
                 $serverFault = true;
                 throw new \Exception(_('Activate plugins failed!'));
@@ -627,7 +628,7 @@ class PluginManagement extends FOGPage
             $ids = ['id' => $plugins];
             $state = ['state' => 1];
             $install = ['installed' => 1];
-            $PluginManager = self::getClass('PluginManager');
+            $PluginManager = new PluginManager();
             if (!$PluginManager->update($ids, '', $state)) {
                 $serverFault = true;
                 throw new \Exception(_('Activate plugins failed!'));
@@ -640,7 +641,7 @@ class PluginManagement extends FOGPage
                 ]
             );
             foreach ($Plugins as &$Plugin) {
-                $pluginObj = self::getClass('Plugin', $Plugin->id);
+                $pluginObj = new Plugin($Plugin->id);
                 if (!$pluginObj->installdb()) {
                     throw new \Exception(
                         _('Failed to install ')
@@ -736,7 +737,7 @@ class PluginManagement extends FOGPage
                 ]
             );
             foreach ($Plugins as &$Plugin) {
-                $pluginObj = self::getClass('Plugin', $Plugin->id);
+                $pluginObj = new Plugin($Plugin->id);
                 if (!$pluginObj->installdb()) {
                     throw new \Exception(
                         _('Failed to update ')
@@ -814,7 +815,7 @@ class PluginManagement extends FOGPage
         try {
             $ids = ['id' => $plugins];
             $state = ['state' => 0];
-            $PluginManager = self::getClass('PluginManager');
+            $PluginManager = new PluginManager();
             if (!$PluginManager->update($ids, '', $state)) {
                 $serverFault = true;
                 throw new \Exception(_('Deactivate plugins failed!'));
@@ -893,7 +894,7 @@ class PluginManagement extends FOGPage
             // with no tables and every query against it threw
             // "Base table or view not found".
             $install = ['installed' => 0, 'schema' => 0];
-            $PluginManager = self::getClass('PluginManager');
+            $PluginManager = new PluginManager();
             if (!$PluginManager->update($ids, '', $state)) {
                 $serverFault = true;
                 throw new \Exception(_('Deactivate plugins failed!'));
@@ -1035,7 +1036,7 @@ class PluginManagement extends FOGPage
                 );
             }
             foreach ($forget as $id => $name) {
-                $plugin = self::getClass('Plugin', $id);
+                $plugin = new Plugin($id);
                 if (!$plugin->destroy()) {
                     $serverFault = true;
                     throw new \Exception(_('Failed to forget ') . $name);

--- a/packages/web/src/Pages/PrinterManagement.php
+++ b/packages/web/src/Pages/PrinterManagement.php
@@ -14,6 +14,9 @@
 namespace FOG\Pages;
 
 use FOG\Base\FOGPage;
+use FOG\Items\Printer;
+use FOG\Managers\PrinterAssociationManager;
+use FOG\Managers\PrinterManager;
 use FOG\Router\HTTPResponseCodes;
 
 /**
@@ -132,7 +135,7 @@ class PrinterManagement extends FOGPage
             $config,
             true
         );
-        $printercopySelector = self::getClass('PrinterManager')
+        $printercopySelector = (new PrinterManager())
             ->buildSelectBox('', 'printercopy');
 
         // Common block: copy-from, type, name and description are shared by
@@ -530,7 +533,7 @@ class PrinterManagement extends FOGPage
                         _('Please enter a printer name.')
                     );
                 }
-                $exists = self::getClass('PrinterManager')
+                $exists = (new PrinterManager())
                     ->exists($printer);
                 if ($exists) {
                     throw new \Exception(
@@ -544,7 +547,7 @@ class PrinterManagement extends FOGPage
                         _('A TCP/IP port printer requires an IP address or hostname.')
                     );
                 }
-                $Printer = self::getClass('Printer')
+                $Printer = (new Printer())
                     ->set('name', $printer)
                     ->set('description', $description)
                     ->set('config', $printertype)
@@ -699,7 +702,7 @@ class PrinterManagement extends FOGPage
                 _('Please enter a printer name.')
             );
         }
-        $exists = self::getClass('PrinterManager')
+        $exists = (new PrinterManager())
             ->exists($printer);
         if ($printer != $this->obj->get('name')
             && $exists
@@ -822,7 +825,7 @@ class PrinterManagement extends FOGPage
                 $this->obj->addHost($hostsToAssoc)->save();
             }
             if (count($hosts ?: []) > 0) {
-                self::getClass('PrinterAssociationManager')->update(
+                (new PrinterAssociationManager())->update(
                     [
                         'hostID' => $hosts,
                         'isDefault' => 1
@@ -830,7 +833,7 @@ class PrinterManagement extends FOGPage
                     '',
                     ['isDefault' => '0']
                 );
-                self::getClass('PrinterAssociationManager')->update(
+                (new PrinterAssociationManager())->update(
                     [
                         'printerID' => $this->obj->get('id'),
                         'hostID' => $hosts,
@@ -852,7 +855,7 @@ class PrinterManagement extends FOGPage
             );
             $hosts = $hosts['remitems'];
             if (count($hosts ?: []) > 0) {
-                self::getClass('PrinterAssociationManager')->update(
+                (new PrinterAssociationManager())->update(
                     [
                         'printerID' => $this->obj->get('id'),
                         'hostID' => $hosts,

--- a/packages/web/src/Pages/RoleManagement.php
+++ b/packages/web/src/Pages/RoleManagement.php
@@ -16,6 +16,9 @@ namespace FOG\Pages;
 use FOG\Auth\Authorization;
 use FOG\Auth\SiteScope;
 use FOG\Base\FOGPage;
+use FOG\Items\Role;
+use FOG\Items\UserGroup;
+use FOG\Managers\RoleManager;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 
@@ -189,14 +192,14 @@ class RoleManagement extends FOGPage
                 $description = trim(
                     (string)filter_input(INPUT_POST, 'description')
                 );
-                $exists = self::getClass('RoleManager')
+                $exists = (new RoleManager())
                     ->exists($role);
                 if ($exists) {
                     throw new \Exception(
                         _('A role already exists with this name!')
                     );
                 }
-                $Role = self::getClass('Role')
+                $Role = (new Role())
                     ->set('name', $role)
                     ->set('description', $description);
                 if (!$Role->save()) {
@@ -292,7 +295,7 @@ class RoleManagement extends FOGPage
             (string)filter_input(INPUT_POST, 'description')
         );
 
-        $exists = self::getClass('RoleManager')
+        $exists = (new RoleManager())
             ->exists($role);
         if ($role != $this->obj->get('name')
             && $exists
@@ -569,7 +572,7 @@ class RoleManagement extends FOGPage
         foreach ($attached as $groupID) {
             $roles = array_map(
                 'intval',
-                (array)self::getClass('UserGroup', $groupID)->get('roles')
+                (array)(new UserGroup($groupID))->get('roles')
             );
             $roles[] = $roleID;
             $groupRoles[$groupID] = array_values(array_unique($roles));
@@ -580,7 +583,7 @@ class RoleManagement extends FOGPage
         foreach (array_diff($current, $attached) as $groupID) {
             $roles = array_map(
                 'intval',
-                (array)self::getClass('UserGroup', $groupID)->get('roles')
+                (array)(new UserGroup($groupID))->get('roles')
             );
             $groupRoles[$groupID] = array_values(
                 array_diff($roles, [$roleID])

--- a/packages/web/src/Pages/SchemaUpdaterPage.php
+++ b/packages/web/src/Pages/SchemaUpdaterPage.php
@@ -332,7 +332,7 @@ class SchemaUpdaterPage extends FOGPage
                     true
                 )
                 : [];
-            $newSchema = self::getClass('Schema', 1);
+            $newSchema = new Schema(1);
             foreach ((array)$items as $version => &$updates) {
                 foreach ((array)$updates as &$update) {
                     if (!$update) {

--- a/packages/web/src/Pages/ServiceConfigurationPage.php
+++ b/packages/web/src/Pages/ServiceConfigurationPage.php
@@ -15,6 +15,8 @@
 namespace FOG\Pages;
 
 use FOG\Base\FOGPage;
+use FOG\Items\Module;
+use FOG\Items\Setting;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 
@@ -262,11 +264,8 @@ class ServiceConfigurationPage extends FOGPage
             }
             unset($module);
         }
-        $Module = self::getClass(
-            'Module',
-            $Module->id
-        );
-        $Service = self::getClass('Setting')
+        $Module = new Module($Module->id);
+        $Service = (new Setting())
             ->set('name', self::$_modNames[$key])
             ->load('name');
         if (isset($_POST['update'])) {

--- a/packages/web/src/Pages/SiteManagement.php
+++ b/packages/web/src/Pages/SiteManagement.php
@@ -14,6 +14,8 @@
 namespace FOG\Pages;
 
 use FOG\Base\FOGPage;
+use FOG\Items\Site;
+use FOG\Managers\SiteManager;
 
 /**
  * Site management page.
@@ -153,14 +155,14 @@ class SiteManagement extends FOGPage
                 // INSERT ... ON DUPLICATE KEY UPDATE -- so without this
                 // check creating a site with an existing name silently
                 // OVERWRITES that site instead of failing.
-                $exists = self::getClass('SiteManager')
+                $exists = (new SiteManager())
                     ->exists($site);
                 if ($exists) {
                     throw new \Exception(
                         _('A site already exists with this name!')
                     );
                 }
-                $Site = self::getClass('Site')
+                $Site = (new Site())
                     ->set('name', $site)
                     ->set('description', $description);
                 if (!$Site->save()) {
@@ -310,7 +312,7 @@ class SiteManagement extends FOGPage
 
         // Same silent-overwrite guard as addPost(); a rename onto an
         // existing name would take that site's row with it.
-        $exists = self::getClass('SiteManager')
+        $exists = (new SiteManager())
             ->exists($site);
         if ($site != $this->obj->get('name')
             && $exists

--- a/packages/web/src/Pages/SnapinManagement.php
+++ b/packages/web/src/Pages/SnapinManagement.php
@@ -18,6 +18,10 @@ use FOG\Exception\SnapinSaveException;
 use FOG\Exception\UploadException;
 use FOG\Items\Snapin;
 use FOG\Items\StorageGroup;
+use FOG\Managers\FileDeleteQueueManager;
+use FOG\Managers\SnapinGroupAssociationManager;
+use FOG\Managers\SnapinManager;
+use FOG\Managers\StorageGroupManager;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 
@@ -279,7 +283,7 @@ class SnapinManagement extends FOGPage
             $sgID = @min(Route::getIds('storagegroup', false));
         }
         $StorageGroup = new StorageGroup($sgID);
-        $StorageGroups = self::getClass('StorageGroupManager')
+        $StorageGroups = (new StorageGroupManager())
             ->buildSelectBox($sgID, '', 'id');
         self::$selected = '';
         self::$selected = $snapinfileexist;
@@ -1159,7 +1163,7 @@ class SnapinManagement extends FOGPage
         $action = trim((string)filter_input(INPUT_POST, 'action'));
         $args = trim((string)filter_input(INPUT_POST, 'args'));
 
-        $exists = self::getClass('SnapinManager')
+        $exists = (new SnapinManager())
             ->exists($snapin);
         if ($snapin != $this->obj->get('name')
             && $exists
@@ -1291,7 +1295,7 @@ class SnapinManagement extends FOGPage
                             $storagegroupID
                         ];
                     }
-                    self::getClass('FileDeleteQueueManager')->insertBatch(
+                    (new FileDeleteQueueManager())->insertBatch(
                         $insert_fields,
                         $insert_values
                     );
@@ -1405,7 +1409,7 @@ class SnapinManagement extends FOGPage
                 $this->obj->get('storagegroups'),
                 [$primary]
             );
-            self::getClass('SnapinGroupAssociationManager')->update(
+            (new SnapinGroupAssociationManager())->update(
                 [
                     'snapinID' => $this->obj->get('id'),
                     'storagegroupID' => $storagegroups,
@@ -1415,7 +1419,7 @@ class SnapinManagement extends FOGPage
                 ['primary' => '0']
             );
             if ($primary) {
-                self::getClass('SnapinGroupAssociationManager')->update(
+                (new SnapinGroupAssociationManager())->update(
                     [
                         'snapinID' => $this->obj->get('id'),
                         'storagegroupID' => $primary,

--- a/packages/web/src/Pages/StorageGroupManagement.php
+++ b/packages/web/src/Pages/StorageGroupManagement.php
@@ -14,7 +14,12 @@
 namespace FOG\Pages;
 
 use FOG\Base\FOGPage;
+use FOG\Items\StorageGroup;
 use FOG\Items\StorageNode;
+use FOG\Managers\ImageAssociationManager;
+use FOG\Managers\SnapinGroupAssociationManager;
+use FOG\Managers\StorageGroupManager;
+use FOG\Managers\StorageNodeManager;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 
@@ -157,14 +162,14 @@ class StorageGroupManagement extends FOGPage
 
         $serverFault = false;
         try {
-            $exists = self::getClass('StorageGroupManager')
+            $exists = (new StorageGroupManager())
                 ->exists($storagegroup);
             if ($exists) {
                 throw new \Exception(
                     _('A storage group exists with this name!')
                 );
             }
-            $StorageGroup = self::getClass('StorageGroup')
+            $StorageGroup = (new StorageGroup())
                 ->set('name', $storagegroup)
                 ->set('description', $description)
                 ->set('trustedcidrs', $trustedcidrs);
@@ -313,7 +318,7 @@ class StorageGroupManagement extends FOGPage
             (string)filter_input(INPUT_POST, 'trustedcidrs')
         );
 
-        $exists = self::getClass('StorageGroupManager')
+        $exists = (new StorageGroupManager())
             ->exists($storagegroup);
         if ($storagegroup != $this->obj->get('name')
             && $exists
@@ -453,7 +458,7 @@ class StorageGroupManagement extends FOGPage
                 $this->obj->addImage($imagesToAssoc)->save();
             }
             if (count($images ?: []) > 0) {
-                self::getClass('ImageAssociationManager')->update(
+                (new ImageAssociationManager())->update(
                     [
                         'imageID' => $images,
                         'primary' => 1
@@ -461,7 +466,7 @@ class StorageGroupManagement extends FOGPage
                     '',
                     ['primary' => '0']
                 );
-                self::getClass('ImageAssociationManager')->update(
+                (new ImageAssociationManager())->update(
                     [
                         'storagegroupID' => $this->obj->get('id'),
                         'imageID' => $images,
@@ -483,7 +488,7 @@ class StorageGroupManagement extends FOGPage
             );
             $images = $images['remitems'];
             if (count($images ?: []) > 0) {
-                self::getClass('ImageAssociationManager')->update(
+                (new ImageAssociationManager())->update(
                     [
                         'storagegroupID' => $this->obj->get('id'),
                         'imageID' => $images,
@@ -620,7 +625,7 @@ class StorageGroupManagement extends FOGPage
                 $this->obj->addSnapin($snapinsToAssoc)->save();
             }
             if (count($snapins ?: []) > 0) {
-                self::getClass('SnapinGroupAssociationManager')->update(
+                (new SnapinGroupAssociationManager())->update(
                     [
                         'snapinID' => $snapins,
                         'primary' => 1
@@ -628,7 +633,7 @@ class StorageGroupManagement extends FOGPage
                     '',
                     ['primary' => '0']
                 );
-                self::getClass('SnapinGroupAssociationManager')->update(
+                (new SnapinGroupAssociationManager())->update(
                     [
                         'storagegroupID' => $this->obj->get('id'),
                         'snapinID' => $snapins,
@@ -650,7 +655,7 @@ class StorageGroupManagement extends FOGPage
             );
             $snapins = $snapins['remitems'];
             if (count($snapins ?: []) > 0) {
-                self::getClass('SnapinGroupAssociationManager')->update(
+                (new SnapinGroupAssociationManager())->update(
                     [
                         'storagegroupID' => $this->obj->get('id'),
                         'snapinID' => $snapins,
@@ -767,7 +772,7 @@ class StorageGroupManagement extends FOGPage
                 $this->obj->get('allnodes'),
                 [$master]
             );
-            self::getClass('StorageNodeManager')->update(
+            (new StorageNodeManager())->update(
                 [
                     'storagegroupID' => $this->obj->get('id'),
                     'id' => $storagenodes,
@@ -777,7 +782,7 @@ class StorageGroupManagement extends FOGPage
                 ['isMaster' => '0']
             );
             if ($master) {
-                self::getClass('StorageNodeManager')->update(
+                (new StorageNodeManager())->update(
                     [
                         'storagegroupID' => $this->obj->get('id'),
                         'id' => $master,

--- a/packages/web/src/Pages/StorageNodeManagement.php
+++ b/packages/web/src/Pages/StorageNodeManagement.php
@@ -14,6 +14,9 @@
 namespace FOG\Pages;
 
 use FOG\Base\FOGPage;
+use FOG\Items\StorageNode;
+use FOG\Managers\StorageGroupManager;
+use FOG\Managers\StorageNodeManager;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 
@@ -129,7 +132,7 @@ class StorageNodeManagement extends FOGPage
                 $labelClass,
                 'storagegroupID',
                 _('Storage Group')
-            ) => self::getClass('StorageGroupManager')
+            ) => (new StorageGroupManager())
             ->buildSelectBox(
                 $storagegroupID,
                 'storagegroupID'
@@ -503,7 +506,7 @@ class StorageNodeManagement extends FOGPage
                 self::$FOGSSH->host = $ip;
                 $warning = !self::$FOGSSH->connect();
             }
-            $exists = self::getClass('StorageNodeManager')
+            $exists = (new StorageNodeManager())
                 ->exists($storagenode);
             if ($exists) {
                 throw new \Exception(
@@ -519,7 +522,7 @@ class StorageNodeManagement extends FOGPage
             } else {
                 $bandwidth = '';
             }
-            $StorageNode = self::getClass('StorageNode')
+            $StorageNode = (new StorageNode())
                 ->set('name', $storagenode)
                 ->set('description', $description)
                 ->set('ip', $ip)
@@ -553,7 +556,7 @@ class StorageNodeManagement extends FOGPage
                     'storagenode',
                     $find
                 );
-                self::getClass('StorageNodeManager')
+                (new StorageNodeManager())
                     ->update(
                         [
                             'id' => array_diff(
@@ -757,7 +760,7 @@ class StorageNodeManagement extends FOGPage
                 $labelClass,
                 'storagegroupID',
                 _('Storage Group')
-            ) => self::getClass('StorageGroupManager')
+            ) => (new StorageGroupManager())
             ->buildSelectBox(
                 $storagegroupID,
                 'storagegroupID'
@@ -1202,7 +1205,7 @@ class StorageNodeManagement extends FOGPage
         if (!$storagenode) {
             throw new \Exception(self::$foglang['StorageNameRequired']);
         }
-        $exists = self::getClass('StorageNodeManager')
+        $exists = (new StorageNodeManager())
             ->exists($storagenode, $this->obj->get('id'));
         if ($storagenode != $this->obj->get('name')
             && $exists
@@ -1251,7 +1254,7 @@ class StorageNodeManagement extends FOGPage
                 'storagenode',
                 $find
             );
-            self::getClass('StorageNodeManager')
+            (new StorageNodeManager())
                 ->update(
                     [
                         'id' => array_diff(
@@ -1353,7 +1356,7 @@ class StorageNodeManagement extends FOGPage
             'name' => _('Information'),
             'id' => 'storagenode-info',
             'generator' => function () {
-                self::getClass('ServerInfo')->index();
+                (new ServerInfo())->index();
             }
         ];
 

--- a/packages/web/src/Pages/TaskManagement.php
+++ b/packages/web/src/Pages/TaskManagement.php
@@ -17,6 +17,17 @@ use FOG\Base\FOGManagerController;
 use FOG\Base\FOGPage;
 use FOG\Items\TaskLog;
 use FOG\Items\TaskType;
+use FOG\Managers\FileDeleteQueueManager;
+use FOG\Managers\HostManager;
+use FOG\Managers\ImageManager;
+use FOG\Managers\MulticastSessionManager;
+use FOG\Managers\ScheduledTaskManager;
+use FOG\Managers\SnapinTaskManager;
+use FOG\Managers\StorageNodeManager;
+use FOG\Managers\TaskManager;
+use FOG\Managers\TaskStateManager;
+use FOG\Managers\TaskTypeManager;
+use FOG\Managers\UserManager;
 use FOG\Router\HTTPResponseCodes;
 use FOG\Router\Route;
 
@@ -957,7 +968,7 @@ class TaskManagement extends FOGPage
     private function _taskJoinColumns()
     {
         $columns = [];
-        foreach (self::getClass('TaskManager')
+        foreach ((new TaskManager())
             ->getColumns() as $common => &$real
         ) {
             $columns[] = [
@@ -966,7 +977,7 @@ class TaskManagement extends FOGPage
             ];
             unset($real);
         }
-        foreach (self::getClass('HostManager')
+        foreach ((new HostManager())
             ->getColumns() as $common => &$real
         ) {
             $columns[] = [
@@ -975,7 +986,7 @@ class TaskManagement extends FOGPage
             ];
             unset($real);
         }
-        foreach (self::getClass('ImageManager')
+        foreach ((new ImageManager())
             ->getColumns() as $common => &$real
         ) {
             $columns[] = [
@@ -984,7 +995,7 @@ class TaskManagement extends FOGPage
             ];
             unset($real);
         }
-        foreach (self::getClass('TaskTypeManager')
+        foreach ((new TaskTypeManager())
             ->getColumns() as $common => &$real
         ) {
             $columns[] = [
@@ -993,7 +1004,7 @@ class TaskManagement extends FOGPage
             ];
             unset($real);
         }
-        foreach (self::getClass('TaskStateManager')
+        foreach ((new TaskStateManager())
             ->getColumns() as $common => &$real
         ) {
             $columns[] = [
@@ -1002,7 +1013,7 @@ class TaskManagement extends FOGPage
             ];
             unset($real);
         }
-        foreach (self::getClass('StorageNodeManager')
+        foreach ((new StorageNodeManager())
             ->getColumns() as $common => &$real
         ) {
             $columns[] = [
@@ -1011,7 +1022,7 @@ class TaskManagement extends FOGPage
             ];
             unset($real);
         }
-        foreach (self::getClass('UserManager')
+        foreach ((new UserManager())
             ->getColumns() as $common => &$real
         ) {
             if (in_array($common, ['id', 'name'])) {
@@ -1115,7 +1126,7 @@ class TaskManagement extends FOGPage
             LEFT OUTER JOIN `taskStates`
             ON `multicastSessions`.`msState` = `taskStates`.`tsID`
             WHERE $where";
-        foreach (self::getClass('MulticastSessionManager')
+        foreach ((new MulticastSessionManager())
             ->getColumns() as $common => &$real
         ) {
             $columns[] = [
@@ -1124,7 +1135,7 @@ class TaskManagement extends FOGPage
             ];
             unset($real);
         }
-        foreach (self::getClass('TaskTypeManager')
+        foreach ((new TaskTypeManager())
             ->getColumns() as $common => &$real
         ) {
             $columns[] = [
@@ -1133,7 +1144,7 @@ class TaskManagement extends FOGPage
             ];
             unset($real);
         }
-        foreach (self::getClass('TaskStateManager')
+        foreach ((new TaskStateManager())
             ->getColumns() as $common => &$real
         ) {
             $columns[] = [
@@ -1288,7 +1299,7 @@ class TaskManagement extends FOGPage
                     ]
                 );
                 $tasks = $tasks['tasks'];
-                self::getClass('TaskManager')->cancel($tasks);
+                (new TaskManager())->cancel($tasks);
             }
             $code = HTTPResponseCodes::HTTP_ACCEPTED;
             $hook = 'TASK_CANCEL_SUCCESS';
@@ -1349,8 +1360,8 @@ class TaskManagement extends FOGPage
                     $find,
                     'taskID'
                 );
-                self::getClass('TaskManager')->cancel($tasks);
-                self::getClass('MulticastSessionManager')->cancel($mtasks);
+                (new TaskManager())->cancel($tasks);
+                (new MulticastSessionManager())->cancel($mtasks);
             }
             $code = HTTPResponseCodes::HTTP_ACCEPTED;
             $hook = 'TASK_CANCEL_SUCCESS';
@@ -1404,7 +1415,7 @@ class TaskManagement extends FOGPage
                     ]
                 );
                 $tasks = $tasks['tasks'];
-                self::getClass('SnapinTaskManager')->cancel($tasks);
+                (new SnapinTaskManager())->cancel($tasks);
             }
             $code = HTTPResponseCodes::HTTP_ACCEPTED;
             $hook = 'TASK_CANCEL_SUCCESS';
@@ -1458,7 +1469,7 @@ class TaskManagement extends FOGPage
                     ]
                 );
                 $tasks = $tasks['tasks'];
-                self::getClass('ScheduledTaskManager')->cancel($tasks);
+                (new ScheduledTaskManager())->cancel($tasks);
             }
             $code = HTTPResponseCodes::HTTP_ACCEPTED;
             $hook = 'TASK_CANCEL_SUCCESS';
@@ -1512,7 +1523,7 @@ class TaskManagement extends FOGPage
                     ]
                 );
                 $tasks = $tasks['tasks'];
-                self::getClass('FileDeleteQueueManager')->cancel($tasks);
+                (new FileDeleteQueueManager())->cancel($tasks);
             }
             $code = HTTPResponseCodes::HTTP_ACCEPTED;
             $hook = 'QUEUED_DELETION_CANCEL_SUCCESS';

--- a/packages/web/src/Pages/UserGroupManagement.php
+++ b/packages/web/src/Pages/UserGroupManagement.php
@@ -16,6 +16,8 @@ namespace FOG\Pages;
 use FOG\Auth\Authorization;
 use FOG\Auth\SiteScope;
 use FOG\Base\FOGPage;
+use FOG\Items\UserGroup;
+use FOG\Managers\UserGroupManager;
 use FOG\Router\HTTPResponseCodes;
 
 /**
@@ -143,14 +145,14 @@ class UserGroupManagement extends FOGPage
                 $description = trim(
                     (string)filter_input(INPUT_POST, 'description')
                 );
-                $exists = self::getClass('UserGroupManager')
+                $exists = (new UserGroupManager())
                     ->exists($usergroup);
                 if ($exists) {
                     throw new \Exception(
                         _('A user group already exists with this name!')
                     );
                 }
-                $UserGroup = self::getClass('UserGroup')
+                $UserGroup = (new UserGroup())
                     ->set('name', $usergroup)
                     ->set('description', $description);
                 if (!$UserGroup->save()) {
@@ -247,7 +249,7 @@ class UserGroupManagement extends FOGPage
             (string)filter_input(INPUT_POST, 'description')
         );
 
-        $exists = self::getClass('UserGroupManager')
+        $exists = (new UserGroupManager())
             ->exists($usergroup);
         if ($usergroup != $this->obj->get('name')
             && $exists

--- a/packages/web/src/Pages/UserManagement.php
+++ b/packages/web/src/Pages/UserManagement.php
@@ -17,6 +17,8 @@ use FOG\Auth\Authorization;
 use FOG\Base\FOGPage;
 use FOG\Items\APIToken;
 use FOG\Items\User;
+use FOG\Managers\APITokenManager;
+use FOG\Managers\UserManager;
 use FOG\Router\HTTPResponseCodes;
 
 /**
@@ -341,14 +343,14 @@ class UserManagement extends FOGPage
             if (!preg_match($userPat, $user)) {
                 throw new \Exception($userErr);
             }
-            $exists = self::getClass('UserManager')
+            $exists = (new UserManager())
                 ->exists($user);
             if ($exists) {
                 throw new \Exception(
                     _('A username already exists with this name!')
                 );
             }
-            $User = self::getClass('User')
+            $User = (new User())
                 ->set('name', $user)
                 ->set('password', $password)
                 ->set('display', $friendly)
@@ -627,7 +629,7 @@ class UserManagement extends FOGPage
         if (!preg_match($userPat, $user)) {
             throw new \Exception($userErr);
         }
-        $exists = self::getClass('UserManager')
+        $exists = (new UserManager())
             ->exists($user);
         if ($user != $this->obj->get('name')
             && $exists
@@ -1177,7 +1179,7 @@ class UserManagement extends FOGPage
         // either: scope decides what this administrator may see at all, and
         // the id decides which of that belongs on this page.
         foreach (
-            self::getClass('APITokenManager')
+            (new APITokenManager())
                 ->visibleTo((int)self::$FOGUser->get('id')) as $token
         ) {
             if ($token['userID'] !== $uid) {
@@ -1243,7 +1245,7 @@ class UserManagement extends FOGPage
         // The owner id is passed, so this card can only ever act on the
         // account it is displayed under. Without it anyone who may edit one
         // user could revoke any token on the server by posting its number.
-        $revoked = self::getClass('APITokenManager')->revokeMany(
+        $revoked = (new APITokenManager())->revokeMany(
             array_map('intval', (array)($_POST['remitems'] ?? [])),
             (int)self::$FOGUser->get('id'),
             (int)$this->obj->get('id')
@@ -1290,7 +1292,7 @@ class UserManagement extends FOGPage
         }
 
         $enabled = (int)filter_input(INPUT_POST, 'enabled') === 1;
-        $changed = self::getClass('APITokenManager')->setEnabledMany(
+        $changed = (new APITokenManager())->setEnabledMany(
             array_map('intval', (array)($_POST['remitems'] ?? [])),
             $enabled,
             (int)self::$FOGUser->get('id'),

--- a/packages/web/src/Reports/Imaging_Report.php
+++ b/packages/web/src/Reports/Imaging_Report.php
@@ -231,7 +231,7 @@ class Imaging_Report extends ReportManagement
         foreach ($rows as $row) {
             $stateID = (int)($row['stateID'] ?? 0);
             if ($stateID > 0 && !isset($states[$stateID])) {
-                $states[$stateID] = (string)self::getClass('TaskState', $stateID)
+                $states[$stateID] = (string)(new TaskState($stateID))
                     ->get('name');
             }
             $data[] = [

--- a/packages/web/src/Reports/Run_History.php
+++ b/packages/web/src/Reports/Run_History.php
@@ -15,6 +15,7 @@ namespace FOG\Reports;
 
 use FOG\Audit\ActivityWindow;
 use FOG\Audit\ReportWindow;
+use FOG\Items\TaskState;
 use FOG\Pages\ReportManagement;
 
 /**
@@ -222,7 +223,7 @@ class Run_History extends ReportManagement
         foreach ($rows as $row) {
             $id = (int)($row['state'] ?? 0);
             if ($id > 0 && !isset($states[$id])) {
-                $states[$id] = (string)self::getClass('TaskState', $id)
+                $states[$id] = (string)(new TaskState($id))
                     ->get('name');
             }
         }

--- a/packages/web/src/Reports/Snapin_Report.php
+++ b/packages/web/src/Reports/Snapin_Report.php
@@ -15,6 +15,7 @@ namespace FOG\Reports;
 
 use FOG\Audit\ReportWindow;
 use FOG\Audit\SnapinStats;
+use FOG\Items\TaskState;
 use FOG\Pages\ReportManagement;
 
 /**
@@ -212,7 +213,7 @@ class Snapin_Report extends ReportManagement
         foreach ($rows as $row) {
             $stateID = (int)($row['stateID'] ?? 0);
             if ($stateID > 0 && !isset($states[$stateID])) {
-                $states[$stateID] = (string)self::getClass('TaskState', $stateID)
+                $states[$stateID] = (string)(new TaskState($stateID))
                     ->get('name');
             }
             $code = (int)($row['code'] ?? 0);

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -32,12 +32,21 @@ use FOG\Items\Host;
 use FOG\Items\Inventory;
 use FOG\Items\MACAddress;
 use FOG\Items\Plugin;
+use FOG\Items\Schema;
 use FOG\Items\Snapin;
 use FOG\Items\SnapinJob;
+use FOG\Items\StorageGroup;
 use FOG\Items\StorageNode;
 use FOG\Items\Task;
+use FOG\Items\TaskState;
+use FOG\Items\User;
 use FOG\Items\UserTracking;
+use FOG\Managers\HostManager;
 use FOG\Managers\PXEMenuOptionsManager;
+use FOG\Managers\SavedFilterManager;
+use FOG\Managers\SnapinJobManager;
+use FOG\Managers\TaskManager;
+use FOG\Managers\UserPrefManager;
 use FOG\Net\Ping;
 use FOG\Util\FOGCron;
 
@@ -2120,7 +2129,7 @@ class Route extends FOGBase
             (string)filter_input(INPUT_SERVER, 'HTTP_FOG_USER_TOKEN')
         );
         $usertoken = trim($usertoken);
-        $pwtoken = self::getClass('User')
+        $pwtoken = (new User())
             ->set('token', $usertoken)
             ->load('token');
         if ($pwtoken->isValid() && $pwtoken->get('api')) {
@@ -2169,7 +2178,7 @@ class Route extends FOGBase
         // Reloading also gives the acting user a fully populated object,
         // matching what the token branch binds -- passwordValidate() only
         // fills in id, name and type on the object it was called against.
-        $apiUser = self::getClass('User', (int)self::$FOGUser->get('id'));
+        $apiUser = new User((int)self::$FOGUser->get('id'));
         if (!$apiUser->isValid() || !$apiUser->get('api')) {
             // A correct password for an account that may not use the API.
             // Distinct from a bad credential and worth telling apart: this
@@ -2366,7 +2375,7 @@ class Route extends FOGBase
     public static function userprefs()
     {
         self::$data = [
-            'prefs' => self::getClass('UserPrefManager')->fetchAll(
+            'prefs' => (new UserPrefManager())->fetchAll(
                 (int)self::$FOGUser->get('id')
             ),
             'msg' => _('success')
@@ -2408,7 +2417,7 @@ class Route extends FOGBase
 
             return;
         }
-        $manager = self::getClass('SavedFilterManager');
+        $manager = new SavedFilterManager();
         $method = strtoupper(self::$reqmethod ?: 'GET');
         if ('GET' === $method) {
             self::$data = [
@@ -2471,7 +2480,7 @@ class Route extends FOGBase
 
             return;
         }
-        $manager = self::getClass('SavedFilterManager');
+        $manager = new SavedFilterManager();
         $method = strtoupper(self::$reqmethod ?: 'GET');
         if ('GET' === $method) {
             $filter = $manager->fetch((int)$id, $userID);
@@ -2668,7 +2677,7 @@ class Route extends FOGBase
         if ($method === 'GET') {
             self::$data = [
                 'key' => $key,
-                'value' => self::getClass('UserPrefManager')
+                'value' => (new UserPrefManager())
                     ->fetch($userID, $key),
                 'msg' => _('success')
             ];
@@ -2708,7 +2717,7 @@ class Route extends FOGBase
                 return;
             }
         }
-        if (!self::getClass('UserPrefManager')->store($userID, $key, $value)) {
+        if (!(new UserPrefManager())->store($userID, $key, $value)) {
             self::sendResponse(
                 HTTPResponseCodes::HTTP_BAD_REQUEST,
                 json_encode(
@@ -2794,7 +2803,7 @@ class Route extends FOGBase
             'fog_backup_%s.sql',
             self::formatTime('now', 'Ymd_His')
         );
-        self::getClass('Schema')->exportdb($backup_name);
+        (new Schema())->exportdb($backup_name);
         exit;
     }
     /**
@@ -4220,7 +4229,7 @@ class Route extends FOGBase
                     'formatter' => function ($d) use (&$taskStates) {
                         $id = (int)$d;
                         if (!isset($taskStates[$id])) {
-                            $taskStates[$id] = self::getClass('TaskState', $id)
+                            $taskStates[$id] = (new TaskState($id))
                                 ->get('name');
                         }
                         return $taskStates[$id] ?: self::EMPTY_CELL;
@@ -4257,10 +4266,7 @@ class Route extends FOGBase
                             ? (int)$row['taskStateID']
                             : 0;
                         if (!isset($taskStates[$stateId])) {
-                            $taskStates[$stateId] = self::getClass(
-                                'TaskState',
-                                $stateId
-                            )->get('name');
+                            $taskStates[$stateId] = (new TaskState($stateId))->get('name');
                         }
                         // An unresolvable state renders as a word, not as
                         // nothing. The `statename` column can afford an
@@ -4332,7 +4338,7 @@ class Route extends FOGBase
                 $groupFor = function ($id) use (&$storageGroups) {
                     $id = (int) $id;
                     if (!isset($storageGroups[$id])) {
-                        $storageGroups[$id] = self::getClass('StorageGroup')
+                        $storageGroups[$id] = (new StorageGroup())
                             ->set('id', $id)
                             ->load();
                     }
@@ -5422,7 +5428,7 @@ class Route extends FOGBase
                 // not start failing the day it becomes blocked.
                 if (isset($vars->state)
                     && (int)$vars->state === 1
-                    && !(int)self::getClass('Plugin', $id)->get('state')
+                    && !(int)(new Plugin($id))->get('state')
                 ) {
                     $blockers = Plugin::activationBlockers([(int)$id]);
                     if (count($blockers)) {
@@ -5823,7 +5829,7 @@ class Route extends FOGBase
     public static function uploadSnapinFiles($id)
     {
         try {
-            $StorageGroup = self::getClass('StorageGroup', (int)$id);
+            $StorageGroup = new StorageGroup((int)$id);
             if (!$StorageGroup->isValid()) {
                 self::sendResponse(
                     HTTPResponseCodes::HTTP_NOT_FOUND,
@@ -5932,7 +5938,7 @@ class Route extends FOGBase
     public static function pluginInstall($id)
     {
         try {
-            $Plugin = self::getClass('Plugin', (int)$id);
+            $Plugin = new Plugin((int)$id);
             if (!$Plugin->isValid()) {
                 // setErrorMessage(), not sendResponse(): every error this
                 // route can answer with is documented as the Error schema,
@@ -6091,7 +6097,7 @@ class Route extends FOGBase
                             _('No active tasks to cancel for this group')
                         );
                     }
-                    self::getClass('TaskManager')->cancel($taskIDs);
+                    (new TaskManager())->cancel($taskIDs);
                     break;
                 case 'host':
                     self::_requireFound($class);
@@ -6160,10 +6166,7 @@ class Route extends FOGBase
                         // Failed task came back from the API reporting success
                         // and stayed Failed.
                         if (!in_array($class->get('stateID'), $states)) {
-                            $stateName = self::getClass(
-                                'TaskState',
-                                $class->get('stateID')
-                            )->get('name');
+                            $stateName = (new TaskState($class->get('stateID')))->get('name');
                             self::_notCancellable(
                                 sprintf(
                                     '%s: %s',
@@ -8743,7 +8746,7 @@ class Route extends FOGBase
                 break;
             case 'image':
                 $findWhere = ['imageID' => $itemIDs];
-                self::getClass('HostManager')->update(
+                (new HostManager())->update(
                     $findWhere,
                     '',
                     // NULL, not 0 -- see schema step 386.
@@ -8783,7 +8786,7 @@ class Route extends FOGBase
                     ]
                 );
                 if (count($activeImageTaskIDs ?: [])) {
-                    self::getClass('TaskManager')
+                    (new TaskManager())
                         ->cancel($activeImageTaskIDs);
                 }
                 $removeItems = [
@@ -8857,7 +8860,7 @@ class Route extends FOGBase
                     unset($sjID);
                 }
                 if (count($sjIDs ?: [])) {
-                    self::getClass('SnapinJobManager')->cancel($sjIDs);
+                    (new SnapinJobManager())->cancel($sjIDs);
                 }
                 break;
             case 'user':
@@ -10168,7 +10171,7 @@ class Route extends FOGBase
      */
     public static function logfiles($id)
     {
-        self::$data = self::getClass('StorageNode', $id)->get('logfiles');
+        self::$data = (new StorageNode($id))->get('logfiles');
     }
     /**
      * Return node's image files.
@@ -10177,7 +10180,7 @@ class Route extends FOGBase
      */
     public static function imagefiles($id)
     {
-        self::$data = self::getClass('StorageNode', $id)->get('images');
+        self::$data = (new StorageNode($id))->get('images');
     }
     /**
      * Return node's snapin files.
@@ -10186,7 +10189,7 @@ class Route extends FOGBase
      */
     public static function snapinfiles($id)
     {
-        self::$data = self::getClass('StorageNode', $id)->get('snapinfiles');
+        self::$data = (new StorageNode($id))->get('snapinfiles');
     }
     /**
      * The five server facts this route publishes, in the order they are

--- a/packages/web/src/Service/FileDeleter.php
+++ b/packages/web/src/Service/FileDeleter.php
@@ -13,6 +13,7 @@
 
 namespace FOG\Service;
 
+use FOG\Items\FileDeleteQueue;
 use FOG\Router\Route;
 
 /**
@@ -220,7 +221,7 @@ class FileDeleter extends FOGService
                         $filedelete->createdTime
                     )
                 );
-                $Task = self::getClass('FileDeleteQueue', $filedelete->id)
+                $Task = (new FileDeleteQueue($filedelete->id))
                     ->set('stateID', self::getProgressState())
                     ->save();
                 $StorageNodes = Route::getList(

--- a/packages/web/src/Service/MulticastManager.php
+++ b/packages/web/src/Service/MulticastManager.php
@@ -13,6 +13,7 @@
 
 namespace FOG\Service;
 
+use FOG\Items\MulticastSession;
 use FOG\Router\Route;
 
 /**
@@ -207,10 +208,7 @@ class MulticastManager extends FOGService
      */
     private function _senderClaimIsFree($curTask)
     {
-        $owner = (int)self::getClass(
-            'MulticastSession',
-            $curTask->getID()
-        )->get('sendernode');
+        $owner = (int)(new MulticastSession($curTask->getID()))->get('sendernode');
 
         return $owner < 1
             || $owner === $curTask->getNodeID();
@@ -260,7 +258,7 @@ class MulticastManager extends FOGService
                         )
                     );
                 }
-                self::getClass('MulticastSession', $Session->id)
+                (new MulticastSession($Session->id))
                     ->set('senderpid', 0)
                     // senderpid is a process id and 0 is a real "no process".
                     // sendernode is a reference, so its "none" is NULL --

--- a/packages/web/src/Service/MulticastTask.php
+++ b/packages/web/src/Service/MulticastTask.php
@@ -13,7 +13,10 @@
 
 namespace FOG\Service;
 
+use FOG\Items\Image;
 use FOG\Items\MulticastSession;
+use FOG\Items\Task;
+use FOG\Managers\MulticastSessionManager;
 use FOG\Router\Route;
 
 /**
@@ -145,7 +148,7 @@ class MulticastTask extends FOGService
                 (int)$Task->sessclients
             );
             if ($count < 1) {
-                self::getClass('MulticastSessionManager')->update(
+                (new MulticastSessionManager())->update(
                     ['id' => $Task->id],
                     '',
                     [
@@ -174,7 +177,7 @@ class MulticastTask extends FOGService
             // unwinds the whole collection pass and takes every other queued
             // session with it. Testing validity here keeps the failure scoped
             // to the one session it belongs to. Refs #907, ADR 0011.
-            if (!self::getClass('Image', $Task->image)->isValid()) {
+            if (!(new Image($Task->image))->isValid()) {
                 self::outall(
                     sprintf(
                         ' | ' . _('Image %s for session %s is missing or invalid; skipping'),
@@ -432,10 +435,7 @@ class MulticastTask extends FOGService
      */
     public function getImageFormat()
     {
-        return (int)self::getClass(
-            'Image',
-            $this->_MultiSess->get('image')
-        )->get('format');
+        return (int)(new Image($this->_MultiSess->get('image')))->get('format');
     }
     /**
      * Returns the client count
@@ -500,10 +500,7 @@ class MulticastTask extends FOGService
      */
     public function getBitrate()
     {
-        return self::getClass(
-            'Image',
-            $this->_MultiSess->get('image')
-        )->getStorageGroup()
+        return (new Image($this->_MultiSess->get('image')))->getStorageGroup()
         ->getMasterStorageNode()
         ->get('bitrate');
     }
@@ -514,10 +511,7 @@ class MulticastTask extends FOGService
      */
     public function getHelloInterval()
     {
-        return self::getClass(
-            'Image',
-            $this->_MultiSess->get('image')
-        )->getStorageGroup()
+        return (new Image($this->_MultiSess->get('image')))->getStorageGroup()
         ->getMasterStorageNode()
         ->get('helloInterval');
     }
@@ -1258,7 +1252,7 @@ class MulticastTask extends FOGService
         ) {
             return false;
         }
-        self::getClass('MulticastSessionManager')->update(
+        (new MulticastSessionManager())->update(
             ['id' => $this->getID()],
             '',
             [
@@ -1284,7 +1278,7 @@ class MulticastTask extends FOGService
         );
         $TaskPercent = [];
         foreach ($MSAssocs as $TaskID) {
-            $TaskPercent[] = self::getClass('Task', $TaskID)->get('percent');
+            $TaskPercent[] = (new Task($TaskID))->get('percent');
         }
         $TaskPercent = array_unique($TaskPercent);
         // Write the one column this owns. updateStats() runs against the
@@ -1294,7 +1288,7 @@ class MulticastTask extends FOGService
         // first-seen snapshot back every tick. That silently undid the
         // clients counter TaskQueue::checkIn() increments as hosts arrive,
         // which is why a session's client count never climbed.
-        self::getClass('MulticastSessionManager')->update(
+        (new MulticastSessionManager())->update(
             ['id' => $this->_intID],
             '',
             ['percent' => self::maxId($TaskPercent)]

--- a/packages/web/src/Service/PingHosts.php
+++ b/packages/web/src/Service/PingHosts.php
@@ -14,6 +14,7 @@
 
 namespace FOG\Service;
 
+use FOG\Managers\HostManager;
 use FOG\Net\Ping;
 use FOG\Router\Route;
 
@@ -479,7 +480,7 @@ class PingHosts extends FOGService
                     // deleted mid-cycle. Do NOT use insertBatch here -- its
                     // INSERT ... ON DUPLICATE KEY UPDATE would resurrect a
                     // deleted host as a blank, nameless row.
-                    self::getClass('HostManager')
+                    (new HostManager())
                         ->update(
                             ['id' => $chunk],
                             '',
@@ -622,7 +623,7 @@ class PingHosts extends FOGService
             // Cleared in one statement. The address is not merely stale, it
             // is known to belong to something else, so leaving it would have
             // every future cycle re-derive the same wrong answer.
-            self::getClass('HostManager')->update(
+            (new HostManager())->update(
                 ['id' => array_keys($recycled)],
                 '',
                 ['ip' => '']

--- a/packages/web/src/Service/TaskScheduler.php
+++ b/packages/web/src/Service/TaskScheduler.php
@@ -14,6 +14,11 @@
 namespace FOG\Service;
 
 use FOG\Boot\UbootTftpSync;
+use FOG\Items\PowerManagement;
+use FOG\Items\ScheduledTask;
+use FOG\Items\Task;
+use FOG\Managers\GroupPowerManagementManager;
+use FOG\Managers\TaskManager;
 use FOG\Router\Route;
 
 /**
@@ -156,7 +161,7 @@ class TaskScheduler extends FOGService
                 ' * '
                 . _('Checking for tasks that can never run...')
             );
-            $reaped = self::getClass('TaskManager')->reapUnrunnable();
+            $reaped = (new TaskManager())->reapUnrunnable();
             foreach ($reaped as $taskID => $why) {
                 self::outall(
                     sprintf(
@@ -182,7 +187,7 @@ class TaskScheduler extends FOGService
             ];
             $Tasks = Route::getList('task', $find);
             foreach ($Tasks as $Task) {
-                if(self::getClass('Task', $Task->id)->expireTaskCheckin()) {
+                if((new Task($Task->id))->expireTaskCheckin()) {
                     self::outall(
                         ' * '
                         . _('Found an expired task, resetting to queued for task of id')
@@ -216,7 +221,7 @@ class TaskScheduler extends FOGService
             // whose only wake schedule is a group grant has no host rows at
             // all, and the daemon would have thrown before ever reaching the
             // grant loop -- a schedule that silently never fires.
-            $GroupPMGrants = self::getClass('GroupPowerManagementManager')
+            $GroupPMGrants = (new GroupPowerManagementManager())
                 ->wakeGrants();
             $gtaskcount = count($GroupPMGrants);
 
@@ -238,7 +243,7 @@ class TaskScheduler extends FOGService
             unset($taskCount);
             // Scheduled Tasks
             foreach ($ScheduledTasks->data as $Task) {
-                $Task = self::getClass('ScheduledTask', $Task->id);
+                $Task = new ScheduledTask($Task->id);
                 $Timer = $Task->getTimer();
                 self::outall(
                     ' * '
@@ -336,7 +341,7 @@ class TaskScheduler extends FOGService
             }
             // Power Management Tasks.
             foreach ($PMTasks->data as $Task) {
-                $Task = self::getClass('PowerManagement', $Task->id);
+                $Task = new PowerManagement($Task->id);
                 $Timer = $Task->getTimer();
                 self::outall(
                     ' * '

--- a/packages/web/src/TaskHandling/TaskError.php
+++ b/packages/web/src/TaskHandling/TaskError.php
@@ -294,7 +294,7 @@ class TaskError extends FOGBase
     private static function _markFailed($Task)
     {
         $failed = TaskState::getFailedState();
-        if (!self::getClass('TaskState', $failed)->isValid()) {
+        if (!(new TaskState($failed))->isValid()) {
             return;
         }
         $Task->set('stateID', $failed)->save();
@@ -308,7 +308,7 @@ class TaskError extends FOGBase
         // the time the join fails the host row is gone too, which makes this
         // the last moment the name can be recorded at all. See TaskLog's
         // $databaseFields and schema step 341.
-        self::getClass('TaskLog')
+        (new TaskLog())
             ->set('taskID', $Task->get('id'))
             ->set('stateID', $Task->get('stateID'))
             ->set('createdBy', 'fos')

--- a/packages/web/src/TaskHandling/TaskQueue.php
+++ b/packages/web/src/TaskHandling/TaskQueue.php
@@ -16,8 +16,12 @@ namespace FOG\TaskHandling;
 use FOG\Audit\Audit;
 use FOG\Boot\UbootTftpSync;
 use FOG\Items\Image;
+use FOG\Items\MulticastSession;
+use FOG\Items\MulticastSessionAssociation;
 use FOG\Items\StorageNode;
+use FOG\Items\Task;
 use FOG\Items\TaskType;
+use FOG\Managers\HostManager;
 use FOG\Router\Route;
 
 /**
@@ -97,7 +101,7 @@ class TaskQueue extends TaskingElement
         if ($taskID < 1) {
             return;
         }
-        $Task = self::getClass('Task', $taskID);
+        $Task = new Task($taskID);
         if (!$Task->isValid()) {
             return;
         }
@@ -142,10 +146,7 @@ class TaskQueue extends TaskingElement
                     : 'getOptimalStorageNode';
                 if ($this->Task->isMulticast()) {
                     $msID = self::minId(Route::getIds('multicastsessionassociation', ['taskID' => $this->Task->get('id')], 'msID'));
-                    $MulticastSession = self::getClass(
-                        'MulticastSession',
-                        $msID
-                    );
+                    $MulticastSession = new MulticastSession($msID);
                     if (!$MulticastSession->isValid()) {
                         throw new \Exception(_('Invalid Multicast Session'));
                     }
@@ -190,10 +191,7 @@ class TaskQueue extends TaskingElement
                     }
                 } else {
                     $this->StorageNode = self::nodeFail(
-                        self::getClass(
-                            'StorageNode',
-                            $this->Task->get('storagenodeID')
-                        ),
+                        new StorageNode($this->Task->get('storagenodeID')),
                         self::$Host->get('id')
                     );
                     $nodeOk = $this->StorageNode instanceof StorageNode &&
@@ -628,7 +626,7 @@ class TaskQueue extends TaskingElement
                 'renderable' => 1
             ]);
             if ($this->Task->isMulticast()) {
-                $MCTask = self::getClass('MulticastSessionAssociation')
+                $MCTask = (new MulticastSessionAssociation())
                     ->set(
                         'taskID',
                         $this->Task->get('id')
@@ -697,7 +695,7 @@ class TaskQueue extends TaskingElement
                     _('Host is not valid; the task cannot be completed')
                 );
             }
-            $updatedHost = self::getClass('HostManager')->update(
+            $updatedHost = (new HostManager())->update(
                 ['id' => self::$Host->get('id')],
                 '',
                 $updateFields

--- a/packages/web/src/TaskHandling/TaskingElement.php
+++ b/packages/web/src/TaskHandling/TaskingElement.php
@@ -135,10 +135,7 @@ abstract class TaskingElement extends FOGBase
                     ['id' => $this->StorageGroup->get($getter)]
                 );
                 foreach ($StorageNodes as &$StorageNode) {
-                    $this->StorageNodes[] = self::getClass(
-                        'StorageNode',
-                        $StorageNode->id
-                    );
+                    $this->StorageNodes[] = new StorageNode($StorageNode->id);
                     unset($StorageNode);
                 }
                 if ($this->Task->isCapture()

--- a/packages/web/status/dbrunning.php
+++ b/packages/web/status/dbrunning.php
@@ -13,6 +13,7 @@
 
 use FOG\Base\FOGCore;
 use FOG\Db\DatabaseManager;
+use FOG\Items\Schema;
 use FOG\Router\HTTPResponseCodes;
 
 /**
@@ -31,7 +32,7 @@ set_time_limit(0);
 $link = DatabaseManager::getLink();
 $redirect = false;
 if ($link) {
-    $redirect = FOGCore::getClass('Schema', 1)
+    $redirect = (new Schema(1))
         ->get('version') == FOG_SCHEMA;
 }
 $ret = [

--- a/packages/web/status/hostgetkey.php
+++ b/packages/web/status/hostgetkey.php
@@ -12,6 +12,7 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Managers\HostManager;
 
 /**
  * Hostgetkey returns the host token for hostinfo getting
@@ -57,7 +58,7 @@ try {
         throw new \Exception(_('Host token is currently in use'));
     }
     if (!FOGCore::$Host->get('token')) {
-        FOGCore::getClass('HostManager')->update(
+        (new HostManager())->update(
             ['id' => FOGCore::$Host->get('id')],
             '',
             [
@@ -68,7 +69,7 @@ try {
         throw new \Exception(FOGCore::$Host->get('token'));
     }
     if (FOGCore::$Host->isValid() && !FOGCore::$Host->get('tokenlock')) {
-        FOGCore::getClass('HostManager')->update(
+        (new HostManager())->update(
             ['id' => FOGCore::$Host->get('id')],
             '',
             ['tokenlock' => true]

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4650,6 +4650,19 @@ parameters:
 			count: 1
 			path: packages/web/src/Router/Route.php
 
+		# StorageGroup::getMasterStorageNode() THROWS when it cannot produce a
+		# valid node, so `!$StorageNode` at the call site can never be true and
+		# PHPStan can see that now the node arrives as a concrete type rather
+		# than getClass()'s object|mixed. The guard is left in place: it is
+		# pre-existing defensive code, and deleting it would make a future
+		# change to that method's contract fatal at this call site instead of
+		# caught here.
+		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 1
+			path: packages/web/src/Router/Route.php
+
 		-
 			message: '#^Access to an undefined static property static\(FOG\\Service\\FOGItemScanner\)\:\:\$sleeptime\.$#'
 			identifier: staticProperty.notFound

--- a/tests/activity-sources.test.php
+++ b/tests/activity-sources.test.php
@@ -43,6 +43,7 @@
 
 use FOG\Base\FOGCore;
 use FOG\Base\Hook;
+use FOG\Items\User;
 use FOG\Router\Route;
 
 require_once __DIR__ . '/lib/fog-test-harness.php';
@@ -53,7 +54,7 @@ $db = FogTestHarness::fakeDb();
 $db->pdo->rowCount = 1;
 $db->pdo->countValue = 1;
 
-$user = FOGCore::getClass('User')->set('id', 1)->set('name', 'fog');
+$user = (new User())->set('id', 1)->set('name', 'fog');
 foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
     FogTestHarness::setStatic($cls, 'FOGUser', $user);
 }

--- a/tests/api-only-users.test.php
+++ b/tests/api-only-users.test.php
@@ -146,7 +146,7 @@ $t->check(
 );
 // Same request, the other artifact: a userAuths row outlives the response
 // even if the cookie somehow did not reach the browser.
-$authRowAt = strpos($pwBody, "getClass('UserAuth')");
+$authRowAt = strpos($pwBody, 'new UserAuth(');
 $t->check(
     'the refusal also precedes the userAuths row',
     false !== $refusalAt && false !== $authRowAt && $refusalAt < $authRowAt

--- a/tests/api-token-store.test.php
+++ b/tests/api-token-store.test.php
@@ -234,7 +234,7 @@ $t->check(
 $t->check(
     'resolve() refuses a token whose owner is gone',
     (bool)preg_match(
-        '/\$user\s*=\s*self::getClass\(\s*\'User\'.*?if\s*\(!\$user->isValid\(\)\)\s*\{(.*?)return null;/s',
+        '/\$user\s*=\s*new User\(.*?if\s*\(!\$user->isValid\(\)\)\s*\{(.*?)return null;/s',
         $modelSrc
     )
 );
@@ -448,7 +448,7 @@ $t->check(
         '/private function _resolve\(.*?\$token = \$this->visibleToken\(/s',
         $mgrSrc
     )
-    && !preg_match('/getClass\(.APIToken.,\s*\$tokenID/', $configSrc)
+    && !preg_match('/new APIToken\(\s*\$tokenID/', $configSrc)
 );
 
 // ---------------------------------------------------------------------------

--- a/tests/db-failure-is-recorded.test.php
+++ b/tests/db-failure-is-recorded.test.php
@@ -55,7 +55,12 @@
 
 use FOG\Base\FOGBase;
 use FOG\Base\FOGCore;
+use FOG\Items\Host;
+use FOG\Items\Task;
 use FOG\Items\TaskLog;
+use FOG\Items\TaskType;
+use FOG\Items\User;
+use FOG\Managers\TaskLogManager;
 
 require_once __DIR__ . '/lib/fog-test-harness.php';
 
@@ -147,7 +152,7 @@ FogTestHarness::setStatic('DatabaseManager', 'DB', $db);
 
 // The condition every machine-facing request boots into: LoadGlobals builds
 // `new User(0)` because there is no session to read FOG_USER from.
-$anon = FOGCore::getClass('User');
+$anon = new User();
 $GLOBALS['currentUser'] = $anon;
 FogTestHarness::setStatic('FOGBase', 'FOGUser', $anon);
 if ($anon->isValid()) {
@@ -199,7 +204,7 @@ $failures = [];
 // ---------------------------------------------------------------------
 // 1. An existing row whose write was rejected must not report success.
 // ---------------------------------------------------------------------
-$existing = FOGCore::getClass('TaskLog');
+$existing = new TaskLog();
 $existing->set('id', 4242)
     ->set('taskID', 7)
     ->set('text', 'save-failure existing row');
@@ -216,7 +221,7 @@ if (false !== $result) {
 // 2. A failed write must leave a record with no user signed in.
 // ---------------------------------------------------------------------
 $before = fogLogContents();
-$newRow = FOGCore::getClass('TaskLog');
+$newRow = new TaskLog();
 $newRow->set('taskID', 9)->set('text', 'save-failure new row');
 $newRow->save();
 $after = fogLogContents();
@@ -230,15 +235,15 @@ if ($after === $before) {
 // 3. The sink itself: TaskError::_logRow() discards save()'s return, so
 //    only a fix inside the framework can cover it.
 // ---------------------------------------------------------------------
-$host = FOGCore::getClass('Host');
+$host = new Host();
 $host->set('id', 11);
 FogTestHarness::setStatic('FOGBase', 'Host', $host);
 
-$task = FOGCore::getClass('Task');
+$task = new Task();
 $task->set('id', 33)->set('stateID', 3);
 // getTaskTypeText() dereferences the loaded TaskType object; the fake
 // database answers lazy loads with marker strings, so it is seeded directly.
-$task->set('type', FOGCore::getClass('TaskType')->set('id', 1)->set('name', 'Deploy'));
+$task->set('type', (new TaskType())->set('id', 1)->set('name', 'Deploy'));
 
 $before = fogLogContents();
 $writesBefore = $db->writes;
@@ -274,7 +279,7 @@ if ($db->writes === $writesBefore) {
 // ---------------------------------------------------------------------
 $db->rejectReads = true;
 $before = fogLogContents();
-$reader = FOGCore::getClass('TaskLog');
+$reader = new TaskLog();
 $reader->set('id', 8080)->load('id');
 if (fogLogContents() === $before) {
     $failures[] = 'a rejected SELECT in load() left no record -- an object '
@@ -286,7 +291,7 @@ if (fogLogContents() === $before) {
 // rejected read returns an EMPTY set, which the caller reads as "none of
 // those ids exist" rather than "the question was not asked".
 $before = fogLogContents();
-FOGCore::getClass('TaskLog')->loadMany([1, 2, 3], 'id');
+(new TaskLog())->loadMany([1, 2, 3], 'id');
 if (fogLogContents() === $before) {
     $failures[] = 'a rejected SELECT in loadMany() left no record -- the '
         . 'caller cannot tell an empty result from an unasked question';
@@ -318,7 +323,7 @@ $db->rejectReads = true;
 $db->rejectReads = false;
 $db->rejectFetch = true;
 $before = fogLogContents();
-$fetchReader = FOGCore::getClass('TaskLog');
+$fetchReader = new TaskLog();
 $fetchReader->set('id', 9090)->load('id');
 if (fogLogContents() === $before) {
     $failures[] = 'a SELECT that ran but could not be FETCHED left no record '
@@ -329,7 +334,7 @@ if (fogLogContents() === $before) {
 // assertion -- driving load() alone leaves the bulk read's check position
 // unpinned.
 $before = fogLogContents();
-FOGCore::getClass('TaskLog')->loadMany([4, 5, 6], 'id');
+(new TaskLog())->loadMany([4, 5, 6], 'id');
 if (fogLogContents() === $before) {
     $failures[] = 'a bulk SELECT that ran but could not be FETCHED left no '
         . 'record -- the caller reads the empty set as "none of those ids '
@@ -379,7 +384,7 @@ if ('the original cause' !== $realDb->error) {
 //    catch that handles both.
 // ---------------------------------------------------------------------
 $before = fogLogContents();
-FOGCore::getClass('TaskLog')->load('id');
+(new TaskLog())->load('id');
 if (fogLogContents() !== $before) {
     $failures[] = 'loading an object with no id wrote a fault line -- that is '
         . "load()'s normal control flow, not a database failure, and at that "
@@ -393,7 +398,7 @@ $db->rejectReads = false;
 //    The API's bulk edit is its busiest caller.
 // ---------------------------------------------------------------------
 $before = fogLogContents();
-$mass = FOGCore::getClass('TaskLogManager')->update(
+$mass = (new TaskLogManager())->update(
     ['id' => 1],
     'AND',
     ['text' => 'save-failure mass update']
@@ -412,7 +417,7 @@ if (fogLogContents() === $before) {
 // whether to CREATE, so an unreadable database becomes a duplicate row
 // rather than an error.
 $db->rejectReads = true;
-$manager = FOGCore::getClass('TaskLogManager');
+$manager = new TaskLogManager();
 $before = fogLogContents();
 // idField is 'name' by default and taskLog has no such column; hostName is
 // a real one, so the probe fails on the DATABASE rather than on the model.

--- a/tests/event-frame-readers.test.php
+++ b/tests/event-frame-readers.test.php
@@ -35,6 +35,8 @@
 
 use FOG\Base\FOGCore;
 use FOG\Base\Hook;
+use FOG\Items\Host;
+use FOG\Items\User;
 use FOG\Router\Route;
 
 require_once __DIR__ . '/lib/fog-test-harness.php';
@@ -45,7 +47,7 @@ $db = FogTestHarness::fakeDb();
 $db->pdo->rowCount = 1;
 $db->pdo->countValue = 1;
 
-$admin = FOGCore::getClass('User')->set('id', 1)->set('name', 'fog');
+$admin = (new User())->set('id', 1)->set('name', 'fog');
 foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
     FogTestHarness::setStatic($cls, 'FOGUser', $admin);
 }
@@ -230,7 +232,7 @@ foreach ($cases as $classname => $cols) {
     FogTestHarness::setStatic(
         'Route',
         'relCache',
-        ['host:41' => FOGCore::getClass('Host')->set('id', 41)->set('name', 'renamed')]
+        ['host:41' => (new Host())->set('id', 41)->set('name', 'renamed')]
     );
     $out = $link(41, $row);
     $t->check(

--- a/tests/fk-columns-clear-to-null.test.php
+++ b/tests/fk-columns-clear-to-null.test.php
@@ -230,7 +230,7 @@ $source = (string)file_get_contents($webroot . '/src/Pages/HostManagement.php');
 $check(
     'massEditPost() checks the update return rather than discarding it',
     1 === preg_match(
-        '/if\s*\(\s*!\s*self::getClass\(\s*.HostManager.\s*\)\s*'
+        '/if\s*\(\s*!\s*\(\s*new\s+HostManager\(\s*\)\s*\)\s*'
         . '->update\(\s*\[\s*.id.\s*=>\s*\$hosts\s*\]/s',
         $source
     )

--- a/tests/getclass-literals.test.php
+++ b/tests/getclass-literals.test.php
@@ -1,7 +1,28 @@
 <?php
 /**
- * Every getClass()/getManager() string literal must name a class that is
- * actually declared, spelled exactly as it is declared.
+ * getClass() may no longer be called with a string literal, and every literal
+ * that IS still allowed must name a class spelled exactly as declared.
+ *
+ * TWO invariants, and the first one is the newer and larger of the two.
+ *
+ * 1. A LITERAL getClass() IS REFUSED. `getClass('Host')` is `new Host()` with
+ *    the type erased: FOGBase::getClass() is documented `@return object|mixed`,
+ *    so PHPStan cannot check a single thing done to the result and no editor
+ *    can follow it to a definition. The 459 sites that used to be spelled that
+ *    way became plain `new` expressions, and this stops them growing back.
+ *
+ *    getClass() itself stays, for the one shape `new` cannot express: a class
+ *    named by a VARIABLE. `Route`, `Authorization::_scopeClassVars()` and
+ *    `OpenAPI::_entitySchema()` hold a lowercase API string and turn it into a
+ *    class through FOGBase::qualify(); that is what the function is for now.
+ *
+ *    The props form -- `getClass('X', '', true)` -- is also still allowed,
+ *    because it returns ReflectionClass::getDefaultProperties() rather than an
+ *    instance and has no `new` equivalent at all. So is 'ReflectionClass',
+ *    which getClass() special-cases.
+ *
+ * 2. Every literal that survives must name a class that is actually declared,
+ *    spelled exactly as it is declared.
  *
  * PHP resolves class names case-insensitively, so getClass('snapinjob') has
  * always found SnapinJob and getClass('MACAddressASsociationManager') has
@@ -35,10 +56,16 @@ $root = dirname(__DIR__);
 chdir($root);
 
 /*
- * Below this and the scan is not scanning anything -- a broken tokenizer
- * loop or a bad file filter would otherwise report a clean pass.
+ * Below this and the scan is not scanning anything -- a broken tokenizer loop
+ * or a bad file filter would otherwise report a clean pass.
+ *
+ * Anchored on DECLARED classes rather than on literals, which is the whole
+ * point of invariant 1: the literals are supposed to trend to zero, so
+ * counting them would make the gate weaker every time it succeeded. The
+ * declarations are walked by the same loop over the same files, so an empty
+ * count still proves the scan died.
  */
-const MIN_LITERALS = 200;
+const MIN_DECLARED = 300;
 
 $files = array_filter(
     explode("\n", (string) shell_exec('git ls-files "*.php"')),
@@ -51,6 +78,7 @@ $files = array_filter(
 
 $declared = [];   // exact name => true
 $literals = [];   // literal => [file:line, ...]
+$banned = [];     // [name, file:line] for a literal getClass() with no excuse
 
 foreach ($files as $file) {
     $tokens = token_get_all(file_get_contents($file));
@@ -121,7 +149,45 @@ foreach ($files as $file) {
             continue;
         }
         $name = trim($tokens[$k][1], "'\"");
-        $literals[$name][] = $file . ':' . $tokens[$k][2];
+        $where = $file . ':' . $tokens[$k][2];
+        $literals[$name][] = $where;
+        if ('getClass' !== $token[1]) {
+            continue;
+        }
+        // Invariant 1: which of the two excused shapes is this, if either?
+        // getClass() special-cases ReflectionClass, and the third argument
+        // asks for getDefaultProperties() rather than an instance. Neither
+        // has a `new` equivalent; everything else does.
+        if ('reflectionclass' === strtolower($name)) {
+            continue;
+        }
+        $depth = 0;
+        $argc = 1;
+        $third = '';
+        for ($m = $j; $m < $count; $m++) {
+            $tok = $tokens[$m];
+            if (is_string($tok) && false !== strpos('([{', $tok)) {
+                $depth++;
+                continue;
+            }
+            if (is_string($tok) && false !== strpos(')]}', $tok)) {
+                if (0 === --$depth) {
+                    break;
+                }
+                continue;
+            }
+            if (1 === $depth && ',' === $tok) {
+                $argc++;
+                continue;
+            }
+            if (3 === $argc && is_array($tok) && T_WHITESPACE !== $tok[0]) {
+                $third .= $tok[1];
+            }
+        }
+        if (3 === $argc && 'true' === strtolower(trim($third))) {
+            continue;
+        }
+        $banned[] = [$name, $where];
     }
 }
 
@@ -132,12 +198,25 @@ foreach ($literals as $sites) {
 
 $fail = false;
 
-if ($total < MIN_LITERALS) {
+if (count($declared) < MIN_DECLARED) {
     fwrite(
         STDERR,
-        "FAIL: only $total getClass()/getManager() literal(s) found, expected "
-        . "at least " . MIN_LITERALS . ". The scan is not scanning.\n"
+        'FAIL: only ' . count($declared) . ' class declaration(s) found, '
+        . 'expected at least ' . MIN_DECLARED . ". The scan is not scanning.\n"
     );
+    $fail = true;
+}
+
+// Invariant 1. Anything left here is a literal getClass() that is neither the
+// props form nor ReflectionClass, so it has a plain `new` equivalent.
+if ($banned !== []) {
+    fwrite(
+        STDERR,
+        'FAIL: ' . count($banned) . " literal getClass() call(s); use new:\n"
+    );
+    foreach ($banned as list($name, $where)) {
+        fwrite(STDERR, "  $where: getClass('$name') -- write new $name(...)\n");
+    }
     $fail = true;
 }
 

--- a/tests/grid-header-column-agreement.test.php
+++ b/tests/grid-header-column-agreement.test.php
@@ -37,6 +37,8 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Items\User;
+use FOG\Pages\HostManagement;
 
 require_once __DIR__ . '/lib/fog-test-harness.php';
 
@@ -48,7 +50,7 @@ $db->pdo->countValue = 1;
 
 // Unrestricted, so the header set is captured whole rather than the subset
 // one permission set happens to reach.
-$admin = FOGCore::getClass('User')->set('id', 1)->set('name', 'fog');
+$admin = (new User())->set('id', 1)->set('name', 'fog');
 foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
     FogTestHarness::setStatic($cls, 'FOGUser', $admin);
 }
@@ -69,7 +71,7 @@ $t = new FogChecks();
 function hostHeaderRow($pingActive)
 {
     FogTestHarness::setStatic('FOGBase', 'fogpingactive', $pingActive);
-    $page = FOGCore::getClass('HostManagement');
+    $page = new HostManagement();
     $row = $page->buildHeaderRow();
     preg_match_all('/<th\b[^>]*>/', $row, $ths);
     preg_match_all('/data-col="([^"]+)"/', $row, $cols);

--- a/tests/grid-host-name-order.test.php
+++ b/tests/grid-host-name-order.test.php
@@ -41,6 +41,7 @@
 
 use FOG\Base\FOGCore;
 use FOG\Base\Hook;
+use FOG\Items\User;
 use FOG\Router\Route;
 
 require_once __DIR__ . '/lib/fog-test-harness.php';
@@ -53,7 +54,7 @@ $db->pdo->countValue = 1;
 
 // Unrestricted, so the column table is captured whole rather than the subset
 // one permission set happens to reach. Same reasoning as the column contract.
-$admin = FOGCore::getClass('User')->set('id', 1)->set('name', 'fog');
+$admin = (new User())->set('id', 1)->set('name', 'fog');
 foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
     FogTestHarness::setStatic($cls, 'FOGUser', $admin);
 }

--- a/tests/group-capture-tasking.test.php
+++ b/tests/group-capture-tasking.test.php
@@ -19,6 +19,7 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Items\Group;
 use FOG\Router\Route;
 
 require __DIR__ . '/lib/fog-test-harness.php';
@@ -219,7 +220,7 @@ function taskSelection(array $hosts, $tasktype)
     global $inserts;
     $inserts = [];
     $error = '';
-    $Group = FOGCore::getClass('Group')
+    $Group = (new Group())
         ->set('name', 'selection')
         ->set('hosts', $hosts);
     try {

--- a/tests/group-grants-are-owned.test.php
+++ b/tests/group-grants-are-owned.test.php
@@ -40,6 +40,8 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Items\Group;
+use FOG\Items\User;
 
 require_once __DIR__ . '/lib/fog-test-harness.php';
 
@@ -49,7 +51,7 @@ $t = new FogChecks();
 $db = FogTestHarness::fakeDb();
 $root = dirname(__DIR__) . '/packages/web';
 
-$admin = FOGCore::getClass('User')->set('id', 1)->set('name', 'fog');
+$admin = (new User())->set('id', 1)->set('name', 'fog');
 foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
     FogTestHarness::setStatic($cls, 'FOGUser', $admin);
 }
@@ -70,7 +72,7 @@ function runGroup($db, $method, $arg, $groupID = 3, $respond = null)
 {
     $db->log = [];
     $db->responder = $respond;
-    FOGCore::getClass('Group')
+    (new Group())
         ->set('id', $groupID)
         ->{$method}($arg);
     $db->responder = null;

--- a/tests/group-order-is-settable.test.php
+++ b/tests/group-order-is-settable.test.php
@@ -38,6 +38,7 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Items\Group;
 
 require_once __DIR__ . '/lib/fog-test-harness.php';
 
@@ -105,7 +106,7 @@ $t->check(
 function saveGroupWithOrder($db)
 {
     $db->log = [];
-    FOGCore::getClass('Group')
+    (new Group())
         ->set('name', 'Lab')
         ->set('order', 7)
         ->save();
@@ -121,7 +122,7 @@ foreach (saveGroupWithOrder($db) as $sql) {
 }
 $t->check('saving a group writes the groupOrder column', $wrote);
 
-$loaded = FOGCore::getClass('Group')->set('order', 0);
+$loaded = (new Group())->set('order', 0);
 $t->check(
     'an order of 0 reads back as 0 rather than as unset',
     $loaded->get('order') === 0 || $loaded->get('order') === '0'

--- a/tests/group-power-management-is-a-grant.test.php
+++ b/tests/group-power-management-is-a-grant.test.php
@@ -220,7 +220,7 @@ if (preg_match(
 if ('' !== $post) {
     $check(
         'a scheduled save creates a GroupPowerManagement row',
-        false !== strpos($post, "getClass('GroupPowerManagement')")
+        false !== strpos($post, 'new GroupPowerManagement(')
         && false !== strpos($post, "->set('groupID', \$groupID)")
     );
     // THE FAN-OUT MUST BE REACHABLE ONLY FROM THE ON-DEMAND BRANCH. The old
@@ -255,13 +255,13 @@ if ('' !== $post) {
     $check(
         'the per-host fan-out is INSIDE the on-demand branch',
         '' !== $branch
-        && false !== strpos($branch, "getClass('PowerManagementManager')")
+        && false !== strpos($branch, 'new PowerManagementManager(')
     );
     $check(
         'the grant is created OUTSIDE the on-demand branch',
         '' !== $branch
-        && false === strpos($branch, "getClass('GroupPowerManagement')")
-        && false !== strpos($post, "getClass('GroupPowerManagement')")
+        && false === strpos($branch, 'new GroupPowerManagement(')
+        && false !== strpos($post, 'new GroupPowerManagement(')
     );
     // And the branch must not fall through: without the return, an immediate
     // action would fan out AND leave a standing grant behind it.

--- a/tests/history-untranslated-and-bounded.test.php
+++ b/tests/history-untranslated-and-bounded.test.php
@@ -45,6 +45,7 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Items\History;
 
 require __DIR__ . '/lib/fog-test-harness.php';
 
@@ -146,7 +147,7 @@ $t->check(
     && false !== strpos($helper, "'%s ID: %s'")
     && false !== strpos($helper, "' Name: %s'")
 );
-$history = FOGCore::getClass('History');
+$history = new History();
 $req = new \ReflectionProperty(get_class($history), 'databaseFieldsRequired');
 $req->setAccessible(true);
 $t->check(

--- a/tests/host-list-queue-task.test.php
+++ b/tests/host-list-queue-task.test.php
@@ -48,6 +48,7 @@
 
 use FOG\Auth\Authorization;
 use FOG\Base\FOGCore;
+use FOG\Items\Group;
 use FOG\Pages\HostManagement;
 
 require_once __DIR__ . '/lib/fog-test-harness.php';
@@ -228,7 +229,7 @@ $t->check(
 $db = FogTestHarness::fakeDb();
 $mark = count($db->log);
 
-$Selection = FOGCore::getClass('Group');
+$Selection = new Group();
 $Selection->set('name', '3 selected hosts');
 $Selection->set('hosts', [4, 9, 17]);
 $hosts = $Selection->get('hosts');
@@ -263,7 +264,7 @@ $db->responder = static function ($sql) use ($db) {
 
     return null;
 };
-$Real = FOGCore::getClass('Group');
+$Real = new Group();
 $Real->set('id', 3);
 $t->check(
     'a saved group still loads its members',

--- a/tests/host-list-quick-tasks.test.php
+++ b/tests/host-list-quick-tasks.test.php
@@ -58,6 +58,7 @@
 
 use FOG\Base\FOGCore;
 use FOG\Items\TaskType;
+use FOG\Items\User;
 use FOG\Pages\HostManagement;
 
 require_once __DIR__ . '/lib/fog-test-harness.php';
@@ -137,7 +138,7 @@ $page = new HostManagement();
  * @return string the emitted markup
  */
 $emit = static function (array $perms) use ($page, $items) {
-    $user = FOGCore::getClass('User')->set('id', 1)->set('name', 'fog');
+    $user = (new User())->set('id', 1)->set('name', 'fog');
     foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
         FogTestHarness::setStatic($cls, 'FOGUser', $user);
     }

--- a/tests/host-modules-are-tristate.test.php
+++ b/tests/host-modules-are-tristate.test.php
@@ -44,6 +44,8 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Items\Host;
+use FOG\Items\User;
 
 require_once __DIR__ . '/lib/fog-test-harness.php';
 
@@ -53,7 +55,7 @@ $t = new FogChecks();
 $db = FogTestHarness::fakeDb();
 $root = dirname(__DIR__) . '/packages/web';
 
-$admin = FOGCore::getClass('User')->set('id', 1)->set('name', 'fog');
+$admin = (new User())->set('id', 1)->set('name', 'fog');
 foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
     FogTestHarness::setStatic($cls, 'FOGUser', $admin);
 }
@@ -85,7 +87,7 @@ function writeState($db, array $existing, $ids, $state, $hostID = 5)
         }
         return null;
     };
-    FOGCore::getClass('Host')
+    (new Host())
         ->set('id', $hostID)
         ->setModuleState($ids, $state);
     $db->responder = null;

--- a/tests/host-site-csv-label.test.php
+++ b/tests/host-site-csv-label.test.php
@@ -212,7 +212,8 @@ check(
 // share the deduplication and the cascade the Site page goes through.
 check(
     'applyHostSite writes through the Site entity',
-    false !== strpos($apply, "self::getClass('Site',")
+    // methodSource() drops whitespace, so `new Site(` arrives as `newSite(`.
+    false !== strpos($apply, 'newSite(')
 );
 check(
     'hostSiteNames returns an array, not a bare string',

--- a/tests/lib/bootmenu-harness.php
+++ b/tests/lib/bootmenu-harness.php
@@ -70,11 +70,17 @@ class StubModel
     /**
      * Instantiates the record.
      *
-     * @param array $data the field data
+     * Deliberately untyped. FOGController accepts either an id or a field
+     * array, and callers now reach these stubs through a plain `new` rather
+     * than through the harness's getClass() switch, which used to do the
+     * `(array)` cast on the way past. Doing it here keeps what the switch
+     * produced rather than making every call site match the stub.
+     *
+     * @param mixed $data the field data, or the id
      */
-    public function __construct(array $data = [])
+    public function __construct($data = [])
     {
-        $this->data = $data;
+        $this->data = (array)$data;
     }
     /**
      * A record is valid when it carries a non-zero id.
@@ -319,6 +325,48 @@ class Image extends StubModel
  * calls is the behavior under test, and the golden shows it through the
  * storage= argument rather than through the node's identity.
  */
+/**
+ * The unlock key sequence a menu offers.
+ *
+ * Carried the harness's getClass() switch until IpxeBootMenu stopped going
+ * through it; the field values are that arm's, unchanged, because the golden
+ * file records the ascii code this emits.
+ */
+class KeySequence extends StubModel
+{
+    /**
+     * Instantiates the sequence.
+     *
+     * @param string $seq the configured sequence name
+     */
+    public function __construct($seq = '')
+    {
+        $seq = trim((string)$seq);
+        parent::__construct(
+            '' === $seq
+                ? []
+                : ['id' => 1, 'ascii' => '0x1b', 'name' => $seq]
+        );
+    }
+}
+/**
+ * A custom iPXE record, looked up by id.
+ *
+ * Same provenance as KeySequence above: this is the getClass() switch's arm
+ * as a class, so stub-buckets.php can alias it to FOG\Items\Ipxe.
+ */
+class Ipxe extends StubModel
+{
+    /**
+     * Instantiates the record.
+     *
+     * @param int $id the record id
+     */
+    public function __construct($id = 0)
+    {
+        parent::__construct(['id' => (int)$id]);
+    }
+}
 class StorageGroup extends StubModel
 {
     /**

--- a/tests/lib/fog-test-harness.php
+++ b/tests/lib/fog-test-harness.php
@@ -37,6 +37,7 @@
 use FOG\Base\EventManager;
 use FOG\Base\FOGCore;
 use FOG\Base\HookManager;
+use FOG\Items\User;
 
 /**
  * One prepared statement's worth of canned rows.
@@ -387,7 +388,7 @@ class FogTestHarness
         // has to exist before the first hook is built, even an anonymous one.
         // It falls back to $GLOBALS['currentUser'] when that user is invalid,
         // so both are seeded.
-        $anon = FOGCore::getClass('User');
+        $anon = new User();
         $GLOBALS['currentUser'] = $anon;
         self::setStatic('FOGBase', 'FOGUser', $anon);
 

--- a/tests/lib/rehearsal-runner.php
+++ b/tests/lib/rehearsal-runner.php
@@ -127,7 +127,7 @@ class RehearsalRunner extends \FOG\Base\FOGBase
             $ran++;
         }
         if ($stamp) {
-            $schema = self::getClass('Schema', 1);
+            $schema = new \FOG\Items\Schema(1);
             $schema->set('version', $landed)->save();
         }
 

--- a/tests/null-tasks-cannot-be-created-or-stranded.test.php
+++ b/tests/null-tasks-cannot-be-created-or-stranded.test.php
@@ -231,7 +231,7 @@ check(
  */
 check(
     'it goes through TaskManager::cancel, not a bare state update',
-    false !== strpos($imageCase, "getClass('TaskManager')"),
+    false !== strpos($imageCase, 'new TaskManager('),
     $failures,
     $checks
 );

--- a/tests/ping-alive-codes.test.php
+++ b/tests/ping-alive-codes.test.php
@@ -33,6 +33,7 @@
 
 use FOG\Base\FOGCore;
 use FOG\Base\Hook;
+use FOG\Items\User;
 use FOG\Net\Ping;
 use FOG\Router\Route;
 
@@ -128,7 +129,7 @@ $db = FogTestHarness::fakeDb();
 $db->pdo->rowCount = 1;
 $db->pdo->countValue = 1;
 
-$admin = FOGCore::getClass('User')->set('id', 1)->set('name', 'fog');
+$admin = (new User())->set('id', 1)->set('name', 'fog');
 foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
     FogTestHarness::setStatic($cls, 'FOGUser', $admin);
 }

--- a/tests/power-actions-are-tasks.test.php
+++ b/tests/power-actions-are-tasks.test.php
@@ -52,6 +52,7 @@
  * @link     https://fogproject.org
  */
 
+use FOG\Items\Host;
 use FOG\Pages\HostManagement;
 
 require_once __DIR__ . '/lib/fog-test-harness.php';
@@ -231,7 +232,7 @@ if (preg_match(
 // 4. The host's Power Management tab is schedules only.
 // -------------------------------------------------------------------------
 $host = new HostManagement();
-$obj = \FOG\Base\FOGCore::getClass('Host');
+$obj = new Host();
 $obj->set('id', 5);
 $objProp = new \ReflectionProperty(get_class($host), 'obj');
 $objProp->setAccessible(true);

--- a/tests/printer-grants-reach-the-client.test.php
+++ b/tests/printer-grants-reach-the-client.test.php
@@ -53,6 +53,8 @@
 
 use FOG\Base\FOGCore;
 use FOG\Client\PrinterClient;
+use FOG\Items\Host;
+use FOG\Items\User;
 
 require_once __DIR__ . '/lib/fog-test-harness.php';
 
@@ -61,7 +63,7 @@ FogTestHarness::boot('printer-grants-reach-the-client');
 $t = new FogChecks();
 $db = FogTestHarness::fakeDb();
 
-$admin = FOGCore::getClass('User')->set('id', 1)->set('name', 'fog');
+$admin = (new User())->set('id', 1)->set('name', 'fog');
 foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
     FogTestHarness::setStatic($cls, 'FOGUser', $admin);
 }
@@ -230,7 +232,7 @@ function askServer(
     FogTestHarness::setStatic(
         'FOGBase',
         'Host',
-        FOGCore::getClass('Host')->set('id', $hostID)->set('printerLevel', $level)
+        (new Host())->set('id', $hostID)->set('printerLevel', $level)
     );
     // newInstanceWithoutConstructor(), and this is the whole reason the
     // endpoint looked untestable. FOGClient's constructor resolves the host

--- a/tests/relationship-filter-in-join.test.php
+++ b/tests/relationship-filter-in-join.test.php
@@ -37,6 +37,7 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Items\Host;
 
 require __DIR__ . '/lib/fog-test-harness.php';
 
@@ -67,11 +68,11 @@ function relFilterBuild($class)
  *    and the test would be measuring nothing.
  */
 $relProp = new \ReflectionProperty(
-    get_class(FOGCore::getClass('Host')),
+    get_class(new Host()),
     'databaseFieldClassRelationships'
 );
 $relProp->setAccessible(true);
-$rels = $relProp->getValue(FOGCore::getClass('Host'));
+$rels = $relProp->getValue(new Host());
 $macRel = $rels['MACAddressAssociation'] ?? null;
 $t->check(
     'Host still declares a filtered relationship to MACAddressAssociation',

--- a/tests/route-cascade-contract.test.php
+++ b/tests/route-cascade-contract.test.php
@@ -51,6 +51,7 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Items\User;
 use FOG\Router\Route;
 
 require_once __DIR__ . '/lib/fog-test-harness.php';
@@ -63,7 +64,7 @@ $db = FogTestHarness::fakeDb();
 $db->pdo->rowCount = 1;
 $db->pdo->countValue = 1;
 
-$admin = FOGCore::getClass('User')->set('id', 1)->set('name', 'fog');
+$admin = (new User())->set('id', 1)->set('name', 'fog');
 foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
     FogTestHarness::setStatic($cls, 'FOGUser', $admin);
 }

--- a/tests/route-column-contract.test.php
+++ b/tests/route-column-contract.test.php
@@ -54,6 +54,7 @@
 
 use FOG\Base\FOGCore;
 use FOG\Base\Hook;
+use FOG\Items\User;
 use FOG\Router\Route;
 
 require_once __DIR__ . '/lib/fog-test-harness.php';
@@ -69,7 +70,7 @@ $db->pdo->countValue = 1;
 
 // An unrestricted user: the table must be captured whole, not the subset one
 // permission set happens to reach.
-$admin = FOGCore::getClass('User')->set('id', 1)->set('name', 'fog');
+$admin = (new User())->set('id', 1)->set('name', 'fog');
 foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
     FogTestHarness::setStatic($cls, 'FOGUser', $admin);
 }

--- a/tests/route-getter-contract.test.php
+++ b/tests/route-getter-contract.test.php
@@ -46,6 +46,7 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Items\User;
 use FOG\Router\Route;
 
 require_once __DIR__ . '/lib/fog-test-harness.php';
@@ -58,7 +59,7 @@ $db = FogTestHarness::fakeDb();
 $db->pdo->rowCount = 1;
 $db->pdo->countValue = 1;
 
-$admin = FOGCore::getClass('User')->set('id', 1)->set('name', 'fog');
+$admin = (new User())->set('id', 1)->set('name', 'fog');
 foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
     FogTestHarness::setStatic($cls, 'FOGUser', $admin);
 }

--- a/tests/route-read-path-guards.test.php
+++ b/tests/route-read-path-guards.test.php
@@ -56,6 +56,7 @@ use FOG\Auth\Authorization;
 use FOG\Auth\SiteScope;
 use FOG\Base\FOGCore;
 use FOG\Base\Hook;
+use FOG\Items\User;
 use FOG\Router\Route;
 
 require_once __DIR__ . '/lib/fog-test-harness.php';
@@ -171,7 +172,7 @@ function runChild($case)
     // The parent asserts the CLI arm, this asserts the request arm, and
     // between them they pin the gate rather than just one side of it.
     if ('scope-sql' === $case) {
-        $scoped = FOGCore::getClass('User')->set('id', 7)->set('name', 'scoped');
+        $scoped = (new User())->set('id', 7)->set('name', 'scoped');
         foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
             FogTestHarness::setStatic($cls, 'FOGUser', $scoped);
         }
@@ -884,7 +885,7 @@ $t->check('an ordinary setting keeps its value', 'bzImage' === ($plainSetting['v
  *    user with no site, silently. Each case below is asserted by identity.
  * ===========================================================================
  */
-$scopedUser = FOGCore::getClass('User')->set('id', 7)->set('name', 'scoped');
+$scopedUser = (new User())->set('id', 7)->set('name', 'scoped');
 foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
     FogTestHarness::setStatic($cls, 'FOGUser', $scopedUser);
 }
@@ -1317,7 +1318,7 @@ Route::$data = [];
  * ===========================================================================
  */
 $savedFogUser = FogTestHarness::getStatic('Authorization', 'FOGUser');
-$scopedUser2 = FOGCore::getClass('User')->set('id', 7)->set('name', 'scoped');
+$scopedUser2 = (new User())->set('id', 7)->set('name', 'scoped');
 foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
     FogTestHarness::setStatic($cls, 'FOGUser', $scopedUser2);
 }

--- a/tests/route-write-path-guards.test.php
+++ b/tests/route-write-path-guards.test.php
@@ -60,6 +60,7 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Items\User;
 use FOG\Router\Route;
 
 require_once __DIR__ . '/lib/fog-test-harness.php';
@@ -159,7 +160,7 @@ function runChild($case)
         return null;
     };
 
-    $admin = FOGCore::getClass('User')->set('id', 1)->set('name', 'fog');
+    $admin = (new User())->set('id', 1)->set('name', 'fog');
     foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
         FogTestHarness::setStatic($cls, 'FOGUser', $admin);
     }

--- a/tests/task-error-report.test.php
+++ b/tests/task-error-report.test.php
@@ -298,7 +298,7 @@ if (false === strpos($page, 'value="failed"')) {
 // 4. Guarded on the row existing. The web tree can be updated before the
 //    schema step runs, and writing a stateID with no taskStates row behind it
 //    is worse than leaving the task alone.
-if (!preg_match('#getClass\(\s*\'TaskState\'.*?isValid\(\)#s', $src)) {
+if (!preg_match('#new TaskState\(.*?isValid\(\)#s', $src)) {
     $fails[] = 'the endpoint writes the Failed state without checking the row'
         . ' exists, so a server updated ahead of its schema gets tasks'
         . ' pointing at a state that is not there';

--- a/tests/tasklog-records-cancel.test.php
+++ b/tests/tasklog-records-cancel.test.php
@@ -34,6 +34,7 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Items\Host;
 
 require __DIR__ . '/lib/fog-test-harness.php';
 
@@ -68,7 +69,7 @@ class CancelTask extends \FOG\Items\Task
     }
 }
 
-$host = FOGCore::getClass('Host')
+$host = (new Host())
     ->set('id', 42)
     ->set('name', 'lab-07');
 

--- a/tests/tasklog-report-retention.test.php
+++ b/tests/tasklog-report-retention.test.php
@@ -39,6 +39,8 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Items\Host;
+use FOG\Items\TaskLog;
 
 require __DIR__ . '/lib/fog-test-harness.php';
 
@@ -60,7 +62,7 @@ $t->check(
     (function () {
         $p = new \ReflectionProperty('FOG\Items\TaskLog', 'databaseFields');
         $p->setAccessible(true);
-        $fields = $p->getValue(FOGCore::getClass('TaskLog'));
+        $fields = $p->getValue(new TaskLog());
         return isset($fields['hostID'], $fields['hostName'], $fields['taskTypeName'])
             && 'logHostID' === $fields['hostID']
             && 'logHostName' === $fields['hostName']
@@ -68,7 +70,7 @@ $t->check(
     })()
 );
 
-$host = FOGCore::getClass('Host')
+$host = (new Host())
     ->set('id', 42)
     ->set('name', 'lab-07');
 

--- a/tests/tasklog-stamps-transition-time.test.php
+++ b/tests/tasklog-stamps-transition-time.test.php
@@ -29,6 +29,8 @@
  */
 
 use FOG\Base\FOGCore;
+use FOG\Items\Host;
+use FOG\Items\Image;
 
 require __DIR__ . '/lib/fog-test-harness.php';
 
@@ -71,12 +73,12 @@ class TransitionTask extends \FOG\Items\Task
     }
 }
 
-$host = FOGCore::getClass('Host')
+$host = (new Host())
     ->set('id', 42)
     ->set('name', 'lab-07');
 // Image declares name/path/imageTypeID/osID required, and recordState() only
 // takes the name off an image that isValid() -- so all four are set here.
-$image = FOGCore::getClass('Image')
+$image = (new Image())
     ->set('id', 9)
     ->set('name', 'win11-base')
     ->set('path', 'win11-base')

--- a/tests/unrunnable-tasks-are-reaped.test.php
+++ b/tests/unrunnable-tasks-are-reaped.test.php
@@ -95,7 +95,7 @@ check(
 check(
     'it refuses to run until the Failed state row exists',
     1 === preg_match(
-        "/getClass\('TaskState',\s*\\\$failed\)->isValid\(\)/",
+        "/\\(new TaskState\\(\\\$failed\\)\\)->isValid\\(\\)/",
         $reap
     ),
     $failures,


### PR DESCRIPTION
`FOGBase::getClass('Host')` was how core instantiated almost everything — **459 sites across 120 files**. This replaces every one whose class name is a *literal* with a plain `new`, and keeps `getClass()` for the one shape `new` cannot express.

## Why now

The factory exists because the Phase 3 namespacing migration needed a chokepoint: one function that turned a bare name into whatever the namespace happened to be that week, so 226 files could be renamed without touching those call sites. `docs/refactor-brief.md` says exactly that. **That migration is finished**, and what the literal sites are left paying is that `getClass()` is declared `@return object|mixed` — so PHPStan cannot check anything done to the result, and no editor can follow one to a definition.

It was never a substitution seam, which is the usual argument for keeping a factory: `qualify()` consults core's map *before* the plugins', and ADR 0013 says that ordering is what stops a plugin answering a core name.

## What the type erasure was hiding

Converting the tree produced **90 PHPStan errors against a baseline that reports zero**. Every one is pre-existing and was previously unreachable:

| Finding | What it was |
|---|---|
| `Schema::dropDuplicateData()` | `@return void` on a method whose body ends `return $queries;`, and `@param string $table` on a parameter indexed `[0]`, `[1]`, `[2]`. **74 of the 90.** |
| `FOGController::destroy()`, `Module::save()` | `@return object` on methods that `return false;` — so every `if (!$x->destroy())` guard in the tree read as dead code |
| `StorageNode::get()` | `@return object` on a method returning trimmed **strings**, which is why four `trim()` calls looked like `trim(object)` |
| `HostManagement::pendingMacsAjax()` | `$errt` assigned only inside two branches of a `try`, read unconditionally in the `catch` |

All corrected here — the annotations now match their bodies, and `$errt` is initialised before the `try`.

**One behavior change, called out:** `dropDuplicateData()`'s three bare `return;` guards became `return [];`. `fastmerge()` does `$array1 += $other`, and `array + null` is fatal on PHP 8, so that path was a latent crash rather than a no-op. It is not reachable from today's call sites (every one passes a non-empty literal), which is why nobody has hit it.

**One error is left in `phpstan-baseline.neon`**, with a comment saying why: a `!$StorageNode` guard after a method that throws rather than returning null. It is genuinely dead, but deleting defensive code on the strength of a docblock — in a PR that just proved this tree's docblocks unreliable — is the wrong direction.

## What stays `getClass()`

- **A class named by a variable — 56 sites.** `Route`, `Authorization::_scopeClassVars()`, `OpenAPI::_entitySchema()` and `FOGPage::$childClass` hold a lowercase string that arrived over the API or in a URL and turn it into a class through `qualify()`. Nothing else can do that.
- **`getClass('X', '', true)`** — returns `getDefaultProperties()`, not an instance. Three sites.
- **`getClass('ReflectionClass', …)`** — the factory special-cases it.

## Tests

- `tests/getclass-literals.test.php` now refuses a literal `getClass()`, and its scan-sanity anchor counts *declarations* rather than *literals* — counting literals would weaken the gate every time it succeeded. **Both halves were verified by reintroducing the defect and watching them go red**, and by confirming the props form still passes.
- **Eight tests read the source as text** and pinned the old spelling (`strpos($post, "getClass('GroupPowerManagement')")`). Updated to the new spelling, not loosened to accept both — accepting both would let the old form back in through the gate's own blind spot.
- **The boot-menu harness needed two stub classes.** `KeySequence` and `Ipxe` existed only as arms of `bootmenu-harness.php`'s own `getClass()` switch, so there was nothing for `stub-buckets.php` to alias. Promoted to classes; the golden iPXE output is **byte-identical**.
- Full suite: 318/319. The one failure, `certificate-table.test.php`, fails identically on `working-1.6` — environmental, not from this change.
- Both PHPStan passes green, unscoped.

## The tool

`bin/getclass-to-new.php` did the sweep and is kept, for the same reason fog-plugins keeps `bin/qualify-core-references.php`. It is **token-based**, so it leaves alone the 30 `getClass(` occurrences that live inside strings, docblocks and commented-out code, and it resolves names through the same core-then-plugins order `qualify()` does — so it cannot silently repoint a call at a plugin class.

## Downstream

- **fog-plugins** carries ~157 of its own literals and its docs taught this pattern. Converted in the same sweep (separate PR); `docs/plugin-development.md` here is updated to match. Plugins get inline FQCN rather than imports, because their own `tests/core-references-are-qualified.test.php` refuses a bare core name.
- **`feat/agent-enroll` (#1707)** touches the heaviest files here (`HostManagement.php`, `Route.php`, `Host.php`, `Group.php`, `FOGBase.php`). The same tool has been run on that branch so the two sides make an identical transformation to shared lines and the merge auto-resolves instead of conflicting.
- No route classes added or removed, so no FogApi sync is needed.

Refs ADR 0043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01684dJC9hw1jY4KjzV81BLC
