### PR TITLE
docs: the prescriptive examples say new, not getClass

### DIFF
--- a/docs/STORAGE_NODE_SELECTION_HOOKS.md
+++ b/docs/STORAGE_NODE_SELECTION_HOOKS.md
@@ -87,7 +87,7 @@ class MyStorageHook extends Hook
         $StorageGroup = $arguments['StorageGroup'];
 
         // ...your selection logic, e.g. by subnet, weighting, etc...
-        $chosen = self::getClass('StorageNode', $someNodeId);
+        $chosen = new \FOG\Items\StorageNode($someNodeId);
 
         if ($chosen->isValid()) {
             $arguments['StorageNode'] = $chosen;   // override FOG's choice

--- a/docs/adr/0013-flat-fog-namespace-and-the-reverse-alias-abi.md
+++ b/docs/adr/0013-flat-fog-namespace-and-the-reverse-alias-abi.md
@@ -4,6 +4,17 @@
 
 accepted
 
+## Amended 2026-09-04 — the literals this record counts are gone
+
+[ADR 0043](0043-a-class-is-named-at-the-call-site-not-fetched-by-string.md)
+retired the literal `getClass('X')`, so the "~520 literals" and "~350
+literals" counted below are now `new` expressions and the roughly 150 inside
+`fog-plugins` are fully qualified. Nothing here is withdrawn: `qualify()`, its
+short-name map and the core-before-plugins order are unchanged and still
+load-bearing — they now serve names held in **variables**, which is what
+`Route`, `Authorization` and `OpenAPI` hand it, rather than names spelled out
+at the call site.
+
 ## Amended 2026-08-31 — plugins are namespaced too, and the alias advice is withdrawn
 
 > **Superseded the same day by [ADR 0035](0035-a-plugin-is-laid-out-like-core.md),

--- a/docs/development/foreign-keys.md
+++ b/docs/development/foreign-keys.md
@@ -284,7 +284,7 @@ where.**
 `deletemass('image')` does this today:
 
 ```php
-self::getClass('HostManager')->update($findWhere, '', ['imageID' => 0]);
+(new HostManager())->update($findWhere, '', ['imageID' => null]);
 ```
 
 An image assigned to hosts *can* be deleted; the hosts are unassigned. That

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -882,7 +882,7 @@ Once your callback has proven who somebody is, hand the identity to FOG and
 **say how you proved it**:
 
 ```php
-$user = self::getClass('User', $uid);
+$user = new \FOG\Items\User($uid);
 $user->establishSession('oidc');
 ```
 


### PR DESCRIPTION
Follow-up to #1710, which merged while this commit was still local — the branch was locked by the merge queue, so it could not go in with the rest.

Every doc mentioning `getClass` was triaged. The planning records (`refactor-brief.md`, `refactor-facts.md`, `refactor-phase3-plan.md`, `composer-psr4-plan.md`, `hook-event-plan.md`, the `route-listem` pair) describe what was true when they were written and are **left alone**. What is corrected here is only the prose a developer copies from:

| File | What it was |
|---|---|
| `docs/STORAGE_NODE_SELECTION_HOOKS.md` | the `pickNode()` example a hook author is meant to paste |
| `docs/plugin-development.md` | the `establishSession()` example |
| `docs/development/foreign-keys.md` | **this one had drifted twice** |
| `docs/adr/0013-…` | an amendment, not an edit |

`foreign-keys.md` quotes `deletemass('image')` as evidence that FOG already writes SET NULL in PHP, and the quote still said `['imageID' => 0]` — schema step 386 made that a real `null`. So the quote was wrong about the thing it was cited to prove, independently of this refactor. It now says what the code says.

ADR 0013 counts "~520 `getClass()` literals" as a live fact, which reads as an invitation to add more. It gets a dated amendment rather than a rewrite, and **nothing in it is withdrawn** — `qualify()`, its short-name map and the core-before-plugins order are unchanged and still load-bearing; they now serve names held in variables.

`FOGProject/fog-docs#182` carries the same edit to the two published copies. Its translations are regenerated by `scripts/translate.mjs`, so only the English source is touched there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01684dJC9hw1jY4KjzV81BLC
