### PR TITLE
Build the served TLS chain from what signed the leaf, not from FOG's own CA

### DIFF
--- a/docs/EXTERNAL_CA_AND_LETSENCRYPT.md
+++ b/docs/EXTERNAL_CA_AND_LETSENCRYPT.md
@@ -122,6 +122,44 @@ why the directory is where it is, and why it is not
 issued leaf makes the browser and iPXE happy; `ca.cert.der` is still FOG's own
 root, which is what fog-client pins. Read the caveats before rolling one out.
 
+### The intermediate is found for you
+
+A publicly issued leaf is not a complete chain. It is signed by an
+intermediate — `CN=R10`, `CN=YE2` and friends for Let's Encrypt — and a client
+that trusts the public root still cannot build a path unless that intermediate
+is sent alongside the leaf. Sending only the leaf fails as
+`unable to get local issuer certificate`, which is also what a missing CA looks
+like, so it is easy to misread as "FOG never installed my certificate".
+
+You do not have to tell FOG where the intermediate is. When the leaf is one you
+brought, the installer looks for it in each of these, and uses the first
+certificate that **actually signed the leaf**:
+
+| Looked in | Typical source |
+|---|---|
+| `PKI_web_trust_chain` | FOG's own chain, and what `web-leaf-chain.pem` is adopted into |
+| `/etc/fog/customizations/pki/web-leaf-chain.pem` | the documented drop point |
+| the leaf file itself, after the leaf | you pointed FOG at a `fullchain.pem` |
+| `SSLCertificateChainFile` / `ssl_trusted_certificate` in your live vhost | the config that already worked |
+| `chain.pem`, `fullchain.pem`, `ca.cer` beside the leaf | certbot, acme.sh, dehydrated |
+| `/etc/letsencrypt/live/*/`, `/etc/dehydrated/certs/*/`, `~/.acme.sh/*/` | your ACME client's own tree |
+
+Selection is by signature, not by name: a certificate whose subject matches the
+leaf's issuer but whose key did not sign it is rejected, so a superseded CA of
+the same name cannot poison the chain. The root is never sent even when it is
+found — a client that does not already hold it would not trust it for arriving
+on the wire.
+
+The last row is what makes the common case work. Copying the leaf out to
+somewhere like `/etc/pki/tls/certs/` and pointing FOG at the copy leaves the
+intermediate behind in `/etc/letsencrypt/live/`, a directory the leaf itself
+knows nothing about.
+
+If none of them holds it, the install says so, names the issuer it could not
+find and the places it looked, and serves the leaf alone rather than serving
+something that cannot verify. Note that FOG's self-calls verify strictly, so the
+schema deploy will refuse to run in that state.
+
 ---
 
 ## How iPXE validates HTTPS
@@ -513,6 +551,23 @@ fog-client installer and reboot PXE clients after the switch.
   `basicConstraints CA:TRUE`. You passed a leaf, not an intermediate CA.
 - **`The intermediate CA does not verify against the supplied root`** — `--ca-cert`
   does not chain to `--ca-root`. Check you exported the correct root.
