### PR TITLE
Edit groups can reach a group whose name has a space

### DIFF
--- a/packages/web/management/js/fog/host/fog.host.list.js
+++ b/packages/web/management/js/fog/host/fog.host.list.js
@@ -38,7 +38,15 @@
         var hostGroupUpdateBtn = $('#confirmGroupAdd');
         groupModalSelect.select2({
             tags: true,
-            tokenSeparators: [',', ' '],
+            // COMMA ONLY. A space used to commit the term as a tag too,
+            // which made every group whose name contains one impossible to
+            // reach: typing "Something DarksideMilk" turned into the tag
+            // "Something" at the first space, the search never ran on the
+            // full name, and Add then CREATED a group called "Something"
+            // because an unmatched term is sent in groups_new. Two of the
+            // three groups on the reporter's own server were named that way.
+            // Comma still separates, so pasting a list of names works.
+            tokenSeparators: [','],
             ajax: {
                 url: function(params) {
                     return '../group/names/name='
@@ -106,7 +114,14 @@
         // does the same thing either way, and remove is told which of the
         // names it could not find rather than silently doing nothing.
         function submitMembership(remove) {
-            var items = groupModalSelect.find('option').map(function() {return $(this).val()}).get(),
+            // :selected, not every option. select2's createTag puts the
+            // term you are still typing into the select as an UNSELECTED
+            // <option> so it can be offered as "(new)". Reading every option
+            // submitted that half-typed text as well, so picking
+            // "Something DarksideMilk" out of the list after typing
+            // "Something Dark" joined the right group AND created a junk one
+            // named for the fragment.
+            var items = groupModalSelect.find('option:selected').map(function() {return $(this).val()}).get(),
                 hosts = $.getSelectedIds(table),
                 groups = [],
                 groups_new = [];

--- a/tests/group-modal-reaches-names-with-spaces.test.php
+++ b/tests/group-modal-reaches-names-with-spaces.test.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Edit groups (host list): a group whose name contains a space must be
+ * reachable, and a term you are still typing must not be submitted.
+ *
+ * Both defects live in loadGroupSelect()/submitMembership() in
+ * fog.host.list.js, both were reported together on 2026-09-09, and both are
+ * silent -- the modal answers 200 and the grid redraws either way. What you
+ * get is the wrong group.
+ *
+ * 1. SPACE WAS A TOKEN SEPARATOR. `tokenSeparators: [',', ' ']` tells
+ *    select2 to commit the search term as a tag the moment you press space.
+ *    So "Something DarksideMilk" became the tag "Something" at the first
+ *    space; the ajax search never ran on the whole name, the real group
+ *    could not be offered, and Add sent "Something" in groups_new -- which
+ *    the server CREATES, because an unmatched name is how you make a new
+ *    group here. Two of the three groups on the reporting server had spaces
+ *    in their names, so the feature was unusable for most of them.
+ *
+ *    Measured in a browser against the shipped select2 and the real group
+ *    names: with ' ' a separator, typing "Something " left one tag,
+ *    "Something", and an empty dropdown; without it, "Something Dark" stayed
+ *    in the search box and "Something DarksideMilk" was offered and
+ *    clickable.
+ *
+ *    Comma stays. Pasting a comma-separated list of names is the reason
+ *    tokenSeparators is set at all, and a comma cannot appear in a name that
+ *    was typed into this same control.
+ *
+ * 2. THE SUBMIT READ EVERY OPTION, NOT THE SELECTED ONES. select2's
+ *    createTag() puts the term you are typing into the <select> as an
+ *    UNSELECTED <option> so it can be offered as "(new)". submitMembership()
+ *    read `.find('option')`, so that fragment went to the server as well:
+ *    typing "Something Dark", then clicking "Something DarksideMilk" in the
+ *    list, joined the right group AND created a junk one called "Something
+ *    Dark". Verified in the same harness -- after the pick the select held
+ *    <option value="Something Dark"> unselected and <option value="1">
+ *    selected.
+ *
+ * Both are pinned as the DEFINITION that decides the behavior -- the option
+ * value select2 is constructed with, and the selector the submit reads --
+ * not as a mention of either name.
+ *
+ * Usage: php tests/group-modal-reaches-names-with-spaces.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('group-modal-names-with-spaces');
+
+$t = new FogChecks();
+
+$path = dirname(__DIR__)
+    . '/packages/web/management/js/fog/host/fog.host.list.js';
+$src = (string)file_get_contents($path);
+$t->check('fog.host.list.js was read', '' !== $src);
+
+// Comments stripped before matching: every claim below is about the code
+// select2 and jQuery actually run, and this file explains both fixes in
+// prose right beside them. Without this a gate can be satisfied by its own
+// documentation.
+$code = (string)preg_replace('#//[^\n]*#', '', $src);
+
+// -- 1. the separator list -------------------------------------------------
+if (!preg_match('#tokenSeparators:\s*\[([^\]]*)\]#', $code, $m)) {
+    $t->check('loadGroupSelect() sets tokenSeparators', false);
+    $t->finish();
+}
+// Each element read as a QUOTED STRING, not by splitting on commas: the list
+// configures a comma, so a split would consume the very entry it is meant to
+// read -- and trimming quotes off " ' ' " leaves nothing at all, which is how
+// the first version of this gate passed a mutation that restored the space.
+preg_match_all('#\'((?:[^\'\\\\]|\\\\.)*)\'#', $m[1], $mm);
+$separators = $mm[1];
+$t->check(
+    'the separator list parsed into at least one entry',
+    count($separators) > 0
+);
+
+$t->check(
+    'a space is NOT a token separator, so a name can contain one',
+    !in_array(' ', $separators, true)
+);
+$t->check(
+    'and a comma still is, so a pasted list still splits',
+    in_array(',', $separators, true)
+);
+
+// -- 2. what the submit reads ---------------------------------------------
+// Anchored on the assignment, not on the string 'option:selected' anywhere
+// in the file: the selector only matters in the statement that builds the
+// list of ids the POST carries.
+$t->check(
+    'submitMembership() reads only the SELECTED options',
+    1 === preg_match(
+        '#var\s+items\s*=\s*groupModalSelect\s*\.\s*'
+        . 'find\(\s*[\'"]option:selected[\'"]\s*\)#',
+        $code
+    )
+);
+$t->check(
+    'and never every option, which would submit the term being typed',
+    0 === preg_match(
+        '#groupModalSelect\s*\.\s*find\(\s*[\'"]option[\'"]\s*\)#',
+        $code
+    )
+);
+
+$t->finish();


### PR DESCRIPTION
Reported while asking how to type a group name containing a space. The answer
was "you can't" — and finding out why turned up a second, worse defect in the
same handler.

## 1. A space committed the tag

`loadGroupSelect()` set `tokenSeparators: [',', ' ']`, so select2 committed
the search term as a tag at the first space. Typing **Something DarksideMilk**:

- became the tag `Something` the moment space was pressed;
- the ajax search never ran on the full name, so the real group could never
  be offered;
- and **Add** then *created* a group called `Something`, because a term that
  matches nothing is sent in `groups_new` and that is how this control makes
  a new group.

Two of the three groups on the reporting server have spaces in their names.

Comma stays a separator — pasting a comma-separated list of names is why
`tokenSeparators` is set at all, and a comma can't occur in a name typed into
this same box.

## 2. The submit read every option, not the selected ones

select2's `createTag()` parks the term you are *still typing* in the
`<select>` as an **unselected** `<option>` so it can be offered as "(new)".
`submitMembership()` read `.find('option')` — so that fragment went to the
server too.

Type `Something Dark`, then click **Something DarksideMilk** in the list, and
you join the right group **and** create a junk one named for the fragment.
Now `.find('option:selected')`.

## Measured

In a browser, against the shipped select2 and the real group names:

| | tags after typing | dropdown |
|---|---|---|
| `' '` a separator, type `Something ` | `["Something"]` | empty |
| `' '` removed, type `Something Dark` | none committed | `Something DarksideMilk` offered, clickable |

Picking it left `<option value="1" selected>` beside the unselected
`<option value="Something Dark">` that the old submit would also have sent.

## Notes

- **No `FOG_BCACHE_VER` bump.** `Page::assetVersion()` appends the file's own
  mtime to `?ver=`, so a changed JS file busts its own cache.
- To be clear about what was *not* wrong: the dropdown of existing groups was
  already implemented and works — `/group/names/name=%term%` answers and the
  results render. The space separator was cutting the search off before it
  could match anything with a space in it.

## The gate

`tests/group-modal-reaches-names-with-spaces.test.php` pins both
*definitions* — the separator list select2 is constructed with, and the
selector the submit reads. All three mutations run: restoring `' '`, dropping
`','`, and reverting to `.find('option')` each fail it.

Worth recording: the first version of the separator check **passed** when the
space was restored. It split the list on commas and then trimmed quotes off
`' '`, which leaves nothing, so the space entry vanished before it could be
compared. It reads each element as a quoted string now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A767exFmz6sQUcuZofqE1V
