### PR TITLE
Quick-task confirmation is reachable again

### DIFF
--- a/packages/web/src/Base/FOGPageRender.php
+++ b/packages/web/src/Base/FOGPageRender.php
@@ -444,6 +444,24 @@ trait FOGPageRender
      * @var bool
      */
     protected static $_unadjustedSeen = false;
+    /**
+     * Modal markup a note-card action built, held back until the card has
+     * closed.
+     *
+     * #edit-info-card is position:sticky with a z-index, which makes it a
+     * stacking context: every z-index inside it is resolved against its
+     * siblings, not against the page. A .modal in there therefore paints
+     * BELOW the backdrop and the app header however high its own z-index
+     * is, and the backdrop swallows the clicks on its buttons. Same class
+     * of trap as the flex/float mismatch in the button rules -- the
+     * property that breaks it is on the container, not on the modal.
+     *
+     * Set by renderQuickTaskActions(), drained by renderInfoCard(). One
+     * render per request, the same lifetime as $_unadjustedSeen above.
+     *
+     * @var string
+     */
+    protected static $_infoCardModals = '';
     protected static function dateOrNever($value, $table = '', $column = '')
     {
         if (!$value || !self::validDate($value)) {
@@ -646,10 +664,14 @@ trait FOGPageRender
         // clicked button's data-confirm, rather than one per button: two
         // would eventually say the same thing in two different wordings.
         //
-        // Emitted next to the buttons, the way assocDelModal() sits in its
-        // card-footer. A .modal is position:fixed and display:none until
-        // shown, so it adds nothing to the flex row it nominally lives in.
-        $modal = self::makeModal(
+        // NOT emitted next to the buttons, which is where assocDelModal()
+        // sits in its card-footer. That works there because a plain .card
+        // is position:relative with z-index:auto; #edit-info-card is
+        // position:sticky WITH a z-index, so it is a stacking context and
+        // a modal inside it can never rise above the backdrop. Held in
+        // $_infoCardModals and emitted by renderInfoCard() once the card
+        // has closed.
+        self::$_infoCardModals .= self::makeModal(
             'quicktask-confirm-modal',
             '<h4 class="card-title">' . \Initiator::e(_('Create tasking'))
             . '</h4>',
@@ -672,7 +694,7 @@ trait FOGPageRender
 
         return '<div class="btn-group" role="group" aria-label="'
             . \Initiator::e(_('Quick tasks'))
-            . '">' . $buttons . '</div>' . $modal;
+            . '">' . $buttons . '</div>';
     }
 
     protected function renderInfoCard()
@@ -756,6 +778,14 @@ trait FOGPageRender
         }
         echo '</div>';
         echo '</div>';
+        // Outside the card, and therefore outside its stacking context, so
+        // the modal's own z-index is resolved against the page and it lands
+        // above the backdrop and the header. Drained, so a second call in
+        // the same request cannot emit the same modal id twice.
+        if ('' !== self::$_infoCardModals) {
+            echo self::$_infoCardModals;
+            self::$_infoCardModals = '';
+        }
     }
 
     /**

--- a/tests/info-card-quick-tasks.test.php
+++ b/tests/info-card-quick-tasks.test.php
@@ -136,6 +136,11 @@ $emit = static function (
         FogTestHarness::setStatic($cls, 'FOGUser', $user);
     }
     FogTestHarness::setStatic('Authorization', '_permCache', [1 => $perms]);
+    // The builder APPENDS its modal to a static the card drains later, so
+    // without this every emit in this file would stack onto the last one's
+    // leftovers and the "no buttons means no modal" checks would read a
+    // modal an earlier call had left behind.
+    FogTestHarness::setStatic(HostManagement::class, '_infoCardModals', '');
 
     return (string)HostManagement::renderQuickTaskActions(
         $node,
@@ -143,6 +148,18 @@ $emit = static function (
         $typeIds,
         $target
     );
+};
+
+/**
+ * The modal the last $emit() built, taken from where it is parked.
+ *
+ * @return string
+ */
+$deferred = static function () {
+    $prop = new \ReflectionProperty(HostManagement::class, '_infoCardModals');
+    $prop->setAccessible(true);
+
+    return (string)$prop->getValue();
 };
 
 $hostTypes = [TaskType::DEPLOY, TaskType::CAPTURE];
@@ -237,6 +254,9 @@ $field = static function (array $buttons, $type, $field) {
 };
 
 $markup = $emit(['*'], 'host', $hostTypes);
+// Read before the next $emit() below clears it -- the store holds one
+// render, not a history.
+$markupModal = $deferred();
 $hostButtons = $parse($markup);
 $groupButtons = $parse(
     $emit(['*'], 'group', $groupTypes, 'all 12 hosts in group "Lab"')
@@ -324,27 +344,28 @@ $t->check(
 // modal that failed to render would leave the script showing nothing and
 // firing nothing -- a dead button, not an unguarded one, but still broken.
 $t->check(
-    'a confirmation modal ships with the buttons',
-    false !== strpos($markup, 'id="quicktask-confirm-modal"')
+    'a confirmation modal is built alongside the buttons',
+    false !== strpos($markupModal, 'id="quicktask-confirm-modal"')
 );
 $t->check(
     'it has the body the script writes the confirmation into',
-    false !== strpos($markup, 'id="quicktask-confirm-text"')
+    false !== strpos($markupModal, 'id="quicktask-confirm-text"')
 );
 $t->check(
     'it can be dismissed without tasking anything',
-    false !== strpos($markup, 'id="quicktask-confirm-cancel"')
-    && false !== strpos($markup, 'data-bs-dismiss="modal"')
+    false !== strpos($markupModal, 'id="quicktask-confirm-cancel"')
+    && false !== strpos($markupModal, 'data-bs-dismiss="modal"')
 );
 $t->check(
     'and it has the commit button the script fires on',
-    false !== strpos($markup, 'id="quicktask-confirm-go"')
+    false !== strpos($markupModal, 'id="quicktask-confirm-go"')
 );
 // No modal without buttons: a page whose task types are all gone emits
 // neither, rather than a confirmation for nothing.
+$emit(['*'], 'host', [9998, 9999]);
 $t->check(
     'no buttons means no modal either',
-    false === strpos($emit(['*'], 'host', [9998, 9999]), 'quicktask-confirm-modal')
+    '' === $deferred()
 );
 $t->check(
     'a task type this server has deleted simply loses its button',
@@ -355,6 +376,89 @@ $t->check(
 $t->check(
     'and a page whose every type is gone emits nothing at all',
     '' === $emit(['*'], 'host', [9998, 9999])
+);
+
+// -------------------------------------------------------------------------
+// 2c. Where the modal is emitted. THE BUG THIS SECTION EXISTS FOR.
+// -------------------------------------------------------------------------
+// #edit-info-card is position:sticky WITH a z-index (fog-default-ui.scss),
+// which makes it a stacking context: every z-index inside it is resolved
+// against the card's siblings, not against the page. A .modal emitted in
+// there is therefore painted BELOW the modal backdrop (1050) and below the
+// app header (1034) however high its own z-index is -- so the dialog appears
+// behind the header, and the backdrop is the topmost element over Cancel and
+// Create, which swallows both clicks. Reported 2026-09-09 against Host ->
+// Edit -> Deploy, and measured in a browser against the shipped stylesheets:
+// document.elementFromPoint() over #quicktask-confirm-go returned
+// .modal-backdrop.
+//
+// So the check is structural, not textual: the modal must not be a
+// DESCENDANT of the card. A plain .card is position:relative/z-index:auto
+// and is not a stacking context, which is why assocDelModal() sitting in a
+// card-footer has always worked -- the property that breaks it is on the
+// container, not on the modal.
+$card = static function ($actions) {
+    $page = (new \ReflectionClass(HostManagement::class))
+        ->newInstanceWithoutConstructor();
+    $page->notes = ['Host' => 'bench-01'];
+    $page->noteSources = [];
+    $page->noteActions = $actions;
+    $render = new \ReflectionMethod(HostManagement::class, 'renderInfoCard');
+    $render->setAccessible(true);
+    ob_start();
+    $render->invoke($page);
+
+    return (string)ob_get_clean();
+};
+
+$html = $card($emit(['*'], 'host', $hostTypes));
+$t->check(
+    'the info card emits the confirmation modal',
+    false !== strpos($html, 'id="quicktask-confirm-modal"')
+);
+$t->check(
+    'and the quick task buttons',
+    false !== strpos($html, 'fog-quicktask')
+);
+
+$dom = new \DOMDocument();
+// The fragment is not a document and carries entities; libxml would warn on
+// both and the warnings are not the thing under test.
+libxml_use_internal_errors(true);
+$dom->loadHTML(
+    '<!DOCTYPE html><html><body>' . $html . '</body></html>',
+    LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+);
+libxml_clear_errors();
+$xpath = new \DOMXPath($dom);
+$modalNode = $xpath->query('//*[@id="quicktask-confirm-modal"]')->item(0);
+$cardNode = $xpath->query('//*[@id="edit-info-card"]')->item(0);
+$t->check(
+    'both nodes parse out of the rendered card',
+    null !== $modalNode && null !== $cardNode
+);
+$inside = false;
+for ($n = $modalNode; null !== $n; $n = $n->parentNode) {
+    if ($n === $cardNode) {
+        $inside = true;
+        break;
+    }
+}
+$t->check(
+    'the modal is NOT inside #edit-info-card, whose z-index would bury it',
+    !$inside
+);
+// The store is drained, so a page that renders its card twice in one request
+// cannot emit two elements sharing the modal's id -- which would leave
+// jQuery's #quicktask-confirm-modal pointing at whichever came first, quite
+// possibly the one still trapped in the card.
+$t->check(
+    'the modal is emitted exactly once',
+    1 === substr_count($html, 'id="quicktask-confirm-modal"')
+);
+$t->check(
+    'and the store is drained, so re-rendering the card emits no second copy',
+    false === strpos($card($markup), 'id="quicktask-confirm-modal"')
 );
 
 // -------------------------------------------------------------------------


### PR DESCRIPTION
## What was broken

Host → Edit → **Deploy** (and Deploy/Multi-Cast on a group) opened the "Create
tasking" confirmation *behind* the app header, and neither **Cancel** nor
**Create** could be clicked — the backdrop sat over both.

## Why

`renderQuickTaskActions()` emitted the modal next to the buttons, the way
`assocDelModal()` sits in a card-footer. That is safe there because a plain
`.card` is `position: relative` with `z-index: auto`, so it is **not** a
stacking context.

`#edit-info-card` is `position: sticky` **with** `z-index: 3`
(`fog-default-ui.scss`), which *is* one. Every z-index inside it is then
resolved against the card's siblings rather than against the page, so the
modal's 1055 could never clear the backdrop's 1050 or `.app-header`'s 1034.

The modal's own comment reasoned the other way round — that 3 "stays well
below the modal/backdrop layer (1050+)". True of the card against the
backdrop; it says nothing about a modal trapped inside the card.

Same shape as the flex/float mismatch already documented in `CLAUDE.md`: the
property that breaks it is on the **container**, not on the element.

## Measured

On a page carrying the real ancestor chain and the shipped stylesheets,
`document.elementFromPoint()` at the centre of `#quicktask-confirm-go`:

| | topmost element |
|---|---|
| modal inside `#edit-info-card` | `div.modal-backdrop` |
| modal outside it | `button#quicktask-confirm-go` |

## The change

The builder parks its modal in `FOGPageRender::$_infoCardModals`;
`renderInfoCard()` emits it after the card closes and drains the store, so a
card rendered twice in one request cannot produce two elements sharing the
modal's id.

## The gate

`tests/info-card-quick-tasks.test.php` now renders the info card, parses it
and asserts the modal is **not a descendant** of `#edit-info-card`. Verified
red: putting the modal back into the returned button markup fails that check
(plus the four that read the modal). A string search for
`quicktask-confirm-modal` would have stayed green either way, which is the
whole reason the check is structural.

`phpstan` both passes clean; the quick-task, info-card and card-tools tests
pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A767exFmz6sQUcuZofqE1V
