### PR TITLE
Assert the certificates page in whichever shape the host is in

### DIFF
--- a/tests/certificate-table.test.php
+++ b/tests/certificate-table.test.php
@@ -238,10 +238,29 @@ $t->check(
 );
 
 /*
- * 5. The page itself. This runs where the PKI helper is absent (no sudoers
- *    rule for whoever runs the suite), which is the storage-node shape: the
- *    warning, then a tab card carrying the one section that survives.
+ * 5. The page itself, in whichever of its two shapes this host is in.
+ *
+ *    Which one is not a choice: _pkiStatus() returns null where the helper is
+ *    absent -- no sudoers rule for whoever runs the suite, which is a bare CI
+ *    runner and is also the storage-node shape -- and a status array on a
+ *    server that has actually been installed, which is every FOG developer's
+ *    own box. This block used to assert the absent shape unconditionally, so
+ *    it passed on CI and reported two failures to anyone running the suite on
+ *    a working install: no warning to find, and a chain tab that legitimately
+ *    has content.
+ *
+ *    Branching rather than skipping. The card, the tab wiring and the
+ *    collapse ban are the same either way and are asserted once; only the
+ *    warning and the chain tab differ, and each shape is a real gate in the
+ *    environment that produces it.
  */
+$pkiStatus = new \ReflectionMethod(
+    'FOG\\Pages\\FOGConfigurationPage',
+    '_pkiStatus'
+);
+$pkiStatus->setAccessible(true);
+$helperPresent = null !== $pkiStatus->invoke(null);
+
 ob_start();
 $page->certificates();
 $rendered = (string) ob_get_clean();
@@ -255,19 +274,30 @@ $t->check(
     false !== strpos($rendered, 'id="pki-own"')
         && false !== strpos($rendered, 'data-bs-toggle="tab"')
 );
-$t->check(
-    'a section with nothing to show is not an empty tab',
-    false === strpos($rendered, 'id="pki-chain"')
-);
-$t->check(
-    'the missing-helper warning is rendered',
-    false !== strpos($rendered, 'helper is not installed')
-);
-$t->check(
-    'and it is ABOVE the tabs, not behind one of them',
-    strpos($rendered, 'helper is not installed')
-        < strpos($rendered, 'nav nav-tabs')
-);
+if ($helperPresent) {
+    $t->check(
+        'with the helper present the chain section has content, so it is a tab',
+        false !== strpos($rendered, 'id="pki-chain"')
+    );
+    $t->check(
+        'and the missing-helper warning is NOT rendered',
+        false === strpos($rendered, 'helper is not installed')
+    );
+} else {
+    $t->check(
+        'a section with nothing to show is not an empty tab',
+        false === strpos($rendered, 'id="pki-chain"')
+    );
+    $t->check(
+        'the missing-helper warning is rendered',
+        false !== strpos($rendered, 'helper is not installed')
+    );
+    $t->check(
+        'and it is ABOVE the tabs, not behind one of them',
+        strpos($rendered, 'helper is not installed')
+            < strpos($rendered, 'nav nav-tabs')
+    );
+}
 $t->check(
     'nothing on the page ships behind a collapse an AJAX visit cannot open',
     false === strpos($rendered, 'collapsed-card')


### PR DESCRIPTION
Found while running `tests/run-all.sh` for #1722, not related to it.

## The problem

Section 5 of `tests/certificate-table.test.php` renders the Certificates page and asserts the **missing-helper** shape unconditionally — no `pki-chain` tab, and the "helper is not installed" warning above the tabs.

That shape is real, but it is not the only one. `_pkiStatus()` returns `null` where the PKI helper is absent — a bare CI runner, and a storage node — and a status array on a server that has actually been installed, which is every FOG developer's own box. On the latter the chain section legitimately has content, so it legitimately gets a tab, and there is no warning to find.

The result: green on CI, two failures locally, on assertions nobody had touched.

```
FAIL (2 of 33):
  - a section with nothing to show is not an empty tab
  - the missing-helper warning is rendered
```

A suite that is red on a working install makes every later branch's run ambiguous — you cannot tell an inherited failure from one you just caused without going and checking the base by hand. That is the cost worth removing; the page itself is behaving correctly in both shapes.

## The change

The test asks `_pkiStatus()` which shape the page is in and asserts the matching one.

**Branching rather than skipping**, deliberately. Skipping would drop all coverage of that section on exactly the machines FOG is developed on. The card, the tab wiring and the collapse ban are identical in both shapes and are still asserted once, unconditionally; only the warning and the chain tab differ.

## Verification

- Passes on this box (helper present): `ok 32 checks passed`.
- Forcing the absent-helper arm on a host that *has* the helper still fails on exactly those two assertions, so neither arm is vacuous — the CI shape is still a real gate.
- `phpstan analyse -c phpstan-tests.neon`: clean, no baseline entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEqEBT67DfLDm6hm51BaUX
