### PR TITLE
Certificates page: trust the host store too, so a public certificate needs no root imported

### DIFF
--- a/docs/EXTERNAL_CA_AND_LETSENCRYPT.md
+++ b/docs/EXTERNAL_CA_AND_LETSENCRYPT.md
@@ -568,6 +568,11 @@ fog-client installer and reboot PXE clients after the switch.
 - **`no trust path builds for that certificate` on the Certificates page** — the
   upload carried the leaf alone. Upload the leaf **and** its intermediates
   (certbot's `fullchain.pem`, not `cert.pem`).
+
+  You do **not** need to import the root for a public CA. The page verifies
+  against FOG's own anchor bundle *and* the host trust store, so Let's Encrypt
+  and commercial issuers pass on the intermediates alone. Importing a root is
+  only for a private or corporate CA the host does not already trust.
 - **Clients stop trusting the server after a renewal** — the pinned CA changed.
   See [Renewal and rotation](#renewal-and-rotation); clients must re-pin the new
   `ca.cert.der`.

--- a/packages/pki/fog-pki-admin
+++ b/packages/pki/fog-pki-admin
@@ -731,19 +731,53 @@ sortLeafMaterial() {
 
 # Does a path build for this leaf, against what this server ACTUALLY trusts?
 #
-# ${PKI_WEB_ANCHOR} is the same bundle FOG verifies its own HTTPS self-calls
-# against, so this asks the question that matters rather than a weaker one: an
-# administrator who has imported their corporate root passes, and one who has
-# not is told so before the vhost is repointed.
+# TWO anchors, because this server has two, and a leaf only has to satisfy one
+# of them:
+#
+#   1. ${PKI_WEB_ANCHOR} -- FOG's own root, plus any root imported on this
+#      page. This is the bundle FOG verifies its own HTTPS self-calls against,
+#      so an administrator who has imported their corporate root passes.
+#   2. The HOST trust store -- the public CAs, for a leaf from Let's Encrypt or
+#      a commercial issuer.
+#
+# Only the first used to be consulted, and `openssl verify -trusted` REPLACES
+# the default trust locations rather than adding to them, so there was no path
+# by which a publicly trusted leaf could pass. The practical effect was that
+# uploading certbot's own fullchain.pem -- leaf + intermediate, which is
+# complete and publicly verifiable, and is the exact file every ACME client
+# produces -- was refused with "no trust path builds for that certificate",
+# advising the administrator to "import the issuing root ... if it is not a
+# public CA" when it demonstrably was one. fullchain.pem carries no root, by
+# design, so there was nothing they could have supplied to satisfy it either;
+# the only way through was to hunt down ISRG Root X1 and import it as though
+# Let's Encrypt were a private CA.
+#
+# Checked in that order so the answer for FOG's own and for imported roots is
+# reached without consulting anything else, and so the failure path is
+# unchanged for a genuinely untrusted leaf.
+#
+# The host store legitimately contains FOG's own root -- _installCATrustAnchor()
+# puts it there -- so step 2 can succeed via it. That is not a loophole: the
+# question is whether this server trusts the issuer, and a root in its own
+# trust store is trusted by every client on the box, curl included.
 verifyLeafChain() {
     local leaf="$1" chain="$2"
-    [[ -n $PKI_WEB_ANCHOR && -s $PKI_WEB_ANCHOR ]] || return 1
-    if [[ -s $chain ]]; then
-        openssl verify -trusted "$PKI_WEB_ANCHOR" -untrusted "$chain" "$leaf" \
-            >/dev/null 2>&1
-    else
-        openssl verify -trusted "$PKI_WEB_ANCHOR" "$leaf" >/dev/null 2>&1
+    if [[ -n $PKI_WEB_ANCHOR && -s $PKI_WEB_ANCHOR ]]; then
+        if [[ -s $chain ]]; then
+            openssl verify -trusted "$PKI_WEB_ANCHOR" -untrusted "$chain" "$leaf" \
+                >/dev/null 2>&1 && return 0
+        else
+            openssl verify -trusted "$PKI_WEB_ANCHOR" "$leaf" >/dev/null 2>&1 && return 0
+        fi
     fi
+    # No -trusted and no -CAfile: the default trust locations, which is the
+    # host store, are exactly what is being asked about here.
+    if [[ -s $chain ]]; then
+        openssl verify -untrusted "$chain" "$leaf" >/dev/null 2>&1 && return 0
+    else
+        openssl verify "$leaf" >/dev/null 2>&1 && return 0
+    fi
+    return 1
 }
 
 # Refuse anything that would leave this server worse off than it is now.

--- a/tests/pki-admin-helper.test.sh
+++ b/tests/pki-admin-helper.test.sh
@@ -128,6 +128,14 @@ mkleaf plain   "www.example.org" corp
 # leave the interesting case untested.
 mkleaf corpleaf "corpleaf.example.org" corpint
 
+# A stand-in for a PUBLIC issuer: root -> intermediate -> leaf, in the shape
+# Let's Encrypt uses. Deliberately never imported on the page, so the only way
+# a path can build for it is out of the HOST trust store -- which is what the
+# section at the bottom of this file injects with SSL_CERT_FILE.
+mkroot pubroot "Test Root X1" 3650
+mkint  pubint  "YE2"          pubroot
+mkleaf publeaf "publeaf.example.org" pubint
+
 # An expired root has to be MINTED expired: openssl req -days cannot go
 # negative, so back-date with -not_before/-not_after via a CA-signed self
 # issuance is fussier than simply using faketime. Use a 1-day root and
@@ -951,6 +959,66 @@ mv "$CONF.away" "$CONF"
 # the only way to exercise the rest of the script at all. It is one line and
 # the sudoers rule is what actually places the boundary; noted rather than
 # faked with an assertion that proves nothing.
+
+echo
+echo "== a publicly trusted leaf needs no root imported =="
+# verifyLeafChain() used to consult ${PKI_WEB_ANCHOR} and NOTHING ELSE, and
+# `openssl verify -trusted` REPLACES the default trust locations rather than
+# adding to them. So there was no path by which a publicly trusted leaf could
+# pass: uploading certbot's own fullchain.pem -- leaf + intermediate, complete
+# and publicly verifiable, the exact file every ACME client produces -- was
+# refused with "no trust path builds for that certificate", while the refusal
+# advised importing the issuing root "if it is not a public CA". It was one,
+# and fullchain.pem carries no root by design, so nothing the administrator
+# could supply would have satisfied it either.
+#
+# The host store is injected with SSL_CERT_FILE rather than by writing into the
+# runner's real trust store: openssl reads it for the DEFAULT locations, which
+# is precisely the code path under test, and the test stays hermetic.
+#
+# pubroot is never imported on the page, so ${PKI_WEB_ANCHOR} cannot be what
+# makes this pass -- checked below rather than assumed.
+rm -f "$CUSTOM/"web-leaf*
+# The precondition, checked rather than assumed: if pubroot were in the anchor
+# then step 1 of verifyLeafChain() would answer and the host-store path below
+# would never be reached, so the whole case would pass while proving nothing.
+if openssl verify -trusted "$ZONE/ca/.trustAnchor.pem" -untrusted "$WORK/pubint.pem" \
+        "$WORK/publeaf.pem" >/dev/null 2>&1; then
+    bad "fixture error: the public leaf already verifies against FOG's anchor"
+else
+    ok "the public leaf does NOT verify against FOG's anchor bundle"
+fi
+
+install -m 0644 "$WORK/publeaf.pem" "$CUSTOM/web-leaf.pem"
+install -m 0600 "$WORK/publeaf.key" "$CUSTOM/web-leaf.key"
+install -m 0644 "$WORK/pubint.pem"  "$CUSTOM/web-leaf-chain.pem"
+
+SSL_CERT_FILE="$WORK/hoststore.pem"
+cat "$WORK/pubroot.pem" > "$SSL_CERT_FILE"
+export SSL_CERT_FILE
+out=$("$HELPER" adopt-custom-leaf 2>&1)
+check "$?" "0" "a leaf whose root is in the host store is adopted"
+case "$out" in
+    *"no trust path builds"*) bad "it still refused: $out" ;;
+    *)                        ok "and is not refused for having no trust path" ;;
+esac
+check "$(subjectOf "$CUSTOM/web-leaf.pem")" "subject=CN=publeaf.example.org" \
+    "and it is the public leaf that got adopted"
+
+# The refusal still has to work. Same leaf, same chain, a host store that does
+# not carry its root -- otherwise the fix above would be "accept everything".
+rm -f "$CUSTOM/"web-leaf*
+install -m 0644 "$WORK/publeaf.pem" "$CUSTOM/web-leaf.pem"
+install -m 0600 "$WORK/publeaf.key" "$CUSTOM/web-leaf.key"
+install -m 0644 "$WORK/pubint.pem"  "$CUSTOM/web-leaf-chain.pem"
+cat "$WORK/corp.pem" > "$SSL_CERT_FILE"
+out=$("$HELPER" adopt-custom-leaf 2>&1)
+check "$?" "1" "a leaf trusted by neither anchor nor host store is still refused"
+case "$out" in
+    *"no trust path builds"*) ok "and still says no trust path builds" ;;
+    *)                        bad "the refusal blamed something else: $out" ;;
+esac
+unset SSL_CERT_FILE
 
 echo
 printf '%d passed, %d failed\n' "$PASS" "$FAIL"