+- **`curl: (60) unable to get local issuer certificate` against your own
+  server, with a publicly issued leaf** — the served chain is missing the
+  intermediate. Check what is actually on the wire rather than what is on disk:
+
+  ```
+  openssl s_client -connect <name>:443 -servername <name> 2>/dev/null \
+      | grep -E '^ *[0-9] s:|^ *i:'
+  ```
+
+  A chain whose only entries are your leaf and `CN=FOG Web CA` is the shape this
+  used to produce: FOG's own intermediate sent beside a foreign leaf, which
+  cannot be part of that path, and the real intermediate omitted. Put the
+  issuer's certificate anywhere in
+  [the list above](#the-intermediate-is-found-for-you) and re-run the installer.
+- **`no trust path builds for that certificate` on the Certificates page** — the
+  upload carried the leaf alone. Upload the leaf **and** its intermediates
+  (certbot's `fullchain.pem`, not `cert.pem`).
 - **Clients stop trusting the server after a renewal** — the pinned CA changed.
   See [Renewal and rotation](#renewal-and-rotation); clients must re-pin the new
   `ca.cert.der`.

--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -9919,8 +9919,194 @@ _resolveWebLeafPaths() {
 #
 # Both stay empty when there is no intermediate, and the callers fall back to
 # ${PKI_web_vhost_cert}, so a direct-signed server emits byte-identical config to before.
+# The chain paths the LIVE vhost names, one per line, or nothing. Companion to
+# _vhostCertPath()/_vhostKeyPath(), which deliberately exclude these because
+# they are looking for the leaf.
+#
+# All three directives, because all three carry intermediates in the wild:
+# Apache's SSLCertificateChainFile is the documented place for them,
+# SSLCACertificateFile is where plenty of guides put them anyway, and nginx's
+# ssl_trusted_certificate is the nearest equivalent. Whether a certificate
+# found this way is actually usable is not decided here -- _walkChainFromLeaf
+# checks signatures, so a wrong file costs nothing but a read.
+_vhostChainPaths() {
+    [[ -n $etcconf && -f $etcconf ]] || return 0
+    grep -oiE '^[[:space:]]*(SSLCertificateChainFile|SSLCACertificateFile|ssl_trusted_certificate)[[:space:]]+[^;[:space:]]+' \
+        "$etcconf" 2>/dev/null | awk '{print $NF}'
+}
+# Every certificate that MIGHT belong in the chain for ${PKI_web_vhost_cert},
+# concatenated to stdout. A candidate pool, not an answer: nothing here is
+# trusted for having been found, because _walkChainFromLeaf accepts a
+# certificate only if its key actually signed the one below it.
+#
+# That split is what makes searching safe. Guessing at file locations would be
+# reckless if the guess were believed; it is free when every candidate has to
+# prove itself cryptographically.
+_webChainCandidates() {
+    local p d f base pkitree
+    # FOG's own chain, always and first. A FOG-issued leaf therefore walks
+    # exactly the path it always has, and this function needs no branch for it.
+    [[ -n ${PKI_web_trust_chain} && -s ${PKI_web_trust_chain} ]] && \
+        cat "${PKI_web_trust_chain}" 2>>$error_log
+    # Everything below is about a leaf FOG did not issue. For FOG's own leaf
+    # the chain file above is the whole truth, and reading the admin's vhost or
+    # scanning ACME trees could only add candidates the walk has to reject.
+    { _externallyManagedLeaf || [[ ${PKI_web_cert_publicly_trusted} == yes ]]; } || return 0
+    [[ -n ${PKI_web_vhost_cert} && -s ${PKI_web_vhost_cert} ]] || return 0
+    pkitree="$(readlink -f "$(_pkiRootDir)" 2>/dev/null)"
+
+    # (e) The blessed drop point for a certificate you bring:
+    #     $(_customPkiDir)/web-leaf-chain.pem, which readme.txt in
+    #     /etc/fog/customizations tells administrators to use.
+    #
+    #     _adoptCustomChain() already reads that file -- but only from the
+    #     signal-0 arm of _detectExternalCertManagement(), which is to say
+    #     only when a matching web-leaf.pem/web-leaf.key PAIR was dropped
+    #     beside it. An administrator whose leaf lives anywhere else (an ACME
+    #     client's tree, /etc/pki/tls/certs, a mounted secret) has no pair to
+    #     drop, so the chain they supplied at the documented path was read by
+    #     nothing. Reading it here decouples the chain from the pair.
+    p="$(_customPkiDir)/web-leaf-chain.pem"
+    [[ -s $p ]] && cat "$p" 2>>$error_log
+
+    # (a) The leaf file itself. An admin who pointed FOG at fullchain.pem has
+    #     already supplied the intermediate -- _writeWebChainFiles reads only
+    #     the FIRST certificate out of this file for the leaf, and everything
+    #     after it used to be discarded.
+    cat "${PKI_web_vhost_cert}" 2>>$error_log
+
+    # (b) What the live vhost serves as its chain. _writeWebChainFiles runs
+    #     BEFORE beginManagedVhost(), so $etcconf is still the administrator's
+    #     own file -- the configuration that was working before FOG rewrote it.
+    #
+    #     Any path resolving under FOG's own pki/ tree is skipped. That tree
+    #     holds this function's own output, and feeding derived output back in
+    #     as input is exactly GH-1120: see tests/web-chain-feedback.test.sh for
+    #     the fourteen-certificate bundle it produced.
+    for p in $(_vhostChainPaths); do
+        [[ -n $p && -s $p ]] || continue
+        [[ -n $pkitree && "$(readlink -f "$p" 2>/dev/null)" == "$pkitree"/* ]] && continue
+        cat "$p" 2>>$error_log
+    done
+
+    # (c) The leaf's own directory. certbot writes chain.pem and fullchain.pem
+    #     beside cert.pem, acme.sh writes ca.cer and fullchain.cer, dehydrated
+    #     writes chain.pem -- so for a leaf FOG was pointed at IN PLACE the
+    #     intermediate is one readdir away.
+    base="$(readlink -f "${PKI_web_vhost_cert}" 2>/dev/null)"
+    d="$(dirname "${base:-/}")"
+    if [[ -n $d && -d $d && ( -z $pkitree || $d != "$pkitree"* ) ]]; then
+        for f in chain.pem fullchain.pem ca.cer fullchain.cer chain.crt fullchain.crt; do
+            [[ -s "$d/$f" ]] && cat "$d/$f" 2>>$error_log
+        done
+        for f in "$d"/*-chain.pem "$d"/*.chain.pem; do
+            [[ -s $f ]] && cat "$f" 2>>$error_log
+        done
+    fi
+
+    # (d) The ACME client trees themselves, wherever the leaf lives.
+    #
+    #     (c) is not enough on its own and the difference is the common case:
+    #     an administrator who COPIES the leaf out to /etc/pki/tls/certs and
+    #     points FOG at the copy has left the intermediate behind in
+    #     /etc/letsencrypt/live, one directory the leaf knows nothing about.
+    #     That server has the certificate it needs, on disk, and every earlier
+    #     source misses it.
+    #
+    #     Bounded and cheap: three known layouts, a fixed set of file names, no
+    #     recursive walk of the filesystem. Reading a chain belonging to some
+    #     unrelated domain is harmless because the signature check rejects it.
+    for d in /etc/letsencrypt/live/* /etc/dehydrated/certs/* \
+             /root/.acme.sh/* "${HOME:-/root}"/.acme.sh/*; do
+        [[ -d $d ]] || continue
+        for f in chain.pem fullchain.pem ca.cer fullchain.cer; do
+            [[ -s "$d/$f" ]] && cat "$d/$f" 2>>$error_log
+        done
+    done
+    return 0
+}
+# The intermediates that cryptographically link the leaf in $1 upwards, out of
+# the candidate pool $2, written to stdout in leaf-first order -- which is the
+# order TLS wants and NOT the order the pool is in.
+#
+# Returns 0 when the leaf's issuer was located (whether that issuer turned out
+# to be an intermediate worth sending or a root that must not be), and 1 when
+# nothing in the pool issued this leaf. The caller needs that distinction: no
+# output means "nothing to send" in the first case and "this server is about to
+# serve an unverifiable leaf" in the second.
+#
+# Selection is by SIGNATURE, not by name. A subject DN equal to the leaf's
+# issuer DN is a claim anyone can make -- a superseded CA of the same name, a
+# private CA that happens to share a corporate name, a stale copy from before a
+# key rotation -- and serving the wrong one produces a chain that fails exactly
+# like serving nothing, while looking correct to anyone reading subject lines.
+# -partial_chain treats the candidate as an anchor, which reduces the question
+# to the only one that matters: did this key sign the certificate below it?
+_walkChainFromLeaf() {
+    local leaf="$1" pool="$2" tmpd cur want found f subj issuer hop st=1
+    [[ -n $leaf && -s $leaf && -n $pool && -s $pool ]] || return 1
+    command -v openssl >/dev/null 2>&1 || return 1
+    tmpd=$(mktemp -d) || return 1
+    cur="$tmpd/cur.pem"
+    # The leaf ONLY. openssl x509 reads the first certificate out of a bundle,
+    # which is the leaf in anything a web server will accept -- and is the same
+    # reason _writeWebChainFiles reads this file the way it does.
+    openssl x509 -in "$leaf" -out "$cur" 2>>$error_log || { rm -rf "$tmpd"; return 1; }
+    _splitPemBundle "$pool" "$tmpd" >/dev/null 2>&1
+    # Bounded rather than "until it ends". Cross-signed CAs make it possible
+    # for a pool to contain a cycle, and a real chain is never this deep.
+    for hop in 1 2 3 4 5 6 7 8; do
+        want=$(openssl x509 -in "$cur" -noout -issuer -nameopt RFC2253 2>/dev/null)
+        want="${want#issuer=}"
+        [[ -n $want ]] || break
+        found=""
+        for f in "$tmpd"/c*.pem; do
+            [[ -f $f ]] || continue
+            subj=$(openssl x509 -in "$f" -noout -subject -nameopt RFC2253 2>/dev/null)
+            [[ -n $subj && ${subj#subject=} == "$want" ]] || continue
+            openssl verify -partial_chain -trusted "$f" "$cur" >/dev/null 2>&1 || continue
+            found="$f"
+            break
+        done
+        [[ -n $found ]] || break
+        # The issuer exists and signed what is below it, so the path is real
+        # from here down however far up it goes.
+        st=0
+        subj=$(openssl x509 -in "$found" -noout -subject -nameopt RFC2253 2>/dev/null)
+        issuer=$(openssl x509 -in "$found" -noout -issuer -nameopt RFC2253 2>/dev/null)
+        # A self-signed match is the ROOT, and the root is never sent: a client
+        # that does not already hold it will not trust it for arriving on the
+        # wire, and one that does hold it did not need the copy.
+        [[ ${subj#subject=} == "${issuer#issuer=}" ]] && break
+        cat "$found"
+        cp -f "$found" "$cur" >>$error_log 2>&1 || break
+    done
+    rm -rf "$tmpd" >>$error_log 2>&1
+    return $st
+}
+# Said out loud, because the failure it describes is silent from the server's
+# own point of view: the web server starts, the vhost is valid, and a browser
+# holding the intermediate from another site shows a good padlock. What breaks
+# is every client that does NOT already hold it, FOG's own self-calls included.
+_warnNoWebIntermediate() {
+    local issuer
+    issuer=$(openssl x509 -in "${PKI_web_vhost_cert}" -noout -issuer -nameopt RFC2253 2>/dev/null)
+    echo " * WARNING: no intermediate certificate was found for the web leaf."
+    echo "   Leaf:   ${PKI_web_vhost_cert}"
+    echo "   Issuer: ${issuer#issuer=}"
+    echo "   Nothing on this server chains to that issuer, so FOG is serving the"
+    echo "   leaf ALONE. Clients that do not already hold the intermediate will"
+    echo "   reject it as \"unable to get local issuer certificate\" -- including"
+    echo "   this installer's own calls, so the schema deploy will refuse to run."
+    echo "   Put the issuer's certificate in any ONE of these and re-run:"
+    echo "     - ${PKI_web_vhost_cert} itself, after the leaf (i.e. a fullchain)"
+    echo "     - chain.pem, fullchain.pem or ca.cer beside it"
+    echo "     - SSLCertificateChainFile / ssl_trusted_certificate in your vhost"
+    echo "   Your ACME client already has it: certbot keeps it as chain.pem in"
+    echo "   /etc/letsencrypt/live/<name>/, acme.sh as ca.cer."
+}
 _writeWebChainFiles() {
-    local leafdir block subj issuer
+    local leafdir
     sslfullchain=""
     sslchainonly=""
     # -s, not -f. An EMPTY certificate file passes -f, and cat'ing it into the
@@ -9931,7 +10117,13 @@ _writeWebChainFiles() {
     # down, and the leaf on disk was correct the whole time, so nothing about
     # the failure pointed at the file that was actually wrong.
     [[ -n ${PKI_web_vhost_cert} && -s ${PKI_web_vhost_cert} ]] || return 0
-    [[ -n ${PKI_web_trust_chain} && -s ${PKI_web_trust_chain} ]] || return 0
+    # No test on ${PKI_web_trust_chain} here any more. It used to be a
+    # precondition, on the premise that FOG's chain file was the only possible
+    # source of an intermediate -- which is false for every leaf FOG did not
+    # issue, and returning early meant an ACME server never even looked for
+    # the certificate sitting in its own /etc/letsencrypt/live. The chain file
+    # is now one candidate among several; _webChainCandidates handles it being
+    # absent, and a pool that ends up empty is handled below.
 
     leafdir="$(_pkiZoneDir web)/leaf"
     mkdir -p "$leafdir" >>$error_log 2>&1
@@ -9947,23 +10139,22 @@ _writeWebChainFiles() {
     # validateExternalCA writes the root FIRST -- and an admin-supplied chain
     # may be in any order at all. _rootFromChain selects the other way round off
     # the same property, so neither reader depends on the order.
-    local tmpd f
+    local tmpd
     tmpd=$(mktemp -d) || return 0
-    _splitPemBundle "${PKI_web_trust_chain}" "$tmpd"
-    for f in "$tmpd"/c*.pem; do
-        [[ -f $f ]] || continue
-        subj=$(openssl x509 -in "$f" -noout -subject 2>/dev/null)
-        issuer=$(openssl x509 -in "$f" -noout -issuer 2>/dev/null)
-        [[ -z $subj ]] && continue
-        # -subject prints "subject=..." and -issuer "issuer=...", so compare the
-        # values rather than the whole line.
-        [[ ${subj#subject=} == "${issuer#issuer=}" ]] && continue
-        cat "$f" >> "$chainonly"
-    done
+    _webChainCandidates > "$tmpd/pool.pem" 2>>$error_log
+    _walkChainFromLeaf "${PKI_web_vhost_cert}" "$tmpd/pool.pem" > "$chainonly" 2>>$error_log
+    local located=$?
     rm -rf "$tmpd" >>$error_log 2>&1
 
     if [[ ! -s $chainonly ]]; then
         rm -f "$chainonly" >>$error_log 2>&1
+        # Empty is the CORRECT answer for a leaf signed directly by a root:
+        # one certificate is already a complete path, and the callers fall
+        # back to ${PKI_web_vhost_cert}. _walkChainFromLeaf says which of the
+        # two silences apply -- it returns 0 when it found the leaf's issuer
+        # (as a root, so nothing to send) and 1 when it found nothing at all,
+        # which is a server about to serve an unverifiable leaf.
+        [[ $located -ne 0 ]] && _warnNoWebIntermediate
         return 0
     fi
     # Assemble beside the live file, not over it. This bundle is what the web

--- a/tests/web-chain-external-leaf.test.sh
+++ b/tests/web-chain-external-leaf.test.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+#
+# Guards the served TLS chain when the leaf was issued OUTSIDE FOG.
+#
+#   tests/web-chain-external-leaf.test.sh
+#
+# _writeWebChainFiles() assembles what the web server sends. It used to take
+# the intermediates from ${PKI_web_trust_chain} unconditionally, with no test
+# that those certificates had anything to do with the leaf in
+# ${PKI_web_vhost_cert}. On a server whose leaf comes from an ACME client that
+# is two wrong things at once:
+#
+#   - it SENDS a certificate that cannot be in the path -- "CN=FOG Web CA"
+#     alongside a Let's Encrypt leaf
+#   - it OMITS the one intermediate that is required
+#
+# Observed live: a fog server presenting
+#
+#     0 s:CN=fog.example.com   i:C=US, O=Let's Encrypt, CN=YE2
+#     1 s:CN=FOG Web CA        i:CN=FOG Server CA
+#
+# with the LE intermediate nowhere on the wire. Every client that trusts the
+# public root still cannot build a path, so the installer's own self-calls fail
+# -- backupDB and the strict updateDB schema deploy both exit curl 60, "unable
+# to get local issuer certificate" -- while a browser with the intermediate
+# already cached from another site shows a perfectly good padlock. That
+# combination is what makes it hard to place.
+#
+# The fix is one mechanism rather than two: the intermediates are no longer
+# "everything in the chain file that is not self-signed", they are the
+# certificates that CRYPTOGRAPHICALLY link the leaf upwards, walked one issuer
+# at a time out of a candidate pool. FOG's own chain file is in that pool, so a
+# FOG-issued leaf is unaffected; an externally managed leaf additionally
+# contributes the intermediates its ACME client left on disk.
+#
+# Name matching alone is not enough and is pinned below: a certificate whose
+# subject equals the leaf's issuer but whose key did not sign the leaf must be
+# rejected, or a stale CA of the same name silently poisons the chain.
+#
+# Needs openssl. Runs on generated fixtures -- no install, no network, no root.
+#
+# Exit status 0 = pass or skip, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+command -v openssl >/dev/null 2>&1 || { echo "SKIP: openssl is not installed"; exit 0; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+error_log="$WORK/error.log"
+: > "$error_log"
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+dots() { :; }
+errorStat() { :; }
+
+# --- fixture helpers ---------------------------------------------------------
+# A self-signed CA at $1.key/$1.pem with subject $2.
+mkroot() {
+    openssl req -x509 -new -nodes -newkey rsa:2048 -sha256 -days 30 \
+        -subj "/CN=$2" -keyout "$1.key" -out "$1.pem" >/dev/null 2>&1
+}
+# A CA at $1.key/$1.pem with subject $2, signed by $3.key/$3.pem.
+mkint() {
+    openssl req -new -nodes -newkey rsa:2048 -sha256 -subj "/CN=$2" \
+        -keyout "$1.key" -out "$1.csr" >/dev/null 2>&1
+    printf 'basicConstraints=critical,CA:TRUE\nkeyUsage=critical,keyCertSign,cRLSign\n' \
+        > "$1.ext"
+    openssl x509 -req -in "$1.csr" -CA "$3.pem" -CAkey "$3.key" -CAcreateserial \
+        -sha256 -days 30 -extfile "$1.ext" -out "$1.pem" >/dev/null 2>&1
+}
+# An end-entity certificate at $1.key/$1.pem with CN $2, signed by $3.key/$3.pem.
+mkleaf() {
+    openssl req -new -nodes -newkey rsa:2048 -sha256 -subj "/CN=$2" \
+        -keyout "$1.key" -out "$1.csr" >/dev/null 2>&1
+    openssl x509 -req -in "$1.csr" -CA "$3.pem" -CAkey "$3.key" -CAcreateserial \
+        -sha256 -days 30 -out "$1.pem" >/dev/null 2>&1
+}
+# Subjects of every certificate in $1, one per line. -nameopt RFC2253 pins the
+# formatting: openssl's own default is not stable across versions (3.0.13 on
+# the CI runner prints "CN = x" with spaces, 3.5.7 prints "CN=x" without), and
+# a test that compares against the default passes only on the machine it was
+# written on. See tests/web-chain-feedback.test.sh for the run that caught it.
+subjects() {
+    [[ -s $1 ]] || return 0
+    local d; d=$(mktemp -d); local f
+    awk -v d="$d" '/-----BEGIN CERTIFICATE-----/{n++} n{print > (d "/c" n ".pem")}' "$1"
+    for f in "$d"/c*.pem; do
+        [[ -f $f ]] || continue
+        openssl x509 -in "$f" -noout -subject -nameopt RFC2253 2>/dev/null | sed 's/^subject=//'
+    done
+    rm -rf "$d"
+}
+ncerts() { grep -c 'BEGIN CERTIFICATE' "$1" 2>/dev/null || echo 0; }
+has() { subjects "$1" | grep -qx "$2"; }
+
+# --- the two PKIs ------------------------------------------------------------
+fogprogramdir="$WORK/opt/fog"
+PKI_root_dir="$WORK/etc/fog/pki"
+PKI_client_cert_dir="$WORK/opt/fog/snapins/ssl"
+webdirdest="$WORK/var/www/fog"
+webdir="$PKI_root_dir/web"
+leafdir="$webdir/leaf"
+cadir="$webdir/ca"
+mkdir -p "$leafdir" "$cadir" "$PKI_client_cert_dir" "$webdirdest/management/other/ssl"
+
+# FOG's own: root -> Web CA -> leaf.
+mkroot "$cadir/root" "FOG Server CA" || { echo "ERROR: fixture root CA failed" >&2; exit 1; }
+mkint "$cadir/.fogWebCA" "FOG Web CA" "$cadir/root"
+mkleaf "$leafdir/fogleaf" "fogserver" "$cadir/.fogWebCA"
+cp "$leafdir/fogleaf.pem" "$leafdir/.webLeaf.pem"
+cp "$leafdir/fogleaf.key" "$leafdir/.webLeaf.key"
+PKI_root_ca_cert="$cadir/root.pem"
+PKI_web_ca_cert="$cadir/.fogWebCA.pem"
+PKI_web_trust_chain="$cadir/.fogWebCAchain.pem"
+cat "$cadir/.fogWebCA.pem" "$cadir/root.pem" > "$PKI_web_trust_chain"
+
+# A public PKI standing in for Let's Encrypt: root -> YE2 -> leaf, in an ACME
+# client's tree, which is the shape certbot leaves behind.
+acme="$WORK/etc/letsencrypt/live/fog"
+mkdir -p "$acme"
+mkroot "$WORK/pubroot" "Test Root X1"
+mkint "$WORK/ye2" "YE2" "$WORK/pubroot"
+mkleaf "$acme/cert" "fogserver" "$WORK/ye2"
+cp "$WORK/ye2.pem" "$acme/chain.pem"
+cat "$acme/cert.pem" "$acme/chain.pem" > "$acme/fullchain.pem"
+
+fullchain="$leafdir/.webFullChain.pem"
+chainonly="$leafdir/.webChain.pem"
+
+# A leaf on its own, away from any sibling chain file, for the cases that test
+# discovery from somewhere other than the leaf's own directory.
+bare="$WORK/etc/pki/tls/certs"
+mkdir -p "$bare"
+cp "$acme/cert.pem" "$bare/letsencryptfog.pem"
+cp "$acme/cert.key" "$bare/letsencryptfog.key"
+
+reset() { rm -f "$fullchain" "$chainonly"; etcconf=""; sslchainonly=""; sslfullchain=""; }
+
+echo "web chain, externally managed leaf:"
+
+# --- 1. the reported bug -----------------------------------------------------
+reset
+PKI_web_vhost_cert="$acme/cert.pem"
+PKI_web_vhost_key="$acme/cert.key"
+_writeWebChainFiles
+is "$(ncerts "$fullchain")" "2" "an ACME leaf assembles leaf + its own intermediate"
+is "$(has "$fullchain" "CN=YE2"; echo $?)" "0" "the intermediate that signed the leaf is served"
+is "$(has "$fullchain" "CN=FOG Web CA"; echo $?)" "1" "FOG's Web CA is NOT served next to a foreign leaf"
+is "$(subjects "$fullchain" | head -1)" "CN=fogserver" "the leaf is first in the bundle"
+
+# --- 2. the leaf file is itself a fullchain (source a) -----------------------
+reset
+PKI_web_vhost_cert="$acme/fullchain.pem"
+PKI_web_vhost_key="$acme/cert.key"
+_writeWebChainFiles
+is "$(ncerts "$fullchain")" "2" "a leaf pointed at fullchain.pem yields leaf + intermediate once"
+is "$(has "$fullchain" "CN=YE2"; echo $?)" "0" "the intermediate inside the leaf file is used"
+
+# --- 3. the live vhost names the chain (source b) ----------------------------
+reset
+PKI_web_vhost_cert="$bare/letsencryptfog.pem"
+PKI_web_vhost_key="$bare/letsencryptfog.key"
+etcconf="$WORK/fog.conf"
+cat > "$etcconf" <<EOF
+    SSLCertificateFile $bare/letsencryptfog.pem
+    SSLCertificateChainFile $acme/chain.pem
+EOF
+_writeWebChainFiles
+is "$(has "$fullchain" "CN=YE2"; echo $?)" "0" "SSLCertificateChainFile in the live vhost is honored"
+is "$(has "$fullchain" "CN=FOG Web CA"; echo $?)" "1" "and FOG's Web CA still is not served"
+
+# --- 4. a vhost chain path inside FOG's own tree is not evidence -------------
+# The derived bundle is reachable as an input -- that is what GH-1120 was --
+# so a scraped path under FOG's pki/ tree must be ignored rather than fed back.
+reset
+PKI_web_vhost_cert="$bare/letsencryptfog.pem"
+PKI_web_vhost_key="$bare/letsencryptfog.key"
+etcconf="$WORK/fog-fogchain.conf"
+cat > "$etcconf" <<EOF
+    SSLCertificateFile $bare/letsencryptfog.pem
+    SSLCertificateChainFile $PKI_web_trust_chain
+EOF
+_writeWebChainFiles
+is "$(has "$fullchain" "CN=FOG Web CA"; echo $?)" "1" \
+    "a scraped chain path inside FOG's pki tree is ignored"
+
+# --- 5. nothing discoverable: leaf-only, never the wrong CA ------------------
+reset
+PKI_web_vhost_cert="$bare/letsencryptfog.pem"
+PKI_web_vhost_key="$bare/letsencryptfog.key"
+etcconf=""
+# NOT $(_writeWebChainFiles): a command substitution runs it in a subshell, so
+# $sslchainonly below would read the value this shell already had and the
+# assertion would pass without the function having set anything.
+_writeWebChainFiles > "$WORK/nochain.out" 2>&1
+out="$(cat "$WORK/nochain.out")"
+is "$(ncerts "$chainonly")" "0" "no discoverable intermediate leaves the chain file empty"
+is "$sslchainonly" "" "and \$sslchainonly empty, so the caller serves the leaf alone"
+is "$(printf '%s' "$out" | grep -qi 'intermediate'; echo $?)" "0" \
+    "the admin is told an intermediate could not be found"
+
+# --- 6. a FOG-issued leaf is unaffected --------------------------------------
+reset
+PKI_web_vhost_cert="$leafdir/.webLeaf.pem"
+PKI_web_vhost_key="$leafdir/.webLeaf.key"
+_writeWebChainFiles
+is "$(ncerts "$fullchain")" "2" "a FOG-issued leaf still assembles leaf + Web CA"
+is "$(has "$fullchain" "CN=FOG Web CA"; echo $?)" "0" "with FOG's Web CA, which did sign it"
+is "$(has "$fullchain" "CN=FOG Server CA"; echo $?)" "1" "and without the root, which must not be sent"
+
+# --- 7. the same name is not the same CA ------------------------------------
+# Name matching alone would accept this. A CA with the leaf's issuer DN but a
+# different key did not sign the leaf, and serving it produces a chain that
+# fails to verify exactly like serving nothing -- while looking correct to
+# anyone reading subject lines.
+reset
+mkroot "$WORK/otherroot" "Test Root X1"
+mkint "$WORK/ye2-impostor" "YE2" "$WORK/otherroot"
+imp="$WORK/impostor"
+mkdir -p "$imp"
+cp "$acme/cert.pem" "$imp/cert.pem"
+cp "$acme/cert.key" "$imp/cert.key"
+cp "$WORK/ye2-impostor.pem" "$imp/chain.pem"
+PKI_web_vhost_cert="$imp/cert.pem"
+PKI_web_vhost_key="$imp/cert.key"
+_writeWebChainFiles
+is "$(ncerts "$chainonly")" "0" "an intermediate with the right name but the wrong key is rejected"
+
+# --- 8. the documented drop point, without a pair beside it -----------------
+# /etc/fog/customizations/pki/web-leaf-chain.pem is what readme.txt tells
+# administrators to use. _adoptCustomChain() reads it only when a matching
+# web-leaf.pem/.key pair was dropped there too, which an admin whose leaf lives
+# in an ACME tree has no way to do -- so the file they were told to supply was
+# read by nothing.
+reset
+PKI_custom_dir="$WORK/etc/fog/customizations/pki"
+mkdir -p "$PKI_custom_dir"
+cp "$acme/chain.pem" "$PKI_custom_dir/web-leaf-chain.pem"
+PKI_web_vhost_cert="$bare/letsencryptfog.pem"
+PKI_web_vhost_key="$bare/letsencryptfog.key"
+etcconf=""
+_writeWebChainFiles
+is "$(has "$fullchain" "CN=YE2"; echo $?)" "0"     "web-leaf-chain.pem is honored with no web-leaf pair beside it"
+PKI_custom_dir=""
+
+
+echo
+echo "  passed: $PASS  failed: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## The bug

`_writeWebChainFiles()` took the intermediates from `${PKI_web_trust_chain}`
unconditionally, with no test that those certificates had anything to do with
the leaf in `${PKI_web_vhost_cert}`. On a server whose leaf comes from an ACME
client that is two wrong things at once: it **sends** a certificate that cannot
be in the path, and it **omits** the one that is required.

Reported from a live server with a working Let's Encrypt certificate:

```
 0 s:CN=fog.example.com   i:C=US, O=Let's Encrypt, CN=YE2      <- the leaf
 1 s:CN=FOG Web CA        i:CN=FOG Server CA                   <- wrong issuer, inert
                           ^ the LE intermediate is nowhere on the wire
Verify return code: 21 (unable to verify the first certificate)
```

Every client that trusts the public root still cannot build a path, so
`backupDB` and the strict `updateDB` schema deploy both fail:

```
 * Checking web server serves FOG...............Warning
 * Backing up database..........................Failed
   Reason: curl exited 60 ... SSL certificate problem: unable to get local
   issuer certificate
```

Meanwhile a browser holding that intermediate cached from another site shows a
perfectly good padlock. That combination is what makes it hard to place: the
server verifies correct from outside and cannot verify itself.

## The fix

The intermediates are no longer "everything in the chain file that is not
self-signed". They are the certificates that cryptographically link the leaf
upwards, walked one issuer at a time out of a candidate pool.

**Selection is by signature, not by name.** A subject DN equal to the leaf's
issuer DN is a claim a superseded CA of the same name can also make, and
serving the wrong one produces a chain that fails exactly like serving nothing
— while looking correct to anyone reading subject lines. `-partial_chain`
reduces it to the only question that matters: did this key sign the certificate
below it?

FOG's own chain file is in the pool, so **a FOG-issued leaf walks exactly the
path it always has.** A leaf FOG did not issue additionally contributes:

| Source | Typical case |
|---|---|
| `$(_customPkiDir)/web-leaf-chain.pem` | the documented drop point |
| the leaf file itself, past the leaf | FOG pointed at a `fullchain.pem` |
| `SSLCertificateChainFile` / `SSLCACertificateFile` / `ssl_trusted_certificate` in the live vhost | the config that already worked |
| `chain.pem`, `fullchain.pem`, `ca.cer` beside the leaf | certbot, acme.sh, dehydrated |
| `/etc/letsencrypt/live/*/`, `/etc/dehydrated/certs/*/`, `~/.acme.sh/*/` | the ACME client's own tree |

That last row is what makes the reported case work. Copying a leaf out to
`/etc/pki/tls/certs/` and pointing FOG at the copy leaves the intermediate
behind in `/etc/letsencrypt/live/`, a directory the leaf knows nothing about,
and no earlier source reaches it.

Searching is safe because **nothing found is trusted for having been found** — a
wrong file costs one read. Any path resolving under FOG's own `pki/` tree is
skipped regardless: that tree holds this function's own output, and feeding
derived output back in as input is GH-1120.

### Also fixes: the drop point was coupled to the pair

`_adoptCustomChain()` reads `web-leaf-chain.pem` only from the signal-0 arm of
`_detectExternalCertManagement()` — that is, only when a matching
`web-leaf.pem`/`web-leaf.key` **pair** was dropped beside it. An administrator
whose leaf lives in an ACME tree has no pair to drop, so the chain file they
were told to supply was read by nothing. Reading it in the candidate pool
decouples the two.

### When nothing signs the leaf

The install says so, naming the issuer it could not find and the places it
looked, and serves the leaf alone rather than something that cannot verify. It
also says that the schema deploy will refuse to run in that state, since it
verifies strictly.

Empty stays **silent** for a leaf signed directly by a root — one certificate is
already a complete path — so a direct-signed server emits the config it always
did.

## Testing

`tests/web-chain-external-leaf.test.sh`, 17 assertions on generated fixtures:
no install, no network, no root. Two PKIs are built (FOG's own root → Web CA →
leaf, and a public-style root → `YE2` → leaf in a certbot-shaped tree) and each
discovery source, the feedback guard, the leaf-only fallback and the
FOG-issued-leaf regression are checked separately.

Mutation-tested rather than merely green:

| Mutation | Result |
|---|---|
| implementation reverted to `HEAD` | 11 of 17 fail |
| `-partial_chain` signature gate removed | the impostor-CA assertion fails, alone |

`tests/web-chain-feedback.test.sh` still passes 9/9 — it pins the
fourteen-certificate feedback loop, which this change must not reintroduce.

`client-zone-migration`, `client-cert-flags` and `client-repin-warning` fail
identically before and after this change on the same base; they are unrelated
and pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ps28eGTALgieR6TBUSafVg
