### PR TITLE
Info card: one-click Deploy/Capture, and no more "Primary Group"

### DIFF
--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -5316,6 +5316,7 @@ function reinitialize() {
   setupPasswordReveal();
   setupUniversalSearch();
   setupInfoCard();
+  setupInfoCardActions();
 };
 
 /**
@@ -5381,6 +5382,73 @@ function setupInfoCard() {
         note.text(value);
       });
   });
+}
+
+
+/**
+ * The info card's one-click task buttons.
+ *
+ * Straight to the create endpoint. The options form at
+ * ?node={node}&sub=deploy is skipped deliberately -- Deploy, Capture and
+ * Multi-Cast need nothing off it, and fetching it only to post it back
+ * unchanged is the click this exists to remove. Everything that form's POST
+ * is checked for -- a pending host, an assigned and enabled image, a
+ * protected image on a capture, one image across a multicast -- is checked
+ * in deployPost(), not in the form, so nothing is skipped but the rendering.
+ *
+ * scheduleType is the one field that must be sent: validateScheduleType()
+ * throws on an absent value rather than defaulting, so an empty body would
+ * come back "Invalid scheduling type".
+ *
+ * Every button confirms first. The list grid's equivalents do not, but there
+ * you have ticked a row to get them; here you arrive on this page just by
+ * clicking a host name, and one stray click would deploy over a running
+ * machine -- or, from a group, over all of them. The text is built server
+ * side (FOGPageRender::renderQuickTaskActions) because it is translated.
+ */
+function setupInfoCardActions() {
+  // Guards the window between the click and the server's answer. Per button
+  // rather than one flag for the card: Deploy and Capture are different
+  // taskings and there is no reason firing one should block the other. The
+  // button stays enabled underneath so nothing has to re-enable it on a
+  // refusal; this is only about the impatient double-click, which would
+  // otherwise be two identical taskings.
+  var running = {};
+
+  // Delegated and namespaced: the card is torn down and rebuilt with the
+  // page on every AJAX nav, so a direct binding would be lost on the first
+  // one and doPageLoad() would stack a new one per visit.
+  $(document)
+    .off('click.fogQuickTask')
+    .on('click.fogQuickTask', '.fog-quicktask', function(e) {
+      e.preventDefault();
+      var btn = $(this),
+        node = btn.data('node'),
+        id = btn.data('id'),
+        type = btn.data('type'),
+        key = node + ':' + id + ':' + type;
+      if (running[key]) {
+        return;
+      }
+      if (!window.confirm(btn.data('confirm'))) {
+        return;
+      }
+      running[key] = true;
+      $.apiCall(
+          'post',
+          '../management/index.php?node=' + encodeURIComponent(node)
+            + '&sub=deploy&id=' + encodeURIComponent(id)
+            + '&type=' + encodeURIComponent(type),
+          {scheduleType: 'instant'},
+          function() {
+            // Both outcomes land here and both only need the lock released.
+            // apiCall has already drawn the toast, and there is nothing on
+            // this page to repaint: the card's Last Deployed is the date the
+            // last task FINISHED, which a task just queued has not.
+            running[key] = false;
+          }
+      );
+    });
 }
 
 // Select2 builds its search inputs with neither id/name nor a label, tripping

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -2403,6 +2403,10 @@ msgid "Create Users On First Login"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "Create a %1$s task for %2$s?"
+msgstr "Benutzer erfolgreich erstellt"
+
+#, fuzzy, php-format
 msgid "Create a %s"
 msgstr "Neue %s erstellen"
 
@@ -7846,6 +7850,10 @@ msgstr ""
 msgid "Queued deletion is not active and cannot be canceled"
 msgstr "Snapin ist geschützt und kann nicht gelöscht werden"
 
+#, fuzzy
+msgid "Quick tasks"
+msgstr "Aktive Multicast-Tasks"
+
 msgid "RESOURCES"
 msgstr ""
 
@@ -10389,7 +10397,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -11829,6 +11836,10 @@ msgstr ""
 msgid "ago"
 msgstr "vor"
 
+#, php-format
+msgid "all %1$d hosts in group \"%2$s\""
+msgstr ""
+
 #, fuzzy
 msgid "all current storage nodes"
 msgstr "momentanen Speicherknoten löschen."
@@ -12123,6 +12134,10 @@ msgstr ""
 
 msgid "host"
 msgstr "Host"
+
+#, fuzzy, php-format
+msgid "host \"%s\""
+msgstr "Hosts"
 
 #, fuzzy
 msgid "host is"
@@ -13785,10 +13800,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "min (all)"
 #~ msgstr "Aktiviert"
-
-#, fuzzy
-#~ msgid "multicast tasks!"
-#~ msgstr "Aktive Multicast-Tasks"
 
 #, fuzzy
 #~ msgid "no database to"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -2406,6 +2406,10 @@ msgid "Create Users On First Login"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "Create a %1$s task for %2$s?"
+msgstr "User created"
+
+#, fuzzy, php-format
 msgid "Create a %s"
 msgstr "Create New %s"
 
@@ -7857,6 +7861,10 @@ msgstr ""
 msgid "Queued deletion is not active and cannot be canceled"
 msgstr "Snapin is protected and cannot be deleted"
 
+#, fuzzy
+msgid "Quick tasks"
+msgstr "Active Multicast Tasks"
+
 msgid "RESOURCES"
 msgstr ""
 
@@ -10398,7 +10406,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -11837,6 +11844,10 @@ msgstr ""
 msgid "ago"
 msgstr " ago"
 
+#, php-format
+msgid "all %1$d hosts in group \"%2$s\""
+msgstr ""
+
 #, fuzzy
 msgid "all current storage nodes"
 msgstr "Invalid storage node"
@@ -12128,6 +12139,10 @@ msgid "hit rate"
 msgstr ""
 
 msgid "host"
+msgstr "host"
+
+#, fuzzy, php-format
+msgid "host \"%s\""
 msgstr "host"
 
 #, fuzzy
@@ -13746,10 +13761,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "min (all)"
 #~ msgstr "Enabled"
-
-#, fuzzy
-#~ msgid "multicast tasks!"
-#~ msgstr "Active Multicast Tasks"
 
 #, fuzzy
 #~ msgid "no database to"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2424,6 +2424,10 @@ msgid "Create Users On First Login"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "Create a %1$s task for %2$s?"
+msgstr "creado por el usuario"
+
+#, fuzzy, php-format
 msgid "Create a %s"
 msgstr "Crear nuevo grupo"
 
@@ -7976,6 +7980,10 @@ msgstr ""
 msgid "Queued deletion is not active and cannot be canceled"
 msgstr "está protegido, no se permite la eliminación"
 
+#, fuzzy
+msgid "Quick tasks"
+msgstr "MulticastTask"
+
 msgid "RESOURCES"
 msgstr ""
 
@@ -10557,7 +10565,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -11998,6 +12005,10 @@ msgstr ""
 msgid "ago"
 msgstr " hace"
 
+#, php-format
+msgid "all %1$d hosts in group \"%2$s\""
+msgstr ""
+
 #, fuzzy
 msgid "all current storage nodes"
 msgstr "nodo de almacenamiento no válido"
@@ -12290,6 +12301,10 @@ msgid "hit rate"
 msgstr ""
 
 msgid "host"
+msgstr "anfitrión"
+
+#, fuzzy, php-format
+msgid "host \"%s\""
 msgstr "anfitrión"
 
 #, fuzzy
@@ -13892,10 +13907,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "min (all)"
 #~ msgstr "habilitado"
