### PR TITLE
Agent Activity: group by host in the grid, and expand in it

### DIFF
--- a/packages/web/management/js/fog/agentactivity/fog.agentactivity.list.js
+++ b/packages/web/management/js/fog/agentactivity/fog.agentactivity.list.js
@@ -1,26 +1,35 @@
 /**
- * Agent activity, one row per host, expanded on demand.
+ * Agent activity: one grid, grouped by host, expanded in place.
  *
  * Read only by construction, not by omission: `auditlog` has no create,
  * update or delete route anywhere in FOG (ADR 0021 Decision 8), so there is
- * nothing here to wire a row action to.
+ * nothing here to wire a row action to. The page declares that once, in
+ * AgentActivityManagement::$selectable, and the toolbar follows.
  *
- * NO rowGroup, and not for the reason fog.audit.list.js gives. Grouping by
- * host is the whole point of this page, but rowGroup groups only within the
- * current PAGE, and the audit grid is serverSide -- so one hostname would
- * head a dozen separate pages. The summary this table renders is grouped in
- * SQL instead, which is exact across the whole table, and it is bounded by
- * the size of the fleet where a flat list of agent rows is not. The scroller
- * survives as a side effect: registerTable() auto-pages any table using
- * rowGroup, and this one does not use it.
+ * WHY NOT A CHILD ROW. The first version of this file opened a nested
+ * DataTable per host through `row.child()`. A DataTables row has ONE child
+ * slot; registerTable() turns Responsive on for every grid, and Responsive
+ * owns that slot. So the nested table was never built -- clicking expand
+ * rendered Responsive's hidden-column list instead, on a live install, at a
+ * width where nothing was hidden to begin with. Adding rows to the grid
+ * itself has no such conflict, and it is what makes an expanded host look
+ * like the rest of FOG instead of a grid inside a grid with its own
+ * scrollbar and pager.
  *
- * The summary is CLIENT side -- one row per host is a bounded set, and
- * sorting a fleet by "last seen" has to sort the fleet, not the page. Each
- * expanded host's rows are server side, because that set is not bounded --
- * and they go through registerTable() like every other grid, so they carry
- * the same infinite scroll. Collapsed grouping and infinite scroll were
- * never actually in tension: the tension is between rowGroup and Scroller,
- * and grouping in SQL means there is no rowGroup to have it with.
+ * WHY EVERY GROUP KEEPS ONE ROW. Collapse is a search filter over the event
+ * rows, and RowGroup draws its headers from the rows that SURVIVE the
+ * filter: a group left with none renders no header, and the host vanishes
+ * from the page. So each host's newest event is seeded into the table and
+ * is never filtered. It anchors the header, and it is the row worth reading
+ * when everything is collapsed -- what each agent last did.
+ *
+ * WHY THE SEED IS SEPARATE FROM THE EXPANSION. An agent writes a row per
+ * changed fact per host and FOG_AUDIT_RETENTION_DAYS defaults to 0 (keep
+ * forever), so the flat event set is unbounded -- it cannot be loaded
+ * client side, which is equally why rowGroup over a `serverSide` grid is
+ * not an option (it would group within one page). The seed is bounded by
+ * the fleet, each expansion by ROWS_PER_HOST. Nothing here loads a set
+ * bounded by neither.
  */
 (function($) {
   var $table = $('#agentactivity-table');
@@ -28,6 +37,34 @@
   if (!$table.length) {
     return;
   }
+
+  // How many rows one expansion pulls. A host that has been enrolled for a
+  // year has thousands, and putting all of them into the browser to answer
+  // "what has this machine been doing" is the cost the summary exists to
+  // avoid. Past this the header says so and offers the host's own page.
+  var ROWS_PER_HOST = 500;
+
+  // hostName -> true while that host's events are showing. Keyed by name
+  // because that is what RowGroup groups on and what startRender is handed;
+  // the id travels on the row data for the fetch.
+  var expanded = {};
+  // hostName -> true once its rows are in the table, so a collapse and a
+  // second expand do not re-fetch what is already loaded.
+  var loaded = {};
+  // hostName -> true while a fetch is in flight, so a double click on a
+  // header cannot start two.
+  var loading = {};
+  // hostName -> total the server reported, when it is more than we asked
+  // for. Read by the header to say what is not being shown.
+  var truncated = {};
+
+  var outcomeClass = {
+    allowed: 'text-bg-success',
+    denied: 'text-bg-danger',
+    failed: 'text-bg-warning',
+    partial: 'text-bg-warning',
+    unknown: 'text-bg-secondary'
+  };
 
   // Every column escapes. An audit row carries subject labels and detail
   // text that came from a machine on the network, so its contents are
@@ -44,154 +81,286 @@
     };
   }
 
