### PR TITLE
Agent Activity: stop paging a grid whose unit is hosts

### DIFF
--- a/packages/web/management/js/fog/agentactivity/fog.agentactivity.list.js
+++ b/packages/web/management/js/fog/agentactivity/fog.agentactivity.list.js
@@ -243,6 +243,33 @@
       startRender: groupHeader
     },
     processing: true,
+    // NO PAGING, and that is the whole reason this page reads correctly.
+    //
+    // Paging counts ROWS; this page's unit is HOSTS. Expanding one host with
+    // 83 events at 25 rows a page filled pages one to three with that host
+    // and pushed every other host onto page four -- and RowGroup redraws a
+    // group's header on each page the group spans, so the same host appeared
+    // four times, expanded, which is what it looked like to the person
+    // reading it. Neither is a bug in RowGroup: both are what paging by row
+    // means when the thing being grouped is bigger than a page.
+    //
+    // There is no page length that fixes it, because the number of rows an
+    // expansion adds is a property of the host, not of the setting. Turning
+    // paging off removes the unit mismatch instead of tuning it: collapsed,
+    // the grid is one row per host; expanded, it gets longer and you scroll.
+    // The seed is bounded by the fleet (MAX_HOSTS) and each expansion by
+    // ROWS_PER_HOST, so "no paging" is not "no limit".
+    //
+    // Scroller is not the alternative -- registerTable() excludes any
+    // rowGroup table from it, because its virtual row-height math cannot
+    // reconcile injected header rows.
+    paging: false,
+    // ...and with it the "entries per page" control, which paging is the
+    // only thing that gives a value. Left in, it renders as an empty box
+    // beside its own label in both themes -- not a contrast problem, a
+    // control with nothing to say. dom keeps `l` for every other grid, so
+    // this is the switch that removes it here.
+    lengthChange: false,
     // Client side: the seed is one row per host, which is bounded by the
     // fleet, and rowGroup cannot group a server-side grid beyond one page.
     serverSide: false,
@@ -267,6 +294,23 @@
   // list of hosts and what each last did, and you go looking from there.
   // Nothing to do to arrange it -- `expanded` starts empty and the filter
   // above keeps every non-anchor row out until a header is clicked.