### PR DESCRIPTION
> Follow-up to #1729 — same family of bug, other side of the same server.
> Merged up to `working-1.6` after #1732 landed (both touch
> `tests/pki-admin-helper.test.sh`; git resolved it without conflict, and both
> sections are present and passing).
> The new test cannot run outside a user namespace, so its assertions are
> CI-verified only; see **Testing** for what was verified locally and how.

## The bug

`verifyLeafChain()` in `packages/pki/fog-pki-admin` consulted `${PKI_WEB_ANCHOR}`
and nothing else:

```bash
openssl verify -trusted "$PKI_WEB_ANCHOR" -untrusted "$chain" "$leaf"
```

`-trusted` **replaces** the default trust locations rather than adding to them,
and `rebuildAnchor()` composes that bundle from FOG's own root plus self-signed
certs found in `PKI_WEB_CHAIN`/`PKI_EXTERNAL_ROOT`. The host trust store is
never consulted, so **there was no path by which a publicly trusted leaf could
pass.**

Uploading certbot's own `fullchain.pem` — leaf + intermediate, complete and
publicly verifiable, the exact file every ACME client produces — was refused
with:

> no trust path builds for that certificate. Its issuer is `C=US, O=Let's Encrypt, CN=YE2`, and this server has nothing that chains to it — supply the intermediates, and **import the issuing root on this page if it is not a public CA**.