-
-#, fuzzy
-#~ msgid "multicast tasks!"
-#~ msgstr "MulticastTask"
 
 #, fuzzy
 #~ msgid "not found on disk"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2403,6 +2403,10 @@ msgid "Create Users On First Login"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "Create a %1$s task for %2$s?"
+msgstr "Benutzer erfolgreich erstellt"
+
+#, fuzzy, php-format
 msgid "Create a %s"
 msgstr "Neue %s erstellen"
 
@@ -7847,6 +7851,10 @@ msgstr ""
 msgid "Queued deletion is not active and cannot be canceled"
 msgstr "Snapin ist geschützt und kann nicht gelöscht werden"
 
+#, fuzzy
+msgid "Quick tasks"
+msgstr "Aktive Multicast-Tasks"
+
 msgid "RESOURCES"
 msgstr ""
 
@@ -10390,7 +10398,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -11830,6 +11837,10 @@ msgstr ""
 msgid "ago"
 msgstr "vor"
 
+#, php-format
+msgid "all %1$d hosts in group \"%2$s\""
+msgstr ""
+
 #, fuzzy
 msgid "all current storage nodes"
 msgstr "momentanen Speicherknoten löschen."
@@ -12124,6 +12135,10 @@ msgstr ""
 
 msgid "host"
 msgstr "Host"
+
+#, fuzzy, php-format
+msgid "host \"%s\""
+msgstr "Hosts"
 
 #, fuzzy
 msgid "host is"
@@ -13786,10 +13801,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "min (all)"
 #~ msgstr "Aktiviert"
-
-#, fuzzy
-#~ msgid "multicast tasks!"
-#~ msgstr "Aktive Multicast-Tasks"
 
 #, fuzzy
 #~ msgid "no database to"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2406,6 +2406,10 @@ msgid "Create Users On First Login"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "Create a %1$s task for %2$s?"
+msgstr "utilisateur créé"
+
+#, fuzzy, php-format
 msgid "Create a %s"
 msgstr "Créer un nouveau %s"
 
@@ -7842,6 +7846,10 @@ msgstr ""
 msgid "Queued deletion is not active and cannot be canceled"
 msgstr "Snapin est protégé et ne peut être supprimé"
 
+#, fuzzy
+msgid "Quick tasks"
+msgstr "Tâches Multicast actifs"
+
 msgid "RESOURCES"
 msgstr ""
 
@@ -10382,7 +10390,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -11822,6 +11829,10 @@ msgstr ""
 msgid "ago"
 msgstr " depuis"
 
+#, php-format
+msgid "all %1$d hosts in group \"%2$s\""
+msgstr ""
+
 #, fuzzy
 msgid "all current storage nodes"
 msgstr "nœud de stockage non valide"
@@ -12113,6 +12124,10 @@ msgid "hit rate"
 msgstr ""
 
 msgid "host"
+msgstr "hôte"
+
+#, fuzzy, php-format
+msgid "host \"%s\""
 msgstr "hôte"
 
 #, fuzzy
@@ -13735,10 +13750,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "min (all)"
 #~ msgstr "Activée"
-
-#, fuzzy
-#~ msgid "multicast tasks!"
-#~ msgstr "Tâches Multicast actifs"
 
 #, fuzzy
 #~ msgid "no database to"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -2348,6 +2348,10 @@ msgid "Create Users On First Login"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "Create a %1$s task for %2$s?"
+msgstr "Creazione utente riuscita"
+
+#, fuzzy, php-format
 msgid "Create a %s"
 msgstr "Crea nuovo %s"
 
@@ -7639,6 +7643,10 @@ msgstr ""
 msgid "Queued deletion is not active and cannot be canceled"
 msgstr "Snapin è protetto e non può essere cancellato"
 
+#, fuzzy
+msgid "Quick tasks"
+msgstr "Compiti multicast attivi"
+
 msgid "RESOURCES"
 msgstr ""
 
@@ -10105,7 +10113,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -11505,6 +11512,10 @@ msgstr ""
 msgid "ago"
 msgstr "fa"
 
+#, php-format
+msgid "all %1$d hosts in group \"%2$s\""
+msgstr ""
+
 msgid "all current storage nodes"
 msgstr "tutti i nodi di archiviazione attivi"
 
@@ -11787,6 +11798,10 @@ msgstr ""
 
 msgid "host"
 msgstr "host"
+
+#, fuzzy, php-format
+msgid "host \"%s\""
+msgstr "hosts"
 
 #, fuzzy
 msgid "host is"
@@ -13386,10 +13401,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "min (all)"
 #~ msgstr "Abilitato"
-
-#, fuzzy
-#~ msgid "multicast tasks!"
-#~ msgstr "Compiti multicast attivi"
 
 #~ msgid "no database to"
 #~ msgstr "Nessun database a"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -2333,6 +2333,10 @@ msgid "Create Users On First Login"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "Create a %1$s task for %2$s?"
+msgstr "タスク状態を作成"
+
+#, fuzzy, php-format
 msgid "Create a %s"
 msgstr "新しい %s を作成"
 
@@ -7619,6 +7623,10 @@ msgstr ""
 msgid "Queued deletion is not active and cannot be canceled"
 msgstr "スナップインは保護されているため削除できません"
 
+#, fuzzy
+msgid "Quick tasks"
+msgstr "マルチキャストタスク"
+
 msgid "RESOURCES"
 msgstr ""
 
@@ -10062,7 +10070,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -11461,6 +11468,10 @@ msgstr ""
 msgid "ago"
 msgstr "前"
 
+#, php-format
+msgid "all %1$d hosts in group \"%2$s\""
+msgstr ""
+
 msgid "all current storage nodes"
 msgstr "現在のすべてのストレージノード"
 
@@ -11742,6 +11753,10 @@ msgid "hit rate"
 msgstr "ビットレート"
 
 msgid "host"
+msgstr "ホスト"
+
+#, fuzzy, php-format
+msgid "host \"%s\""
 msgstr "ホスト"
 
 #, fuzzy
@@ -14894,10 +14909,6 @@ msgstr ""
 
 #~ msgid "more secure"
 #~ msgstr "より安全"
-
-#, fuzzy
-#~ msgid "multicast tasks!"
-#~ msgstr "マルチキャストタスク"
 
 #~ msgid "no login will appear"
 #~ msgstr "ログイン画面は表示されません"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -2077,6 +2077,10 @@ msgid "Create Users On First Login"
 msgstr ""
 
 #, php-format
+msgid "Create a %1$s task for %2$s?"
+msgstr ""
+
+#, php-format
 msgid "Create a %s"
 msgstr ""
 
@@ -6722,6 +6726,9 @@ msgstr ""
 msgid "Queued deletion is not active and cannot be canceled"
 msgstr ""
 
+msgid "Quick tasks"
+msgstr ""
+
 msgid "RESOURCES"
 msgstr ""
 
@@ -8906,7 +8913,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -10185,6 +10191,10 @@ msgstr ""
 msgid "ago"
 msgstr ""
 
+#, php-format
+msgid "all %1$d hosts in group \"%2$s\""
+msgstr ""
+
 msgid "all current storage nodes"
 msgstr ""
 
@@ -10439,6 +10449,10 @@ msgid "hit rate"
 msgstr ""
 
 msgid "host"
+msgstr ""
+
+#, php-format
+msgid "host \"%s\""
 msgstr ""
 
 msgid "host is"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -2406,6 +2406,10 @@ msgid "Create Users On First Login"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "Create a %1$s task for %2$s?"
+msgstr "usuário criado"
+
+#, fuzzy, php-format
 msgid "Create a %s"
 msgstr "Criar novo %s"
 
