### PR TITLE
Certificates page: make forcing netboot HTTPS a switch, and give it a way back to derived

### DIFF
--- a/packages/pki/fog-pki-admin
+++ b/packages/pki/fog-pki-admin
@@ -108,6 +108,18 @@ shift
 # default.
 PREF_KEYS="PKI_web_cert_publicly_trusted WEB_https_redirect BOOT_rebuild_ipxe_with_my_ca BOOT_url_proto"
 
+# Keys the status report may READ but that nothing may WRITE through this verb.
+# Two lists rather than one, because they answer different questions and
+# conflating them is how BOOT_url_proto_forced would become settable by
+# accident: PREF_KEYS is the write allowlist and the security boundary,
+# REPORT_KEYS is only what the page is allowed to see.
+#
+# BOOT_url_proto_forced is here because the page cannot otherwise tell a
+# DERIVED https from a FORCED one -- _resolveNetbootProto() reads it to decide
+# whether to re-derive at all -- and a switch that cannot tell those apart
+# renders the wrong state on every server whose transport was derived.
+REPORT_KEYS="$PREF_KEYS BOOT_url_proto_forced"
+
 # The value domain, per key.
 #
 # It was one ^(yes|no)$ for all three, and that pattern is the security
@@ -118,7 +130,7 @@ PREF_KEYS="PKI_web_cert_publicly_trusted WEB_https_redirect BOOT_rebuild_ipxe_wi
 # ADR 0036's rule requires. It is the implementation that generalizes.
 prefPattern() {
     case "$1" in
-        BOOT_url_proto) printf '%s' '^(http|https)$' ;;
+        BOOT_url_proto) printf '%s' '^(http|https|auto)$' ;;
         *)              printf '%s' '^(yes|no)$' ;;
     esac
 }
@@ -1009,7 +1021,7 @@ EOF
 
     printf '  "preferences": {'
     first=1
-    for key in $PREF_KEYS; do
+    for key in $REPORT_KEYS; do
         [[ $first -eq 1 ]] || printf ', '
         first=0
         printf '%s: %s' "$(jstr "$key")" "$(jstr "$(readSetting "$key")")"
@@ -1336,6 +1348,30 @@ set-preference)
     # quoted one would match the pattern as a literal string.
     pattern=$(prefPattern "$key")
     [[ $value =~ $pattern ]] || die "value for ${key} must match ${pattern}"
+    # `auto` is not a transport, it is the ABSENCE of a forced one, so it
+    # clears the force rather than writing itself into BOOT_url_proto.
+    # _resolveNetbootProto() then re-derives from the two steering keys on
+    # every run, which is what it does on a server nobody has forced.
+    #
+    # Without this there is no way back. Both real transports set
+    # BOOT_url_proto_forced=yes when the installer reads them, so a page that
+    # could only write http or https was a one-way door: a server deriving
+    # https from a public certificate would be pinned by the first toggle and
+    # never derive again, whatever its certificate later became.
+    #
+    # It writes BOOT_url_proto_forced, a key deliberately absent from
+    # PREF_KEYS, and that is not a hole in ADR 0036's refusal. The refusal was
+    # about FORCING https with neither steering key set -- "not a thing a
+    # misclick should reach". This only ever writes `no`, and clearing a force
+    # can do nothing but return the value to whatever derivation already says.
+    # Reaching forced=yes still requires posting https to a key whose control
+    # says so.
+    if [[ $key == BOOT_url_proto && $value == auto ]]; then
+        writeSetting BOOT_url_proto_forced no \
+            || die "could not clear BOOT_url_proto_forced in .fogsettings"
+        echo "OK"
+        exit 0
+    fi
     writeSetting "$key" "$value" || die "could not update ${key} in .fogsettings"
     echo "OK"
     ;;

--- a/packages/web/management/js/fog/about/fog.about.certificates.js
+++ b/packages/web/management/js/fog/about/fog.about.certificates.js
@@ -175,37 +175,11 @@
     });
   });
 
