### PR TITLE
A single snapin task is no longer recorded as All Snapins

### DIFF
--- a/packages/web/src/Items/Host.php
+++ b/packages/web/src/Items/Host.php
@@ -1179,6 +1179,33 @@ class Host extends FOGController
             if ($TaskType->isSnapinTasking) {
                 switch ($TaskType->id) {
                     case TaskType::SINGLE_SNAPIN:
+                        // CONVERTS an existing task; never creates one.
+                        //
+                        // The conversion exists because a host has one task
+                        // row and several queued snapins: asking for a second,
+                        // different snapin while one is already queued leaves
+                        // a task that is no longer about a single snapin, so
+                        // it is relabeled All Snapins.
+                        //
+                        // None of that is true of a host with no live task,
+                        // and this arm used to run for one anyway. $Task is
+                        // then an empty object, no snapin is queued, so
+                        // $curSnapins is empty, in_array() is false, and three
+                        // fields plus a save() INSERT a task typed All Snapins
+                        // and named "Multiple Snapin -- orig Single" -- for a
+                        // first, ordinary, single-snapin task. Being valid, it
+                        // then skips _createTasking() below, so the type is
+                        // never corrected. Only the one snapin the admin
+                        // picked is ever queued, so the task RUNS right and
+                        // reads wrong, in the list and in the audit trail.
+                        // Reported in forum topic 18238.
+                        //
+                        // 1.5 guarded the whole block on $Task->isValid()
+                        // (host.class.php:1359); e959f9d70 lost the guard
+                        // while flattening the surrounding branches in 2018.
+                        if (!$Task->isValid()) {
+                            break;
+                        }
                         $find = [
                             'jobID' => $this->get('snapinjob')->get('id'),
                             'stateID' => self::fastmerge(
@@ -1193,27 +1220,8 @@ class Host extends FOGController
                         );
                         if (!in_array($deploySnapins, $curSnapins)) {
                             $Task
-                                ->set('hostID', $this->get('hostID'))
                                 ->set('name', _('Multiple Snapin -- orig Single'))
                                 ->set('typeID', TaskType::ALL_SNAPINS);
-                            // A task reached here is normally a NEW one --
-                            // the branch above cancels any live non-imaging
-                            // task and replaces it with an empty object, and
-                            // a live imaging task has already thrown. Three
-                            // fields and a save() therefore INSERTS, and
-                            // taskStateID was not among them: save()'s
-                            // optional-*id branch filled it with 0, which is
-                            // not a taskStates row, so the task never showed
-                            // in Active Tasks and never ran. Schema step 389
-                            // turns that into a visible 1452 rather than a
-                            // silent dud; this is the actual fix.
-                            //
-                            // Guarded rather than unconditional so that an
-                            // existing task being converted keeps whatever
-                            // state it is already in.
-                            if (!$Task->get('stateID')) {
-                                $Task->set('stateID', self::getQueuedState());
-                            }
                             if (!$Task->save()) {
                                 $serverFault = true;
                                 throw new \Exception(_('Unable to update task'));

--- a/tests/null-tasks-cannot-be-created-or-stranded.test.php
+++ b/tests/null-tasks-cannot-be-created-or-stranded.test.php
@@ -251,9 +251,11 @@ check(
  * that: it set hostID, name and typeID on a task object the branch above had
  * just replaced with an empty one, then saved.
  *
- * Both halves are pinned. The required-field list is the general fix; the
- * guard at that call site is what keeps that specific path from throwing
- * "Required database field" at an administrator instead of working.
+ * The required-field list is the general fix. The call site is now fixed at
+ * the root instead of being made to insert a valid row: that arm CONVERTS an
+ * existing task and has no business creating one, so it bails when there is
+ * none and lets the ordinary _createTasking() path run. See
+ * single-snapin-task-keeps-its-type.test.php, which pins that.
  */
 $task = file_get_contents($root . '/packages/web/src/Items/Task.php');
 $required = '';
@@ -277,7 +279,7 @@ check(
 $host = file_get_contents($root . '/packages/web/src/Items/Host.php');
 $convert = '';
 if (preg_match(
-    "/\\\$Task\s*\n\s*->set\('hostID'.*?Multiple Snapin -- orig Single.*?if \(!\\\$Task->save\(\)\)/s",
+    "/case TaskType::SINGLE_SNAPIN:.*?if \(!\\\$Task->save\(\)\)/s",
     $host,
     $m
 )) {
@@ -289,20 +291,20 @@ check(
     $failures,
     $checks
 );
+/*
+ * The stateless-task fix at this call site is now the absence of a save
+ * rather than a better one: nothing is written unless there is already a
+ * task to convert, so there is no INSERT here to leave without a state.
+ */
 check(
-    'and it supplies a stateID before saving',
-    false !== strpos($convert, "->set('stateID', self::getQueuedState())"),
+    'and it writes nothing unless a task already exists',
+    false !== strpos($convert, "if (!\$Task->isValid())"),
     $failures,
     $checks
 );
-/*
- * Guarded, not unconditional. The same block also runs against an EXISTING
- * task being converted, and forcing that one back to Queued would restart
- * work already in progress.
- */
 check(
-    'only when the task does not already have one',
-    false !== strpos($convert, "if (!\$Task->get('stateID'))"),
+    'and no longer invents the task it was meant to be updating',
+    false === strpos($convert, "->set('hostID'"),
     $failures,
     $checks
 );

--- a/tests/single-snapin-task-keeps-its-type.test.php
+++ b/tests/single-snapin-task-keeps-its-type.test.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * A Single Snapin task must be recorded as a Single Snapin task.
+ *
+ * THE FAILURE. Host::createImagePackage()'s SINGLE_SNAPIN arm exists to
+ * CONVERT a task that is already running one snapin when a second, different
+ * one is asked for: a host has one `tasks` row and many queued snapins, so
+ * the row stops being about a single snapin and is relabeled All Snapins.
+ *
+ * It ran for a host with no live task as well. $Task is then an empty object,
+ * nothing is queued, so the snapinTasks lookup comes back empty, in_array()
+ * is false, and the arm sets three fields and saves -- INSERTING a task typed
+ * All Snapins (12) and named "Multiple Snapin -- orig Single" for a first,
+ * ordinary, single-snapin request. That task is valid, so the
+ * `if (!$Task->isValid())` further down skips _createTasking() and the type
+ * is never corrected. Only the snapin the admin picked is ever queued, so the
+ * task runs correctly and reads wrong everywhere it is read: Active Tasks,
+ * the task list's Task Type column, and the audit trail.
+ *
+ * The same request made for several hosts at once goes through
+ * Group::createImagePackage(), which batch-inserts $TaskType->id verbatim and
+ * is therefore right -- so one host tasked from its own page and forty tasked
+ * from the host list produced two different task types for the same action.
+ * Reported in forum topic 18238.
+ *
+ * 1.5 guarded the whole block on $Task->isValid()
+ * (packages/web/lib/fog/host.class.php:1359 on dev-branch); e959f9d70 lost
+ * the guard in 2018 while flattening the surrounding branches.
+ *
+ * WHAT THIS PINS is the guard and the two things it must not break: the
+ * conversion itself, and the fact that the arm is a conversion rather than a
+ * creation. Proved against a live database by
+ * background_scripts/probe_single_snapin_tasktype.php, which fails on an
+ * unpatched tree.
+ *
+ * Usage: php tests/single-snapin-task-keeps-its-type.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$failures = [];
+$checks = 0;
+
+function check($what, $ok, &$failures, &$checks)
+{
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+}
+
+$host = (string) file_get_contents($root . '/packages/web/src/Items/Host.php');
+
+$arm = '';
+if (preg_match(
+    '/case TaskType::SINGLE_SNAPIN:(.*?)\n\s+case TaskType::ALL_SNAPINS:/s',
+    $host,
+    $m
+)) {
+    $arm = $m[1];
+}
+check(
+    'the SINGLE_SNAPIN arm was found',
+    '' !== $arm,
+    $failures,
+    $checks
+);
+
+/*
+ * The guard has to come BEFORE the save, not merely exist somewhere in the
+ * arm -- a check after the write would be no check at all.
+ */
+$guardAt = strpos($arm, 'if (!$Task->isValid())');
+$saveAt = strpos($arm, '$Task->save()');
+check(
+    'it bails out when the host has no task to convert',
+    false !== $guardAt,
+    $failures,
+    $checks
+);
+check(
+    'and does so before anything is written',
+    false !== $guardAt && false !== $saveAt && $guardAt < $saveAt,
+    $failures,
+    $checks
+);
+
+/*
+ * A conversion, not a creation. Setting hostID is what a new row needs and an
+ * existing one already has, so its presence is the signature of the arm
+ * believing it may insert.
+ */
+check(
+    'it does not set hostID -- it is updating, not creating',
+    false === strpos($arm, "->set('hostID'"),
+    $failures,
+    $checks
+);
+
+/*
+ * The behavior the arm exists for still has to happen: a second, different
+ * snapin on a host that already has one queued relabels the task.
+ */
+check(
+    'the conversion to All Snapins is still there',
+    false !== strpos($arm, "->set('typeID', TaskType::ALL_SNAPINS)"),
+    $failures,
+    $checks
+);
+check(
+    'and still only when the requested snapin is not already queued',
+    false !== strpos($arm, 'if (!in_array($deploySnapins, $curSnapins))'),
+    $failures,
+    $checks
+);
+
+/*
+ * The corrected path: with the arm standing down, the ordinary creation
+ * below has to be the thing that writes the task, and it takes the type it
+ * was asked for.
+ */
+check(
+    '_createTasking is still what writes a task the arm did not convert',
+    false !== strpos($host, '$Task = $this->_createTasking(')
+    && false !== strpos($host, "\$TaskType->id,"),
+    $failures,
+    $checks
+);
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks checks passed\n";
+exit(0);


### PR DESCRIPTION
## What

`Host::createImagePackage()`'s `SINGLE_SNAPIN` arm exists to **convert** a task that is already running one snapin when a second, different one is asked for. It ran for a host with **no live task** as well: `$Task` is an empty object, nothing is queued, so the `snapinTasks` lookup comes back empty, `in_array()` is false, and the arm sets three fields and saves — *inserting* a task typed **All Snapins (12)** named `Multiple Snapin -- orig Single` for a first, ordinary, single-snapin request. Being valid, that task then skips `_createTasking()` below, so the type is never corrected.

Only the snapin the administrator picked is ever queued, so the task **runs correctly and reads wrong**: Active Tasks, the task list's Task Type column and the audit trail all name a task nobody asked for. Tasking several hosts at once goes through `Group::createImagePackage()`, which batch-inserts `$TaskType->id` verbatim — so one host tasked from its own page and forty tasked from the host list disagreed about what had been asked for.

1.5 guarded the whole block on `$Task->isValid()` (`packages/web/lib/fog/host.class.php:1359` on `dev-branch`); the guard was lost in 2018 (e959f9d70) while flattening the surrounding branches. Restored here, which also makes the `hostID`/`stateID` defaults that were added for the insert unnecessary — there is no insert left on this path.

Reported in [forum topic 18238](https://forums.fogproject.org/topic/18238/task-0).

## Verification

Against the live 1.6 install (`beta.5317`), with a throwaway host that no hardware can boot into:

| | task row written |
|---|---|
| before | `taskTypeID=12`, `taskName="Multiple Snapin -- orig Single"` |
| after | `taskTypeID=13`, `taskName="Single Snapin Task - <host> <time>"` |

A second, different snapin on that same host still converts the same task row to `taskTypeID=12`, which is the behavior the arm exists for.

## Gates

`tests/single-snapin-task-keeps-its-type.test.php` is new and fails on the unpatched tree (3 of 7 checks). `tests/null-tasks-cannot-be-created-or-stranded.test.php` pinned the *old* insert (that it supplied a `stateID` and set `hostID`); those two checks are replaced by the stronger invariant that nothing is written on this path at all, and it fails on the unpatched tree too (2 of 20).

Both phpstan passes clean; the full local `tests/*.test.php` sweep is green.

## Downstream

None. No route class list changes, no schema change, no OpenAPI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8UmmbQHjihkSkd3r94Jgw