### PR TITLE
Certificates page: make the netboot transport two radios, titled as the force it performs

### DIFF
--- a/packages/web/management/js/fog/about/fog.about.certificates.js
+++ b/packages/web/management/js/fog/about/fog.about.certificates.js
@@ -175,34 +175,48 @@
     });
   });
 
-  // The netboot transport is a select, not a switch, so it posts its own word
-  // rather than a flag. Same one-key-per-call shape as the switches below: the
-  // helper rewrites a single .fogsettings line per call, so two administrators
-  // changing different settings cannot overwrite each other's.
-  $('.pki-pref-select').on('change', function() {
-    var sel = $(this),
-      wanted = sel.val(),
-      previous = sel.data('previous') || wanted;
-    sel.prop('disabled', true);
-    $.apiCall('post', sel.data('action'), {
+  // The netboot transport is a radio group, not a switch, so it posts its own
+  // word rather than a flag. Same one-key-per-call shape as the switches
+  // below: the helper rewrites a single .fogsettings line per call, so two
+  // administrators changing different settings cannot overwrite each other's.
+  //
+  // `change` fires only on the radio being SELECTED, never on the one being
+  // cleared, so this runs once per click rather than twice.
+  $('.pki-pref-radio').on('change', function() {
+    var hit = $(this),
+      wanted = hit.val(),
+      // The whole group, so the revert below can re-check a sibling and so
+      // both inputs are locked while the call is out. Grouped by name rather
+      // than by data-key: name is what makes them mutually exclusive in the
+      // first place, so it cannot drift from the group the browser sees.
+      group = $('.pki-pref-radio[name="' + hit.attr('name') + '"]'),
+      previous = group.filter(function() {
+        return $(this).data('previous');
+      }).val() || wanted;
+    group.prop('disabled', true);
+    $.apiCall('post', hit.data('action'), {
       action: 'setPreference',
-      key: sel.data('key'),
+      key: hit.data('key'),
       value: wanted
     }, function(err) {
-      sel.prop('disabled', false);
+      group.prop('disabled', false);
       if (err) {
         // Put it back to what the server still holds, for the reason the
         // switches do: this card's whole job is to say what the next installer
         // run will do, and a control that lies about that is worse than none.
-        sel.val(previous);
+        group.filter('[value="' + previous + '"]').prop('checked', true);
         return;
       }
-      sel.data('previous', wanted);
+      group.removeData('previous');
+      hit.data('previous', true);
     });
   }).each(function() {
-    // Remember the starting value, so a rejected change has something to
-    // revert to -- `change` has already replaced it by the time we are called.
-    $(this).data('previous', $(this).val());
+    // Remember which one started checked, so a rejected change has something
+    // to revert to -- the browser has already moved the selection by the time
+    // `change` reaches us.
+    if (this.checked) {
+      $(this).data('previous', true);
+    }
   });
 
   // One handler for all three switches. Each posts only its own key, so two

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -3686,6 +3686,9 @@ msgstr ""
 msgid "Force"
 msgstr "zwingen"
 
+msgid "Force netboot over HTTP or HTTPS"
+msgstr ""
+
 #, fuzzy
 msgid "Foreign key preparation"
 msgstr "Imagereplikation"
@@ -6340,9 +6343,6 @@ msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
 msgid "Nested group search failed"
 msgstr "Benutzer-Update fehlgeschlagen"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "Netzwerkinformationen"
 
@@ -8595,7 +8595,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Setting either one here FORCES it -- the installer records BOOT_url_proto_forced and stops deriving the transport from the two settings above, so it keeps what you set even if those change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -3688,6 +3688,9 @@ msgstr ""
 msgid "Force"
 msgstr "Force"
 
+msgid "Force netboot over HTTP or HTTPS"
+msgstr ""
+
 #, fuzzy
 msgid "Foreign key preparation"
 msgstr "Image Replicator"
@@ -6352,9 +6355,6 @@ msgstr "Event must be a string"
 msgid "Nested group search failed"
 msgstr "User update failed"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "Network Information"
 
@@ -8606,7 +8606,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Setting either one here FORCES it -- the installer records BOOT_url_proto_forced and stops deriving the transport from the two settings above, so it keeps what you set even if those change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3734,6 +3734,9 @@ msgstr ""
 msgid "Force"
 msgstr "Fuerza"
 
+msgid "Force netboot over HTTP or HTTPS"
+msgstr ""
+
 #, fuzzy
 msgid "Foreign key preparation"
 msgstr "replicador de imagen"
@@ -6451,9 +6454,6 @@ msgstr "Evento debe ser una cadena"
 msgid "Nested group search failed"
 msgstr "actualización Valoración falló"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "Información de la red"
 
@@ -8729,7 +8729,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Setting either one here FORCES it -- the installer records BOOT_url_proto_forced and stops deriving the transport from the two settings above, so it keeps what you set even if those change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3686,6 +3686,9 @@ msgstr ""
 msgid "Force"
 msgstr "zwingen"
 
+msgid "Force netboot over HTTP or HTTPS"
+msgstr ""
+
 #, fuzzy
 msgid "Foreign key preparation"
 msgstr "Imagereplikation"
@@ -6341,9 +6344,6 @@ msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
 msgid "Nested group search failed"
 msgstr "Benutzer-Update fehlgeschlagen"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "Netzwerkinformationen"
 
@@ -8596,7 +8596,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Setting either one here FORCES it -- the installer records BOOT_url_proto_forced and stops deriving the transport from the two settings above, so it keeps what you set even if those change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -3688,6 +3688,9 @@ msgstr ""
 msgid "Force"
 msgstr "Obliger"
 
+msgid "Force netboot over HTTP or HTTPS"
+msgstr ""
+
 #, fuzzy
 msgid "Foreign key preparation"
 msgstr "image Replicator"
@@ -6337,9 +6340,6 @@ msgstr "Événement doit être une chaîne"
 msgid "Nested group search failed"
 msgstr "mise à jour de l'utilisateur a échoué"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "Réseau d'information"
 
@@ -8590,7 +8590,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Setting either one here FORCES it -- the installer records BOOT_url_proto_forced and stops deriving the transport from the two settings above, so it keeps what you set even if those change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -3608,6 +3608,9 @@ msgstr ""
 msgid "Force"
 msgstr "Forza"
 
+msgid "Force netboot over HTTP or HTTPS"
+msgstr ""
+
 #, fuzzy
 msgid "Foreign key preparation"
 msgstr "replica dell'immagine"
@@ -6170,9 +6173,6 @@ msgstr "Nuova chiave deve essere una stringa"
 msgid "Nested group search failed"
 msgstr "Aggiornamento utente non riuscita"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "Informationi di rete"
 
@@ -8371,7 +8371,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Setting either one here FORCES it -- the installer records BOOT_url_proto_forced and stops deriving the transport from the two settings above, so it keeps what you set even if those change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -3587,6 +3587,9 @@ msgstr "アクセスが拒否されました（無効な CSRF トークン）"
 msgid "Force"
 msgstr "強制"
 
+msgid "Force netboot over HTTP or HTTPS"
+msgstr ""
+
 #, fuzzy
 msgid "Foreign key preparation"
 msgstr "イメージレプリケーション"
@@ -6144,9 +6147,6 @@ msgstr "ユーザー名は 41 文字未満で指定してください"
 msgid "Nested group search failed"
 msgstr "ユーザーの更新に失敗しました！"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "ネットワーク情報"
 
@@ -8342,7 +8342,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Setting either one here FORCES it -- the installer records BOOT_url_proto_forced and stops deriving the transport from the two settings above, so it keeps what you set even if those change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -3183,6 +3183,9 @@ msgstr ""
 msgid "Force"
 msgstr ""
 
+msgid "Force netboot over HTTP or HTTPS"
+msgstr ""
+
 msgid "Foreign key preparation"
 msgstr ""
 
@@ -5423,9 +5426,6 @@ msgstr ""
 msgid "Nested group search failed"
 msgstr ""
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr ""
 
@@ -7376,7 +7376,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Setting either one here FORCES it -- the installer records BOOT_url_proto_forced and stops deriving the transport from the two settings above, so it keeps what you set even if those change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -3688,6 +3688,9 @@ msgstr ""
 msgid "Force"
 msgstr "Força"
 
+msgid "Force netboot over HTTP or HTTPS"
+msgstr ""
+
 #, fuzzy
 msgid "Foreign key preparation"
 msgstr "Replicator imagem"
@@ -6339,9 +6342,6 @@ msgstr "Evento deve ser uma string"
 msgid "Nested group search failed"
 msgstr "atualização do utilizador falhou"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "Informações de rede"
 
@@ -8593,7 +8593,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Setting either one here FORCES it -- the installer records BOOT_url_proto_forced and stops deriving the transport from the two settings above, so it keeps what you set even if those change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -3688,6 +3688,9 @@ msgstr ""
 msgid "Force"
 msgstr "力"
 
+msgid "Force netboot over HTTP or HTTPS"
+msgstr ""
+
 #, fuzzy
 msgid "Foreign key preparation"
 msgstr "图像复制"
@@ -6339,9 +6342,6 @@ msgstr "事件必须是字符串"
 msgid "Nested group search failed"
 msgstr "用户更新失败"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "网络信息"
 
@@ -8593,7 +8593,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Setting either one here FORCES it -- the installer records BOOT_url_proto_forced and stops deriving the transport from the two settings above, so it keeps what you set even if those change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
 msgstr ""
 
 msgid "Serial Number"

--- a/packages/web/src/Pages/FOGConfigurationPage.php
+++ b/packages/web/src/Pages/FOGConfigurationPage.php
@@ -1322,32 +1322,60 @@ class FOGConfigurationPage extends FOGPage
         // The netboot transport, rendered after the three switches and inside
         // the same card, because it is not a fourth independent preference --
         // it is the same decision the other two steer. Kept out of $meta
-        // because its domain is http|https, so it is a select rather than a
-        // switch, and a checkbox would have to invent which way is "on".
+        // because its domain is http|https rather than yes|no, so a switch
+        // would have to invent which way is "on".
+        //
+        // RADIOS, not a select. Both are honest about the domain, but a select
+        // shows one value and hides the other behind a click, which on a row
+        // whose whole point is "this is a choice between two transports" reads
+        // as a status badge rather than a control -- and at form-select-sm in
+        // a narrow first column it rendered as a bare `http` chip that did not
+        // look interactive at all. Two radios show the domain AND the current
+        // value at once, which is what the three switches beside it do.
+        //
+        // Titled "Force" because that is what writing this key does. The page
+        // cannot set BOOT_url_proto_forced -- it is deliberately absent from
+        // the helper's allowlist (ADR 0036) -- but it does not need to:
+        // _resolveInstallMode() sets it to yes whenever an explicit value is
+        // supplied, so recording a transport here IS forcing it, and a title
+        // that said only "fetches over" hid the irreversible half of that.
         $proto = 'https' === (string) ($prefs['BOOT_url_proto'] ?? 'http')
             ? 'https' : 'http';
         $protoRow = '<tr><td class="text-nowrap">';
-        $protoRow .= '<select class="form-select form-select-sm pki-pref-select"'
-            . ' id="BOOT_url_proto" data-key="BOOT_url_proto"'
-            . ' data-action="' . \Initiator::e($this->formAction) . '"'
-            . ($mayEdit ? '' : ' disabled') . '>';
         foreach (['http' => _('http'), 'https' => _('https')] as $val => $label) {
-            $protoRow .= '<option value="' . \Initiator::e($val) . '"'
-                . ($proto === $val ? ' selected' : '') . '>'
-                . \Initiator::e($label) . '</option>';
+            $protoId = 'BOOT_url_proto_' . $val;
+            $protoRow .= '<div class="form-check form-check-inline mb-0">'
+                . '<input class="form-check-input pki-pref-radio" type="radio"'
+                . ' name="BOOT_url_proto"'
+                . ' id="' . \Initiator::e($protoId) . '"'
+                . ' value="' . \Initiator::e($val) . '"'
+                . ' data-key="BOOT_url_proto"'
+                . ' data-action="' . \Initiator::e($this->formAction) . '"'
+                . ($proto === $val ? ' checked' : '')
+                . ($mayEdit ? '' : ' disabled')
+                . '>'
+                . '<label class="form-check-label" for="' . \Initiator::e($protoId)
+                . '">' . \Initiator::e($label) . '</label>'
+                . '</div>';
         }
-        $protoRow .= '</select></td>';
-        $protoRow .= '<td><label class="form-check-label" for="BOOT_url_proto">'
-            . '<strong>' . _('Netboot fetches boot.php over') . '</strong>'
+        $protoRow .= '</td>';
+        // Pointed at the radio that is ALREADY checked, so the setting name
+        // stays the click target the switches' names are without the click
+        // changing anything -- a title that silently flipped the transport
+        // would be the one misclick ADR 0036 spent a rejected alternative on.
+        $protoRow .= '<td><label class="form-check-label" for="BOOT_url_proto_'
+            . \Initiator::e($proto) . '">'
+            . '<strong>' . _('Force netboot over HTTP or HTTPS') . '</strong>'
             . '<br><code class="small">BOOT_url_proto</code></label></td>';
         $protoRow .= '<td><small class="text-muted">' . _(
             'Separate from the HTTP redirect above, which never applies to the '
-            . 'paths a bootloader fetches for itself. Choosing https here also '
-            . 'FORCES it: the installer stops deriving the transport and keeps '
-            . 'what you set. If iPXE cannot validate the certificate this '
-            . 'server serves, every netboot stops at boot.php and nothing '
-            . 'server-side says why -- so decide it together with the two '
-            . 'settings above, not on its own.'
+            . 'paths a bootloader fetches for itself. Setting either one here '
+            . 'FORCES it -- the installer records BOOT_url_proto_forced and '
+            . 'stops deriving the transport from the two settings above, so it '
+            . 'keeps what you set even if those change. If iPXE cannot '
+            . 'validate the certificate this server serves, every netboot '
+            . 'stops at boot.php and nothing server-side says why -- so decide '
+            . 'it together with the two settings above, not on its own.'
         ) . '</small></td></tr>';
 
         $rows = '';

--- a/tests/certificate-table.test.php
+++ b/tests/certificate-table.test.php
@@ -303,4 +303,86 @@ $t->check(
     false === strpos($rendered, 'collapsed-card')
 );
 
+/*
+ * 6. The netboot transport row. Two radios rather than a select, because a
+ *    select showed one value and hid the other behind a click -- which on a
+ *    row whose point is "this is a choice between two transports" read as a
+ *    status badge, not a control.
+ *
+ *    Pinned on the rendered row, not on a call site, because the failure is
+ *    entirely in what the browser receives: a radio group that lost its shared
+ *    `name` still renders as two radios and still posts, but both can be
+ *    checked at once and the row stops describing a single setting. The
+ *    ALREADY-checked `for` target is here for a sharper reason -- pointing the
+ *    title at a fixed id would make one click on the setting name silently
+ *    force the transport, which is the exact misclick ADR 0036 spent a
+ *    rejected alternative refusing to expose.
+ */
+$prefsOf = function ($proto, $mayEdit) use ($invoke) {
+    return $invoke('_certificatePreferences', [
+        ['preferences' => ['BOOT_url_proto' => $proto]],
+        $mayEdit
+    ]);
+};
+
+$protoHtml = $prefsOf('http', true);
+$t->check(
+    'the netboot transport is a radio group, not a select',
+    2 === substr_count($protoHtml, 'type="radio"')
+        && false === strpos($protoHtml, 'pki-pref-select')
+        && false === strpos($protoHtml, '<select')
+);
+$t->check(
+    'both radios share one name, so they are mutually exclusive',
+    2 === substr_count($protoHtml, 'name="BOOT_url_proto"')
+);
+$t->check(
+    'exactly one radio is checked',
+    1 === substr_count($protoHtml, ' checked')
+);
+$t->check(
+    'and it is the transport the helper reported',
+    false !== strpos(
+        $protoHtml,
+        'id="BOOT_url_proto_http" value="http" data-key="BOOT_url_proto"'
+    )
+);
+$t->check(
+    'the setting name is worded as the force it performs',
+    false !== strpos($protoHtml, 'Force netboot over HTTP or HTTPS')
+);
+$t->check(
+    'and it says which key records that force',
+    false !== strpos($protoHtml, 'BOOT_url_proto_forced')
+);
+$t->check(
+    'the title label points at the radio already checked, so a click on it '
+        . 'cannot change the transport',
+    false !== strpos($protoHtml, 'for="BOOT_url_proto_http"><strong>')
+);
+
+$protoHttps = $prefsOf('https', true);
+$t->check(
+    'https is what is checked when https is what is set',
+    false !== strpos($protoHttps, 'id="BOOT_url_proto_https" value="https"')
+        && false !== strpos($protoHttps, 'for="BOOT_url_proto_https"><strong>')
+        && 1 === substr_count($protoHttps, ' checked')
+);
+
+// Counted on the radio tags themselves. The three switches above carry
+// `disabled` under the same condition, so a count over the whole body would
+// pass whatever the radios did.
+$radiosDisabled = function ($html) {
+    return preg_match_all('/type="radio"[^>]*\sdisabled/', $html);
+};
+$protoRo = $prefsOf('http', false);
+$t->check(
+    'a caller without system.pki gets both radios disabled',
+    2 === $radiosDisabled($protoRo)
+);
+$t->check(
+    'and the writable render disables neither',
+    0 === $radiosDisabled($protoHtml)
+);
+
 $t->finish();


### PR DESCRIPTION
> Draft. See **Not verified locally** before merging — `phpstan` could not be run
> here, and this adds assertions to a file the tests baseline counts.

## Before


```
[ON ]  The web certificate chains to a public CA      Turn this on for a Let's Encrypt or …
[   ]  Redirect HTTP to HTTPS                         Off by default on purpose. …
[   ]  Rebuild iPXE with this server's CA embedded    Only needed for HTTPS netboot …
┌────┐
│http│  Netboot fetches boot.php over                 Separate from the HTTP redirect above, …
└────┘
```

Two problems, both in what the browser receives.

**It does not look like a control.** A `form-select-sm` in the table's narrow
first column renders as a bare `http` chip — a status badge sitting beside three
switches that are obviously interactive. A select also shows one value and hides
the other behind a click, on a row whose entire subject is a choice between two
transports.

**The title is a dangling phrase.** `Netboot fetches boot.php over` was written
to be completed by the select. With the control in the cell to its left the
sentence never finishes, and the three rows above it are all complete
statements.

## After

```
( ) http  (o) https   Force netboot over HTTP or HTTPS
                      BOOT_url_proto
```

Two radios show the domain *and* the current value at once, which is what the
switches beside them do. This does not fight the prior decision: the comment
that chose a select argued *"its domain is http|https, so it is a select rather
than a switch, and a checkbox would have to invent which way is 'on'"* — radios
satisfy that reasoning better than the select did.

**Titled `Force`, because forcing is what writing this key does.** The page
cannot set `BOOT_url_proto_forced` — it is deliberately absent from the helper's
allowlist, and ADR 0036 spends a rejected alternative on why — but it does not
need to: `_resolveInstallMode()` sets that key to `yes` whenever an explicit
value is supplied, so **recording a transport here *is* forcing it.** The old
title hid that. The description now names the key that records it and says the
derivation stops, rather than mentioning it only for the `https` case.

The title's label points at the radio that is **already checked**, so the
setting name stays the click target the switches' names are without a click on
it changing anything. Pointing it at a fixed id would make one click on the
title silently force the transport — the exact misclick that same rejected
alternative refused to expose.

## JS

`change` fires only on the radio being *selected*, never on the one being
cleared, so it still posts once per click and keeps the one-key-per-call shape.
The revert on error re-checks a sibling rather than restoring a value, and the
group is located by shared `name` — the attribute that makes them mutually
exclusive in the first place, so it cannot drift from the group the browser
sees.

## Testing

`tests/certificate-table.test.php` gains ten assertions on the **rendered row**,
not on a call site — the failure mode here is entirely in the markup. A radio
group that lost its shared `name` still renders as two radios and still posts,
but both can be checked at once and the row stops describing one setting.

| | |
|---|---|
| baseline | 33 checks |
| now | 43 checks, all passing |
| against the previous markup | **9 of the 10 new ones fail** |
| with the shared `name` removed | exactly the mutual-exclusivity assertion fails |

The tenth is a negative guard (the writable render disables neither radio) and
passes either way by design.

`tests/certificate-management-permission.test.php` 19/19 — it inspects the
helper's allowlist, which this does not touch, and is the test that would catch
an attempt to make `BOOT_url_proto_forced` settable from the page.

### Not verified locally

- **`phpstan` (both passes) was not run** — no `vendor/` on this machine. Worth
  noting because the `tests/` pass baselines *occurrence counts*, and this adds
  a `preg_match_all` and two closures to a baselined file; if a `count:` needs
  bumping, CI is where it will show.
- **The gettext catalog was not regenerated** — no `xgettext` here, and the
  pre-commit hook skipped it. One translatable string changed and one was
  reworded, so `messages.pot` and the `.po` files will drift until the
  `regenerate` job corrects them.
- **Not rendered in a browser.** The markup and its assertions are verified; how it actually looks in the row is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ps28eGTALgieR6TBUSafVg