-  // The netboot transport is a select, not a switch, so it posts its own word
-  // rather than a flag. Same one-key-per-call shape as the switches below: the
-  // helper rewrites a single .fogsettings line per call, so two administrators
-  // changing different settings cannot overwrite each other's.
-  $('.pki-pref-select').on('change', function() {
-    var sel = $(this),
-      wanted = sel.val(),
-      previous = sel.data('previous') || wanted;
-    sel.prop('disabled', true);
-    $.apiCall('post', sel.data('action'), {
-      action: 'setPreference',
-      key: sel.data('key'),
-      value: wanted
-    }, function(err) {
-      sel.prop('disabled', false);
-      if (err) {
-        // Put it back to what the server still holds, for the reason the
-        // switches do: this card's whole job is to say what the next installer
-        // run will do, and a control that lies about that is worse than none.
-        sel.val(previous);
-        return;
-      }
-      sel.data('previous', wanted);
-    });
-  }).each(function() {
-    // Remember the starting value, so a rejected change has something to
-    // revert to -- `change` has already replaced it by the time we are called.
-    $(this).data('previous', $(this).val());
-  });
-
-  // One handler for all three switches. Each posts only its own key, so two
+  // One handler for ALL FOUR switches, the netboot transport included -- it
+  // used to need its own because it was a select posting a word. It is a
+  // switch now and posts the same flag as the rest; the page turns that flag
+  // into `https` or `auto` on the way to the helper, because "force https" is
+  // the yes/no this row actually asks. Each posts only its own key, so two
   // administrators changing different preferences cannot overwrite each
   // other's -- the helper rewrites a single line of .fogsettings per call.
   $('.pki-pref').on('change', function() {

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -3687,6 +3687,10 @@ msgid "Force"
 msgstr "zwingen"
 
 #, fuzzy
+msgid "Force netboot over HTTPS"
+msgstr "Neustarten"
+
+#, fuzzy
 msgid "Foreign key preparation"
 msgstr "Imagereplikation"
 
@@ -6340,9 +6344,6 @@ msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
 msgid "Nested group search failed"
 msgstr "Benutzer-Update fehlgeschlagen"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "Netzwerkinformationen"
 
@@ -8595,7 +8596,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself -- netboot is excluded from that redirect even when it is on. Left off, FOG derives the transport on every run from the two settings above. Turning it on records BOOT_url_proto_forced and stops that: https is kept even if those settings later change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- and the machines it stops are the ones that cannot fix themselves. Turning it back off returns to deriving."
 msgstr ""
 
 msgid "Serial Number"
@@ -11985,6 +11986,10 @@ msgstr "Temporäre Datei konnte nicht gelesen werden."
 msgid "could not be killed"
 msgstr "Temporäre Datei konnte nicht gelesen werden."
 
+#, php-format
+msgid "currently %1$s (%2$s)"
+msgstr ""
+
 msgid "cycles since last line"
 msgstr ""
 
@@ -11993,6 +11998,15 @@ msgstr "Tag"
 
 msgid "deploy task occurs for it"
 msgstr "es eine Verteilungs-Task gibt."
+
+msgid "derived"
+msgstr ""
+
+msgid "derived from the embedded-CA setting above"
+msgstr ""
+
+msgid "derived from the public CA setting above"
+msgstr ""
 
 msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
 msgstr ""
@@ -12087,6 +12101,10 @@ msgid "for user"
 msgstr ""
 
 #, fuzzy
+msgid "forced"
+msgstr "zwingen"
+
+#, fuzzy
 msgid "foreign key(s) could not be added"
 msgstr "Temporäre Datei konnte nicht gelesen werden."
 
@@ -12174,12 +12192,6 @@ msgstr "Stunde"
 #, fuzzy
 msgid "hr"
 msgstr "Stunde"
-
-msgid "http"
-msgstr ""
-
-msgid "https"
-msgstr ""
 
 #, fuzzy
 msgid "iPXE Config Update Fail"
@@ -13201,10 +13213,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "Ich bin nicht der FOG-Web-Server"
-
-#, fuzzy
-#~ msgid "Force Reboot"
-#~ msgstr "Neustarten"
 
 #~ msgid "Green FOG"
 #~ msgstr "Green FOG"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -3689,6 +3689,10 @@ msgid "Force"
 msgstr "Force"
 
 #, fuzzy
+msgid "Force netboot over HTTPS"
+msgstr "Reboot"
+
+#, fuzzy
 msgid "Foreign key preparation"
 msgstr "Image Replicator"
 
@@ -6352,9 +6356,6 @@ msgstr "Event must be a string"
 msgid "Nested group search failed"
 msgstr "User update failed"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "Network Information"
 
@@ -8606,7 +8607,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself -- netboot is excluded from that redirect even when it is on. Left off, FOG derives the transport on every run from the two settings above. Turning it on records BOOT_url_proto_forced and stops that: https is kept even if those settings later change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- and the machines it stops are the ones that cannot fix themselves. Turning it back off returns to deriving."
 msgstr ""
 
 msgid "Serial Number"
@@ -11991,6 +11992,10 @@ msgstr "Could not read temp file"
 msgid "could not be killed"
 msgstr "Could not read temp file"
 
+#, php-format
+msgid "currently %1$s (%2$s)"
+msgstr ""
+
 msgid "cycles since last line"
 msgstr ""
 
@@ -11998,6 +12003,15 @@ msgid "day"
 msgstr ""
 
 msgid "deploy task occurs for it"
+msgstr ""
+
+msgid "derived"
+msgstr ""
+
+msgid "derived from the embedded-CA setting above"
+msgstr ""
+
+msgid "derived from the public CA setting above"
 msgstr ""
 
 msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
@@ -12093,6 +12107,10 @@ msgid "for user"
 msgstr ""
 
 #, fuzzy
+msgid "forced"
+msgstr "Force"
+
+#, fuzzy
 msgid "foreign key(s) could not be added"
 msgstr "Could not read temp file"
 
@@ -12180,12 +12198,6 @@ msgstr "1 hour"
 #, fuzzy
 msgid "hr"
 msgstr "here"
-
-msgid "http"
-msgstr ""
-
-msgid "https"
-msgstr ""
 
 #, fuzzy
 msgid "iPXE Config Update Fail"
@@ -13195,10 +13207,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "I am not the fog web server"
-
-#, fuzzy
-#~ msgid "Force Reboot"
-#~ msgstr "Reboot"
 
 #~ msgid "Green FOG"
 #~ msgstr "Green FOG"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3735,6 +3735,10 @@ msgid "Force"
 msgstr "Fuerza"
 
 #, fuzzy
+msgid "Force netboot over HTTPS"
+msgstr "Reiniciar"
+
+#, fuzzy
 msgid "Foreign key preparation"
 msgstr "replicador de imagen"
 
@@ -6451,9 +6455,6 @@ msgstr "Evento debe ser una cadena"
 msgid "Nested group search failed"
 msgstr "actualización Valoración falló"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "Información de la red"
 
@@ -8729,7 +8730,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself -- netboot is excluded from that redirect even when it is on. Left off, FOG derives the transport on every run from the two settings above. Turning it on records BOOT_url_proto_forced and stops that: https is kept even if those settings later change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- and the machines it stops are the ones that cannot fix themselves. Turning it back off returns to deriving."
 msgstr ""
 
 msgid "Serial Number"
@@ -12150,6 +12151,10 @@ msgstr "No se pudo leer el archivo temporal"
 msgid "could not be killed"
 msgstr "No se pudo leer el archivo temporal"
 
+#, php-format
+msgid "currently %1$s (%2$s)"
+msgstr ""
+
 msgid "cycles since last line"
 msgstr ""
 
@@ -12157,6 +12162,15 @@ msgid "day"
 msgstr ""
 
 msgid "deploy task occurs for it"
+msgstr ""
+
+msgid "derived"
+msgstr ""
+
+msgid "derived from the embedded-CA setting above"
+msgstr ""
+
+msgid "derived from the public CA setting above"
 msgstr ""
 
 msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
@@ -12253,6 +12267,10 @@ msgid "for user"
 msgstr ""
 
 #, fuzzy
+msgid "forced"
+msgstr "Fuerza"
+
+#, fuzzy
 msgid "foreign key(s) could not be added"
 msgstr "No se pudo leer el archivo temporal"
 
@@ -12340,12 +12358,6 @@ msgstr "1 hora"
 #, fuzzy
 msgid "hr"
 msgstr "aquí"
-
-msgid "http"
-msgstr ""
-
-msgid "https"
-msgstr ""
 
 #, fuzzy
 msgid "iPXE Config Update Fail"
@@ -13354,10 +13366,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Failed to update/create image log"
 #~ msgstr "No se pudo crear Complemento de empleo"
-
-#, fuzzy
-#~ msgid "Force Reboot"
-#~ msgstr "Reiniciar"
 
 #, fuzzy
 #~ msgid "Green FOG"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3687,6 +3687,10 @@ msgid "Force"
 msgstr "zwingen"
 
 #, fuzzy
+msgid "Force netboot over HTTPS"
+msgstr "Neustarten"
+
+#, fuzzy
 msgid "Foreign key preparation"
 msgstr "Imagereplikation"
 
@@ -6341,9 +6345,6 @@ msgstr "Neuer Schlüsselname muss eine Zeichenfolge sein."
 msgid "Nested group search failed"
 msgstr "Benutzer-Update fehlgeschlagen"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "Netzwerkinformationen"
 
@@ -8596,7 +8597,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself -- netboot is excluded from that redirect even when it is on. Left off, FOG derives the transport on every run from the two settings above. Turning it on records BOOT_url_proto_forced and stops that: https is kept even if those settings later change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- and the machines it stops are the ones that cannot fix themselves. Turning it back off returns to deriving."
 msgstr ""
 
 msgid "Serial Number"
@@ -11986,6 +11987,10 @@ msgstr "Temporäre Datei konnte nicht gelesen werden."
 msgid "could not be killed"
 msgstr "Temporäre Datei konnte nicht gelesen werden."
 
+#, php-format
+msgid "currently %1$s (%2$s)"
+msgstr ""
+
 msgid "cycles since last line"
 msgstr ""
 
@@ -11994,6 +11999,15 @@ msgstr "Tag"
 
 msgid "deploy task occurs for it"
 msgstr "es eine Verteilungs-Task gibt."
+
+msgid "derived"
+msgstr ""
+
+msgid "derived from the embedded-CA setting above"
+msgstr ""
+
+msgid "derived from the public CA setting above"
+msgstr ""
 
 msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
 msgstr ""
@@ -12088,6 +12102,10 @@ msgid "for user"
 msgstr ""
 
 #, fuzzy
+msgid "forced"
+msgstr "zwingen"
+
+#, fuzzy
 msgid "foreign key(s) could not be added"
 msgstr "Temporäre Datei konnte nicht gelesen werden."
 
@@ -12175,12 +12193,6 @@ msgstr "Stunde"
 #, fuzzy
 msgid "hr"
 msgstr "Stunde"
-
-msgid "http"
-msgstr ""
-
-msgid "https"
-msgstr ""
 
 #, fuzzy
 msgid "iPXE Config Update Fail"
@@ -13202,10 +13214,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "Ich bin nicht der FOG-Web-Server"
-
-#, fuzzy
-#~ msgid "Force Reboot"
-#~ msgstr "Neustarten"
 
 #~ msgid "Green FOG"
 #~ msgstr "Green FOG"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -3689,6 +3689,10 @@ msgid "Force"
 msgstr "Obliger"
 
 #, fuzzy
+msgid "Force netboot over HTTPS"
+msgstr "Réinitialiser"
+
+#, fuzzy
 msgid "Foreign key preparation"
 msgstr "image Replicator"
 
@@ -6337,9 +6341,6 @@ msgstr "Événement doit être une chaîne"
 msgid "Nested group search failed"
 msgstr "mise à jour de l'utilisateur a échoué"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "Réseau d'information"
 
@@ -8590,7 +8591,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself -- netboot is excluded from that redirect even when it is on. Left off, FOG derives the transport on every run from the two settings above. Turning it on records BOOT_url_proto_forced and stops that: https is kept even if those settings later change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- and the machines it stops are the ones that cannot fix themselves. Turning it back off returns to deriving."
 msgstr ""
 
 msgid "Serial Number"
@@ -11976,6 +11977,10 @@ msgstr "Impossible de lire le fichier temporaire"
 msgid "could not be killed"
 msgstr "Impossible de lire le fichier temporaire"
 
+#, php-format
+msgid "currently %1$s (%2$s)"
+msgstr ""
+
 msgid "cycles since last line"
 msgstr ""
 
@@ -11983,6 +11988,15 @@ msgid "day"
 msgstr ""
 
 msgid "deploy task occurs for it"
+msgstr ""
+
+msgid "derived"
+msgstr ""
+
+msgid "derived from the embedded-CA setting above"
+msgstr ""
+
+msgid "derived from the public CA setting above"
 msgstr ""
 
 msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
@@ -12078,6 +12092,10 @@ msgid "for user"
 msgstr ""
 
 #, fuzzy
+msgid "forced"
+msgstr "Obliger"
+
+#, fuzzy
 msgid "foreign key(s) could not be added"
 msgstr "Impossible de lire le fichier temporaire"
 
@@ -12165,12 +12183,6 @@ msgstr "1 heure"
 #, fuzzy
 msgid "hr"
 msgstr "ici"
-
-msgid "http"
-msgstr ""
-
-msgid "https"
-msgstr ""
 
 #, fuzzy
 msgid "iPXE Config Update Fail"
@@ -13180,10 +13192,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "Je ne suis pas le serveur web de brouillard"
-
-#, fuzzy
-#~ msgid "Force Reboot"
-#~ msgstr "Réinitialiser"
 
 #~ msgid "Green FOG"
 #~ msgstr "FOG vert"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -3609,6 +3609,10 @@ msgid "Force"
 msgstr "Forza"
 
 #, fuzzy
+msgid "Force netboot over HTTPS"
+msgstr "Riavvio"
+
+#, fuzzy
 msgid "Foreign key preparation"
 msgstr "replica dell'immagine"
 
@@ -6170,9 +6174,6 @@ msgstr "Nuova chiave deve essere una stringa"
 msgid "Nested group search failed"
 msgstr "Aggiornamento utente non riuscita"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "Informationi di rete"
 
@@ -8371,7 +8372,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself -- netboot is excluded from that redirect even when it is on. Left off, FOG derives the transport on every run from the two settings above. Turning it on records BOOT_url_proto_forced and stops that: https is kept even if those settings later change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- and the machines it stops are the ones that cannot fix themselves. Turning it back off returns to deriving."
 msgstr ""
 
 msgid "Serial Number"
@@ -11656,6 +11657,10 @@ msgstr "Impossibile leggere il file temporaneo"
 msgid "could not be killed"
 msgstr "Impossibile leggere il file temporaneo"
 
+#, php-format
+msgid "currently %1$s (%2$s)"
+msgstr ""
+
 msgid "cycles since last line"
 msgstr ""
 
@@ -11664,6 +11669,15 @@ msgstr "giorno"
 
 msgid "deploy task occurs for it"
 msgstr "attività di distribuzione avviene per esso"
+
+msgid "derived"
+msgstr ""
+
+msgid "derived from the embedded-CA setting above"
+msgstr ""
+
+msgid "derived from the public CA setting above"
+msgstr ""
 
 msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
 msgstr ""
@@ -11754,6 +11768,10 @@ msgid "for user"
 msgstr ""
 
 #, fuzzy
+msgid "forced"
+msgstr "Forza"
+
+#, fuzzy
 msgid "foreign key(s) could not be added"
 msgstr "Impossibile leggere il file temporaneo"
 
@@ -11835,12 +11853,6 @@ msgstr "ora"
 
 msgid "hr"
 msgstr "ore"
-
-msgid "http"
-msgstr ""
-
-msgid "https"
-msgstr ""
 
 #, fuzzy
 msgid "iPXE Config Update Fail"
@@ -12823,10 +12835,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "Io non sono il server web fog"
-
-#, fuzzy
-#~ msgid "Force Reboot"
-#~ msgstr "Riavvio"
 
 #~ msgid "Green FOG"
 #~ msgstr "FOG verde"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -3587,6 +3587,9 @@ msgstr "アクセスが拒否されました（無効な CSRF トークン）"
 msgid "Force"
 msgstr "強制"
 
+msgid "Force netboot over HTTPS"
+msgstr ""
+
 #, fuzzy
 msgid "Foreign key preparation"
 msgstr "イメージレプリケーション"
@@ -6144,9 +6147,6 @@ msgstr "ユーザー名は 41 文字未満で指定してください"
 msgid "Nested group search failed"
 msgstr "ユーザーの更新に失敗しました！"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "ネットワーク情報"
 
@@ -8342,7 +8342,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself -- netboot is excluded from that redirect even when it is on. Left off, FOG derives the transport on every run from the two settings above. Turning it on records BOOT_url_proto_forced and stops that: https is kept even if those settings later change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- and the machines it stops are the ones that cannot fix themselves. Turning it back off returns to deriving."
 msgstr ""
 
 msgid "Serial Number"
@@ -11610,6 +11610,10 @@ msgstr "完了できませんでした"
 msgid "could not be killed"
 msgstr "強制終了できませんでした"
 
+#, php-format
+msgid "currently %1$s (%2$s)"
+msgstr ""
+
 msgid "cycles since last line"
 msgstr ""
 
@@ -11618,6 +11622,15 @@ msgstr "日"
 
 msgid "deploy task occurs for it"
 msgstr "展開タスクが実行されたとき"
+
+msgid "derived"
+msgstr ""
+
+msgid "derived from the embedded-CA setting above"
+msgstr ""
+
+msgid "derived from the public CA setting above"
+msgstr ""
 
 msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
 msgstr ""
@@ -11711,6 +11724,10 @@ msgid "for user"
 msgstr "ユーザーを作成しますか？"
 
 #, fuzzy
+msgid "forced"
+msgstr "強制"
+
+#, fuzzy
 msgid "foreign key(s) could not be added"
 msgstr "強制終了できませんでした"
 
@@ -11793,12 +11810,6 @@ msgstr "時間"
 
 msgid "hr"
 msgstr "時間"
-
-msgid "http"
-msgstr ""
-
-msgid "https"
-msgstr ""
 
 #, fuzzy
 msgid "iPXE Config Update Fail"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -3183,6 +3183,9 @@ msgstr ""
 msgid "Force"
 msgstr ""
 
+msgid "Force netboot over HTTPS"
+msgstr ""
+
 msgid "Foreign key preparation"
 msgstr ""
 
@@ -5423,9 +5426,6 @@ msgstr ""
 msgid "Nested group search failed"
 msgstr ""
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr ""
 
@@ -7376,7 +7376,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself -- netboot is excluded from that redirect even when it is on. Left off, FOG derives the transport on every run from the two settings above. Turning it on records BOOT_url_proto_forced and stops that: https is kept even if those settings later change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- and the machines it stops are the ones that cannot fix themselves. Turning it back off returns to deriving."
 msgstr ""
 
 msgid "Serial Number"
@@ -10320,6 +10320,10 @@ msgstr ""
 msgid "could not be killed"
 msgstr ""
 
+#, php-format
+msgid "currently %1$s (%2$s)"
+msgstr ""
+
 msgid "cycles since last line"
 msgstr ""
 
@@ -10327,6 +10331,15 @@ msgid "day"
 msgstr ""
 
 msgid "deploy task occurs for it"
+msgstr ""
+
+msgid "derived"
+msgstr ""
+
+msgid "derived from the embedded-CA setting above"
+msgstr ""
+
+msgid "derived from the public CA setting above"
 msgstr ""
 
 msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
@@ -10411,6 +10424,9 @@ msgstr ""
 msgid "for user"
 msgstr ""
 
+msgid "forced"
+msgstr ""
+
 msgid "foreign key(s) could not be added"
 msgstr ""
 
@@ -10482,12 +10498,6 @@ msgid "hour"
 msgstr ""
 
 msgid "hr"
-msgstr ""
-
-msgid "http"
-msgstr ""
-
-msgid "https"
 msgstr ""
 
 msgid "iPXE Config Update Fail"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -3689,6 +3689,10 @@ msgid "Force"
 msgstr "Força"
 
 #, fuzzy
+msgid "Force netboot over HTTPS"
+msgstr "reinicialização"
+
+#, fuzzy
 msgid "Foreign key preparation"
 msgstr "Replicator imagem"
 
@@ -6339,9 +6343,6 @@ msgstr "Evento deve ser uma string"
 msgid "Nested group search failed"
 msgstr "atualização do utilizador falhou"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "Informações de rede"
 
@@ -8593,7 +8594,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself -- netboot is excluded from that redirect even when it is on. Left off, FOG derives the transport on every run from the two settings above. Turning it on records BOOT_url_proto_forced and stops that: https is kept even if those settings later change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- and the machines it stops are the ones that cannot fix themselves. Turning it back off returns to deriving."
 msgstr ""
 
 msgid "Serial Number"
@@ -11979,6 +11980,10 @@ msgstr "Não foi possível ler arquivo temporário"
 msgid "could not be killed"
 msgstr "Não foi possível ler arquivo temporário"
 
+#, php-format
+msgid "currently %1$s (%2$s)"
+msgstr ""
+
 msgid "cycles since last line"
 msgstr ""
 
@@ -11986,6 +11991,15 @@ msgid "day"
 msgstr ""
 
 msgid "deploy task occurs for it"
+msgstr ""
+
+msgid "derived"
+msgstr ""
+
+msgid "derived from the embedded-CA setting above"
+msgstr ""
+
+msgid "derived from the public CA setting above"
 msgstr ""
 
 msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
@@ -12081,6 +12095,10 @@ msgid "for user"
 msgstr ""
 
 #, fuzzy
+msgid "forced"
+msgstr "Força"
+
+#, fuzzy
 msgid "foreign key(s) could not be added"
 msgstr "Não foi possível ler arquivo temporário"
 
@@ -12168,12 +12186,6 @@ msgstr "1 hora"
 #, fuzzy
 msgid "hr"
 msgstr "Aqui"
-
-msgid "http"
-msgstr ""
-
-msgid "https"
-msgstr ""
 
 #, fuzzy
 msgid "iPXE Config Update Fail"
@@ -13183,10 +13195,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "Eu não sou o servidor web nevoeiro"
-
-#, fuzzy
-#~ msgid "Force Reboot"
-#~ msgstr "reinicialização"
 
 #~ msgid "Green FOG"
 #~ msgstr "FOG verde"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -3689,6 +3689,10 @@ msgid "Force"
 msgstr "力"
 
 #, fuzzy
+msgid "Force netboot over HTTPS"
+msgstr "重启"
+
+#, fuzzy
 msgid "Foreign key preparation"
 msgstr "图像复制"
 
@@ -6339,9 +6343,6 @@ msgstr "事件必须是字符串"
 msgid "Nested group search failed"
 msgstr "用户更新失败"
 
-msgid "Netboot fetches boot.php over"
-msgstr ""
-
 msgid "Network Information"
 msgstr "网络信息"
 
@@ -8593,7 +8594,7 @@ msgstr ""
 msgid "Sent as an Authorization: Bearer header, on its own &mdash; no fog-api-token header is needed alongside it. Each token acts with this user's roles."
 msgstr ""
 
-msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself. Choosing https here also FORCES it: the installer stops deriving the transport and keeps what you set. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- so decide it together with the two settings above, not on its own."
+msgid "Separate from the HTTP redirect above, which never applies to the paths a bootloader fetches for itself -- netboot is excluded from that redirect even when it is on. Left off, FOG derives the transport on every run from the two settings above. Turning it on records BOOT_url_proto_forced and stops that: https is kept even if those settings later change. If iPXE cannot validate the certificate this server serves, every netboot stops at boot.php and nothing server-side says why -- and the machines it stops are the ones that cannot fix themselves. Turning it back off returns to deriving."
 msgstr ""
 
 msgid "Serial Number"
@@ -11979,6 +11980,10 @@ msgstr "无法读取临时文件"
 msgid "could not be killed"
 msgstr "无法读取临时文件"
 
+#, php-format
+msgid "currently %1$s (%2$s)"
+msgstr ""
+
 msgid "cycles since last line"
 msgstr ""
 
@@ -11986,6 +11991,15 @@ msgid "day"
 msgstr ""
 
 msgid "deploy task occurs for it"
+msgstr ""
+
+msgid "derived"
+msgstr ""
+
+msgid "derived from the embedded-CA setting above"
+msgstr ""
+
+msgid "derived from the public CA setting above"
 msgstr ""
 
 msgid "difference(s) from the manifest. Nothing was changed -- these are reported, not repaired."
@@ -12081,6 +12095,10 @@ msgid "for user"
 msgstr ""
 
 #, fuzzy
+msgid "forced"
+msgstr "力"
+
+#, fuzzy
 msgid "foreign key(s) could not be added"
 msgstr "无法读取临时文件"
 
@@ -12168,12 +12186,6 @@ msgstr "1小时"
 #, fuzzy
 msgid "hr"
 msgstr "这里"
-
-msgid "http"
-msgstr ""
-
-msgid "https"
-msgstr ""
 
 #, fuzzy
 msgid "iPXE Config Update Fail"
@@ -13183,10 +13195,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Files do not match on server"
 #~ msgstr "我不是雾Web服务器"
-
-#, fuzzy
-#~ msgid "Force Reboot"
-#~ msgstr "重启"
 
 #~ msgid "Green FOG"
 #~ msgstr "绿雾"

--- a/packages/web/src/Pages/FOGConfigurationPage.php
+++ b/packages/web/src/Pages/FOGConfigurationPage.php
@@ -1321,33 +1321,76 @@ class FOGConfigurationPage extends FOGPage
         ];
         // The netboot transport, rendered after the three switches and inside
         // the same card, because it is not a fourth independent preference --
-        // it is the same decision the other two steer. Kept out of $meta
-        // because its domain is http|https, so it is a select rather than a
-        // switch, and a checkbox would have to invent which way is "on".
+        // it is the same decision the other two steer.
+        //
+        // A SWITCH, like the other three, and the domain it switches is not
+        // http|https. The transport is DERIVED on every run from the two
+        // settings above unless somebody has forced it, so the real question
+        // this row asks is "forced to https, or left to derive" -- which is a
+        // yes/no. Rendering the raw http|https domain instead was the mistake:
+        // both of those values set BOOT_url_proto_forced=yes when the
+        // installer reads them, so a control offering only those two was a
+        // one-way door. A server deriving https from a public certificate got
+        // pinned by the first interaction and never derived again.
+        //
+        // Off therefore posts `auto`, which clears the force rather than
+        // writing a transport -- see the helper's set-preference verb.
+        //
+        // Forcing plain http is deliberately NOT offered here. It is the rare
+        // case (a public certificate iPXE still cannot validate), it is the
+        // direction that breaks netboot rather than the one that repairs it,
+        // and installfog.sh --netboot-proto http still does it.
         $proto = 'https' === (string) ($prefs['BOOT_url_proto'] ?? 'http')
             ? 'https' : 'http';
+        $protoForced = 'yes' === (string) ($prefs['BOOT_url_proto_forced'] ?? 'no');
+        // Checked only when https was CHOSEN. A derived https is the same
+        // value and a different fact: nobody forced it, and it will follow the
+        // certificate if that changes.
+        $protoOn = $protoForced && 'https' === $proto;
+        // Why it is what it is, in the page's own words. Recomputed from the
+        // two steering keys rather than reported by the helper, because they
+        // are the same two switches rendered directly above this row -- so the
+        // sentence and the controls it refers to cannot disagree.
+        if ($protoForced) {
+            $protoWhy = _('forced');
+        } elseif ('yes' === (string) ($prefs['PKI_web_cert_publicly_trusted'] ?? 'no')) {
+            $protoWhy = _('derived from the public CA setting above');
+        } elseif ('yes' === (string) ($prefs['BOOT_rebuild_ipxe_with_my_ca'] ?? 'no')) {
+            $protoWhy = _('derived from the embedded-CA setting above');
+        } else {
+            $protoWhy = _('derived');
+        }
         $protoRow = '<tr><td class="text-nowrap">';
-        $protoRow .= '<select class="form-select form-select-sm pki-pref-select"'
+        $protoRow .= '<div class="form-check form-switch mb-0">';
+        $protoRow .= '<input class="form-check-input pki-pref" type="checkbox"'
             . ' id="BOOT_url_proto" data-key="BOOT_url_proto"'
             . ' data-action="' . \Initiator::e($this->formAction) . '"'
-            . ($mayEdit ? '' : ' disabled') . '>';
-        foreach (['http' => _('http'), 'https' => _('https')] as $val => $label) {
-            $protoRow .= '<option value="' . \Initiator::e($val) . '"'
-                . ($proto === $val ? ' selected' : '') . '>'
-                . \Initiator::e($label) . '</option>';
-        }
-        $protoRow .= '</select></td>';
+            . ($protoOn ? ' checked' : '')
+            . ($mayEdit ? '' : ' disabled')
+            . '>';
+        $protoRow .= '</div></td>';
         $protoRow .= '<td><label class="form-check-label" for="BOOT_url_proto">'
-            . '<strong>' . _('Netboot fetches boot.php over') . '</strong>'
-            . '<br><code class="small">BOOT_url_proto</code></label></td>';
+            . '<strong>' . _('Force netboot over HTTPS') . '</strong>'
+            . '<br><code class="small">BOOT_url_proto</code>'
+            . ' <span class="small text-muted">&middot; '
+            . sprintf(
+                /* translators: 1: http or https, 2: why that value is in effect */
+                _('currently %1$s (%2$s)'),
+                \Initiator::e($proto),
+                \Initiator::e($protoWhy)
+            )
+            . '</span></label></td>';
         $protoRow .= '<td><small class="text-muted">' . _(
             'Separate from the HTTP redirect above, which never applies to the '
-            . 'paths a bootloader fetches for itself. Choosing https here also '
-            . 'FORCES it: the installer stops deriving the transport and keeps '
-            . 'what you set. If iPXE cannot validate the certificate this '
-            . 'server serves, every netboot stops at boot.php and nothing '
-            . 'server-side says why -- so decide it together with the two '
-            . 'settings above, not on its own.'
+            . 'paths a bootloader fetches for itself -- netboot is excluded '
+            . 'from that redirect even when it is on. Left off, FOG derives '
+            . 'the transport on every run from the two settings above. Turning '
+            . 'it on records BOOT_url_proto_forced and stops that: https is '
+            . 'kept even if those settings later change. If iPXE cannot '
+            . 'validate the certificate this server serves, every netboot '
+            . 'stops at boot.php and nothing server-side says why -- and the '
+            . 'machines it stops are the ones that cannot fix themselves. '
+            . 'Turning it back off returns to deriving.'
         ) . '</small></td></tr>';
 
         $rows = '';
@@ -2175,7 +2218,12 @@ class FOGConfigurationPage extends FOGPage
         // re-checks against that key's own literal pattern, and that check is
         // the boundary, because .fogsettings is sourced as shell by root.
         if ('BOOT_url_proto' === $key) {
-            $value = 'https' === $raw ? 'https' : 'http';
+            // Off is `auto`, never `http`. The switch means "force https", so
+            // its off state is the absence of a force -- and writing `http`
+            // would instead PIN http, which is a different setting and the one
+            // that cannot be undone from this page. The helper turns `auto`
+            // into BOOT_url_proto_forced=no.
+            $value = $raw ? 'https' : 'auto';
         } else {
             $value = $raw ? 'yes' : 'no';
         }

--- a/tests/certificate-management-permission.test.php
+++ b/tests/certificate-management-permission.test.php
@@ -169,17 +169,52 @@ $results[] = pkiPermCheck(
  * quietly acquire a permissive default.
  */
 $results[] = pkiPermCheck(
-    'the netboot transport is constrained to http or https',
+    'the netboot transport is constrained to http, https or auto',
     1 === preg_match(
-        "#BOOT_url_proto\\)\\s+printf '%s' '\\^\\(http\\|https\\)\\$'#",
+        "#BOOT_url_proto\\)\\s+printf '%s' '\\^\\(http\\|https\\|auto\\)\\$'#",
         $helper
     ),
-    'the ^(http|https)$ pattern is not bound to BOOT_url_proto'
+    'the ^(http|https|auto)$ pattern is not bound to BOOT_url_proto'
 );
 $results[] = pkiPermCheck(
-    'http is reachable through no key but BOOT_url_proto',
-    1 === preg_match_all("#'\\^\\(http\\|https\\)\\\$'#", $helper),
-    'the http|https domain appears more than once in fog-pki-admin'
+    'that domain is reachable through no key but BOOT_url_proto',
+    1 === preg_match_all("#'\\^\\(http\\|https\\|auto\\)\\\$'#", $helper),
+    'the http|https|auto domain appears more than once in fog-pki-admin'
+);
+/*
+ * `auto` is the third member and is NOT a transport: it means "no forced
+ * transport", and the verb turns it into BOOT_url_proto_forced=no rather than
+ * writing it anywhere. It exists because both real transports set that flag
+ * when the installer reads them, so without it the page had no way back to
+ * deriving -- the first toggle pinned the server for good.
+ *
+ * The danger in a verb that can write a key outside PREF_KEYS is that it grows
+ * a second one, so both halves are pinned: which key it writes, and that the
+ * only value it can write there is `no`.
+ */
+$results[] = pkiPermCheck(
+    'auto clears the force rather than writing a transport',
+    1 === preg_match('#\$key == BOOT_url_proto && \$value == auto#', $helper)
+        && 1 === preg_match('#writeSetting BOOT_url_proto_forced no#', $helper),
+    'set-preference does not turn auto into BOOT_url_proto_forced=no'
+);
+$results[] = pkiPermCheck(
+    'and it can only ever write `no` to that flag',
+    0 === preg_match('#writeSetting BOOT_url_proto_forced yes#', $helper),
+    'the helper can set BOOT_url_proto_forced=yes, which ADR 0036 refuses'
+);
+/*
+ * The page's own half of the same contract. An off switch must post `auto`;
+ * posting `http` would PIN http, which is a different setting, the one this
+ * page deliberately does not offer, and the one that cannot be undone here.
+ */
+$pageSrc = (string) file_get_contents(
+    __DIR__ . '/../packages/web/src/Pages/FOGConfigurationPage.php'
+);
+$results[] = pkiPermCheck(
+    'the page turns an off switch into auto, never into http',
+    1 === preg_match("#\\\$value = \\\$raw \\? 'https' : 'auto';#", $pageSrc),
+    'FOGConfigurationPage does not map the off state to auto'
 );
 $results[] = pkiPermCheck(
     'the value is matched against a pattern the helper chose, not the caller',

--- a/tests/certificate-table.test.php
+++ b/tests/certificate-table.test.php
@@ -303,4 +303,91 @@ $t->check(
     false === strpos($rendered, 'collapsed-card')
 );
 
+/*
+ * 6. The netboot transport row. A SWITCH, like the three above it, because the
+ *    yes/no it actually asks is "forced to https, or left to derive" -- not
+ *    which of two transports, which is what it used to render.
+ *
+ *    That distinction is the bug, not a preference. _resolveNetbootProto()
+ *    derives the transport on every run UNLESS BOOT_url_proto_forced is yes,
+ *    and both http and https set that flag when the installer reads them. So a
+ *    control offering only those two was a one-way door: a server deriving
+ *    https from a public certificate was pinned by the first interaction and
+ *    never derived again. Off posts `auto`, which clears the force.
+ *
+ *    Checked state and displayed state are asserted SEPARATELY at each of the
+ *    four combinations, because they are different facts that happen to
+ *    coincide in one of them: derived-https and forced-https are the same
+ *    transport and only one of them is a choice.
+ */
+$prefsOf = function (array $prefs, $mayEdit = true) use ($invoke) {
+    return $invoke('_certificatePreferences', [['preferences' => $prefs], $mayEdit]);
+};
+// Scoped to the transport input's own tag. `checked` appears on whichever of
+// the other three switches is on, so a substring test over the whole body
+// would answer about the wrong control.
+$switchOn = function ($html) {
+    return 1 === preg_match('/id="BOOT_url_proto"[^>]*\schecked/', $html);
+};
+
+$derivedHttp = $prefsOf(['BOOT_url_proto' => 'http', 'BOOT_url_proto_forced' => 'no']);
+$t->check(
+    'the netboot transport is a switch, not a select or a radio group',
+    false !== strpos($derivedHttp, 'id="BOOT_url_proto" data-key="BOOT_url_proto"')
+        && false === strpos($derivedHttp, '<select')
+        && false === strpos($derivedHttp, 'type="radio"')
+);
+$t->check(
+    'it is the fourth switch, sharing the class the other three post through',
+    4 === substr_count($derivedHttp, 'class="form-check-input pki-pref"')
+        && 4 === substr_count($derivedHttp, 'form-check form-switch')
+);
+$t->check(
+    'the setting is named for the force it performs',
+    false !== strpos($derivedHttp, 'Force netboot over HTTPS')
+);
+$t->check(
+    'a derived http is off, and says it was derived',
+    !$switchOn($derivedHttp)
+        && false !== strpos($derivedHttp, 'currently http (derived)')
+);
+
+// The case the old control could not express: https is in effect, and nobody
+// chose it. A switch that read the transport alone would render this ON and
+// then pin it the moment anyone touched it.
+$derivedHttps = $prefsOf([
+    'BOOT_url_proto' => 'https',
+    'BOOT_url_proto_forced' => 'no',
+    'PKI_web_cert_publicly_trusted' => 'yes'
+]);
+$t->check(
+    'a DERIVED https is off, not on -- nobody forced it',
+    !$switchOn($derivedHttps)
+);
+$t->check(
+    'and it names the setting it was derived from',
+    false !== strpos($derivedHttps, 'currently https (derived from the public CA setting above)')
+);
+
+$forcedHttps = $prefsOf(['BOOT_url_proto' => 'https', 'BOOT_url_proto_forced' => 'yes']);
+$t->check(
+    'a FORCED https is the only state that renders on',
+    $switchOn($forcedHttps)
+        && false !== strpos($forcedHttps, 'currently https (forced)')
+);
+
+// Reachable from the CLI, never from this page -- but it still has to render
+// truthfully when the installer put it there.
+$forcedHttp = $prefsOf(['BOOT_url_proto' => 'http', 'BOOT_url_proto_forced' => 'yes']);
+$t->check(
+    'a forced http renders off and says it was forced',
+    !$switchOn($forcedHttp)
+        && false !== strpos($forcedHttp, 'currently http (forced)')
+);
+
+$t->check(
+    'a caller without system.pki gets all four switches disabled',
+    4 === substr_count($prefsOf(['BOOT_url_proto' => 'http'], false), ' disabled')
+);
+
 $t->finish();

--- a/tests/pki-admin-helper.test.sh
+++ b/tests/pki-admin-helper.test.sh
@@ -450,6 +450,41 @@ check "$(settingOf BOOT_url_proto)" "https" "and the value lands in the file"
 check "$?" "0" "and accepts http"
 check "$(settingOf BOOT_url_proto)" "http" "and back again"
 
+# `auto` is the third member of that domain and the only one that is not a
+# transport. It means "nothing is forcing this", so it clears the flag instead
+# of writing itself anywhere.
+#
+# Without it the page was a one-way door. _resolveNetbootProto() re-derives the
+# transport on every run UNLESS BOOT_url_proto_forced is yes, and BOTH real
+# transports set that flag when the installer reads them -- so a server
+# deriving https from a public certificate was pinned by the first toggle and
+# never derived again, whatever its certificate later became.
+"$HELPER" set-preference BOOT_url_proto https >/dev/null 2>&1
+"$HELPER" set-preference BOOT_url_proto auto >/dev/null 2>&1
+check "$?" "0" "set-preference accepts auto for BOOT_url_proto"
+check "$(settingOf BOOT_url_proto_forced)" "no" "and auto clears the forced flag"
+check "$(settingOf BOOT_url_proto)" "https" \
+    "while leaving the transport itself alone, for the installer to re-derive"
+
+# The flag is writable ONLY as auto's effect, never as a key in its own right.
+# ADR 0036 refuses the latter: forcing https with neither steering key set
+# breaks PXE for machines that cannot fix themselves.
+before=$(sha256sum "$SETTINGS" | cut -d' ' -f1)
+"$HELPER" set-preference BOOT_url_proto_forced yes >/dev/null 2>&1
+check "$?" "1" "set-preference refuses BOOT_url_proto_forced as a key"
+"$HELPER" set-preference BOOT_url_proto_forced no >/dev/null 2>&1
+check "$?" "1" "and refuses it even for the value auto is allowed to write"
+check "$(sha256sum "$SETTINGS" | cut -d' ' -f1)" "$before" \
+    "neither attempt changed the file"
+
+# The page cannot render the switch correctly without knowing whether the
+# transport was chosen or derived, and the two are the same value.
+out=$("$HELPER" status 2>&1)
+case "$out" in
+    *'"BOOT_url_proto_forced":'*) ok "status reports the forced flag" ;;
+    *) bad "status does not report BOOT_url_proto_forced" ;;
+esac
+
 # The domains must not leak into one another. A switch that accepted a
 # transport, or a transport that accepted yes, would mean the per-key lookup
 # had collapsed back to one permissive pattern.


### PR DESCRIPTION
> Draft. Replaces #1731, which proposed radios — wrong control, and it missed
> the one-way-door bug below. See **Not verified locally** before merging.
>
> Touches `tests/pki-admin-helper.test.sh`, which draft #1730 also touches —
> whichever lands second will need a trivial merge.

## The row today

```
[ON ]  The web certificate chains to a public CA        …
[   ]  Redirect HTTP to HTTPS                           …
[   ]  Rebuild iPXE with this server's CA embedded      …
┌────┐
│http│  Netboot fetches boot.php over                   …
└────┘
```

**It does not read as a control.** A `form-select-sm` in the narrow first column
renders as a bare `http` chip beside three switches that are obviously
interactive, and the title `Netboot fetches boot.php over` is a dangling phrase
the select was there to complete.

**And `http|https` is not the question this row asks.** `_resolveNetbootProto()`
*derives* the transport on every run from the two settings above it:

```bash
[[ ${BOOT_url_proto_forced} == yes && -n ${BOOT_url_proto} ]] && return 0
if [[ ${PKI_web_cert_publicly_trusted} == yes || ${BOOT_rebuild_ipxe_with_my_ca} == yes ]]; then
    BOOT_url_proto="https"   # else http
```

**Both** real transports set `BOOT_url_proto_forced=yes` when the installer
reads them. So the control offered two values, both of which pinned the server,
and none that released it — **a one-way door.** A server deriving `https` from a
public certificate was pinned by the first interaction and never derived again,
whatever its certificate later became. Nothing said so: the row went on
displaying the same word it displayed before.

## The row now

```
[   ]  Force netboot over HTTPS
       BOOT_url_proto  ·  currently https (derived from the public CA setting above)
```

A fourth switch, beside the three it belongs with, asking the yes/no it actually
means: *forced to https, or left to derive.*

**Off posts `auto`** — a third member of the domain that is not a transport. The
helper turns it into `BOOT_url_proto_forced=no` and writes nothing else, so the
next run derives again.

That writes a key deliberately absent from `PREF_KEYS`, and I do not think it is
a hole in ADR 0036's refusal. That refusal was about **forcing HTTPS** with
neither steering key set — *"not a thing a misclick should reach."* `auto` only
ever writes `no`, and clearing a force can do nothing but return the value to
what derivation already says. Reaching `forced=yes` still means posting `https`
to a control that says so, and `set-preference` still refuses
`BOOT_url_proto_forced` as a key in either direction. **This is the judgement
call most worth a second opinion.**

**The row says what is in effect and why** — `(forced)` vs `(derived from the
public CA setting above)` vs `(derived)`. A derived `https` and a forced `https`
are the same word and a different fact, and the switch cannot render correctly
without telling them apart. That needs the flag reported, so `status` loops over
a new `REPORT_KEYS`. Two lists on purpose: `PREF_KEYS` stays the write allowlist
and the security boundary; `REPORT_KEYS` is only what the page may see.

**Forcing plain http leaves the page.** Rare case, the direction that breaks
netboot rather than repairs it, and `installfog.sh --netboot-proto http` still
does it. The row still renders a CLI-forced http truthfully.

The bespoke JS handler goes away with the select — the switch posts the same
flag as the other three, and the page maps that flag to `https`/`auto`.

Not changed, because it is already true and pinned: netboot is excluded from the
HTTP→HTTPS redirect (`vhost-netboot-exclusion` 13/13).

## Testing

| suite | |
|---|---|
| `certificate-table` | 33 → 42, all passing |
| `certificate-management-permission` | 19 → 22, all passing |
| `vhost-netboot-exclusion` | 13/13 |
| `install-settings-resolution` | 50/50 |
| `boolean-encoding` | 42/42 |

All four states are pinned **separately** — checked-state and displayed-state
are different facts that coincide in only one of them.

Mutation-tested rather than merely green:

| mutation | result |
|---|---|
| upstream's select row | 7 of 9 new `certificate-table` assertions fail |
| switch reads the transport, ignoring the forced flag | exactly the derived-`https` assertion fails |
| `auto` falls through and writes itself as a transport | exactly the auto-contract assertion fails |
| page maps off to `http` instead of `auto` | exactly that assertion fails |

### Not verified locally

- **`phpstan` (both passes) did not run** — no `vendor/` here. The `tests/` pass
  baselines *occurrence counts*, and this adds `preg_match`/`preg_match_all` and
  closures to two baselined files, so a `count:` may need bumping.
- **`pki-admin-helper.test.sh` SKIPs here** — it needs `unshare`/root, so its
  new assertions are CI-verified only. The page-side and source-level contracts
  it pairs with do run locally and pass.
- **Not rendered in a browser.** Markup and assertions are verified; how the row
  looks is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ps28eGTALgieR6TBUSafVg
