### PR TITLE
Multicast sessions are created queued, so the daemon can see them

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -11698,3 +11698,55 @@ $this->schema[] = [
     "ALTER TABLE `hosts` "
     . "ADD COLUMN IF NOT EXISTS `hostAgentUpdateState` varchar(16) NOT NULL DEFAULT ''",
 ];
+// 436
+$this->schema[] = [
+    // Repair multicast sessions that were written with no state at all.
+    //
+    // Step 386 converted `multicastSessions`.`msState` from the integer 0 to
+    // NULL along with eight other columns, reading the 0 as the "no
+    // reference" sentinel it is everywhere else. It was not one here.
+    // FOGMulticastManager selects the sessions it may start with
+    // `stateID IN getQueuedStates()`, and that list is `range(0, 2)` -- the
+    // 0 is deliberately in it, and it is what "created, not yet started"
+    // meant. A NULL matches no IN list, so from that step until the fix in
+    // this commit every session created was invisible to the daemon: the
+    // tasks were queued, the machines PXE booted and sat waiting, and no
+    // udp-sender was ever started. The Active Multicast Tasks grid could not
+    // show those rows either -- it joins msState to taskStates -- so there
+    // was no button to cancel them with. Reported in forum topic 18238.
+    //
+    // The write path is fixed in Group, Host and ImageManagement. This is
+    // for the rows an install is already carrying, which no code change
+    // reaches.
+    //
+    // TWO OUTCOMES, decided by whether anything is still waiting on the
+    // session, because the two cases want opposite answers:
+    //
+    //   still has an active task -- the administrator asked for this and
+    //   never canceled it, and its machines may be sitting in FOS right now
+    //   waiting for a stream. Queued, so the daemon does what was asked.
+    //
+    //   nothing active left -- the tasks were canceled, completed or reaped
+    //   out from under it. Nothing will ever join, so Canceled: an honest
+    //   record that it did not run, and one the grid can finally show.
+    //
+    // Queuing EVERY stranded row instead would start a sender for sessions
+    // whose moment has passed, unattended, on the first page load after an
+    // upgrade. Canceling every row instead would throw away exactly the
+    // sessions someone is waiting on -- which on the install that reported
+    // this is a room of 36 machines.
+    //
+    // Ordered so the cancel arm cannot see rows the queue arm just wrote:
+    // it is scoped to `msState IS NULL`, and the queue arm has already
+    // taken its rows out of that set.
+    "UPDATE `multicastSessions` "
+    . "SET `msState` = 1 "
+    . "WHERE `msState` IS NULL "
+    . "AND `msID` IN ("
+    . "SELECT DISTINCT `a`.`msID` "
+    . "FROM `multicastSessionsAssoc` `a` "
+    . "INNER JOIN `tasks` `t` ON `t`.`taskID` = `a`.`tID` "
+    . "WHERE `t`.`taskStateID` IN (1, 2, 3)"
+    . ")",
+    "UPDATE `multicastSessions` SET `msState` = 5 WHERE `msState` IS NULL",
+];

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -130,7 +130,7 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 435);
+        define('FOG_SCHEMA', 436);
         define('FOG_BCACHE_VER', 364);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as

--- a/packages/web/src/Items/Group.php
+++ b/packages/web/src/Items/Group.php
@@ -761,10 +761,24 @@ class Group extends FOGController
                     ->set('logpath', $Image->get('path'))
                     ->set('image', $Image->get('id'))
                     ->set('interface', $StorageNode->get('interface'))