@@ -7844,6 +7848,10 @@ msgstr ""
 msgid "Queued deletion is not active and cannot be canceled"
 msgstr "Snapin está protegido e não pode ser excluído"
 
+#, fuzzy
+msgid "Quick tasks"
+msgstr "Tarefas Multicast ativos"
+
 msgid "RESOURCES"
 msgstr ""
 
@@ -10385,7 +10393,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -11825,6 +11832,10 @@ msgstr ""
 msgid "ago"
 msgstr " atrás"
 
+#, php-format
+msgid "all %1$d hosts in group \"%2$s\""
+msgstr ""
+
 #, fuzzy
 msgid "all current storage nodes"
 msgstr "nó de armazenamento inválido"
@@ -12116,6 +12127,10 @@ msgid "hit rate"
 msgstr ""
 
 msgid "host"
+msgstr "anfitrião"
+
+#, fuzzy, php-format
+msgid "host \"%s\""
 msgstr "anfitrião"
 
 #, fuzzy
@@ -13738,10 +13753,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "min (all)"
 #~ msgstr "ativado"
-
-#, fuzzy
-#~ msgid "multicast tasks!"
-#~ msgstr "Tarefas Multicast ativos"
 
 #, fuzzy
 #~ msgid "no database to"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -2406,6 +2406,10 @@ msgid "Create Users On First Login"
 msgstr ""
 
 #, fuzzy, php-format
+msgid "Create a %1$s task for %2$s?"
+msgstr "用户创建"
+
+#, fuzzy, php-format
 msgid "Create a %s"
 msgstr "新建%s"
 
@@ -7844,6 +7848,10 @@ msgstr ""
 msgid "Queued deletion is not active and cannot be canceled"
 msgstr "管理单元被保护，不能被删除"
 
+#, fuzzy
+msgid "Quick tasks"
+msgstr "活动组播任务"
+
 msgid "RESOURCES"
 msgstr ""
 
@@ -10385,7 +10393,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -11825,6 +11832,10 @@ msgstr ""
 msgid "ago"
 msgstr "前"
 
+#, php-format
+msgid "all %1$d hosts in group \"%2$s\""
+msgstr ""
+
 #, fuzzy
 msgid "all current storage nodes"
 msgstr "无效的存储节点"
@@ -12116,6 +12127,10 @@ msgid "hit rate"
 msgstr ""
 
 msgid "host"
+msgstr "主办"
+
+#, fuzzy, php-format
+msgid "host \"%s\""
 msgstr "主办"
 
 #, fuzzy
@@ -13738,10 +13753,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "min (all)"
 #~ msgstr "启用"
