### PR TITLE
Tab commits a group name in the Edit groups modal, and ';' separates

### DIFF
--- a/packages/web/management/js/fog/host/fog.host.list.js
+++ b/packages/web/management/js/fog/host/fog.host.list.js
@@ -64,8 +64,14 @@
             // full name, and Add then CREATED a group called "Something"
             // because an unmatched term is sent in groups_new. Two of the
             // three groups on the reporter's own server were named that way.
-            // Comma still separates, so pasting a list of names works.
-            tokenSeparators: [','],
+            // Comma and semicolon separate, so pasting a list of names
+            // works either way round. Same trade-off as the space in
+            // miniature -- a group actually named "Lab;Annex" cannot be
+            // TYPED whole -- but it is recoverable where the space was not:
+            // the search runs on every keystroke before the separator, so
+            // the real group is already in the list to be picked, and Tab
+            // or Enter below commits the whole term without one.
+            tokenSeparators: [',', ';'],
             ajax: {
                 url: function(params) {
                     return '../group/names/name='
@@ -119,6 +125,42 @@
                 }
                 return $result;
             }
+        });
+
+        // TAB COMMITS THE HIGHLIGHTED OPTION, the way Enter already does.
+        //
+        // Without this Tab throws the term away: select2 binds its own
+        // keydown on the search field, closes the dropdown on Tab and clears
+        // what you typed, so a name typed and tabbed simply vanished.
+        // Measured before the change -- type "Lab Room Two", press Tab, and
+        // the select holds no option and the field is empty.
+        //
+        // CAPTURE phase, because select2's handler is bound first and a
+        // bubbling one would only run after it had already closed. And the
+        // key is re-dispatched as Enter rather than the option being
+        // selected directly: select2 hangs no data on the results <li>
+        // ($(li).data('data') is undefined here), so its own Enter path is
+        // the available API and reuses the code Enter is already tested on.
+        //
+        // Shift+Tab is left alone so it still moves focus backwards out of
+        // the control, and with nothing highlighted Tab keeps its normal
+        // meaning. The listener needs no teardown: it is on the container
+        // select2 builds, which select2('destroy') removes when the modal
+        // closes.
+        groupModalSelect.next('.select2-container').each(function() {
+            this.addEventListener('keydown', function(e) {
+                if (e.key !== 'Tab' || e.shiftKey) {
+                    return;
+                }
+                if (!groupModal.find('.select2-results__option--highlighted').length) {
+                    return;
+                }
+                e.preventDefault();
+                e.stopPropagation();
+                $(e.target).trigger(
+                    $.Event('keydown', {which: 13, keyCode: 13, key: 'Enter'})
+                );
+            }, true);
         });
 
         // One submit for both directions. The only thing that differs on the

--- a/tests/group-modal-reaches-names-with-spaces.test.php
+++ b/tests/group-modal-reaches-names-with-spaces.test.php
@@ -54,9 +54,27 @@
  *    bootstrap-5 theme's 1056 rule never matches it, and a modal is a
  *    stacking context regardless.
  *
- * All three are pinned as the DEFINITION that decides the behavior -- the
- * option values select2 is constructed with, and the selector the submit
- * reads -- not as a mention of any of their names.
+ * 4. TAB THREW THE TERM AWAY. Requested 2026-09-09 alongside a semicolon
+ *    separator. Enter already committed the highlighted option -- measured
+ *    on the shipped build: type "Lab Room One", press Enter, and the select
+ *    holds that exact string, spaces and all -- but Tab did not. select2
+ *    binds its own keydown on the search field, closes the dropdown on Tab
+ *    and clears the box, so the name simply vanished.
+ *
+ *    The handler is CAPTURE phase because select2's is bound first and a
+ *    bubbling one only runs after the dropdown has already closed, and it
+ *    re-dispatches Enter rather than selecting the option itself: select2
+ *    hangs no data on the results <li> ($(li).data('data') is undefined),
+ *    so its own Enter path is the available API and is the code Enter is
+ *    already exercised on. Measured after: typing "Lab Room Two" and
+ *    pressing Tab leaves that one chip with focus still in the box; and
+ *    arrowing down to "Something DarksideMilk" and pressing Tab yields
+ *    <option value="1">, the group's ID, not its name.
+ *
+ * All four are pinned as the DEFINITION that decides the behavior -- the
+ * option values select2 is constructed with, the selector the submit reads,
+ * and the listener that intercepts the key -- not as a mention of any of
+ * their names.
  *
  * Usage: php tests/group-modal-reaches-names-with-spaces.test.php
  * Exit status 0 = pass, 1 = fail.
@@ -108,8 +126,12 @@ $t->check(
     !in_array(' ', $separators, true)
 );
 $t->check(
-    'and a comma still is, so a pasted list still splits',
+    'a comma still is, so a pasted list still splits',
     in_array(',', $separators, true)
+);
+$t->check(
+    'and so is a semicolon',
+    in_array(';', $separators, true)
 );
 
 // -- 2. what the submit reads ---------------------------------------------