-                    // A session that has not started names no state. NULL
-                    // rather than 0 since schema step 386 -- taskStates
-                    // has no row with tsID 0.
-                    ->set('stateID', null)
+                    // QUEUED, and never NULL or 0. FOGMulticastManager
+                    // selects sessions with `stateID IN getQueuedStates()`,
+                    // which is range(0, 2) -- so the 0 this used to write was
+                    // matched by that list and the session was picked up.
+                    // Schema step 386 read the 0 as the "no reference"
+                    // sentinel it is everywhere else and made it NULL, and a
+                    // NULL matches no IN list: the session was created, its
+                    // tasks were queued, the machines booted and waited, and
+                    // no udp-sender was ever started. The Active Multicast
+                    // Tasks grid could not show it either -- it joins
+                    // msState to taskStates -- so there was no way to cancel
+                    // it from the UI. Reported in forum topic 18238.
+                    //
+                    // 1 is a real taskStates row, which is what the column's
+                    // foreign key wants, and "queued" is what an unstarted
+                    // session actually IS. The daemon moves it to In-Progress
+                    // when it starts the sender.
+                    ->set('stateID', self::getQueuedState())
                     ->set('starttime', $now->format('Y-m-d H:i:s'))
                     ->set('percent', 0)
                     ->set('isDD', $Image->get('imageTypeID'))

--- a/packages/web/src/Items/Host.php
+++ b/packages/web/src/Items/Host.php
@@ -1548,10 +1548,13 @@ class Host extends FOGController
                         ->set('logpath', $this->getImage()->get('path'))
                         ->set('image', $this->getImage()->get('id'))
                         ->set('interface', $StorageNode->get('interface'))
-                        // A session that has not started names no state. NULL
-                        // rather than 0 since schema step 386 -- taskStates
-                        // has no row with tsID 0.
-                        ->set('stateID', null)
+                        // QUEUED, never NULL or 0. Same reason as
+                        // Group::createImagePackage()'s session: the
+                        // daemon selects on stateID IN getQueuedStates(),
+                        // and the NULL schema step 386 introduced matches
+                        // no IN list, so nothing ever started the sender.
+                        // Forum topic 18238.
+                        ->set('stateID', self::getQueuedState())
                         ->set('starttime', self::niceDate()->format('Y-m-d H:i:s'))
                         ->set('percent', 0)
                         ->set('isDD', $this->getImage()->get('imageTypeID'))

--- a/packages/web/src/Pages/ImageManagement.php
+++ b/packages/web/src/Pages/ImageManagement.php
@@ -1954,10 +1954,12 @@ class ImageManagement extends FOGPage
             ->set('name', $sessionname)
             ->set('port', MulticastSession::allocatePort())
             ->set('image', $Image->get('id'))
-            // A session that has not started names no state. NULL
-            // rather than 0 since schema step 386 -- taskStates
-            // has no row with tsID 0.
-            ->set('stateID', null)
+            // QUEUED, and never NULL or 0. Same reason as
+            // Group::createImagePackage()'s session: the daemon selects on
+            // `stateID IN getQueuedStates()`, and the NULL schema step 386
+            // introduced matches no IN list, so nothing ever started the
+            // sender. Forum topic 18238.
+            ->set('stateID', self::getQueuedState())
             ->set('sessclients', $sessioncount)
             ->set('isDD', $Image->get('imageTypeID'))
             ->set('starttime', self::storageNow())