-
-#, fuzzy
-#~ msgid "multicast tasks!"
-#~ msgstr "活动组播任务"
 
 #, fuzzy
 #~ msgid "no database to"

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -100,6 +100,18 @@ abstract class FOGPage extends FOGBase
      */
     public $noteSources = [];
     /**
+     * Pre-rendered action buttons for the info card, or ''.
+     *
+     * Sits to the right of the notes in the same card. Built by a page's
+     * edit() -- renderQuickTaskActions() is the only builder today -- and
+     * echoed by renderInfoCard(). A string rather than a spec array because
+     * the only thing the renderer does with it is echo it, and the pages
+     * that set it are already building markup with makeButton().
+     *
+     * @var string
+     */
+    public $noteActions = '';
+    /**
      * Table header data
      *
      * @var array

--- a/packages/web/src/Base/FOGPageRender.php
+++ b/packages/web/src/Base/FOGPageRender.php
@@ -562,11 +562,19 @@ trait FOGPageRender
      * reason: those are the types that need no options, which is the whole
      * reason they can be one click.
      *
-     * Neutral outline buttons rather than a type color. Nothing here is the
-     * card's commit action -- the General tab's Update is -- and these are
-     * shortcuts sitting in a header strip, not a decision cluster in a form
-     * footer. The weight that a red button would carry is carried instead
-     * by the confirmation, which names the target and cannot be skipped.
+     * btn-secondary, and neither of them primary. Nothing here is the card's
+     * commit action -- the General tab's Update is -- so these are two
+     * shortcuts in a header strip, not a decision cluster in a form footer,
+     * and the weight a red button would carry is carried by the
+     * confirmation instead. It is also what the list grid's own quick
+     * buttons are, since DataTables draws its button bar that way.
+     *
+     * Filled, NOT btn-outline-secondary, and that is a contrast decision
+     * rather than a taste one. Outline keeps #6c757d as the TEXT color, and
+     * against the dark card (#212529) that is 3.29:1 -- under the 4.5:1 AA
+     * floor for body-sized text. Filled puts white on #6c757d instead and
+     * holds 4.69:1 in both themes. Measured against the shipped
+     * adminlte4.min.css + fog-default-ui.min.css, not assumed.
      *
      * @param string $node    Page node, e.g. 'host' or 'group'. Also decides
      *                        the permission: ?node=X&sub=deploy resolves to
@@ -616,7 +624,7 @@ trait FOGPageRender
                 'quicktask-' . \Initiator::e($node) . '-' . (int)$TaskType->get('id'),
                 '<i class="fas fa-' . \Initiator::e((string)$TaskType->get('icon'))
                 . '"></i> ' . \Initiator::e($name),
-                'btn btn-outline-secondary fog-quicktask',
+                'btn btn-secondary fog-quicktask',
                 'type="button"'
                 . ' data-node="' . \Initiator::e($node) . '"'
                 . ' data-id="' . (int)$id . '"'

--- a/packages/web/src/Base/FOGPageRender.php
+++ b/packages/web/src/Base/FOGPageRender.php
@@ -546,23 +546,120 @@ trait FOGPageRender
         return $attrs;
     }
 
+    /**
+     * The info card's one-click task buttons.
+     *
+     * The host and group LIST grids have carried these since
+     * HostManagement::_quickTaskItems(): the two or three task types that
+     * take no options, fired straight at the create endpoint instead of
+     * fetching an options form only to post it back untouched. This is the
+     * same affordance on the edit pages, so an admin already looking at a
+     * host or a group does not have to go back to the grid, find the row
+     * again and tick it to do the obvious thing to it.
+     *
+     * Deploy and Capture for a host, Deploy and Multi-Cast for a group --
+     * the same pairing _quickTaskItems() documents, and for the same
+     * reason: those are the types that need no options, which is the whole
+     * reason they can be one click.
+     *
+     * Neutral outline buttons rather than a type color. Nothing here is the
+     * card's commit action -- the General tab's Update is -- and these are
+     * shortcuts sitting in a header strip, not a decision cluster in a form
+     * footer. The weight that a red button would carry is carried instead
+     * by the confirmation, which names the target and cannot be skipped.
+     *
+     * @param string $node    Page node, e.g. 'host' or 'group'. Also decides
+     *                        the permission: ?node=X&sub=deploy resolves to
+     *                        X.task via Authorization::_subToAction(), so
+     *                        the gate here and the gate the POST hits are
+     *                        the same string by construction.
+     * @param int    $id      The entity being edited.
+     * @param array  $typeIds TaskType ids, in the order they should appear.
+     * @param string $target  Already-translated description of what the task
+     *                        lands on, e.g. 'host "foo"'. Interpolated into
+     *                        the confirmation. Built by the caller because
+     *                        only the caller knows whether it is one machine
+     *                        or a group of them.
+     *
+     * @return string The button group markup, or '' if none may be shown.
+     */
+    public static function renderQuickTaskActions(
+        $node,
+        $id,
+        array $typeIds,
+        $target
+    ) {
+        // Same refusal _quickTaskItems() makes: a user without the
+        // permission would be shown buttons whose POST can only be denied.
+        if (!Authorization::can($node . '.task')) {
+            return '';
+        }
+
+        $buttons = '';
+        foreach ($typeIds as $typeId) {
+            $TaskType = new TaskType($typeId);
+            // A server whose taskTypes row was deleted simply loses that
+            // button, the same way the accordion and the grid lose theirs.
+            if (!$TaskType->isValid()) {
+                continue;
+            }
+            $name = (string)$TaskType->get('name');
+            // Built here, not in the script. gettext runs server side, so a
+            // sentence assembled in JS would never reach the .pot -- the
+            // same reason noteSourceAttrs() builds its on/off labels here.
+            $confirm = sprintf(
+                _('Create a %1$s task for %2$s?'),
+                $name,
+                $target
+            );
+            $buttons .= self::makeButton(
+                'quicktask-' . \Initiator::e($node) . '-' . (int)$TaskType->get('id'),
+                '<i class="fas fa-' . \Initiator::e((string)$TaskType->get('icon'))
+                . '"></i> ' . \Initiator::e($name),
+                'btn btn-outline-secondary fog-quicktask',
+                'type="button"'
+                . ' data-node="' . \Initiator::e($node) . '"'
+                . ' data-id="' . (int)$id . '"'
+                . ' data-type="' . (int)$TaskType->get('id') . '"'
+                . ' data-confirm="' . \Initiator::e($confirm) . '"'
+            );
+        }
+        if ('' === $buttons) {
+            return '';
+        }
+
+        return '<div class="btn-group" role="group" aria-label="'
+            . \Initiator::e(_('Quick tasks'))
+            . '">' . $buttons . '</div>';
+    }
+
     protected function renderInfoCard()
     {
         $notes = (array)$this->notes;
         $sources = (array)$this->noteSources;
+        $actions = (string)$this->noteActions;
         // Mirrors PLUGINS_INJECT_TABDATA in tabFields(): a plugin that adds
         // a tab to a core page can add its line here too. 1.5's equivalent
         // rode SUB_MENULINK_DATA, which 1.6 repurposed for the sidebar node
         // menu, so there is no back-compat name to keep.
+        //
+        // 'actions' rides the same event rather than getting one of its own:
+        // a plugin adding a button to this card is doing the same thing as a
+        // plugin adding a line to it, and a second event would mean two
+        // registrations for one card.
         self::$HookManager->processEvent(
             'EDIT_INFO_DATA',
             [
                 'notes' => &$notes,
                 'noteSources' => &$sources,
+                'noteActions' => &$actions,
                 'obj' => &$this->obj
             ]
         );
-        if (!count($notes)) {
+        // Either half is enough to be worth drawing. A page with buttons and
+        // no notes is unusual but not wrong, and returning early on the note
+        // count alone would silently drop the buttons.
+        if (!count($notes) && '' === trim($actions)) {
             return;
         }
         echo '<div class="card mb-3" id="edit-info-card">';
@@ -591,6 +688,16 @@ trait FOGPageRender
                 '<span class="text-muted">&mdash;</span>' :
                 \Initiator::e($value);
             echo '</div>';
+            echo '</div>';
+        }
+        // Last in the row and pushed to the far edge with ms-auto, so the
+        // buttons sit clear of the notes however many notes there are. A
+        // flex auto margin, not a float: the row is display:flex and a float
+        // would do nothing here.
+        if ('' !== trim($actions)) {
+            echo '<div class="col ms-auto d-flex align-items-center"'
+                . ' id="edit-info-actions">';
+            echo $actions;
             echo '</div>';
         }
         echo '</div>';

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -131,7 +131,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 430);
-        define('FOG_BCACHE_VER', 360);
+        define('FOG_BCACHE_VER', 361);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/src/Pages/GroupManagement.php
+++ b/packages/web/src/Pages/GroupManagement.php
@@ -1757,9 +1757,12 @@ class GroupManagement extends FOGPage
      */
     public function edit()
     {
+        // Read once: the note below and the quick-task confirmation both
+        // want it, and getHostCount() is a query.
+        $hostCount = (int)$this->obj->getHostCount();
         $this->notes = [
             _('Group') => $this->obj->get('name'),
-            _('Members') => (string)$this->obj->getHostCount()
+            _('Members') => (string)$hostCount
         ];
         // Info-card notes that mirror a General-tab control, so the card
         // tracks the form instead of going stale until the next page
@@ -1769,6 +1772,29 @@ class GroupManagement extends FOGPage
         $this->noteSources = [
             _('Group') => '#group'
         ];
+        // Deploy and Multi-Cast, one click, from whichever tab is open.
+        // Multi-Cast rather than Capture: capturing is a thing you do to
+        // one machine, and a group is by definition more than one. Not a
+        // style call -- deployPost() below throws "Groups cannot create
+        // capture tasks" outright, so a Capture button here could only ever
+        // produce a toast saying no. The list grid draws the same line on
+        // ttIsAccess ('host' vs 'group').
+        //
+        // The member count goes in the confirmation, not just the name. A
+        // group's size is the fact that decides whether you meant to press
+        // this, and it is the one thing the button itself cannot show.
+        if ($hostCount > 0) {
+            $this->noteActions = self::renderQuickTaskActions(
+                'group',
+                (int)$this->obj->get('id'),
+                [TaskType::DEPLOY, TaskType::MULTICAST],
+                sprintf(
+                    _('all %1$d hosts in group "%2$s"'),
+                    $hostCount,
+                    $this->obj->get('name')
+                )
+            );
+        }
         $tabData = [];
 
         // General

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -4473,9 +4473,18 @@ class HostManagement extends FOGPage
     public function edit()
     {
         // Identity plus the facts you cannot see from the other twenty
-        // tabs: which image is assigned, when it was last imaged, and which
-        // group it belongs to.
-        $primaryGroup = new Group(self::minId($this->obj->get('groups')));
+        // tabs: which image is assigned and when it was last imaged.
+        //
+        // No group line. It used to say "Primary Group", meaning
+        // minId($this->obj->get('groups')) -- the lowest-id group the host
+        // happened to be in. There is no primary group: a group GRANTS, and
+        // what a host ends up with is resolved from every group it belongs
+        // to at task time, ordered by groupOrder (ADR 0038, and see
+        // FOG\Assign\Resolver). So the label named a rank that does not
+        // exist and the value picked one membership arbitrarily. Listing
+        // them all instead was considered and dropped: a host in eight
+        // groups blows the card out, and the Group Associations tab already
+        // shows them properly.
         // Whichever of the two clients last spoke, named so the card is not
         // ambiguous about which one it is reporting.
         //
@@ -4518,11 +4527,6 @@ class HostManagement extends FOGPage
                 $this->obj->get('deployed'),
                 'hosts',
                 'hostLastDeploy'
-            ),
-            _('Primary Group') => (
-                $primaryGroup->isValid() ?
-                $primaryGroup->get('name') :
-                _('None')
             )
         ];
         // Info-card notes that mirror a General-tab control, so the card
@@ -4534,6 +4538,18 @@ class HostManagement extends FOGPage
             _('Host') => '#host',
             _('Assigned Image') => '#image'
         ];
+        // Deploy and Capture, one click, from whichever tab is open. Gated
+        // on pending for the same reason the Tasks tab below is: a pending
+        // host cannot be tasked, and deployPost() refuses it anyway, so
+        // offering the button only produces a toast saying no.
+        if (!$this->obj->get('pending')) {
+            $this->noteActions = self::renderQuickTaskActions(
+                'host',
+                (int)$this->obj->get('id'),
+                [TaskType::DEPLOY, TaskType::CAPTURE],
+                sprintf(_('host "%s"'), $this->obj->get('name'))
+            );
+        }
         $tabData = [];
 
         // General

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3165,6 +3165,12 @@ parameters:
 			path: packages/web/src/Pages/ActivityManagement.php
 
 		-