+
+  // Every reload starts over, because a reload throws the rows away.
+  //
+  // The toolbar's Refresh is `dt.clear().draw(); dt.ajax.reload();` -- it
+  // empties the table and re-fetches the seed. Without this the maps below
+  // survived that: a host still marked `loaded` was never re-fetched, so its
+  // rows were gone and clicking its header did nothing at all. It read as
+  // the expander breaking permanently after one press of Refresh.
+  //
+  // xhr.dt fires when the new seed lands, including the first load, where
+  // resetting empty maps costs nothing.
+  $table.on('xhr.dt', function() {
+    expanded = {};
+    loaded = {};
+    loading = {};
+    truncated = {};
+  });
 
   function loadHost(name, hostID, done) {
     if (loading[name]) {

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -10416,7 +10416,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -10425,7 +10425,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -10583,7 +10583,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -10417,7 +10417,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -10409,7 +10409,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -10132,7 +10132,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -10089,7 +10089,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -8929,7 +8929,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -10412,7 +10412,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -10412,7 +10412,6 @@ msgstr ""
 msgid "The term goes in q. limit caps results PER CLASS, not overall, and this route is not paged -- there is no nextUrl to follow. Within a class, names that start with the term sort first. Both fields may also be sent as POST body fields. Also reachable as /search."
 msgstr ""
 
-#, php-format
 msgid "The term. Because it is a path segment, a term containing / ? # or % cannot travel this way; use /unisearch?q= instead."
 msgstr ""
 

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -131,7 +131,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 430);
-        define('FOG_BCACHE_VER', 363);
+        define('FOG_BCACHE_VER', 364);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/tests/agent-activity-grouping.test.php
+++ b/tests/agent-activity-grouping.test.php
@@ -179,6 +179,42 @@ $t->check(
         && 1 === preg_match("/_\('Outcome'\),\s*_\('Host'\)/", $page)
 );
 
+// 5. Paging is OFF, and that is load bearing rather than cosmetic.
+//
+// Paging counts rows; this page's unit is hosts. With 25 rows a page, one
+// expanded host with 83 events filled pages one to three and pushed every
+// other host onto page four -- and rowGroup redraws a group's header on each
+// page the group spans, so that host appeared four times, expanded. No page
+// length fixes it: the row count an expansion adds belongs to the host, not
+// to the setting.
+$t->check(
+    'the grid does not page',
+    1 === preg_match('/paging:\s*false/', $js)
+);
+// The length control has no value once paging is off, so it renders as an
+// empty box next to its own label -- reported in both themes as unreadable,
+// which it was, because there was nothing in it to read.
+$t->check(
+    'the entries-per-page control is removed with it',
+    1 === preg_match('/lengthChange:\s*false/', $js)
+);
+
+// 6. A reload starts over. Refresh is dt.clear().draw() + ajax.reload(), so
+// the rows go away; a host still marked loaded was never re-fetched and its
+// header stopped responding entirely. That read as the expander breaking
+// permanently after one press of Refresh.
+$t->check(
+    'every per-host map is reset when new data arrives',
+    1 === preg_match(
+        '/on\(\x27xhr\.dt\x27[^)]*\)?[^{]*\{\s*'
+        . 'expanded\s*=\s*\{\};\s*'
+        . 'loaded\s*=\s*\{\};\s*'
+        . 'loading\s*=\s*\{\};\s*'
+        . 'truncated\s*=\s*\{\};/s',
+        $js
+    )
+);
+
 // 4. The cap is judged against this host's count, not the whole audit log.
 $t->check(
     'truncation reads recordsFiltered, not recordsTotal',


### PR DESCRIPTION
Follow-up to #1715, from testing it in a real browser. Three faults, one root.

**Paging counts rows; this page's unit is hosts.**

Expanding `telliottwin11` (83 events) at 25 rows a page filled pages 1–3 with that host
and pushed every other host onto page 4 — and rowGroup redraws a group's header on every
page the group spans, so the host appeared **four times, each apparently expanded**:

```
page1: [telliottwin11]
page2: [telliottwin11]
page3: [telliottwin11]
page4: [telliottwin11, 7550precision, fogagent-vm, WS-014, ...]
```

That is not a rowGroup bug; it is what paging by row does when the grouped thing is
bigger than a page. And no page length fixes it, because the rows an expansion adds are
a property of the host, not of the setting.

So **paging is off**. Collapsed, the grid is one row per host; expanded, it gets longer
and you scroll. The seed is still bounded by `MAX_HOSTS` and each expansion by
`ROWS_PER_HOST` — this is not "no limit". Scroller is not the alternative:
`registerTable()` excludes any rowGroup table from it.

**The empty "entries per page" box.** With paging gone the length control has nothing to
put in itself and rendered as an empty box beside its own label — reported as unreadable
in both themes, which it was, because there was nothing in it to read. `lengthChange:
false` removes the control instead of styling an empty one.

**Refresh killed the expander.** The toolbar's Refresh is `dt.clear().draw()` +
`ajax.reload()`, which throws the rows away and re-fetches the seed. The per-host maps
survived it, so a host still marked `loaded` was never re-fetched, its rows were gone,
and clicking its header did nothing. It read as the expander breaking permanently after
one press. They now reset on `xhr.dt`.

## Verified on the live install

| | |
|---|---|
| group headers, collapsed / expanded | 21 / 21 |
| duplicate headers when expanded | none |
| hosts displaced by an expansion | none |
| length control / pager present | 0 / 0 |
| expand after pressing Refresh | works (21 → 103 rows) |

Checked in both themes.

Three more gates in `tests/agent-activity-grouping.test.php` (24 checks now), **each
proven by reintroducing the defect and watching it go red**. Both PHPStan passes clean,
unscoped; suite 335 passed, 1 failed — `certificate-table.test.php`, which fails
identically on an unmodified base checkout and is green in CI.

`FOG_BCACHE_VER` 363 → 364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWJMQYE2br8E7Ehr55SJp2