@@ -142,6 +164,45 @@ $t->check(
         . 'dropdownParent:\s*groupModal\b#s',
         substr($code, 0, (int)strpos($code, 'submitMembership'))
     )
+);
+
+
+// -- 4. Tab commits, the way Enter does ------------------------------------
+// Three separate things decide this and all three are pinned: the listener
+// must be on the select2 container, in the CAPTURE phase (bubbling runs too
+// late -- select2 has closed the dropdown by then), and it must hand select2
+// the key it acts on. A check for the string 'Tab' alone would pass a
+// handler bound the wrong way round, which is the version that does nothing.
+$tab = (string)strstr($code, "next('.select2-container')");
+$t->check(
+    'the Tab handler is bound to the select2 container',
+    '' !== $tab
+);
+$t->check(
+    'in the capture phase, ahead of select2 own keydown',
+    1 === preg_match(
+        '#addEventListener\(\s*[\'"]keydown[\'"]\s*,.*?,\s*true\s*\)#s',
+        (string)substr($tab, 0, 1200)
+    )
+);
+$t->check(
+    'it acts on Tab and leaves Shift+Tab alone',
+    1 === preg_match(
+        '#e\.key\s*!==\s*[\'"]Tab[\'"]\s*\|\|\s*e\.shiftKey#',
+        $tab
+    )
+);
+$t->check(
+    'only when the dropdown has something highlighted',
+    1 === preg_match(
+        '#!groupModal\.find\(\s*[\'"]\.select2-results__option--highlighted[\'"]\s*\)\.length#',
+        $tab
+    )
+);
+$t->check(
+    'and it commits by re-dispatching the key select2 already handles',
+    1 === preg_match('#which:\s*13#', $tab)
+    && 1 === preg_match('#preventDefault\(\)#', $tab)
 );
 
 $t->finish();


### PR DESCRIPTION
## What

Two things in the host **Edit groups** modal:

- `;` joins `,` as a token separator.
- **Tab** now commits what you typed, the way Enter already did.

## Enter needed no code

Measured on the shipped build before writing anything: type `Lab Room One`,
press Enter, and select2 creates that exact tag, spaces intact. It already
worked. No change was made for it.

## Why Tab needed code, and why it looks like this

select2 binds its own `keydown` on the search field. On Tab it closes the
dropdown and clears the box, so the typed name was simply discarded — no
chip, no option, empty field.

Three implementation details, each forced:

- **Capture phase** (`addEventListener(..., true)`). select2's handler is
  bound first, so a bubbling handler runs only after the dropdown has already
  closed and the term is gone.
- **Bound to the `.select2-container`**, not the search field. The field is
  destroyed and recreated as the dropdown opens and closes; the container
  survives, and `select2('destroy')` removes it when the modal closes, so
  there is no listener to tear down by hand.
- **Re-dispatches Enter** rather than selecting the option directly. select2
  hangs no data on the results `<li>` — `$(li).data('data')` is `undefined` —
  so its own Enter path is the available API, and it reuses the code path
  Enter is already exercised on.

Shift+Tab is left alone so it still moves focus out of the control, and with
nothing highlighted Tab keeps its normal meaning.

## The semicolon trade-off

Same shape as the space separator removed in #1736, but much smaller. A group
actually named `Lab;Annex` cannot be **typed** whole. Unlike the space, it is
recoverable: the search runs on every keystroke before the separator, so the
real group is already listed to be clicked, and Tab or Enter commit the whole
term without needing a separator at all.

## Verification

Driven against this branch's own `loadGroupSelect()` source, loaded into a
page carrying the real modal and the shipped stylesheets — not a hand-written
copy of the options, with asserts that the extracted source contained both
the new separators and the Tab block.

| Input | Result |
|---|---|
| `Lab Room Two` + Tab | one chip, spaces intact, focus still in the search box |
| ArrowDown to an existing group + Tab | `<option value="1">` — the group's ID, not its name |
| `Alpha;Beta,Gamma` | chips `Alpha`, `Beta`; `Gamma` left in the box |
| `Lab Room One` + Enter | unchanged, still works |

Before the fix, the first case produced `tags: []`, `chips: []`, `search: ""`.

## Gate

`tests/group-modal-reaches-names-with-spaces.test.php` goes from 7 to 13
checks. Six mutations, each failing exactly one check:

- semicolon removed from `tokenSeparators`
- space restored to `tokenSeparators`
- capture flag `true` → `false`
- Shift+Tab guard dropped
- highlighted-option guard neutered
- re-dispatch changed from Enter to Tab

Restored: 13 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A767exFmz6sQUcuZofqE1V