+			message: '#^Constructor of class FOG\\Pages\\AgentActivityManagement has an unused parameter \$name\.$#'
+			identifier: constructor.unusedParameter
+			count: 1
+			path: packages/web/src/Pages/AgentActivityManagement.php
+
+		-
 			message: '#^Constructor of class FOG\\Pages\\ApiDocumentation has an unused parameter \$name\.$#'
 			identifier: constructor.unusedParameter
 			count: 1

--- a/phpstan-tests-baseline.neon
+++ b/phpstan-tests-baseline.neon
@@ -13,6 +13,30 @@ parameters:
 			path: tests/activity-sources.test.php
 
 		-
+			message: '#^Call to function in_array\(\) with arguments ''already_joined''\|''joined''\|''refused''\|''unsupported'', array\{''joined'', ''already_joined'', ''failed'', ''unsupported'', ''refused''\} and true will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/agent-directory-join.test.php
+
+		-
+			message: '#^Call to function in_array\(\) with arguments ''refused'', array\{''joined'', ''already_joined'', ''failed'', ''unsupported'', ''refused''\} and true will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/agent-directory-join.test.php
+
+		-
+			message: '#^Call to function in_array\(\) with arguments ''refused'', array\{''joined'', ''already_joined''\} and true will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: tests/agent-directory-join.test.php
+
+		-
+			message: '#^Comparison operation "\>\=" between 3600 and 1800 is always true\.$#'
+			identifier: greaterOrEqual.alwaysTrue
+			count: 1
+			path: tests/agent-directory-join.test.php
+
+		-
 			message: '#^Offset ''directory'' on array\{inventory\: ''FOG\\\\Agent\\\\InventoryFacts'', software\: ''FOG\\\\Agent\\\\SoftwareFacts'', directory\: ''FOG\\\\Agent\\\\DirectoryFacts'', printers\: ''FOG\\\\Agent\\\\PrinterFacts''\} on left side of \?\? always exists and is not nullable\.$#'
 			identifier: nullCoalesce.offset
 			count: 1
@@ -39,6 +63,12 @@ parameters:
 		-
 			message: '#^Strict comparison using \=\=\= between array\{''ad'', ''entra'', ''workgroup'', ''none''\} and array\{''ad'', ''entra'', ''workgroup'', ''none''\} will always evaluate to true\.$#'
 			identifier: identical.alwaysTrue
+			count: 1
+			path: tests/agent-directory.test.php
+
+		-
+			message: '#^Offset ''directory'' on array\{inventory\: ''FOG\\\\Agent\\\\InventoryFacts'', software\: ''FOG\\\\Agent\\\\SoftwareFacts'', directory\: ''FOG\\\\Agent\\\\DirectoryFacts'', printers\: ''FOG\\\\Agent\\\\PrinterFacts'', network\: ''FOG\\\\Agent\\\\NetworkFacts'', secureboot\: ''FOG\\\\Agent\\\\SecureBootFacts''\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
 			count: 1
 			path: tests/agent-directory.test.php
 
@@ -109,6 +139,24 @@ parameters:
 			path: tests/agent-printer-facts.test.php
 
 		-
+			message: '#^Offset ''printers'' on array\{hostname\: ''hostnamechanger'', taskreboot\: ''taskreboot'', snapin\: ''snapinclient'', software\: ''software'', power\: ''powermanagement'', directory\: ''hostnamechanger'', printers\: ''printermanager'', wake\: ''powermanagement''\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: tests/agent-printer-facts.test.php
+
+		-
+			message: '#^Offset ''printers'' on array\{inventory\: ''FOG\\\\Agent\\\\InventoryFacts'', software\: ''FOG\\\\Agent\\\\SoftwareFacts'', directory\: ''FOG\\\\Agent\\\\DirectoryFacts'', printers\: ''FOG\\\\Agent\\\\PrinterFacts'', network\: ''FOG\\\\Agent\\\\NetworkFacts'', secureboot\: ''FOG\\\\Agent\\\\SecureBootFacts''\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: tests/agent-printer-facts.test.php
+
+		-
+			message: '#^Offset ''printers'' on array\{snapin\: ''FOG\\\\Agent\\\\Snapins'', software\: ''FOG\\\\Agent\\\\SoftwareSet'', printers\: ''FOG\\\\Agent\\\\PrinterSet'', directory\: ''FOG\\\\Agent\\\\DirectoryJoin'', wake\: ''FOG\\\\Agent\\\\WakeRelay''\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: tests/agent-printer-facts.test.php
+
+		-
 			message: '#^Call to function in_array\(\) with arguments ''inferred'', array\{''logout'', ''disconnect'', ''service_stop''\} and true will always evaluate to false\.$#'
 			identifier: function.impossibleType
 			count: 1
@@ -125,6 +173,114 @@ parameters:
 			identifier: identical.alwaysTrue
 			count: 1
 			path: tests/agent-user-sessions.test.php
+
+		-
+			message: '#^Call to function in_array\(\) with arguments ''expired''\|''pending'', array\{''sent'', ''failed''\} and true will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: tests/agent-wake-relay.test.php
+
+		-
+			message: '#^Call to function in_array\(\) with arguments ''sent'', array\{''sent'', ''failed''\} and true will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/agent-wake-relay.test.php
+
+		-
+			message: '#^Call to function is_int\(\) with 32 will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/agent-wake-relay.test.php
+
+		-
+			message: '#^Comparison operation "\<\=" between 600 and 3600 is always true\.$#'
+			identifier: smallerOrEqual.alwaysTrue
+			count: 1
+			path: tests/agent-wake-relay.test.php
+
+		-
+			message: '#^Comparison operation "\<\=" between 900 and 3600 is always true\.$#'
+			identifier: smallerOrEqual.alwaysTrue
+			count: 1
+			path: tests/agent-wake-relay.test.php
+
+		-
+			message: '#^Comparison operation "\>" between 3 and 1 is always true\.$#'
+			identifier: greater.alwaysTrue
+			count: 1
+			path: tests/agent-wake-relay.test.php
+
+		-
+			message: '#^Comparison operation "\>" between 32 and 0 is always true\.$#'
+			identifier: greater.alwaysTrue
+			count: 1
+			path: tests/agent-wake-relay.test.php
+
+		-
+			message: '#^Comparison operation "\>" between 600 and 0 is always true\.$#'
+			identifier: greater.alwaysTrue
+			count: 1
+			path: tests/agent-wake-relay.test.php
+
+		-
+			message: '#^Comparison operation "\>" between 900 and 0 is always true\.$#'
+			identifier: greater.alwaysTrue
+			count: 1
+			path: tests/agent-wake-relay.test.php
+
+		-
+			message: '#^Offset ''network'' on array\{inventory\: ''FOG\\\\Agent\\\\InventoryFacts'', software\: ''FOG\\\\Agent\\\\SoftwareFacts'', directory\: ''FOG\\\\Agent\\\\DirectoryFacts'', printers\: ''FOG\\\\Agent\\\\PrinterFacts'', network\: ''FOG\\\\Agent\\\\NetworkFacts'', secureboot\: ''FOG\\\\Agent\\\\SecureBootFacts''\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: tests/agent-wake-relay.test.php
+
+		-
+			message: '#^Offset ''wake'' on array\{hostname\: ''hostnamechanger'', taskreboot\: ''taskreboot'', snapin\: ''snapinclient'', software\: ''software'', power\: ''powermanagement'', directory\: ''hostnamechanger'', printers\: ''printermanager'', wake\: ''powermanagement''\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 2
+			path: tests/agent-wake-relay.test.php
+
+		-
+			message: '#^Offset ''wake'' on array\{snapin\: ''FOG\\\\Agent\\\\Snapins'', software\: ''FOG\\\\Agent\\\\SoftwareSet'', printers\: ''FOG\\\\Agent\\\\PrinterSet'', directory\: ''FOG\\\\Agent\\\\DirectoryJoin'', wake\: ''FOG\\\\Agent\\\\WakeRelay''\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: tests/agent-wake-relay.test.php
+
+		-
+			message: '#^Result of && is always true\.$#'
+			identifier: booleanAnd.alwaysTrue
+			count: 2
+			path: tests/agent-wake-relay.test.php
+
+		-
+			message: '#^Result of method FogChecks\:\:finish\(\) \(void\) is used\.$#'
+			identifier: method.void
+			count: 1
+			path: tests/agent-wake-relay.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between ''FOG\\\\Agent\\\\NetworkFacts'' and ''FOG\\\\Agent\\\\NetworkFacts'' will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: tests/agent-wake-relay.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between ''FOG\\\\Agent\\\\WakeRelay'' and ''FOG\\\\Agent\\\\WakeRelay'' will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: tests/agent-wake-relay.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between ''powermanagement'' and ''powermanagement'' will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: tests/agent-wake-relay.test.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between array\{''id'', ''macs''\} and array\{''id'', ''macs''\} will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: tests/agent-wake-relay.test.php
 
 		-
 			message: '#^Call to new Initiator\(\) on a separate line has no effect\.$#'