--- a/tests/multicast-session-is-queued-not-stateless.test.php
+++ b/tests/multicast-session-is-queued-not-stateless.test.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * A multicast session must be created in a state the daemon can select.
+ *
+ * THE FAILURE. FOGMulticastManager only ever starts a udp-sender for a
+ * session it finds, and it finds them with
+ * `Route::getList('multicastsession', ['stateID' => $queuedStates, ...])`,
+ * where `$queuedStates` is `TaskState::getQueuedStates()` plus the progress
+ * state -- `range(0, 2)` plus 3. The 0 in that range is not padding: it was
+ * the value every session was created with, and it is what "created, not yet
+ * started" meant.
+ *
+ * Schema step 386 converted `multicastSessions`.`msState` from 0 to NULL
+ * along with eight other columns, reading the 0 as the "no reference"
+ * sentinel it is in the other eight. A NULL matches no IN list. From that
+ * commit (650628b1b, 2026-08-29) until the fix this test guards, every
+ * multicast session was invisible to its own daemon: the per-host tasks were
+ * queued and shown, the machines PXE booted and waited, and no sender was
+ * ever started. The Active Multicast Tasks grid could not show the row
+ * either -- `getActiveMulticastTasks()` LEFT JOINs msState to taskStates and
+ * requires `tsName IN ('queued','checked in','in-progress')`, which a NULL
+ * fails -- so there was no way to cancel it from the UI. Reported in forum
+ * topic 18238.
+ *
+ * WHAT THIS PINS is the invariant, not one call site: every place that
+ * creates a MulticastSession must name a state, and it must be one the
+ * daemon's own selection accepts. Written as a scan over all three creators
+ * because a fourth would otherwise reintroduce this silently.
+ *
+ * Proved against a live database by
+ * background_scripts/probe_multicast_session_pickup.php, which creates a
+ * real group multicast task and reports whether the daemon's selection
+ * returns the session. On an unpatched tree it answers NO.
+ *
+ * Usage: php tests/multicast-session-is-queued-not-stateless.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$failures = [];
+$checks = 0;
+
+function check($what, $ok, &$failures, &$checks)
+{
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+}
+
+/* ------------------------------------------------- 1. the queued-state list */
+
+/*
+ * The daemon's accepted set. If this ever stops being a range starting at a
+ * value no session is created with, the reasoning above has to be redone --
+ * so read it rather than assume it.
+ */
+$state = (string) file_get_contents($root . '/packages/web/src/Items/TaskState.php');
+check(
+    'getQueuedStates() is still the list the daemon selects on',
+    (bool) preg_match(
+        '/function getQueuedStates\(\).*?\$queuedStates = range\(0, 2\);/s',
+        $state
+    ),
+    $failures,
+    $checks
+);
+check(
+    'and the literal queued state is a real taskStates row, not 0',
+    (bool) preg_match(
+        '/function getQueuedState\(\).*?\$queuedState = 1;/s',
+        $state
+    ),
+    $failures,
+    $checks
+);
+
+/* ------------------------------------------------------ 2. every creator */
+
+$creators = [
+    'packages/web/src/Items/Group.php',
+    'packages/web/src/Items/Host.php',
+    'packages/web/src/Pages/ImageManagement.php',
+];
+
+$found = 0;
+foreach ($creators as $rel) {
+    $src = (string) file_get_contents($root . '/' . $rel);
+    if (false === strpos($src, 'new MulticastSession()')) {
+        continue;
+    }
+    $found++;
+    /*
+     * The chain runs from `new MulticastSession()` to its terminating
+     * semicolon. Reading the whole chain rather than one line is what makes
+     * "names no state at all" detectable: the bug was an absent value, and a
+     * grep for the wrong value cannot see one.
+     */
+    $chain = '';
+    if (preg_match('/new MulticastSession\(\).*?;/s', $src, $m)) {
+        $chain = $m[0];
+    }
+    check(
+        "$rel: the session chain was found",
+        '' !== $chain,
+        $failures,
+        $checks
+    );
+    check(
+        "$rel: the session is created queued",
+        false !== strpos($chain, "->set('stateID', self::getQueuedState())"),
+        $failures,
+        $checks
+    );
+    check(
+        "$rel: and never stateless",
+        false === strpos($chain, "->set('stateID', null)")
+        && false === strpos($chain, "->set('stateID', 0)"),
+        $failures,
+        $checks
+    );
+}
+check(
+    'all three known session creators were seen',
+    3 === $found,
+    $failures,
+    $checks
+);
+
+/* -------------------------------------------------- 3. the repair for rows */
+
+/*
+ * Existing installs carry sessions written NULL, which no code change
+ * reaches. The repair has to be in the schema, and it has to split on
+ * whether anything is still waiting -- queuing every stranded row would
+ * start senders unattended, canceling every one would throw away the
+ * sessions someone is sitting in front of.
+ */
+$schema = (string) file_get_contents($root . '/packages/web/commons/schema.php');
+check(
+    'a schema step repairs sessions already written with no state',
+    false !== strpos(
+        $schema,
+        "\"UPDATE `multicastSessions` SET `msState` = 5 WHERE `msState` IS NULL\""
+    ),
+    $failures,
+    $checks
+);
+check(
+    'and revives the ones whose tasks are still active rather than killing them',
+    (bool) preg_match(
+        '/UPDATE `multicastSessions`.{0,200}?msState` = 1 .{0,600}?'
+        . 'multicastSessionsAssoc.{0,400}?taskStateID` IN \(1, 2, 3\)/s',
+        $schema
+    ),
+    $failures,
+    $checks
+);
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks checks passed\n";
+exit(0);