It demonstrably *was* a public CA. And `fullchain.pem` carries no root, by
design, so supplying more of it would not have helped: the only way through was
to hunt down ISRG Root X1 and import it as though Let's Encrypt were a private
CA.

Reported from the same server as #1729, which is how it surfaced — the
installer-side chain bug and this one look like one problem to an administrator,
because both say "nothing chains to your issuer" about a certificate that is
fine.

## The fix

This server has two anchors, and a leaf only has to satisfy one:

1. `${PKI_WEB_ANCHOR}` — FOG's own root, plus any root imported on the page.
2. The host trust store — the public CAs.

Both are now consulted, in that order, so the answer for FOG's own and for
imported roots is reached without looking further and the failure path is
unchanged for a genuinely untrusted leaf. The refusal message is untouched and
is now accurate advice rather than advice that could not be followed.

The host store legitimately contains FOG's own root — `_installCATrustAnchor()`
puts it there — so step 2 can succeed via it. That is not a loophole: the
question is whether *this server* trusts the issuer, and a root in its own trust
store is trusted by every client on the box, `curl` included.

Worth noting this is the same `-trusted`-versus-the-system-store distinction
that `_resolveSelfCacert()` and `_detectExternalCertManagement()` both carry
careful comments about. Both of those use `-trusted` **because** they need to
exclude the host store. Here it needed including.

## Testing

`tests/pki-admin-helper.test.sh` gains a section. The host store is injected
with `SSL_CERT_FILE` — openssl reads it for the *default* locations, which is
exactly the code path under test — so the test stays hermetic and never writes
into the runner's real trust store.

Two properties, not one:

- a leaf whose root is in the host store is **adopted**, with the precondition
  *asserted* rather than assumed — if the fixture leaf already verified against
  FOG's anchor, the case would pass while proving nothing;
- the same leaf with a host store that does **not** carry its root is still
  refused, with the same message, so the change cannot degrade into "accept
  everything".

**What was and was not verified locally.** This test re-execs under
`unshare -rm` to get uid 0 and a private mount table, which is unavailable on
the machine this was written on — it `SKIP`s there, so the new assertions are
CI-verified only. The *logic* was verified locally by extracting
`verifyLeafChain()` out of the shipped helper and exercising it directly against
generated fixtures, before and after:

| | before | after |
|---|---|---|
| public leaf + intermediate, root in host store | ✗ refused (2) | ✓ 0 |
| leaf signed by a host-store root, no chain file | ✗ refused (2) | ✓ 0 |
| FOG-issued leaf via `PKI_WEB_ANCHOR` | ✓ 0 | ✓ 0 |
| leaf trusted by neither | ✓ refused | ✓ refused (1) |
| public leaf with no anchor bundle at all | ✗ refused (1) | ✓ 0 |

That probe is a local scaffold and is deliberately not committed; the committed
test is the one that runs as root in CI.

## Review notes

- `export SSL_CERT_FILE` is visible to the helper subprocess for that one
  section and unset afterwards. Every other openssl call in the helper names its
  trust material explicitly with `-trusted`, so none of them change behavior
  under it — worth a second pair of eyes on that claim.
- The function now returns `1` on failure where it previously returned openssl's
  `2`. Every caller tests `if ! verifyLeafChain`, so this is inert, but it is a
  change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ps28eGTALgieR6TBUSafVg