--- a/tests/fixtures/upgrade-rehearsal-baseline.txt
+++ b/tests/fixtures/upgrade-rehearsal-baseline.txt
@@ -1,5 +1,5 @@
-  constraints declared and applicable here: 96
-  constraints actually present:             94
+  constraints declared and applicable here: 99
+  constraints actually present:             97
   MISSING:                                  2
     fk_hostMAC_hmHostID                      CASCADE     orphan rows: 0
     fk_nfsGroupMembers_ngmGroupID            RESTRICT    orphan rows: 1

--- a/tests/info-card-quick-tasks.test.php
+++ b/tests/info-card-quick-tasks.test.php
@@ -236,7 +236,8 @@ $field = static function (array $buttons, $type, $field) {
     return (string)($button[$field] ?? '');
 };
 
-$hostButtons = $parse($emit(['*'], 'host', $hostTypes));
+$markup = $emit(['*'], 'host', $hostTypes);
+$hostButtons = $parse($markup);
 $groupButtons = $parse(
     $emit(['*'], 'group', $groupTypes, 'all 12 hosts in group "Lab"')
 );
@@ -296,6 +297,16 @@ $t->check(
     'the names are the task types own, not placeholders',
     'Deploy' === trim($field($hostButtons, TaskType::DEPLOY, 'name'))
     && 'Capture' === trim($field($hostButtons, TaskType::CAPTURE, 'name'))
+);
+// Not taste: btn-outline-secondary keeps #6c757d as the TEXT color, which
+// against the dark card (#212529) is 3.29:1 -- under the 4.5:1 AA floor for
+// body-sized text. Filled puts white on #6c757d and holds 4.69:1 in both
+// themes. Measured in a browser against the shipped stylesheets; pinned here
+// as the class, because the class is the part a future edit would change.
+$t->check(
+    'the buttons are filled btn-secondary, not outline',
+    false !== strpos($markup, 'class="btn btn-secondary fog-quicktask"')
+    && false === strpos($markup, 'btn-outline-secondary')
 );
 $t->check(
     'a task type this server has deleted simply loses its button',

--- a/tests/info-card-quick-tasks.test.php
+++ b/tests/info-card-quick-tasks.test.php
@@ -1,0 +1,344 @@
+<?php
+/**
+ * One-click tasks on the host and group EDIT pages: the parts that fail
+ * silently.
+ *
+ * The list grid has had Deploy/Capture/Multi-Cast buttons for a while
+ * (tests/host-list-quick-tasks.test.php pins those). The same affordance now
+ * sits in the info card at the top of the edit pages, so an admin already
+ * looking at a host or a group does not have to go back to the grid and find
+ * the row again. FOGPageRender::renderQuickTaskActions() builds them for both
+ * pages. Four things about that are worth a test, and each is invisible when
+ * it breaks.
+ *
+ * 1. THE PERMISSION. These create taskings, so they are gated on
+ *    `{node}.task` -- the action ?node={node}&sub=deploy resolves to through
+ *    Authorization::_subToAction(), which reads the 'deploy' prefix. The gate
+ *    here and the gate the POST hits have to be the same string or a reader
+ *    is shown buttons whose every click is refused, which reads as a broken
+ *    page rather than as a permission problem. Pinned for BOTH nodes,
+ *    because the string is built by concatenation and 'group' taking the
+ *    'host' gate would be invisible on a server where the same people hold
+ *    both.
+ *
+ * 2. THE CONFIRMATION HAS TO BE THERE, AND HAS TO NAME THE TARGET. This is
+ *    the one that matters. Unlike the list, where you tick a row to get the
+ *    buttons, you arrive on an edit page just by clicking a host name -- so
+ *    one stray click would deploy over a running machine, or from a group
+ *    over every machine in it. The script refuses to fire without
+ *    data-confirm, but a data-confirm that came out EMPTY would sail through
+ *    window.confirm('')... and an empty-but-present attribute is exactly what
+ *    a get()-versus-property slip produces. So the attribute is pinned as
+ *    non-empty AND as containing the caller's target text.
+ *
+ * 3. THE VALUES ARE READ THROUGH get(), NOT AS PROPERTIES. Same trap the
+ *    list version documents: TaskType is a FOGController, which declares no
+ *    __get, so `$TaskType->name` is null and `(int)$TaskType->id` is 0 with
+ *    no warning that survives the page's output buffer. Here it would draw a
+ *    nameless button pointed at type 0.
+ *
+ * 4. WHICH PAIR EACH PAGE OFFERS. Deploy and Capture for a host; Deploy and
+ *    Multi-Cast for a group. Capturing is something you do to one machine
+ *    and a group is by definition more than one, so a group offering Capture
+ *    is a real defect -- and one the server would happily act on, since
+ *    GroupManagement::deployPost() does not check ttIsAccess.
+ *
+ * Usage: php tests/info-card-quick-tasks.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+use FOG\Items\TaskType;
+use FOG\Items\User;
+use FOG\Pages\GroupManagement;
+use FOG\Pages\HostManagement;
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('info-card-quick-tasks');
+
+$db = FogTestHarness::fakeDb();
+
+/**
+ * One taskTypes row. Every column, not just the three the builder reads --
+ * FOGController::setQuery() walks $databaseFields and warns on each one it
+ * cannot find, which buries the test's own output.
+ *
+ * @param int    $id   ttID
+ * @param string $name ttName
+ * @param string $icon ttIcon
+ *
+ * @return array
+ */
+$row = static function ($id, $name, $icon) {
+    return [
+        'ttID' => $id,
+        'ttName' => $name,
+        'ttDescription' => $name,
+        'ttIcon' => $icon,
+        'ttKernel' => '',
+        'ttKernelArgs' => '',
+        'ttType' => '',
+        'ttIsAdvanced' => 0,
+        'ttIsAccess' => 'both',
+        'ttInitrd' => ''
+    ];
+};
+$rows = [
+    TaskType::DEPLOY => $row(TaskType::DEPLOY, 'Deploy', 'download'),
+    TaskType::CAPTURE => $row(TaskType::CAPTURE, 'Capture', 'upload'),
+    TaskType::MULTICAST => $row(TaskType::MULTICAST, 'Multi-Cast', 'share-alt')
+];
+// A single flat row, not a list of rows: FOGController::load() reads
+// fetch()->get() as ONE record, and handing it a nested array leaves the
+// object invalid with nothing said.
+$db->responder = static function ($sql, $params) use ($db, $rows) {
+    $db->error = false;
+    if (false === strpos($sql, 'taskTypes')) {
+        return null;
+    }
+    foreach ($params as $value) {
+        if (isset($rows[(int)$value])) {
+            return $rows[(int)$value];
+        }
+    }
+
+    return [];
+};
+
+$t = new FogChecks();
+
+/**
+ * Runs the builder as a user holding the given permissions.
+ *
+ * @param array  $perms   the effective permission list for the acting user
+ * @param string $node    'host' or 'group'
+ * @param array  $typeIds the task types that page asks for
+ * @param string $target  the confirmation's description of the target
+ *
+ * @return string the emitted markup
+ */
+$emit = static function (
+    array $perms,
+    $node,
+    array $typeIds,
+    $target = 'host "bench-01"'
+) {
+    $user = (new User())->set('id', 1)->set('name', 'fog');
+    foreach (['FOGBase', 'Authorization', 'Route'] as $cls) {
+        FogTestHarness::setStatic($cls, 'FOGUser', $user);
+    }
+    FogTestHarness::setStatic('Authorization', '_permCache', [1 => $perms]);
+
+    return (string)HostManagement::renderQuickTaskActions(
+        $node,
+        42,
+        $typeIds,
+        $target
+    );
+};
+
+$hostTypes = [TaskType::DEPLOY, TaskType::CAPTURE];
+$groupTypes = [TaskType::DEPLOY, TaskType::MULTICAST];
+
+// -------------------------------------------------------------------------
+// 1. The permission gate, per node.
+// -------------------------------------------------------------------------
+$t->check(
+    'a reader without host.task is offered no quick tasks on a host',
+    '' === $emit(['host.view', 'host.edit'], 'host', $hostTypes)
+);
+$t->check(
+    'host.task alone is enough',
+    false !== strpos($emit(['host.task'], 'host', $hostTypes), 'fog-quicktask')
+);
+$t->check(
+    'a reader without group.task is offered no quick tasks on a group',
+    '' === $emit(['group.view', 'group.edit'], 'group', $groupTypes)
+);
+$t->check(
+    'host.task does NOT unlock the group card',
+    '' === $emit(['host.task'], 'group', $groupTypes)
+);
+$t->check(
+    'group.task alone is enough',
+    false !== strpos(
+        $emit(['group.task'], 'group', $groupTypes),
+        'fog-quicktask'
+    )
+);
+$t->check(
+    'and a wildcard unlocks both',
+    false !== strpos($emit(['*'], 'host', $hostTypes), 'fog-quicktask')
+    && false !== strpos($emit(['*'], 'group', $groupTypes), 'fog-quicktask')
+);
+
+// -------------------------------------------------------------------------
+// 2. The confirmation. The reason a one-click deploy is safe to sit here.
+// -------------------------------------------------------------------------
+/**
+ * Every button in a run of markup, as [type => [icon, name, confirm]].
+ *
+ * @param string $markup the emitted button group
+ *
+ * @return array
+ */
+$parse = static function ($markup) {
+    preg_match_all(
+        '/<button id="quicktask-[a-z]+-(\d+)"[^>]*?'
+        . 'data-type="(\d+)"[^>]*?data-confirm="([^"]*)"[^>]*?>'
+        . '<i class="fas fa-([^"]*)"><\/i> ([^<]*)<\/button>/',
+        $markup,
+        $m,
+        PREG_SET_ORDER
+    );
+    $out = [];
+    foreach ($m as $b) {
+        // The id's trailing number and data-type are the same value written
+        // twice; if they ever disagree the button and its id name different
+        // taskings, so the parse insists on the pair rather than trusting one.
+        if ((int)$b[1] !== (int)$b[2]) {
+            continue;
+        }
+        $out[(int)$b[2]] = [
+            'confirm' => html_entity_decode($b[3], ENT_QUOTES, 'UTF-8'),
+            'icon' => $b[4],
+            'name' => $b[5]
+        ];
+    }
+
+    return $out;
+};
+
+/**
+ * One field of one button, or '' if that button was never emitted.
+ *
+ * A reader rather than `$buttons[$type]['field'] ?? ''` at each call site:
+ * a missing BUTTON and a missing field are the same failure to a check that
+ * only wants to know whether the text is there.
+ *
+ * @param array  $buttons parsed buttons, keyed by task type id
+ * @param int    $type    the task type wanted
+ * @param string $field   'confirm', 'icon' or 'name'
+ *
+ * @return string
+ */
+$field = static function (array $buttons, $type, $field) {
+    $button = $buttons[$type] ?? [];
+
+    return (string)($button[$field] ?? '');
+};
+
+$hostButtons = $parse($emit(['*'], 'host', $hostTypes));
+$groupButtons = $parse(
+    $emit(['*'], 'group', $groupTypes, 'all 12 hosts in group "Lab"')
+);
+
+$t->check(
+    'every host button carries a non-empty confirmation',
+    2 === count($hostButtons)
+    && 2 === count(
+        array_filter(
+            $hostButtons,
+            static function ($b) {
+                return '' !== trim($b['confirm']);
+            }
+        )
+    )
+);
+$t->check(
+    'the confirmation names the task type and the host',
+    false !== strpos($field($hostButtons, TaskType::DEPLOY, 'confirm'), 'Deploy')
+    && false !== strpos(
+        $field($hostButtons, TaskType::DEPLOY, 'confirm'),
+        'host "bench-01"'
+    )
+);
+$t->check(
+    'a capture confirmation names Capture, not Deploy',
+    false !== strpos(
+        $field($hostButtons, TaskType::CAPTURE, 'confirm'),
+        'Capture'
+    )
+);
+$t->check(
+    'the group confirmation carries the member count and the group name',
+    false !== strpos(
+        $field($groupButtons, TaskType::MULTICAST, 'confirm'),
+        'all 12 hosts in group "Lab"'
+    )
+);
+
+// -------------------------------------------------------------------------
+// 3. What the markup actually carries.
+// -------------------------------------------------------------------------
+// The get()-versus-property bug, stated as what a reader would see: a
+// nameless button pointed at type 0.
+$t->check(
+    'every button carries a real id, name and icon',
+    2 === count(
+        array_filter(
+            $hostButtons,
+            static function ($b) {
+                return '' !== $b['icon'] && '' !== trim($b['name']);
+            }
+        )
+    )
+);
+$t->check(
+    'the names are the task types own, not placeholders',
+    'Deploy' === trim($field($hostButtons, TaskType::DEPLOY, 'name'))
+    && 'Capture' === trim($field($hostButtons, TaskType::CAPTURE, 'name'))
+);
+$t->check(
+    'a task type this server has deleted simply loses its button',
+    [TaskType::DEPLOY] === array_keys(
+        $parse($emit(['*'], 'host', [TaskType::DEPLOY, 9999]))
+    )
+);
+$t->check(
+    'and a page whose every type is gone emits nothing at all',
+    '' === $emit(['*'], 'host', [9998, 9999])
+);
+
+// -------------------------------------------------------------------------
+// 4. The pair each page offers.
+// -------------------------------------------------------------------------
+$t->check(
+    'a host offers Deploy and Capture',
+    [TaskType::DEPLOY, TaskType::CAPTURE] === array_keys($hostButtons)
+);
+$t->check(
+    'a group offers Deploy and Multi-Cast, never Capture',
+    [TaskType::DEPLOY, TaskType::MULTICAST] === array_keys($groupButtons)
+);
+
+// The pages themselves have to ask for those pairs; the builder takes
+// whatever it is handed. Read from the source rather than rendered, because
+// rendering edit() needs a loaded entity and every tab behind it.
+foreach (
+    [
+        'host' => [HostManagement::class, 'TaskType::DEPLOY, TaskType::CAPTURE'],
+        'group' => [
+            GroupManagement::class,
+            'TaskType::DEPLOY, TaskType::MULTICAST'
+        ]
+    ] as $node => $expect
+) {
+    $src = (string)file_get_contents(
+        (new \ReflectionClass($expect[0]))->getFileName()
+    );
+    $t->check(
+        sprintf('%s edit() asks for [%s]', $node, $expect[1]),
+        false !== strpos($src, '[' . $expect[1] . ']')
+    );
+}
+
+$t->finish();


### PR DESCRIPTION
Two changes to the same strip at the top of the host and group edit pages.

**Based on `feat/agent-enroll`, and targeted at it**, because `fe5c6e73e` rewrote the exact `$this->notes` block this touches (the Last Check-In agent/client logic). Doing it on `working-1.6` would have guaranteed a hand-resolved conflict there.

## Removed: the host card's "Primary Group"

It meant `minId($this->obj->get('groups'))` — the lowest-id group the host happened to be in.

There is no primary group. A group *grants*, and what a host ends up with is resolved from every group it belongs to at task time, ordered by `groupOrder` (ADR 0038, `FOG\Assign\Resolver`). So the label named a rank that does not exist and the value picked one membership arbitrarily.

Nothing replaces it. Listing every group instead was considered and dropped: a host in eight groups blows the card out, which makes the card worse rather than better, and the Group Associations tab already shows them properly.

## Added: one-click tasking in the card

Deploy and Capture on the host card; Deploy and Multi-Cast on the group card. From whichever tab is open, so an admin already looking at a host does not have to go back to the grid and find the row again to do the obvious thing to it.

This is not a new pattern. The host **list** has carried the same buttons since `_quickTaskItems()`, for the reason that method documents: these are the task types that need no options, which is the whole reason they can be one click. The pairing is its own — Deploy and Capture are what a single host wants, Deploy and Multi-Cast what a set of them wants. On a group it is also what the server will accept: `GroupManagement::deployPost()` throws *"Groups cannot create capture tasks"* outright.

**Every button confirms first**, and this is the one place it deliberately differs from the list. There you tick a row to get the buttons; here you arrive on the page just by clicking a host name, so one stray click would deploy over a running machine — or, from a group, over all of them. The text is built server side because it is translated, and it names the target: the host, or the group **and its member count**, which is the fact that decides whether you meant to press it and the one thing the button itself cannot show.

### Mechanically

- `FOGPage::$noteActions`, a pre-rendered string, echoed by `renderInfoCard()` in a right-aligned column. `ms-auto`, not a float — the row is `display:flex` and a float would do nothing there.
- It rides the existing `EDIT_INFO_DATA` hook alongside `notes`/`noteSources`, so a plugin adding a button does it the same way it already adds a line.
- `FOGPageRender::renderQuickTaskActions()` builds them, gated on `{node}.task` — the action `?node=X&sub=deploy` resolves to through `Authorization::_subToAction()`, so the gate here and the gate the POST hits are the same string by construction.
- The script posts straight to `?node={node}&sub=deploy` with `scheduleType=instant`, skipping the options form. Everything its POST is checked for — pending host, assigned and enabled image, protected image on a capture, one image across a multicast — is checked in `deployPost()`, not in the form. `scheduleType` is the one field that must be sent: `validateScheduleType()` throws on an absent value rather than defaulting.
- Suppressed where the server would refuse anyway: a pending host, an empty group.

### Button color is a contrast decision, not a taste one

`btn-outline-secondary` keeps `#6c757d` as the *text* color; against the dark card (`#212529`) that is **3.29:1**, under the 4.5:1 AA floor for body-sized text. Filled `btn-secondary` puts white on `#6c757d` and holds **4.69:1** in both themes. Measured in a browser against the shipped `adminlte4.min.css` + `fog-default-ui.min.css`, rendering the real `renderInfoCard()` output. It is also what the list's own quick buttons are, so the two places offering the same tasking now look the same.

Neither is `btn-primary`: nothing here is the card's commit action — the General tab's Update is.

## Verification

`tests/info-card-quick-tasks.test.php` (19 checks) pins the things that fail silently: the permission gate per node (`host.task` must not unlock the group card), the confirmation being present **and** naming the target, the values being read through `get()` rather than as properties, the pair each page asks for, and the filled class. Each was verified by reintroducing the defect and watching it go red.

- `phpstan` pass 1: clean.
- `phpstan`: both passes clean.
- `fogproject / upgrade rehearsal`: green, reproduced locally against a throwaway `mariadb:11.8` container and re-run on a second clean database.

### It also fixes the two failures it inherited

`feat/agent-enroll` was red on `phpstan` and `upgrade rehearsal` before this branch existed, so this one inherited both. Neither was a code defect; both were a baseline the change that moved it did not update. Fixed here in `7c0c45199`, so they clear on the base too when this merges.

- **`phpstan` pass 1** — `AgentActivityManagement`'s constructor takes `$name` and ignores it. That is the shape *every* page in `src/Pages` has, and all 27 others are already in `phpstan-baseline.neon` under `constructor.unusedParameter`; the new page just had no entry. Added one. Changing the constructor instead would leave this page the only one in the directory with a different signature.
- **`phpstan` pass 2** — 26 entries for the agent test files. CI never reported these: the job runs the passes as separate steps with no `continue-on-error`, so pass 1 exiting 1 meant pass 2 never ran. They are the usual test shapes (PHPStan narrows a literal, so an `in_array()` pinning a constant reads as always-true), and `phpstan-tests.neon`'s own header says this pass *"adapts to the tests as they are written, it does not ask them to change"* — so baselined, not rewritten. Generated into a temp file and **merged**: a straight regeneration emits only the 26 unignored errors and would have dropped the 196 already there, and it writes absolute paths that match nothing on a CI checkout. Verified as a set — 196 in, 222 out, 0 lost, no deletions in the diff.
- **`upgrade rehearsal`** — three constraints landed that the fixture did not know about: `fk_agentEnrollment_aeHostID`, `fk_agentWake_awSenderID`, `fk_agentWake_awTargetID`, all agent tables referencing `hosts`. Declared 96 → 99, present 94 → 97; `MISSING` stays at the same 2 named constraints and the integrity block is untouched. The test's own docblock asks for exactly this update in the same commit.
- `tests/run-all.sh`: 332 pass, 1 fail — `certificate-table.test.php`, which fails identically on an untouched `feat/agent-enroll` **and** on `working-1.6`, and passes in CI. Local environment, not this change.
- Rendered through the real `renderInfoCard()` and screenshotted in both themes against the live stylesheets.

`FOG_BCACHE_VER` 360 → 361 for the changed script. It also covers the Agent Activity JS that arrived in the merge, which did not bump it. **`working-1.6` still sits at 360**, so re-check the value against the base when `feat/agent-enroll` merges up — two branches bumping 360 → 361 merge cleanly and silently collide.

No REST route changed, so `OpenAPI::document()` is unaffected. No downstream class-list change, so nothing for FogApi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWJMQYE2br8E7Ehr55SJp2

