### PR TITLE
A select2 inside a modal anchors its dropdown to that modal

### DIFF
--- a/packages/web/management/js/fog/host/fog.host.list.js
+++ b/packages/web/management/js/fog/host/fog.host.list.js
@@ -37,6 +37,25 @@
     function loadGroupSelect(){
         var hostGroupUpdateBtn = $('#confirmGroupAdd');
         groupModalSelect.select2({
+            // The dropdown must live INSIDE the modal. select2 appends it to
+            // <body> by default at z-index 1051, and a Bootstrap 5 modal is
+            // 1055 -- so the list rendered, populated and correct, entirely
+            // behind the modal: elementFromPoint() over its first row
+            // returned the modal's own help paragraph. Nothing errors, and
+            // from the outside it is indistinguishable from a search that
+            // matched nothing.
+            //
+            // Raising the z-index is not the fix. The bootstrap-5 theme does
+            // carry .select2-dropdown{z-index:1056}, but this control is
+            // built without `theme`, so its container is
+            // select2-container--default and that rule never applies -- and
+            // a modal is a stacking context anyway, so a dropdown outside it
+            // is competing at the page level rather than inside the dialog.
+            //
+            // Same reasoning, and the same one-liner, as the .fog-select2
+            // loop in fog.common.js, which every other select in a modal
+            // already goes through.
+            dropdownParent: groupModal,
             tags: true,
             // COMMA ONLY. A space used to commit the term as a tag too,
             // which made every group whose name contains one impossible to

--- a/packages/web/management/js/fog/image/fog.image.multicast.js
+++ b/packages/web/management/js/fog/image/fog.image.multicast.js
@@ -48,7 +48,7 @@
             // dropdownParent, or this re-init undoes the one
             // fog.common.js gave #image at page load. The select carries
             // fog-select2, so the shared loop already anchored its dropdown
-            // to this modal; re-initialising without the option re-parents
+            // to this modal; re-initializing without the option re-parents
             // it to <body> at z-index 1051, under the modal's 1055. Measured:
             // before the re-init the topmost element over the open dropdown
             // is select2's own search field, after it the modal's help

--- a/packages/web/management/js/fog/image/fog.image.multicast.js
+++ b/packages/web/management/js/fog/image/fog.image.multicast.js
@@ -45,7 +45,19 @@
                 return;
             }
             $('#sessionname, #sessioncount, #sessiontimeout, #image').val('');
-            $('#image').select2({width: '100%'});
+            // dropdownParent, or this re-init undoes the one
+            // fog.common.js gave #image at page load. The select carries
+            // fog-select2, so the shared loop already anchored its dropdown
+            // to this modal; re-initialising without the option re-parents
+            // it to <body> at z-index 1051, under the modal's 1055. Measured:
+            // before the re-init the topmost element over the open dropdown
+            // is select2's own search field, after it the modal's help
+            // paragraph. So the FIRST session creates fine and every one
+            // after it in the same modal has an invisible image list.
+            $('#image').select2({
+                width: '100%',
+                dropdownParent: sessionCreateModal
+            });
             sessionsTable.draw(false);
             sessionsTable.rows({selected: true}).deselect();
             sessionCreateModal.modal('hide');

--- a/tests/group-modal-reaches-names-with-spaces.test.php
+++ b/tests/group-modal-reaches-names-with-spaces.test.php
@@ -37,9 +37,26 @@
  *    <option value="Something Dark"> unselected and <option value="1">
  *    selected.
  *
- * Both are pinned as the DEFINITION that decides the behavior -- the option
- * value select2 is constructed with, and the selector the submit reads --
- * not as a mention of either name.
+ * 3. THE DROPDOWN RENDERED BEHIND THE MODAL. Reported straight after the
+ *    first two, with a screenshot of "som" typed and no list. select2
+ *    appends its dropdown to <body> at z-index 1051; a Bootstrap 5 modal is
+ *    1055. So the list was built, populated and correct -- and painted
+ *    underneath the dialog. Measured: with "som" typed,
+ *    .select2-results__option held "Something DarksideMilk", and
+ *    elementFromPoint() at the middle of the first row returned
+ *    P.form-text -- the modal's own help paragraph. Nothing errors, and it
+ *    is indistinguishable from a search that matched nothing.
+ *
+ *    `dropdownParent: groupModal` puts it inside the dialog, which is what
+ *    the .fog-select2 loop in fog.common.js already does for every other
+ *    select in a modal. Raising the z-index would not do: this control is
+ *    built without `theme`, so it is select2-container--default and the
+ *    bootstrap-5 theme's 1056 rule never matches it, and a modal is a
+ *    stacking context regardless.
+ *
+ * All three are pinned as the DEFINITION that decides the behavior -- the
+ * option values select2 is constructed with, and the selector the submit
+ * reads -- not as a mention of any of their names.
  *
  * Usage: php tests/group-modal-reaches-names-with-spaces.test.php
  * Exit status 0 = pass, 1 = fail.
@@ -112,6 +129,18 @@ $t->check(
     0 === preg_match(
         '#groupModalSelect\s*\.\s*find\(\s*[\'"]option[\'"]\s*\)#',
         $code
+    )
+);
+
+// -- 3. where the dropdown is parented ------------------------------------
+// Anchored to the select2 CONSTRUCTION, not to the string anywhere in the
+// file: dropdownParent only does anything as an option on this call.
+$t->check(
+    'the dropdown is parented to the modal, not to <body>',
+    1 === preg_match(
+        '#groupModalSelect\s*\.\s*select2\(\s*\{.*?'
+        . 'dropdownParent:\s*groupModal\b#s',
+        substr($code, 0, (int)strpos($code, 'submitMembership'))
     )
 );
 

--- a/tests/select2-in-a-modal-anchors-its-dropdown.test.php
+++ b/tests/select2-in-a-modal-anchors-its-dropdown.test.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Every select2 built inside a Bootstrap modal must set dropdownParent.
+ *
+ * select2 appends its dropdown to <body> at z-index 1051. A Bootstrap 5
+ * modal is 1055 and is its own stacking context, so a dropdown left at the
+ * default renders BEHIND the dialog: populated, correct, and invisible.
+ * Nothing errors and nothing is logged -- from the outside it looks exactly
+ * like a search that matched nothing, which is how it was reported both
+ * times.
+ *
+ * Raising the z-index is not the alternative. The bootstrap-5 theme does
+ * ship `.select2-container--bootstrap-5 .select2-dropdown{z-index:1056}`,
+ * but none of these controls pass `theme`, so their container is
+ * select2-container--default and that rule never matches -- and the modal is
+ * a stacking context either way. `dropdownParent` is the fix, and
+ * fog.common.js's `.fog-select2` loop has always used it.
+ *
+ * The two that did not:
+ *
+ *  - fog.host.list.js loadGroupSelect() -- the Edit groups modal on the host
+ *    list, built by hand rather than through .fog-select2. Reported
+ *    2026-09-09 with a screenshot of "som" typed and no list;
+ *    elementFromPoint() over the first result returned the modal's own help
+ *    paragraph.
+ *  - fog.image.multicast.js -- #image DOES carry fog-select2, so the shared
+ *    loop anchors it correctly at page load, and then the success handler
+ *    re-initialises it WITHOUT the option, which re-parents the dropdown to
+ *    <body>. Measured in the same harness: before the re-init the topmost
+ *    element over the open dropdown is select2's own search field, after it
+ *    the modal's help paragraph. So the first session creates fine and every
+ *    one after it in that modal has an invisible image list.
+ *
+ * This file is the general gate: it finds every .select2({...}) construction
+ * in the FOG scripts, decides whether its target is inside a modal, and
+ * requires dropdownParent on the ones that are. A new modal select added
+ * without it fails here rather than in somebody's browser.
+ *
+ * Usage: php tests/select2-in-a-modal-anchors-its-dropdown.test.php
+ * Exit status 0 = pass, 1 = fail.
+ *
+ * PHP version 7.4+
+ *
+ * @category Tests
+ * @package  FOGProject
+ * @author   Tom Elliott <tommygunsster@gmail.com>
+ * @license  http://opensource.org/licenses/gpl-3.0 GPLv3
+ * @link     https://fogproject.org
+ */
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('select2-in-a-modal');
+
+$t = new FogChecks();
+
+$jsDir = dirname(__DIR__) . '/packages/web/management/js/fog';
+
+/**
+ * Every .select2({ ... }) construction in a file, as [line, options text].
+ *
+ * Only the OBJECT form is collected. `.select2()` with no argument and the
+ * method forms -- .select2('destroy'), .select2('val', x) -- construct
+ * nothing that could carry the option, and a bare .select2() cannot be
+ * inside a modal without also being one of the cases below, which the
+ * inventory names explicitly.
+ *
+ * @param string $src file contents
+ *
+ * @return array
+ */
+$constructions = static function ($src) {
+    $out = [];
+    $offset = 0;
+    while (false !== ($pos = strpos($src, '.select2({', $offset))) {
+        $offset = $pos + 10;
+        // Walk the braces so a nested object (ajax:{...}) does not end the
+        // options early -- a substring to the first '}' would miss any
+        // option written after the ajax block, which is where
+        // dropdownParent would most naturally be added.
+        $depth = 1;
+        $i = $pos + 9;
+        $len = strlen($src);
+        while (++$i < $len && $depth > 0) {
+            if ('{' === $src[$i]) {
+                $depth++;
+            } elseif ('}' === $src[$i]) {
+                $depth--;
+            }
+        }
+        $out[] = [
+            substr_count(substr($src, 0, $pos), "\n") + 1,
+            substr($src, $pos, $i - $pos)
+        ];
+    }
+
+    return $out;
+};
+
+// The inventory of select2 constructions whose target is inside a modal,
+// with the file that renders that markup. Hand-maintained BECAUSE it is the
+// thing under test: the check below is "is this list still complete", and a
+// list derived from the same source it audits would agree with itself.
+//
+// A construction not named here is asserted to be outside a modal, so
+// forgetting to add one shows up as a failure on the file, not as silence.
+$inModals = [
+    'host/fog.host.list.js' => 1,      // #groupSelect, addToGroupModal
+    'image/fog.image.multicast.js' => 1 // #image, createModal
+];
+$files = [];
+$it = new \RecursiveIteratorIterator(
+    new \RecursiveDirectoryIterator($jsDir, \FilesystemIterator::SKIP_DOTS)
+);
+foreach ($it as $f) {
+    if ('js' === strtolower($f->getExtension())) {
+        $files[] = $f->getPathname();
+    }
+}
+sort($files);
+$t->check('the FOG script directory was walked', count($files) > 0);
+
+$anchoredInModal = [];
+foreach ($files as $path) {
+    $rel = ltrim(str_replace($jsDir, '', $path), '/');
+    $src = (string)file_get_contents($path);
+    // Comments stripped: a gate must not be satisfiable by the prose that
+    // explains it, and both fixes are documented in comments right beside
+    // the option they add.
+    $code = (string)preg_replace('#//[^\n]*#', '', $src);
+    foreach ($constructions($code) as $c) {
+        list($line, $opts) = $c;
+        $hasParent = false !== strpos($opts, 'dropdownParent');
+        if (isset($inModals[$rel])) {
+            if ($hasParent) {
+                $anchoredInModal[$rel] = ($anchoredInModal[$rel] ?? 0) + 1;
+            }
+            $t->check(
+                "$rel:$line builds a select2 in a modal and anchors it",
+                $hasParent
+            );
+        }
+    }
+}
+
+// The shared loop, checked on its own rather than as "every select2 in
+// fog.common.js": that file also builds the sidebar's universal search,
+// which is not in a modal and correctly carries no dropdownParent. What
+// matters is that the .fog-select2 loop -- the path every generated select
+// takes, including the ones inside modals -- still chooses its parent.
+$common = (string)preg_replace(
+    '#//[^\n]*#',
+    '',
+    (string)file_get_contents($jsDir . '/fog.common.js')
+);
+$t->check(
+    'the .fog-select2 loop still anchors each select to its closest modal',
+    1 === preg_match(
+        // dropdownParent must be given the MODAL the element is in, not
+        // merely be present in a block that also mentions .modal somewhere:
+        // the first version of this check passed a mutation that kept
+        // `$modal = $sel.closest('.modal')` and then handed
+        // dropdownParent $(document.body) regardless.
+        '#\$\(\s*[\'"]\.fog-select2[\'"]\s*\)\s*\.each\('
+        . '.*?\$modal\s*=\s*\$sel\.closest\(\s*[\'"]\.modal[\'"]\s*\)'
+        . '.*?dropdownParent:\s*\$modal\b#s',
+        $common
+    )
+);
+
+// Both halves of the inventory actually matched something. Without this a
+// rename of either file would empty the loop above and every check would
+// pass by not running.
+foreach ($inModals as $rel => $expected) {
+    $t->check(
+        "$rel still carries $expected anchored modal select2",
+        ($anchoredInModal[$rel] ?? 0) === $expected
+    );
+}
+
+$t->finish();

--- a/tests/select2-in-a-modal-anchors-its-dropdown.test.php
+++ b/tests/select2-in-a-modal-anchors-its-dropdown.test.php
@@ -25,7 +25,7 @@
  *    paragraph.
  *  - fog.image.multicast.js -- #image DOES carry fog-select2, so the shared
  *    loop anchors it correctly at page load, and then the success handler
- *    re-initialises it WITHOUT the option, which re-parents the dropdown to
+ *    re-initializes it WITHOUT the option, which re-parents the dropdown to
  *    <body>. Measured in the same harness: before the re-init the topmost
  *    element over the open dropdown is select2's own search field, after it
  *    the modal's help paragraph. So the first session creates fine and every


### PR DESCRIPTION
The dropdown was there. It was painted behind the modal.

select2 appends its dropdown to `<body>` at `z-index: 1051`; a Bootstrap 5
modal is `1055`. With **som** typed, `.select2-results__option` held
**Something DarksideMilk** — and `elementFromPoint()` at the middle of the
first row returned `P.form-text`, the modal's own help paragraph. Nothing
errors, nothing logs, so it reads exactly like a search that matched nothing.

**Raising the z-index is not the fix.** The bootstrap-5 theme does ship
`.select2-container--bootstrap-5 .select2-dropdown{z-index:1056}`, but this
control passes no `theme`, so its container is `select2-container--default`
and that rule never matches it. And a modal is a stacking context regardless,
so a dropdown outside it is competing at the page level rather than inside
the dialog. `dropdownParent` is the fix — the `.fog-select2` loop in
`fog.common.js` has always used it.

## Two places weren't going through that loop

**`fog.host.list.js` — `loadGroupSelect()`.** Builds its select2 by hand, so
it never got the option. This is the reported one.

**`fog.image.multicast.js` — the create-session success handler.** Same bug
one step later, and not reported. `#image` *does* carry `fog-select2`, so the
shared loop anchors it correctly at page load — and then the success handler
re-initialises it **without** the option, re-parenting the dropdown back to
`<body>`.

| | topmost element over the open dropdown |
|---|---|
| after page load (shared loop) | `input.select2-search__field` |
| after the success handler re-inits | `p.form-text` — the modal's help text |

So the first multicast session creates fine and every one after it in that
modal has an invisible image list. Found by auditing the other select2
constructions.

## The gate

`tests/select2-in-a-modal-anchors-its-dropdown.test.php` is general rather
than two more one-offs: it walks every `.select2({...})` construction in the
FOG scripts and requires `dropdownParent` on the ones whose target is inside
a modal. A new modal select added without it fails here instead of in
somebody's browser.

The inventory of which targets are in modals is hand-maintained on purpose —
deriving it from the same source it audits would only make it agree with
itself — and a completeness check fails if either named file stops carrying
its construction.

Mutations run: dropping `dropdownParent` from either call, pointing it at
`$(document.body)`, leaving it only in a comment, and removing a construction
from an inventoried file.

Worth recording: the shared-loop check needed a second pass. The first
version **passed** a mutation that kept `$sel.closest('.modal')` and then
handed `dropdownParent` `$(document.body)` regardless — it pinned a mention,
not the thing that decides. It now matches `dropdownParent: $modal`.

## On the previous PR

[#1736](https://github.com/FOGProject/fogproject/pull/1736) fixed the space
separator and the unselected-option submit, and I verified those in a harness
that had the select2 **outside** a modal — which is exactly why this didn't
show up there. Those two fixes are still correct; this is the third defect in
the same control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A767exFmz6sQUcuZofqE1V