### PR DESCRIPTION
## What

`FOGMulticastManager` starts a `udp-sender` only for a session its own selection returns, and that selection is `stateID IN TaskState::getQueuedStates()` plus the progress state — `range(0, 2)` plus 3. **The 0 in that range is not padding.** It is the value every multicast session was created with, and it is what "created, not yet started" meant.

Schema step 386 converted `multicastSessions`.`msState` from 0 to NULL along with eight other columns, reading the 0 as the "no reference" sentinel it is in the other eight. A NULL matches no `IN` list. From 650628b1b (2026-08-29) **every multicast session has been invisible to its own daemon**: the per-host tasks were created and shown queued, the machines PXE booted and sat waiting, and no sender was ever started. `getActiveMulticastTasks()` LEFT JOINs `msState` to `taskStates` and requires `tsName IN ('queued','checked in','in-progress')`, so the grid could not show the row either — there was not even a button to cancel it with.

All three creators — `Group::createImagePackage()`, `Host::createImagePackage()` and `ImageManagement::_createSession()` — now write `getQueuedState()`. That is 1, a real `taskStates` row, which is what the column's foreign key wants and what an unstarted session actually is; the daemon moves it to In-Progress when it starts the sender.

Reported in [forum topic 18238](https://forums.fogproject.org/topic/18238/task-0).

## The repair for rows already written

Schema step 436, splitting on whether anything is still waiting:

| stranded session | becomes | why |
|---|---|---|
| has an associated task in an active state | queued | the admin asked for it and never canceled it; its machines may be sitting in FOS right now |
| nothing active left | canceled | nothing will ever join, and until now the grid could not show it to be canceled by hand |

Queuing every stranded row instead would start senders unattended on the first page load after an upgrade. Canceling every row instead would throw away exactly the sessions someone is waiting on — on the install that reported this, a room of 36 machines.

`FOG_SCHEMA` goes to 436 with it.

## Verification

Against the live 1.6 install, with a two-host throwaway group whose MACs are locally administered and match no hardware, using `background_scripts/probe_multicast_session_pickup.php` — which creates a real group multicast task and then asks the daemon's own selection for the session:

| | `msState` | daemon selection returns it | grid shows it |
|---|---|---|---|
| before | `NULL` | **NO** | 0 |
| after | `1` | **YES** | 1 |

Both runs created the same two queued `tasks` rows and the same two `multicastSessionsAssoc` rows, which is why the failure looked like "everything is there, nothing starts".

## Gates

`tests/multicast-session-is-queued-not-stateless.test.php` is new and fails 8 of 14 checks on the unpatched tree. It scans every `new MulticastSession()` chain rather than one call site, so a fourth creator cannot reintroduce this quietly, and it reads `getQueuedStates()` itself rather than assuming what the daemon accepts.

Both phpstan passes clean; the full local `tests/*.test.php` sweep is green.

## Downstream

None. No route class list changes, no OpenAPI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8UmmbQHjihkSkd3r94Jgw