-  var outcomeClass = {
-    allowed: 'text-bg-success',
-    denied: 'text-bg-danger',
-    failed: 'text-bg-warning',
-    partial: 'text-bg-warning',
-    unknown: 'text-bg-secondary'
-  };
-
-  // The expand control. A button and not a styled cell: it is operated by
-  // keyboard as well as by mouse, and a div with a click handler is not.
-  function toggleColumn() {
+  function outcomeColumn() {
     return {
-      data: null,
-      orderable: false,
-      searchable: false,
-      className: 'agentactivity-toggle',
-      render: function() {
-        return '<button type="button" class="btn btn-sm btn-link p-0'
-          + ' agentactivity-expand" aria-expanded="false"'
-          + ' title="' + $.escapeHtml('Show this host\'s agent activity')
-          + '"><i class="fas fa-chevron-right"></i></button>';
+      data: 'outcome',
+      render: function(d, t) {
+        var v = d === null ? '' : String(d);
+        if (t !== 'display') {
+          return v;
+        }
+        if ('' === v) {
+          return '';
+        }
+        return '<span class="badge ' + (outcomeClass[v] || outcomeClass.unknown)
+          + '">' + $.escapeHtml(v) + '</span>';
       }
     };
   }
 
+  // The seed rows and the fetched rows are the same shape by the time they
+  // reach the table, so one column set serves both and an expanded group is
+  // continuous with its anchor rather than a differently-shaped insert.
+  function seedRow(host) {
+    return {
+      hostID: host.hostID,
+      hostName: host.hostName,
+      events: host.events,
+      createdTime: host.lastTime,
+      type: host.lastType,
+      text: host.lastText,
+      outcome: host.lastOutcome,
+      // What the hidden host column SORTS by -- see groupSortColumn().
+      groupSort: String(host.lastTime) + '|' + String(host.hostID),
+      // Marks the row that must never be filtered out. Without it a
+      // collapsed group loses every row, and with them its header.
+      anchor: true
+    };
+  }
+
+  // `seed` is a row this file already built, NOT the raw summary object --
+  // so the sort key is COPIED from it rather than recomputed. Recomputing it
+  // from seed.lastTime read undefined (a seed row carries createdTime), every
+  // event of a host sorted under "undefined|<id>" instead of beside its
+  // anchor, and the group split in two with its header drawn twice.
+  function eventRow(seed, row) {
+    return {
+      hostID: seed.hostID,
+      hostName: seed.hostName,
+      events: seed.events,
+      createdTime: row.createdTime,
+      type: row.type,
+      text: row.text,
+      outcome: row.outcome,
+      // Identical for every row of one host, which is what keeps the group
+      // contiguous once the table is ordered by it.
+      groupSort: seed.groupSort,
+      anchor: false
+    };
+  }
+
+  // The hidden Host column: displayed as the host name if it were ever
+  // shown, but SORTED by the group's own recency.
+  //
+  // RowGroup starts a new group -- and draws another header -- every time
+  // its dataSrc changes down the ordered rows, so a group is only whole if
+  // the table is ordered by it. Ordering by time alone is not enough: one
+  // host's older events fall past the next host's newest one and its header
+  // is drawn twice. That was measured, not predicted.
+  //
+  // Sorting alphabetically by name would fix contiguity and lose the order
+  // that matters, which is "which agents have done something lately". So
+  // every row of a host sorts on that host's LAST activity plus its id --
+  // one value per group, so groups stay whole, ordered by recency, with the
+  // id breaking a tie between two hosts last seen in the same second.
+  function groupSortColumn() {
+    return {
+      data: 'hostName',
+      visible: false,
+      className: 'noVis',
+      render: function(d, t, row) {
+        if (t === 'sort' || t === 'type') {
+          return row.groupSort;
+        }
+        return t === 'display'
+          ? $.escapeHtml(d === null ? '' : String(d))
+          : d;
+      }
+    };
+  }
+
+  // Collapse hides a group's event rows and leaves its anchor. Registered
+  // once and scoped to this table by node identity -- ext.search is global,
+  // so an unscoped filter would silently apply to every grid on the page.
+  var tableNode = $table.get(0);
+
+  $.fn.dataTable.ext.search.push(function(settings, data, dataIndex, row) {
+    if (settings.nTable !== tableNode) {
+      return true;
+    }
+    return row.anchor === true || expanded[row.hostName] === true;
+  });
+
+  // The group header. It carries what used to be four columns of a summary
+  // grid -- the host, its event count, and now the expand control -- which
+  // is what frees the columns below to be the events themselves.
+  function groupHeader(rows, name) {
+    var d = rows.data()[0] || {},
+      open = expanded[name] === true,
+      count = parseInt(d.events, 10) || 0,
+      note = '';
+
+    if (truncated[name]) {
+      // Said on the header rather than in a row: it is a fact about the
+      // group, and a row saying it would sort and filter like an event.
+      note = ' <span class="text-body-secondary small">'
+        + $.escapeHtml('showing the newest ' + ROWS_PER_HOST) + '</span>';
+    }
+
+    return $('<tr/>')
+      .addClass('agentactivity-group')
+      .attr('data-host', name)
+      .append(
+        $('<td/>')
+          .attr('colspan', 5)
+          .html(
+            '<button type="button" class="btn btn-sm btn-link p-0 me-2'
+            + ' agentactivity-toggle" aria-expanded="' + (open ? 'true' : 'false')
+            + '"><i class="fas '
+            // Whole names, not 'fa-chevron-' plus a half: the icon audit
+            // reads the emitted string and a concatenated name resolves to
+            // nothing it can check.
+            + (open ? 'fa-chevron-down' : 'fa-chevron-right')
+            + '"></i></button>'
+            + '<span class="fw-semibold">' + $.escapeHtml(name) + '</span>'
+            + ' <span class="badge text-bg-secondary">'
+            + $.escapeHtml(String(count)) + '</span>'
+            + note
+          )
+      );
+  }
+
   var table = $table.registerTable(null, {
-    // Newest activity first: the question this page answers is "what have
-    // the agents been doing", and a host silent for a month is not it.
+    // Newest activity first. Ordering by the time column also keeps each
+    // host's rows in the order its agent wrote them, since RowGroup orders
+    // groups by the first ordering column it is grouped on and rows within
+    // a group by whatever follows.
+    // Groups first, then time within a group. Both descending: the most
+    // recently active host heads the page, and its newest event heads it.
     order: [
-      [3, 'desc']
+      [4, 'desc'],
+      [0, 'desc']
     ],
     columns: [
-      toggleColumn(),
-      escaped('hostName'),
-      escaped('events'),
-      escaped('lastTime'),
-      escaped('lastType')
+      escaped('createdTime'),
+      escaped('type'),
+      escaped('text'),
+      outcomeColumn(),
+      groupSortColumn()
     ],
-    rowId: 'hostID',
+    rowGroup: {
+      dataSrc: 'hostName',
+      startRender: groupHeader
+    },
     processing: true,
-    // Client side on purpose -- see the file docblock.
+    // Client side: the seed is one row per host, which is bounded by the
+    // fleet, and rowGroup cannot group a server-side grid beyond one page.
     serverSide: false,
+    // Nothing here is selectable -- auditlog has no write route at all (ADR
+    // 0021 Decision 8) -- and registerTable() drops Select All / Deselect
+    // All when it sees this.
     select: false,
     ajax: {
       url: '../management/index.php?node=agentactivity&sub=getList',
-      type: 'post'
+      type: 'post',
+      dataSrc: function(json) {
+        var out = [];
+        $.each(json.data || [], function(i, host) {
+          out.push(seedRow(host));
+        });
+        return out;
+      }
     }
   });
 
-  // One child table per expanded host, each its own DataTable against the
-  // scoped endpoint. Destroyed on collapse rather than hidden: leaving them
-  // alive means every host a user has ever opened keeps redrawing behind a
-  // closed row.
-  function childTable(hostID) {
-    var id = 'agentactivity-child-' + hostID;
+  // Groups start collapsed, which is the whole point: the page opens as a
+  // list of hosts and what each last did, and you go looking from there.
+  // Nothing to do to arrange it -- `expanded` starts empty and the filter
+  // above keeps every non-anchor row out until a header is clicked.
 
-    return '<div class="p-2"><table id="' + id
-      + '" class="table table-sm w-100"><thead><tr>'
-      + '<th>' + $.escapeHtml('When') + '</th>'
-      + '<th>' + $.escapeHtml('Event') + '</th>'
-      + '<th>' + $.escapeHtml('Detail') + '</th>'
-      + '<th>' + $.escapeHtml('Outcome') + '</th>'
-      + '</tr></thead></table></div>';
-  }
+  function loadHost(name, hostID, done) {
+    if (loading[name]) {
+      return;
+    }
+    loading[name] = true;
 
-  // registerTable(), not a bare .DataTable(). The first version of this file
-  // hand-rolled the child and so opted out of every convention the helper
-  // applies -- including its `dom`, which is where the pager lives. The
-  // result showed the first ten of a host's events with no way to reach the
-  // rest, on a host with seventy-nine of them.
-  //
-  // Going through the helper also means the child gets the SAME infinite
-  // scroll as every other grid: registerTable() turns Scroller on unless the
-  // table uses rowGroup or opts out. So the collapsed-by-host view and
-  // continuous scrolling are not in tension after all -- the tension was
-  // between rowGroup and Scroller, and this design has no rowGroup.
-  function buildChild(hostID) {
-    var dt = $('#agentactivity-child-' + hostID).registerTable(null, {
-      order: [
-        [0, 'desc']
-      ],
-      columns: [
-        escaped('createdTime'),
-        escaped('type'),
-        escaped('text'),
-        {
-          data: 'outcome',
-          render: function(d, t) {
-            var v = d === null ? '' : String(d);
-            if (t !== 'display') {
-              return v;
-            }
-            return '<span class="badge '
-              + (outcomeClass[v] || outcomeClass.unknown) + '">'
-              + $.escapeHtml(v) + '</span>';
-          }
+    $.ajax({
+      url: '../management/index.php?node=agentactivity&sub=getHostActivity&id='
+        + encodeURIComponent(hostID),
+      type: 'post',
+      dataType: 'json',
+      // Route::listem() reads DataTables' own paging parameters, so the cap
+      // is expressed the way that endpoint already understands rather than
+      // by teaching it a second one.
+      data: {start: 0, length: ROWS_PER_HOST},
+      success: function(json) {
+        var rows = (json && json.data) || [],
+          // recordsFiltered, NOT recordsTotal. listem()'s recordsTotal is
+          // every row in auditLog -- 1435 on the lab install -- so testing
+          // against it declared a 134-event host truncated at 500.
+          total = (json && json.recordsFiltered) || rows.length,
+          seed = table.rows().data().toArray().filter(function(r) {
+            return r.hostName === name && r.anchor;
+          })[0],
+          add = [];
+
+        if (total > rows.length) {
+          truncated[name] = true;
         }
-      ],
-      rowId: 'id',
-      processing: true,
-      serverSide: true,
-      // Nothing here is selectable: auditlog has no write route at all
-      // (ADR 0021 Decision 8), so a selection could not act on anything.
-      select: false,
-      // The helper's default viewport is 55vh, which is most of the screen --
-      // right for a page that IS the table, wrong for one nested inside a row
-      // of another. This is tall enough to scroll and short enough that the
-      // host rows below stay reachable.
-      scrollY: '18rem',
-      ajax: {
-        url: '../management/index.php?node=agentactivity'
-          + '&sub=getHostActivity&id=' + encodeURIComponent(hostID),
-        type: 'post'
+
+        $.each(rows, function(i, row) {
+          // The newest row is already on screen as the anchor. Adding it
+          // again would show one event twice under its own header.
+          if (seed && String(row.createdTime) === String(seed.createdTime)
+            && String(row.type) === String(seed.type)) {
+            return;
+          }
+          // A host with no anchor cannot be reached from the UI (there is
+          // no header to click), but the key still has to be per-host so a
+          // programmatic load cannot merge two hosts into one group.
+          add.push(eventRow(
+            seed || {
+              hostID: hostID,
+              hostName: name,
+              events: rows.length,
+              groupSort: String(row.createdTime) + '|' + String(hostID)
+            },
+            row
+          ));
+        });
+
+        if (add.length) {
+          table.rows.add(add);
+        }
+        loaded[name] = true;
+      },
+      complete: function() {
+        loading[name] = false;
+        done();
       }
     });
-
-    // A child row is inserted AFTER the page has laid out, which is the same
-    // situation as a table built inside a hidden tab: Scroller measures a
-    // table that has no height and no width yet, and the header/body split
-    // stays misaligned until something re-measures. fogBindTableAutosize()
-    // does this on shown.bs.tab; there is no such event here, so the sizing
-    // pass runs once the row is actually in the document.
-    setTimeout(function() {
-      try {
-        fogSizeScroller(dt);
-        dt.columns.adjust();
-      } catch (e) {}
-    }, 0);
-
-    return dt;
   }
 
-  $table.on('click', '.agentactivity-expand', function() {
-    var $btn = $(this),
-      row = table.row($btn.closest('tr')),
-      hostID = row.id();
+  // Delegated to the table: RowGroup redraws its headers on every draw, so
+  // a handler bound to the header elements themselves would be lost the
+  // first time anything sorted, searched or added a row.
+  $table.on('click', '.agentactivity-group', function(e) {
+    var name = $(this).attr('data-host'),
+      row = table.rows().data().toArray().filter(function(r) {
+        return r.hostName === name && r.anchor;
+      })[0];
 
-    if (row.child.isShown()) {
-      $('#agentactivity-child-' + hostID).DataTable().destroy();
-      row.child.hide();
-      $btn.attr('aria-expanded', 'false')
-        .find('i').removeClass('fa-chevron-down').addClass('fa-chevron-right');
+    e.preventDefault();
+
+    if (expanded[name]) {
+      expanded[name] = false;
+      table.draw(false);
       return;
     }
 
-    row.child(childTable(hostID)).show();
-    buildChild(hostID);
-    $btn.attr('aria-expanded', 'true')
-      .find('i').removeClass('fa-chevron-right').addClass('fa-chevron-down');
+    expanded[name] = true;
+
+    if (loaded[name] || !row) {
+      table.draw(false);
+      return;
+    }
+
+    // Drawn before the fetch as well as after: the chevron turns over
+    // immediately, so a slow endpoint reads as loading rather than as a
+    // click that did nothing.
+    table.draw(false);
+    loadHost(name, row.hostID, function() {
+      table.draw(false);
+    });
   });
 })(jQuery);

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -4423,6 +4423,23 @@ $.fn.registerTable = function(onSelect, opts) {
   }
   delete opts.extraButtons;
 
+  // A table that does not select does not get the buttons that select.
+  //
+  // `select: false` used to turn selection off and leave Select All and
+  // Deselect All sitting in the toolbar, where they were enabled, clickable
+  // and did nothing -- on 33 tables, including every report pane and the
+  // read-only event logs. The buttons live in `defaults.buttons` while the
+  // opt-out arrives in `opts`, so nothing connected the two.
+  //
+  // Dropped rather than disabled: a permanently grayed-out control still asks
+  // the reader what would enable it. The PHP half of the same statement is
+  // FOGPage::$selectable, which suppresses "Delete selected".
+  if (opts.select === false) {
+    defaults.buttons = defaults.buttons.filter(function(b) {
+      return !b || (b.extend !== 'selectAll' && b.extend !== 'selectNone');
+    });
+  }
+
   // Column resizing is on for every table. Pulled off opts before they reach
   // DataTables, which has no such option and would only carry it around.
   var columnResize = opts.columnResize !== false;

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -5509,10 +5509,6 @@ msgstr "Sprache"
 msgid "Largest images"
 msgstr "Images"
 
-#, fuzzy
-msgid "Last Activity"
-msgstr "Aktiv"
-
 msgid "Last Agent Check-In"
 msgstr ""
 
@@ -5528,10 +5524,6 @@ msgstr ""
 
 msgid "Last Deployed"
 msgstr "Zuletzt verteilt"
-
-#, fuzzy
-msgid "Last Event"
-msgstr "Zuletzt hochgeladen"
 
 msgid "Last Ping"
 msgstr ""
@@ -10424,7 +10416,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -13442,6 +13433,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "LDAP User Filter"
 #~ msgstr "LDAP-Server"
+
+#, fuzzy
+#~ msgid "Last Activity"
+#~ msgstr "Aktiv"
+
+#, fuzzy
+#~ msgid "Last Event"
+#~ msgstr "Zuletzt hochgeladen"
 
 #, fuzzy
 #~ msgid "Latest SVN Version"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -5509,10 +5509,6 @@ msgstr "Language"
 msgid "Largest images"
 msgstr "Images"
 
-#, fuzzy
-msgid "Last Activity"
-msgstr "Active"
-
 msgid "Last Agent Check-In"
 msgstr ""
 
@@ -5528,10 +5524,6 @@ msgstr ""
 
 msgid "Last Deployed"
 msgstr "Last Deployed"
-
-#, fuzzy
-msgid "Last Event"
-msgstr "Host Created"
 
 msgid "Last Ping"
 msgstr ""
@@ -10433,7 +10425,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -13433,6 +13424,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "LDAP User Filter"
 #~ msgstr "LDAP Server"
+
+#, fuzzy
+#~ msgid "Last Activity"
+#~ msgstr "Active"
+
+#, fuzzy
+#~ msgid "Last Event"
+#~ msgstr "Host Created"
 
 #, fuzzy
 #~ msgid "Latest SVN Version"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5602,10 +5602,6 @@ msgstr ""
 msgid "Largest images"
 msgstr "Imagen"
 
-#, fuzzy
-msgid "Last Activity"
-msgstr "Activo"
-
 msgid "Last Agent Check-In"
 msgstr ""
 
@@ -5621,10 +5617,6 @@ msgstr ""
 
 msgid "Last Deployed"
 msgstr "última Desplegado"
-
-#, fuzzy
-msgid "Last Event"
-msgstr "Creado"
 
 msgid "Last Ping"
 msgstr ""
@@ -10591,7 +10583,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -13598,6 +13589,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "LDAP User Filter"
 #~ msgstr "servidor TFTP"
+
+#, fuzzy
+#~ msgid "Last Activity"
+#~ msgstr "Activo"
+
+#, fuzzy
+#~ msgid "Last Event"
+#~ msgstr "Creado"
 
 #, fuzzy
 #~ msgid "Latest SVN Version"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5510,10 +5510,6 @@ msgstr "Sprache"
 msgid "Largest images"
 msgstr "Images"
 
-#, fuzzy
-msgid "Last Activity"
-msgstr "Aktiv"
-
 msgid "Last Agent Check-In"
 msgstr ""
 
@@ -5529,10 +5525,6 @@ msgstr ""
 
 msgid "Last Deployed"
 msgstr "Zuletzt verteilt"
-
-#, fuzzy
-msgid "Last Event"
-msgstr "Zuletzt hochgeladen"
 
 msgid "Last Ping"
 msgstr ""
@@ -10425,7 +10417,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -13443,6 +13434,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "LDAP User Filter"
 #~ msgstr "LDAP-Server"
+
+#, fuzzy
+#~ msgid "Last Activity"
+#~ msgstr "Aktiv"
+
+#, fuzzy
+#~ msgid "Last Event"
+#~ msgstr "Zuletzt hochgeladen"
 
 #, fuzzy
 #~ msgid "Latest SVN Version"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -5509,10 +5509,6 @@ msgstr "La langue"
 msgid "Largest images"
 msgstr "Images"
 
-#, fuzzy
-msgid "Last Activity"
-msgstr "actif"
-
 msgid "Last Agent Check-In"
 msgstr ""
 
@@ -5528,10 +5524,6 @@ msgstr ""
 
 msgid "Last Deployed"
 msgstr "Dernière Déployé"
-
-#, fuzzy
-msgid "Last Event"
-msgstr "hôte Créé"
 
 msgid "Last Ping"
 msgstr ""
@@ -10417,7 +10409,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -13418,6 +13409,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "LDAP User Filter"
 #~ msgstr "Serveur LDAP"
+
+#, fuzzy
+#~ msgid "Last Activity"
+#~ msgstr "actif"
+
+#, fuzzy
+#~ msgid "Last Event"
+#~ msgstr "hôte Créé"
 
 #, fuzzy
 #~ msgid "Latest SVN Version"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -5363,10 +5363,6 @@ msgstr "Lingua"
 msgid "Largest images"
 msgstr "immagini"
 
-#, fuzzy
-msgid "Last Activity"
-msgstr "Attivo"
-
 msgid "Last Agent Check-In"
 msgstr ""
 
@@ -5381,10 +5377,6 @@ msgstr ""
 
 msgid "Last Deployed"
 msgstr "Ultima Distribuita"
-
-#, fuzzy
-msgid "Last Event"
-msgstr "Ultima cattura"
 
 msgid "Last Ping"
 msgstr ""
@@ -10140,7 +10132,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -13060,6 +13051,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "LDAP User Filter"
 #~ msgstr "Server LDAP"
+
+#, fuzzy
+#~ msgid "Last Activity"
+#~ msgstr "Attivo"
+
+#, fuzzy
+#~ msgid "Last Event"
+#~ msgstr "Ultima cattura"
 
 #~ msgid "Latest SVN Version"
 #~ msgstr "Ultima versione di SVN"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -5332,10 +5332,6 @@ msgid "Largest images"
 msgstr "イメージ"
 
 #, fuzzy
-msgid "Last Activity"
-msgstr "有効"
-
-#, fuzzy
 msgid "Last Agent Check-In"
 msgstr "タスクチェックイン日"
 
@@ -5352,10 +5348,6 @@ msgstr "タスクチェックイン日"
 
 msgid "Last Deployed"
 msgstr "最終展開"
-
-#, fuzzy
-msgid "Last Event"
-msgstr "最終キャプチャ"
 
 msgid "Last Ping"
 msgstr ""
@@ -10097,7 +10089,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -13636,6 +13627,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "LDAP User Filter"
 #~ msgstr "ユーザーフィルター"
+
+#, fuzzy
+#~ msgid "Last Activity"
+#~ msgstr "有効"
+
+#, fuzzy
+#~ msgid "Last Event"
+#~ msgstr "最終キャプチャ"
 
 #~ msgid "Last Updated Time"
 #~ msgstr "最終更新時刻"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -4715,9 +4715,6 @@ msgstr ""
 msgid "Largest images"
 msgstr ""
 
-msgid "Last Activity"
-msgstr ""
-
 msgid "Last Agent Check-In"
 msgstr ""
 
@@ -4731,9 +4728,6 @@ msgid "Last Check-In"
 msgstr ""
 
 msgid "Last Deployed"
-msgstr ""
-
-msgid "Last Event"
 msgstr ""
 
 msgid "Last Ping"
@@ -8935,7 +8929,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -5509,10 +5509,6 @@ msgstr "Língua"
 msgid "Largest images"
 msgstr "imagens"
 
-#, fuzzy
-msgid "Last Activity"
-msgstr "Ativo"
-
 msgid "Last Agent Check-In"
 msgstr ""
 
@@ -5528,10 +5524,6 @@ msgstr ""
 
 msgid "Last Deployed"
 msgstr "Última Implantado"
-
-#, fuzzy
-msgid "Last Event"
-msgstr "host criado"
 
 msgid "Last Ping"
 msgstr ""
@@ -10420,7 +10412,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -13421,6 +13412,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "LDAP User Filter"
 #~ msgstr "Servidor LDAP"
+
+#, fuzzy
+#~ msgid "Last Activity"
+#~ msgstr "Ativo"
+
+#, fuzzy
+#~ msgid "Last Event"
+#~ msgstr "host criado"
 
 #, fuzzy
 #~ msgid "Latest SVN Version"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -5509,10 +5509,6 @@ msgstr "语言"
 msgid "Largest images"
 msgstr "图片"
 
-#, fuzzy
-msgid "Last Activity"
-msgstr "活性"
-
 msgid "Last Agent Check-In"
 msgstr ""
 
@@ -5528,10 +5524,6 @@ msgstr ""
 
 msgid "Last Deployed"
 msgstr "最后部署"
-
-#, fuzzy
-msgid "Last Event"
-msgstr "主机创建"
 
 msgid "Last Ping"
 msgstr ""
@@ -10420,7 +10412,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 
@@ -13421,6 +13412,14 @@ msgstr ""
 #, fuzzy
 #~ msgid "LDAP User Filter"
 #~ msgstr "LDAP服务器"
+
+#, fuzzy
+#~ msgid "Last Activity"
+#~ msgstr "活性"
+
+#, fuzzy
+#~ msgid "Last Event"
+#~ msgstr "主机创建"
 
 #, fuzzy
 #~ msgid "Latest SVN Version"

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -69,6 +69,29 @@ abstract class FOGPage extends FOGBase
      */
     public $title;
     /**
+     * Whether this page's grid lets you select and act on rows.
+     *
+     * The toolbar used to decide by NODE NAME -- a hardcoded list of
+     * ['plugin', 'task', 'activity', 'audit'] that a read-only page had to
+     * be added to, and which the next one silently was not: Agent Activity
+     * shipped drawing a red "Delete selected" over a grid whose own JS sets
+     * `select: false` and whose table has no delete route anywhere in FOG
+     * (ADR 0021 Decision 8).
+     *
+     * A page says what it is instead of the toolbar guessing from its URL.
+     * The pages that were in that list set this false, and so does any page
+     * added later -- forgetting it now means the buttons appear, which is
+     * visible, rather than a name missing from a list nobody reads.
+     *
+     * This is the PHP half. Select All / Deselect All are DataTables Buttons
+     * and are dropped by registerTable() when a table passes
+     * `select: false`, which is the same statement made in the layer that
+     * owns those buttons.
+     *
+     * @var bool
+     */
+    public $selectable = true;
+    /**
      * The menu (always display)
      *
      * @var array
@@ -1902,18 +1925,20 @@ abstract class FOGPage extends FOGBase
             if ($sub == 'list') {
                 // Tasks are canceled per-pane, never deleted; the tabbed
                 // task page hits sub=list via the no-sub default, so keep
-                // the delete actionbox off it. Activity and the audit log
-                // are read-only views of the event logs -- ?node=X&sub=list
-                // resolves to index() like any unknown sub does, and without
-                // this they would draw a "Delete selected" neither page
-                // implements. For the audit log there is nothing to
-                // implement it WITH: auditlog and auditchange have no delete
-                // route anywhere in FOG (ADR 0021 Decision 8).
-                if (!in_array(
-                    $node,
-                    ['plugin', 'task', 'activity', 'audit'],
-                    true
-                )) {
+                // the delete actionbox off it. Activity, the audit log and
+                // agent activity are read-only views of the event logs --
+                // ?node=X&sub=list resolves to index() like any unknown sub
+                // does, and without this they would draw a "Delete selected"
+                // none of them implements. For the audit trail there is
+                // nothing to implement it WITH: auditlog and auditchange
+                // have no delete route anywhere in FOG (ADR 0021
+                // Decision 8).
+                //
+                // Read from the page, not from its node name. The list this
+                // replaces had to be edited every time a read-only page was
+                // added and was not when Agent Activity arrived, so that
+                // page shipped a red Delete selected it could not honor.
+                if ($this->selectable) {
                     $actionbox .= self::makeButton(
                         'deleteSelected',
                         _('Delete selected'),

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -131,7 +131,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 430);
-        define('FOG_BCACHE_VER', 362);
+        define('FOG_BCACHE_VER', 363);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/src/Pages/ActivityManagement.php
+++ b/packages/web/src/Pages/ActivityManagement.php
@@ -62,6 +62,15 @@ class ActivityManagement extends FOGPage
      */
     public $node = 'activity';
     /**
+     * This grid does not select.
+     *
+     * Read only: this is a view of the event log, not a table anything here
+     * removes rows from.
+     *
+     * @var bool
+     */
+    public $selectable = false;
+    /**
      * Every source this viewer knows, before any permission is applied.
      *
      * value => [label, api class, extra permission or null].

--- a/packages/web/src/Pages/AgentActivityManagement.php
+++ b/packages/web/src/Pages/AgentActivityManagement.php
@@ -26,19 +26,40 @@ use FOG\Router\Route;
  * install in one flat grid with no host filter, so "what has this machine's
  * agent been doing" meant scrolling past every other machine.
  *
- * SUMMARY FIRST, ROWS ON DEMAND. This page lists one row per host --
- * hostname, how many agent events it has, when the last one was and what it
- * was -- and fetches a host's actual rows only when it is expanded.
+ * ONE GRID, GROUPED BY HOST. Every host that has agent activity gets a
+ * RowGroup header carrying its name and its event count, and under it that
+ * host's newest event. Expanding a header loads the rest of that host's
+ * events and shows them as ordinary rows of the same grid.
  *
- * That shape rather than a flat grid with group headers, for three reasons.
- * DataTables' rowGroup would group only within the current PAGE under
- * `serverSide`, so one hostname would head a dozen separate pages. Any table
- * using rowGroup is auto-paged out of the infinite scroll by registerTable()
- * -- Scroller's virtual row-height math cannot reconcile injected header
- * rows -- and fog.audit.list.js already records that as the reason the audit
- * grid does not group. And an agent writes an audit row per changed fact per
- * host, so a flat list is the one thing that grows without bound while the
- * summary is bounded by the size of the fleet.
+ * The first version of this page was a summary grid whose rows each opened
+ * a nested DataTable through `row.child()`. That never worked in the
+ * browser and could not have: a DataTables row has ONE child slot,
+ * registerTable() turns Responsive on for every grid, and Responsive claims
+ * that slot for its own hidden-column detail. Clicking expand rendered
+ * Responsive's field list and the nested table was never constructed --
+ * measured on a live install at 1920px with no columns hidden. Nothing
+ * errored, which is why it survived a fix (`the expanded host was stuck at
+ * ten rows`) aimed at a pager inside a table that did not exist.
+ *
+ * So the drill-down uses no child row at all. Rows are added to the grid
+ * itself, which is also what makes them look like the rest of FOG rather
+ * than a grid nested inside a grid with its own scrollbar and its own pager.
+ *
+ * WHY EACH GROUP KEEPS A ROW. Collapsing is a search filter over the event
+ * rows, and RowGroup builds its headers from the rows that SURVIVE the
+ * filter -- a group with none left renders no header and the host
+ * disappears. Measured, not assumed. So the newest event of every host is
+ * seeded into the table and never filtered: it is the anchor its header is
+ * drawn from, and it doubles as the thing worth seeing when everything is
+ * collapsed, which is what each agent last did.
+ *
+ * WHY THE SEED IS A SUMMARY QUERY AND THE REST IS NOT. An agent writes a
+ * row per changed fact per host and FOG_AUDIT_RETENTION_DAYS defaults to 0,
+ * "keep everything forever" -- so the flat event set is unbounded and
+ * cannot be loaded client side, which is also why rowGroup over a
+ * `serverSide` grid is not an option here (it would group within one page).
+ * The seed is bounded by the size of the fleet; each expansion is bounded
+ * by a cap. Nothing on this page loads a set bounded by neither.
  *
  * The expand fetches through the SAME endpoint the host page's Agent
  * Activity tab uses, so there is one query behind both surfaces.
@@ -68,6 +89,16 @@ class AgentActivityManagement extends FOGPage
      * @var string
      */
     public $node = 'agentactivity';
+    /**
+     * This grid does not select.
+     *
+     * Read only, like the audit log it reads: `auditlog` has no create, update
+     * or delete route anywhere in FOG (ADR 0021 Decision 8), so there is
+     * nothing here for a selection to act on.
+     *
+     * @var bool
+     */
+    public $selectable = false;
     /**
      * The prefix every type this page shows begins with.
      *
@@ -113,21 +144,31 @@ class AgentActivityManagement extends FOGPage
     {
         $this->title = _('Agent Activity');
 
-        // The first column is the expand control and carries no heading of
-        // its own: a header on it would be a label for a button.
+        // ONE column set for both kinds of row. The grid holds each host's
+        // newest event and, once its group is expanded, the rest of that
+        // host's events -- and those are the same shape, so they are the
+        // same columns. The host itself is not a column: it is the RowGroup
+        // header, which is where the per-host counts and the expand control
+        // live too.
         $this->headerData = [
-            '',
-            _('Host'),
-            _('Events'),
-            _('Last Activity'),
-            _('Last Event')
+            _('When'),
+            _('Event'),
+            _('Detail'),
+            _('Outcome'),
+            _('Host')
         ];
+        // The host column is hidden and stays hidden -- `noVis` keeps it out
+        // of the Column Visibility picker. It exists because RowGroup needs
+        // the table SORTED by its group, and a group is only contiguous if
+        // something orders it: ordering by time alone lets one host's older
+        // rows fall past the next host's newest one, which splits the group
+        // and draws its header a second time. Observed before this existed.
         $this->attributes = [
-            ['class' => 'agentactivity-toggle'],
             [],
             [],
             [],
-            []
+            [],
+            ['class' => 'noVis']
         ];
 
         echo '<div class="card">';
@@ -174,7 +215,8 @@ class AgentActivityManagement extends FOGPage
         $rows = self::$DB->query(
             'SELECT a.`alSubjectID` AS `hostID`, h.`hostName` AS `hostName`, '
             . 's.`events` AS `events`, s.`lastTime` AS `lastTime`, '
-            . 'a.`alType` AS `lastType` '
+            . 'a.`alType` AS `lastType`, a.`alText` AS `lastText`, '
+            . 'a.`alOutcome` AS `lastOutcome` '
             . 'FROM `auditLog` a '
             . 'INNER JOIN ('
             . 'SELECT `alSubjectID`, COUNT(*) AS `events`, '
@@ -214,7 +256,14 @@ class AgentActivityManagement extends FOGPage
                     : self::toDisplayStored(
                         (string) $row['lastTime']
                     )->format('Y-m-d H:i:s'),
-                'lastType' => (string) ($row['lastType'] ?? '')
+                'lastType' => (string) ($row['lastType'] ?? ''),
+                // The newest row IN FULL, not just its type. It is the one
+                // row of the host that is always on screen -- the anchor its
+                // group header is drawn from -- so it has to carry the same
+                // four fields an expanded row does or the collapsed view
+                // would have empty cells under populated headings.
+                'lastText' => (string) ($row['lastText'] ?? ''),
+                'lastOutcome' => (string) ($row['lastOutcome'] ?? '')
             ];
         }
 

--- a/packages/web/src/Pages/AuditManagement.php
+++ b/packages/web/src/Pages/AuditManagement.php
@@ -50,6 +50,16 @@ class AuditManagement extends FOGPage
      */
     public $node = 'audit';
     /**
+     * This grid does not select.
+     *
+     * Read only. `auditlog` and `auditchange` have no delete route anywhere in
+     * FOG (ADR 0021 Decision 8), so there is nothing here for a selection to
+     * act on.
+     *
+     * @var bool
+     */
+    public $selectable = false;
+    /**
      * How many change rows one header may show.
      *
      * Bounded in the query, not in the browser. A create writes one row per

--- a/packages/web/src/Pages/PluginManagement.php
+++ b/packages/web/src/Pages/PluginManagement.php
@@ -39,6 +39,15 @@ class PluginManagement extends FOGPage
      */
     public $node = 'plugin';
     /**
+     * This grid does not select.
+     *
+     * A plugin is installed and uninstalled by its own row action, never by
+     * ticking rows and pressing Delete.
+     *
+     * @var bool
+     */
+    public $selectable = false;
+    /**
      * Initialize the plugin page
      *
      * @param string $name the name of the page.

--- a/packages/web/src/Pages/TaskManagement.php
+++ b/packages/web/src/Pages/TaskManagement.php
@@ -49,6 +49,15 @@ class TaskManagement extends FOGPage
      */
     public $node = 'task';
     /**
+     * This grid does not select.
+     *
+     * Tasks are canceled per-pane, never deleted, so there is nothing for a
+     * selection to act on.
+     *
+     * @var bool
+     */
+    public $selectable = false;
+    /**
      * Initializes the task page items.
      *
      * @param string $name The name to initialize with.

--- a/tests/agent-activity-grouping.test.php
+++ b/tests/agent-activity-grouping.test.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Agent Activity: the grouped grid, and the four bugs that were silent.
+ *
+ * This page shows one RowGroup per host -- the host's name, its event count
+ * and an expand control in the header, that host's newest event as the row
+ * beneath it, and the rest of its events added to the same grid when the
+ * header is clicked. Every part of that arrangement replaces something that
+ * was broken in a way nothing reported.
+ *
+ * 1. NO row.child(). The first version opened a nested DataTable per host
+ *    through `row.child()`. A DataTables row has ONE child slot and
+ *    registerTable() turns Responsive on for every grid, so Responsive owned
+ *    it: the nested table was never constructed and clicking expand rendered
+ *    Responsive's hidden-column list instead. Measured on a live install at
+ *    1920px with zero columns hidden, so it was not a narrow-viewport
+ *    artifact -- and nothing threw, which is how it survived a follow-up fix
+ *    aimed at the pager of a table that did not exist. Any return to
+ *    row.child() on this page returns to that.
+ *
+ * 2. THE ANCHOR ROW IS NEVER FILTERED. Collapse is an ext.search filter, and
+ *    RowGroup builds headers from the rows that SURVIVE it -- a group with
+ *    none left renders no header at all. Verified against the vendored
+ *    RowGroup, not assumed: with one of two groups fully filtered, only the
+ *    other group's header was emitted. So the filter has to let the anchor
+ *    through unconditionally; a filter that reads only the expanded flag
+ *    makes every collapsed host vanish from the page, which looks like an
+ *    empty install.
+ *
+ * 3. EVERY ROW OF A HOST SORTS ALIKE. RowGroup starts a new group each time
+ *    its dataSrc changes down the ORDERED rows, so a group is only whole if
+ *    the table is ordered by it. Ordering by time alone let one host's older
+ *    events fall past the next host's newest, and its header was drawn
+ *    twice. The fix is a hidden column that sorts on a per-GROUP key, and
+ *    the trap inside the fix is that eventRow() is handed a row this file
+ *    already built: recomputing the key from `seed.lastTime` reads undefined
+ *    (a seed row carries createdTime), every event sorts under
+ *    "undefined|<id>", and the group splits exactly as before. So the key is
+ *    COPIED, and that is what this pins.
+ *
+ * 4. TRUNCATION READS recordsFiltered. Route::listem()'s recordsTotal is
+ *    every row in auditLog -- 1435 on the lab install -- not the host's. A
+ *    cap test against it called a 134-event host truncated at 500 and put
+ *    "showing the newest 500" on a header that was showing all of them.
+ *
+ * And the toolbar half, which is not specific to this page: a grid that
+ * passes `select: false` must not be given Select All and Deselect All, and
+ * a page that declares itself unselectable must not be given "Delete
+ * selected". That used to be decided by a hardcoded list of node names,
+ * which this page was not added to -- so it shipped a red Delete selected
+ * over a table with no delete route anywhere in FOG (ADR 0021 Decision 8).
+ *
+ * Usage: php tests/agent-activity-grouping.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+use FOG\Base\FOGPage;
+use FOG\Pages\ActivityManagement;
+use FOG\Pages\AgentActivityManagement;
+use FOG\Pages\AuditManagement;
+use FOG\Pages\PluginManagement;
+use FOG\Pages\TaskManagement;
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('agent-activity-grouping');
+
+$t = new FogChecks();
+
+/**
+ * A file's CODE, with its comment lines removed.
+ *
+ * Every check below asks whether the source still does something, and the
+ * source explains at length why it does it -- including by quoting the
+ * broken shape it replaced. Scanning the raw file makes those explanations
+ * fail the build: the first run of this test went red on `row.child()` and
+ * on the old node list, both of which appear only inside the comments that
+ * say never to go back to them. A gate that cannot survive being described
+ * is a gate that pressures the next person to delete the description.
+ *
+ * Whole comment lines only, which is all this codebase writes -- so no
+ * string containing // is at risk, and every check here matches on a line
+ * of code.
+ *
+ * @param string $path file to read
+ *
+ * @return string
+ */
+$code = static function ($path) {
+    $out = [];
+    foreach (preg_split('/\R/', (string)file_get_contents($path)) as $line) {
+        $trim = ltrim($line);
+        if ('' !== $trim
+            && (0 === strpos($trim, '//')
+                || 0 === strpos($trim, '/*')
+                || 0 === strpos($trim, '*'))
+        ) {
+            continue;
+        }
+        $out[] = $line;
+    }
+    return implode("\n", $out);
+};
+
+$web = dirname(__DIR__) . '/packages/web';
+$js = $code(
+    $web . '/management/js/fog/agentactivity/fog.agentactivity.list.js'
+);
+$common = $code($web . '/management/js/fog/fog.common.js');
+$page = $code(
+    (new \ReflectionClass(AgentActivityManagement::class))->getFileName()
+);
+$base = $code(
+    (new \ReflectionClass(FOGPage::class))->getFileName()
+);
+
+// 1. No child rows on this page, at all. Responsive owns the one slot.
+$t->check(
+    'the grid uses no row.child() -- Responsive owns that slot',
+    false === strpos($js, 'row.child')
+        && false === strpos($js, '.child(')
+);
+
+// The replacement it must be using instead: rows added to the grid itself.
+$t->check(
+    'expanded events are added to the grid (rows.add)',
+    false !== strpos($js, 'table.rows.add(')
+);
+
+// 2. The collapse filter passes the anchor unconditionally. Pinned on the
+// shape of the expression, because a filter that happens to return true for
+// an anchor today by testing something else would not survive a rename.
+$t->check(
+    'the collapse filter lets the anchor row through',
+    1 === preg_match(
+        '/return\s+row\.anchor\s*===\s*true\s*\|\|\s*expanded\[row\.hostName\]/',
+        $js
+    )
+);
+$t->check(
+    'the seed row is marked as the anchor',
+    1 === preg_match('/anchor:\s*true/', $js)
+        && 1 === preg_match('/anchor:\s*false/', $js)
+);
+
+// 3. eventRow() COPIES the group key rather than recomputing it. Recomputing
+// from a seed row is the exact bug: seed.lastTime is undefined.
+$t->check(
+    'eventRow copies groupSort from the seed, never recomputes it',
+    1 === preg_match('/groupSort:\s*seed\.groupSort/', $js)
+        && false === strpos($js, 'String(seed.lastTime)')
+);
+
+// The table has to be ORDERED by the group, or contiguity is luck.
+$t->check(
+    'the grid orders by the hidden group column first',
+    1 === preg_match('/order:\s*\[\s*\[\s*4,\s*\'desc\'\s*\]/', $js)
+);
+$t->check(
+    'the hidden group column sorts on groupSort',
+    1 === preg_match(
+        '/if\s*\(t\s*===\s*\'sort\'\s*\|\|\s*t\s*===\s*\'type\'\)\s*\{\s*return\s+row\.groupSort;/',
+        $js
+    )
+);
+// A fifth <th> has to exist for a fifth column to be addressable, and it
+// must be out of the Column Visibility picker.
+$t->check(
+    'the page emits the hidden Host column as noVis',
+    false !== strpos($page, "['class' => 'noVis']")
+        && 1 === preg_match("/_\('Outcome'\),\s*_\('Host'\)/", $page)
+);
+
+// 4. The cap is judged against this host's count, not the whole audit log.
+$t->check(
+    'truncation reads recordsFiltered, not recordsTotal',
+    false !== strpos($js, 'json.recordsFiltered')
+        && false === strpos($js, 'json.recordsTotal')
+);
+
+// The anchor needs the newest row IN FULL or the collapsed view has empty
+// cells under populated headings.
+foreach (['lastText', 'lastOutcome'] as $field) {
+    $t->check(
+        sprintf('getList() returns %s for the anchor row', $field),
+        false !== strpos($page, "'" . $field . "' =>")
+            && false !== strpos($js, $field)
+    );
+}
+
+// ---- the toolbar half ----
+
+// The PHP seam: a property, not a list of node names.
+$t->check(
+    'FOGPage declares $selectable and defaults it true',
+    1 === preg_match('/public\s+\$selectable\s*=\s*true;/', $base)
+);
+$t->check(
+    'the delete actionbox is gated on $this->selectable',
+    false !== strpos($base, 'if ($this->selectable) {')
+);
+$t->check(
+    'the hardcoded read-only node list is gone',
+    false === strpos($base, "['plugin', 'task', 'activity', 'audit']")
+);
+
+// Every page that was in that list, plus the one it missed.
+foreach (
+    [
+        'agentactivity' => AgentActivityManagement::class,
+        'audit' => AuditManagement::class,
+        'activity' => ActivityManagement::class,
+        'plugin' => PluginManagement::class,
+        'task' => TaskManagement::class
+    ] as $node => $class
+) {
+    $src = $code((new \ReflectionClass($class))->getFileName());
+    $t->check(
+        sprintf('%s declares itself unselectable', $node),
+        1 === preg_match('/public\s+\$selectable\s*=\s*false;/', $src)
+    );
+}
+
+// The JS seam: the buttons that select are dropped when nothing selects.
+$t->check(
+    'registerTable drops selectAll/selectNone on select:false',
+    1 === preg_match(
+        '/if\s*\(opts\.select\s*===\s*false\)\s*\{\s*defaults\.buttons\s*=\s*defaults\.buttons\.filter/',
+        $common
+    )
+    && false !== strpos($common, "b.extend !== 'selectAll'")
+    && false !== strpos($common, "b.extend !== 'selectNone'")
+);
+
+// The page's own grid has to actually make that statement, or the seam is
+// wired to nothing here.
+$t->check(
+    'the agent activity grid passes select: false',
+    1 === preg_match('/select:\s*false/', $js)
+);
+
+$t->finish();

--- a/tests/agent-activity-page.test.php
+++ b/tests/agent-activity-page.test.php
@@ -20,10 +20,16 @@
  *   audit log discloses attempted usernames and refusals; aliasing this
  *   onto it would force anyone who may see what an agent did to also see
  *   every failed sign-in.
- * - NO rowGroup. fog.audit.list.js records why the audit grid does not
- *   group, and registerTable() auto-pages any table that does -- so a
- *   grouped grid would silently lose the infinite scroll. The grouping here
- *   is done in SQL instead.
+ * - rowGroup, grouped on hostName. This bullet used to say the opposite --
+ *   that the grid must NOT group, because registerTable() auto-pages any
+ *   table that does and a grouped grid loses the infinite scroll. That trade
+ *   was real but it was the wrong side of it: the summary-plus-child-table
+ *   arrangement it protected never worked in a browser at all, because
+ *   Responsive owns the one row.child() slot every DataTables row has. The
+ *   page now groups, is paged rather than infinitely scrolled, and expands a
+ *   host by adding rows to the same grid. tests/agent-activity-grouping
+ *   .test.php holds the detail; what is pinned here is that the child table
+ *   does not come back.
  *
  * Usage: php tests/agent-activity-page.test.php
  * Exit status 0 = pass, 1 = fail.
@@ -169,9 +175,9 @@ $t->check(
 // ------------------------------------------------------ the grid contract
 
 $t->check(
-    'the grid does not use rowGroup, which would auto-page it out of the '
-    . 'infinite scroll and group only within one page',
-    false === strpos($jsSrc, 'rowGroup:')
+    'the grid groups on hostName with rowGroup',
+    false !== strpos($jsSrc, 'rowGroup:')
+        && 1 === preg_match('~dataSrc:\s*\x27hostName\x27~', $jsSrc)
 );
 
 // headerData and attributes are positional; a mismatch silently shifts
@@ -214,16 +220,26 @@ $t->check(
 // -- including its `dom`, which is where the pager lives, and its Scroller
 // setup. An expanded host showed the first ten of its events with no way to
 // reach the rest. Reported against a host with seventy-nine of them.
-$t->check(
-    'the expanded host table goes through registerTable, not a bare DataTable',
-    1 === preg_match(
-        '~agentactivity-child-\x27 \+ hostID\)\.registerTable\(~',
-        $jsSrc
+// Comment lines dropped first. The file explains at length why row.child()
+// is not used here, and scanning the prose that says "never do this" for the
+// thing not to do fails the build on the documentation.
+$jsCode = implode(
+    "\n",
+    array_filter(
+        preg_split('/\R/', $jsSrc),
+        static function ($line) {
+            $trim = ltrim($line);
+            return '' === $trim
+                || (0 !== strpos($trim, '//')
+                    && 0 !== strpos($trim, '/*')
+                    && 0 !== strpos($trim, '*'));
+        }
     )
 );
 $t->check(
-    'no bare .DataTable( construction builds the child grid',
-    0 === preg_match('~child-\x27 \+ hostID\)\.DataTable\(\{~', $jsSrc)
+    'no child table is built for an expanded host, by any route',
+    false === strpos($jsCode, 'agentactivity-child-')
+        && 0 === preg_match('~\brow\.child\(~', $jsCode)
 );
 
 // registerTable() sizes a Scroller table on a setTimeout(0) after init. A


### PR DESCRIPTION
## The expand never worked

Clicking a host's chevron on this page rendered DataTables **Responsive's** hidden-column
list. The nested table it was meant to open was never constructed. Measured on a live
install at 1920px with **zero** columns hidden, so it was not a narrow-viewport artifact:

```
childTableInDom: false
childRowText:    "Events 134 / Last Activity 2026-09-04 19:08:39 / Last Event agent.usersession"
hiddenColsBeforeExpand: 0   ->   hiddenColsAfterExpand: 3
```

A DataTables row has **one** child slot. `registerTable()` turns Responsive on for every
grid and Responsive claims that slot, so `row.child()` handed it a table it then
overwrote. Nothing threw — which is why `7b207c2c9` could fix "the expanded host was
stuck at ten rows" by repairing a pager inside a table that did not exist.

## What it is now

One grid, grouped by host with `rowGroup`. The header carries the host, its event count
and the expand control; expanding adds that host's events to the **same grid** as
ordinary rows. No table nested in a table, no second scrollbar, no second pager. The page
opens with every host visible and every group collapsed.

Three things had to be true for that to hold, each found by measuring rather than
reasoning:

| Finding | Consequence |
|---|---|
| A group whose rows are all filtered out renders **no header** | Each host's newest event is seeded and never filtered — it anchors the header and is the row worth seeing when all is collapsed |
| `rowGroup` starts a new group whenever `dataSrc` changes down the **ordered** rows | Ordering by time alone let one host's older events fall past the next host's newest and drew its header twice; a hidden column sorts every row of a host on that host's last-activity time plus its id |
| `listem()`'s `recordsTotal` is every row in `auditLog` (1435 on the lab install), not the host's | The cap notice reads `recordsFiltered`; against `recordsTotal` it told a 134-event host it was truncated at 500 |

The flat event set stays unbounded — `FOG_AUDIT_RETENTION_DAYS` defaults to `0`, keep
forever — which is why the seed is a summary query, each expansion is capped, and
`rowGroup` over a `serverSide` grid was never an option (it groups within one page).

## Select and delete, on every page

Not specific to this page. A grid that passes `select: false` no longer gets Select All
and Deselect All, and a page that declares itself unselectable no longer gets "Delete
selected".

That was decided by a hardcoded list of node names — `['plugin', 'task', 'activity',
'audit']` — which this page was never added to, so it shipped a red **Delete selected**
over a table with no delete route anywhere in FOG (ADR 0021 Decision 8).
`FOGPage::$selectable` replaces the list and `registerTable()` drops the two buttons, so
each half is stated in the layer that enforces it. The **33** tables already passing
`select: false` stop showing two enabled buttons that did nothing.

## Tests

`tests/agent-activity-grouping.test.php` — 21 checks. **Each of its eight gates was
proven by reintroducing the defect and watching it go red**, then restored. It strips
comment lines before scanning: the first run failed on `row.child()` and on the old node
list, both of which appear only inside the comments that say never to go back to them.

`tests/agent-activity-page.test.php` had pinned the arrangement this replaces ("the grid
does not use rowGroup", the child table going through `registerTable`). Those three
checks now assert the opposite, and one of them that no child table returns by any route.

Both PHPStan passes clean, unscoped. Full suite 335 passed, 1 failed —
`certificate-table.test.php`, which fails identically on an unmodified checkout of the
base and is green in CI.

`FOG_BCACHE_VER` 362 → 363. No route changed, so `OpenAPI::document()` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWJMQYE2br8E7Ehr55SJp2