### PR TITLE
Multicast streams name the image file they carry

### DIFF
--- a/packages/web/service/getversion.php
+++ b/packages/web/service/getversion.php
@@ -63,8 +63,14 @@ if (isset($_REQUEST['client'])) {
      *
      * mclvm: multicast tasks emit per-LV LVM image files in sidecar
      * order (fos docs/adr/0007).
+     *
+     * mcstreamid: every multicast stream is prefixed with a fixed-width
+     * header naming the image file it carries, so a receiver can refuse
+     * a stream that is not the one it asked for (issue #1742). A client
+     * that sees this token strips and checks the header; one that does
+     * not must not, or it would eat 128 bytes of payload.
      */
-    $ver = 'mclvm';
+    $ver = 'mclvm mcstreamid';
 } elseif (isset($_REQUEST['url'])) {
     FOGCore::checkAuthAndCSRF();
     $url = $_REQUEST['url'];

--- a/packages/web/src/Service/MulticastTask.php
+++ b/packages/web/src/Service/MulticastTask.php
@@ -213,6 +213,57 @@ class MulticastTask extends FOGService
         return array_filter($NewTasks);
     }
     /**
+     * Shell printf format for the identity header that prefixes every
+     * multicast stream.
+     *
+     * udpcast carries no metadata: the server chains one udp-sender per
+     * image file on a shared portbase, the client opens one udp-receiver
+     * per file it expects, and the Nth receiver gets the Nth stream. If
+     * the two ever fall out of step -- a client that reboots mid-session,
+     * or one whose receiver opens after a sender has already given up on
+     * it -- every partition after that point is restored from the wrong
+     * stream. partclone objects only when the target partition is smaller
+     * than the source; when it is larger the wrong filesystem is written
+     * and the deploy reports success (issue #1742).
+     *
+     * So each stream is introduced by a fixed 128-byte record naming the
+     * image file it carries, and FOS refuses a stream whose name is not
+     * the one it asked for. Fixed width because the client reads the
+     * header with a single dd before it opens the decompressor, and a
+     * count of bytes is the only thing a pipe lets it read without
+     * consuming payload.
+     *
+     * 7 bytes of tag, 120 of left-justified name, one newline. Names are
+     * image file basenames, far short of 120.
+     *
+     * @var string
+     */
+    const STREAM_HEADER_FORMAT = 'FOGMC1 %-120s\n';
+    /**
+     * Byte width of STREAM_HEADER_FORMAT once expanded. FOS reads exactly
+     * this many bytes, so the two must move together.
+     *
+     * @var int
+     */
+    const STREAM_HEADER_BYTES = 128;
+    /**
+     * Reduces a chunked image filename to the stem the client's glob
+     * collapses to: d1p4.img.007 and sys.img.000 both name streams the
+     * client asks for as d1p4.img* and sys.img.*.
+     *
+     * Only ever applied where the emitting branch knows the stream is a
+     * concatenation or the image is split -- rec.img.000 and rec.img.001
+     * are whole partitions under the legacy layouts and keep their names.
+     *
+     * @param string $basename image file basename
+     *
+     * @return string
+     */
+    private static function _streamStem($basename)
+    {
+        return preg_replace('#\.[0-9]{3,}$#', '', $basename);
+    }
+    /**
      * Session ID
      *
      * @var int
@@ -1083,6 +1134,7 @@ class MulticastTask extends FOGService
          * not change. Part of the 065 sink fix.
          */
         $streams = [];
+        $streamIds = [];
         $claimed = [];
         foreach ($sendfiles as $file) {
             if (isset($claimed[$file])) {
@@ -1102,16 +1154,24 @@ class MulticastTask extends FOGService
                 }
                 $matches = array_map('basename', $matches);
                 if ('sys.img.*' === $file) {
+                    // One partition spread over sys.img.000, .001 ...
+                    // The client names it with the same glob, so the id
+                    // is the stem both sides collapse to.
                     $streams[] = $matches;
+                    $streamIds[] = self::_streamStem($matches[0]);
                     continue;
                 }
                 foreach ($matches as $match) {
+                    // rec.img.000 / rec.img.001 are whole partitions, not
+                    // chunks: the client asks for each by its exact name.
                     $streams[] = [$match];
+                    $streamIds[] = $match;
                 }
                 continue;
             }
             if (!$split) {
                 $streams[] = [$file];
+                $streamIds[] = $file;
                 continue;
             }
             /*
@@ -1138,6 +1198,9 @@ class MulticastTask extends FOGService
                 $claimed[$chunk] = true;
             }
             $streams[] = $chunks;
+            // Split layouts are always chunk-suffixed and the client
+            // always globs them, single chunk included.
+            $streamIds[] = self::_streamStem($chunks[0]);
         }
         ob_start();
         foreach ($streams as $i => $stream) {
@@ -1154,20 +1217,24 @@ class MulticastTask extends FOGService
             foreach ($stream as $file) {
                 $paths[] = escapeshellarg($imagedir . DS . $file);
             }
-            if (count($paths) > 1) {
-                // udp-sender accepts a single --file and discards the
-                // rest ("Extra argument ... ignored"), which is why a
-                // multi-chunk partition used to go out truncated. With no
-                // --file it reads stdin, so the chunks are concatenated
-                // onto it in the same order cat would use unicast.
-                printf(
-                    'cat %s | %s;',
-                    implode(' ', $paths),
-                    $cmd
-                );
-                continue;
-            }
-            printf('%s --file %s;', $cmd, $paths[0]);
+            /*
+             * Every stream is prefixed with a fixed 128-byte identity
+             * header naming the image file it carries, and therefore
+             * goes in on stdin -- including the single-file case, which
+             * used to pass --file. udp-sender accepts a single --file
+             * and discards the rest ("Extra argument ... ignored"),
+             * which is separately why a multi-chunk partition used to go
+             * out truncated; with no --file it reads stdin, so chunks
+             * are concatenated onto it in the same order cat would use
+             * unicast.
+             */
+            printf(
+                '{ printf %s %s; cat %s; } | %s;',
+                escapeshellarg(self::STREAM_HEADER_FORMAT),
+                escapeshellarg($streamIds[$i]),
+                implode(' ', $paths),
+                $cmd
+            );
         }
         unset($filelist, $sendfiles, $streams, $lvfiles, $buildcmd);
         return ob_get_clean();

--- a/tests/multicast-streams-are-self-identifying.test.php
+++ b/tests/multicast-streams-are-self-identifying.test.php
@@ -1,0 +1,376 @@
+<?php
+/**
+ * Every multicast stream must announce which image file it carries.
+ *
+ * udpcast carries no metadata. The server chains one udp-sender per image
+ * file on a shared portbase, FOS opens one udp-receiver per file it
+ * expects, and the Nth receiver gets the Nth stream. Position is the only
+ * thing binding them, so a client that reboots mid-session -- or whose
+ * receiver opens after a sender has already stopped waiting for it --
+ * lands one stream out of step, and every partition after that point is
+ * restored from the wrong image. partclone objects only when the target
+ * partition is smaller than the source; when it is larger the wrong
+ * filesystem is written and the deploy reports success. Issue #1742.
+ *
+ * So getCMD() prefixes each stream with a fixed-width record naming the
+ * file, and FOS refuses a stream that is not the one it asked for. These
+ * checks pin the half that lives here: that the header is on EVERY stream
+ * (a single --file invocation would slip through unlabeled), that it is
+ * the width FOS reads, and that the name is the one FOS derives from its
+ * own side of the same layout.
+ *
+ * The naming rule is not uniform, and that asymmetry is the point:
+ *
+ *   d1p2.img            flat            -> d1p2.img      (verbatim)
+ *   d1p1.img.000/.001   split chunks    -> d1p1.img      (stem)
+ *   d1p2.img.000        split, 1 chunk  -> d1p2.img      (stem)
+ *   sys.img.000/.001    ONE partition   -> sys.img       (stem)
+ *   rec.img.000/.001    TWO partitions  -> rec.img.000   (verbatim)
+ *
+ * FOS asks for a chunked partition with a glob (d1p1.img*, sys.img.*) and
+ * for a whole one by name, so both sides land on the same string from
+ * their own layout without either re-deriving the other's ordinal.
+ *
+ * These checks drive the REAL getCMD() over real fixture directories. The
+ * accessors that would reach the database are overridden; the file
+ * enumeration, the glob expansion and the emission are the shipped code.
+ *
+ * Usage: php tests/multicast-streams-are-self-identifying.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+namespace FOG;
+
+use FOG\Service\MulticastTask;
+
+defined('DS') || define('DS', DIRECTORY_SEPARATOR);
+// Normally defined by the generated config; getCMD() interpolates it.
+defined('UDPSENDERPATH') || define('UDPSENDERPATH', '/usr/local/sbin/udp-sender');
+
+/**
+ * Stand-in for the real base class.
+ *
+ * getCMD() reads three globalSettings keys and logs through outall(); it
+ * touches nothing else on the parent. FOG_MULTICAST_ADDRESS is left empty
+ * deliberately -- a value there sends getCMD() into MulticastSession's
+ * port pool, which is a database read and is not what these checks are
+ * about.
+ */
+abstract class FOGBase
+{
+    /**
+     * Settings reader.
+     *
+     * @param mixed $keys One key, or a list of them.
+     *
+     * @return mixed
+     */
+    public static function getSetting($keys)
+    {
+        $answers = [
+            'FOG_MULTICAST_ADDRESS' => '',
+            'FOG_MULTICAST_DUPLEX' => '',
+            'FOG_MULTICAST_RENDEZVOUS' => '',
+            'FOG_MULTICAST_MAX_SESSIONS' => 64,
+        ];
+        if (is_array($keys)) {
+            $out = [];
+            foreach ($keys as $key) {
+                $out[] = isset($answers[$key]) ? $answers[$key] : '';
+            }
+            return $out;
+        }
+        return isset($answers[$keys]) ? $answers[$keys] : '';
+    }
+}
+
+require_once __DIR__ . '/lib/stub-buckets.php';
+require_once dirname(__DIR__) . '/packages/web/src/Service/FOGService.php';
+require_once dirname(__DIR__) . '/packages/web/src/Service/MulticastTask.php';
+
+/**
+ * Drives getCMD() without a session row behind it.
+ */
+class StreamProbe extends MulticastTask
+{
+    /** @var string */
+    public $path = '';
+    /** @var int */
+    public $type = 1;
+    /** @var int */
+    public $format = 5;
+    /** @var int */
+    public $osid = 9;
+
+    /**
+     * Silences the service logger.
+     *
+     * @param string $string Message.
+     *
+     * @return void
+     */
+    public static function outall($string)
+    {
+    }
+
+    // The accessors below are the whole database surface of getCMD().
+    public function getImagePath()
+    {
+        return $this->path;
+    }
+    public function getImageType()
+    {
+        return $this->type;
+    }
+    public function getImageFormat()
+    {
+        return $this->format;
+    }
+    public function getOSID()
+    {
+        return $this->osid;
+    }
+    public function getPartitions()
+    {
+        return 0;
+    }
+    public function getPortBase()
+    {
+        return 63100;
+    }
+    public function getClientCount()
+    {
+        return 1;
+    }
+    public function getInterface()
+    {
+        return 'eno2';
+    }
+    public function getMaxwait()
+    {
+        return 600;
+    }
+    public function getBitrate()
+    {
+        return '';
+    }
+    public function getHelloInterval()
+    {
+        return '';
+    }
+    public function getUDPCastLogFile()
+    {
+        return '/dev/null';
+    }
+}
+
+/** @var string[] $failures Labels of the checks that did not hold. */
+$failures = [];
+/** @var int $checks How many assertions ran. */
+$checks = 0;
+
+/**
+ * Records one assertion.
+ *
+ * @param string $label What is being asserted.
+ * @param bool   $cond  Whether it held.
+ *
+ * @return void
+ */
+function check($label, $cond)
+{
+    global $failures, $checks;
+    $checks++;
+    if (!$cond) {
+        $failures[] = $label;
+    }
+}
+
+/**
+ * Builds a fixture image directory.
+ *
+ * @param string $name  Directory name.
+ * @param array  $files Filenames to create.
+ *
+ * @return string Absolute path.
+ */
+function fixture($name, array $files)
+{
+    $dir = sys_get_temp_dir() . '/fogmcid-' . getmypid() . '/' . $name;
+    if (!is_dir($dir)) {
+        mkdir($dir, 0777, true);
+    }
+    foreach ($files as $file) {
+        file_put_contents($dir . '/' . $file, $file);
+    }
+    return $dir;
+}
+
+/**
+ * Runs the real getCMD() and returns the stream ids it announced, in order.
+ *
+ * @param string $dir    Image directory.
+ * @param int    $type   Image type.
+ * @param int    $format Image format.
+ * @param int    $osid   Image OS id.
+ *
+ * @return array [ids, raw command]
+ */
+function idsFor($dir, $type, $format, $osid = 9)
+{
+    $probe = (new \ReflectionClass('FOG\StreamProbe'))
+        ->newInstanceWithoutConstructor();
+    $probe->path = $dir;
+    $probe->type = $type;
+    $probe->format = $format;
+    $probe->osid = $osid;
+    $cmd = $probe->getCMD();
+    preg_match_all(
+        "#\\{ printf 'FOGMC1 %-120s\\\\n' '([^']*)';#",
+        $cmd,
+        $m
+    );
+    return [$m[1], $cmd];
+}
+
+// --- 1. the header is the width FOS reads -------------------------------
+
+// Read through constant() so the assertions below are a genuine read of
+// the shipped values rather than something the analyzer folds away.
+/** @var int $headerBytes */
+$headerBytes = constant('FOG\\Service\\MulticastTask::STREAM_HEADER_BYTES');
+/** @var string $headerFormat */
+$headerFormat = constant('FOG\\Service\\MulticastTask::STREAM_HEADER_FORMAT');
+check(
+    'STREAM_HEADER_BYTES is 128',
+    128 === $headerBytes
+);
+check(
+    'the format expands to exactly STREAM_HEADER_BYTES',
+    $headerBytes === strlen(
+        sprintf(
+            str_replace('\\n', "\n", $headerFormat),
+            'd1p1.img'
+        )
+    )
+);
+check(
+    'a long LV image name still fits the header',
+    $headerBytes === strlen(
+        sprintf(
+            str_replace('\\n', "\n", $headerFormat),
+            'd1p3.a-rather-long-volume-group-name.img'
+        )
+    )
+);
+
+// --- 2. naming, per layout ---------------------------------------------
+
+$cases = [
+    'flat, one file per partition' => [
+        ['d1p1.img', 'd1p2.img', 'd1p3.img'],
+        1,
+        5,
+        ['d1p1.img', 'd1p2.img', 'd1p3.img'],
+    ],
+    'split, several chunks per partition' => [
+        ['d1p1.img.000', 'd1p1.img.001', 'd1p2.img.000', 'd1p2.img.001'],
+        1,
+        6,
+        ['d1p1.img', 'd1p2.img'],
+    ],
+    'split, a partition small enough for one chunk' => [
+        ['d1p1.img.000', 'd1p2.img.000', 'd1p2.img.001'],
+        1,
+        6,
+        ['d1p1.img', 'd1p2.img'],
+    ],
+    'legacy sys/rec: sys is one partition, rec is per-partition' => [
+        ['rec.img.000', 'sys.img.000', 'sys.img.001'],
+        1,
+        5,
+        ['rec.img.000', 'sys.img'],
+        5,
+    ],
+    'legacy sys/rec: two rec partitions keep their own names' => [
+        ['rec.img.000', 'rec.img.001', 'sys.img.000'],
+        1,
+        5,
+        ['rec.img.000', 'rec.img.001', 'sys.img'],
+        5,
+    ],
+];
+
+foreach ($cases as $label => $case) {
+    list($files, $type, $format, $want) = $case;
+    $osid = isset($case[4]) ? $case[4] : 9;
+    list($got, $cmd) = idsFor(
+        fixture(md5($label), $files),
+        $type,
+        $format,
+        $osid
+    );
+    check(
+        sprintf('%s: stream ids are %s', $label, implode(', ', $want)),
+        $want === $got
+    );
+    check(
+        sprintf('%s: one header per udp-sender', $label),
+        count($got) === substr_count($cmd, 'udp-sender')
+    );
+    check(
+        sprintf('%s: no stream is sent unlabeled via --file', $label),
+        false === strpos($cmd, '--file ')
+    );
+}
+
+// --- 3. the payload is unchanged ---------------------------------------
+
+// The header is prepended, never substituted: the image file itself must
+// still be cat'd in whole, or this would fix the naming by breaking the
+// transfer.
+list($ids, $cmd) = idsFor(
+    fixture('payload', ['d1p1.img', 'd1p2.img']),
+    1,
+    5
+);
+check(
+    'each stream still cats its image file after the header',
+    1 === preg_match_all("#; cat '[^']*d1p1\\.img'; \\}#", $cmd)
+    && 1 === preg_match_all("#; cat '[^']*d1p2\\.img'; \\}#", $cmd)
+);
+check(
+    'the header is inside the pipeline feeding udp-sender',
+    (bool)preg_match(
+        "#\\{ printf 'FOGMC1[^}]*\\} \\| /usr/local/sbin/udp-sender#",
+        $cmd
+    ) || (bool)preg_match("#\\{ printf 'FOGMC1[^}]*\\} \\| \\S*udp-sender#", $cmd)
+);
+
+// --- 4. the capability is advertised -----------------------------------
+
+// FOS must not strip 128 bytes off a server that does not prepend them, so
+// it probes for this token before trusting the header. Without the token
+// on this side the check is dead and the desync is back.
+$caps = file_get_contents(
+    dirname(__DIR__) . '/packages/web/service/getversion.php'
+);
+check(
+    'getversion.php advertises the mcstreamid capability',
+    (bool)preg_match("#\\\$ver = '[^']*\\bmcstreamid\\b[^']*';#", $caps)
+);
+
+// --- report ------------------------------------------------------------
+
+$dir = sys_get_temp_dir() . '/fogmcid-' . getmypid();
+exec('rm -rf ' . escapeshellarg($dir));
+
+if (count($failures)) {
+    fwrite(STDERR, sprintf("FAIL (%d of %d)\n", count($failures), $checks));
+    foreach ($failures as $failure) {
+        fwrite(STDERR, "  - $failure\n");
+    }
+    exit(1);
+}
+fwrite(STDOUT, "PASS ($checks checks)\n");
+exit(0);


### PR DESCRIPTION
Server half of the fix for #1742. Client half is **FOGProject/fos#178** — see
**Ordering**.

## The bug

udpcast carries no metadata. `getCMD()` chains one `udp-sender` per image file
on a shared portbase, FOS opens one `udp-receiver` per file it expects, and
the Nth receiver gets the Nth stream. The glob-expansion comment in this very
method has said so for a while — *"the on-the-wire order, the only thing
keeping the receivers in sync"*.

Nothing detected the two sides disagreeing. A client that reboots mid-session,
or whose receiver opens after a sender has already stopped waiting for it,
lands one stream out of step and every partition after that is restored from
the wrong image.

partclone objects only when the target partition is **smaller** than the
source. In the reported run partition 3's image (135 MB MSR) was caught on its
way onto partition 2 (105 MB EFI) — but only *after* partition 2's had gone
silently onto partition 1, because that target was 300 MB. **A larger target
means the wrong filesystem is written and the deploy reports success.**

That check cannot simply be tightened: for a resizable image a target larger
than the source is legitimate and routine. The comparison that would mean
something is against the size the partition had in the *image*, and nothing on
the wire said which partition that was.

## What this does

Each stream is introduced by a fixed 128-byte record naming its image file, so
FOS can refuse a stream that is not the one it asked for before the target is
touched.

Consequence worth flagging: the single-file case now goes in on **stdin** like
the multi-chunk one, instead of passing `--file`. `udp-sender` reads stdin when
given no `--file` — which the split path has relied on since #898.

## Naming, and why it is decided where it is

The id is decided in the branch that already knows the answer, not re-derived
from a filename afterward, because the rule is not uniform:

| Files on the wire | Layout | Id |
|---|---|---|
| `d1p2.img` | flat partition | `d1p2.img` |
| `d1p1.img.000`, `.001` | split chunks, one partition | `d1p1.img` |
| `d1p2.img.000` | split, one chunk | `d1p2.img` |
| `sys.img.000`, `.001` | **one** partition | `sys.img` |
| `rec.img.000` / `.001` | **two** partitions | `rec.img.000` |

A stream carrying several files is named by the stem they share — which is
exactly what the client's own glob (`d1p1.img*`, `sys.img.*`) collapses to.
The sys/rec asymmetry is FOS's own, and this method already mirrors it when
deciding what to concatenate (#897).

Both sides therefore reach the same string from their own layout, and neither
counts the other's streams. **That is why this is not per-stream ports**, which
was the obvious structural fix: it would make FOS re-derive the same stream
index the server used, and for split and per-LV images that index is not the
partition number — the re-derivation fos ADR-0007 refused, on the grounds that
a divergence there is not a crash but a silent data-placement bug. Per-stream
ports also multiply the per-session port budget, which has to move in lockstep
with the installer's firewall range (`mcastportmin`/`mcastportmax`) and
`MulticastSession::defaultPortPool()` or multicast breaks on any firewalled
server. Full reasoning in fos `docs/adr/0018`.

`getversion.php` advertises `mcstreamid` beside `mclvm`; FOS strips the header
only when it sees that token, because a server that does not prepend one must
not have 128 bytes taken off its payload.

## Verification

`tests/multicast-streams-are-self-identifying.test.php` — 21 checks. It drives
the **real** `getCMD()` over fixture image directories (flat, split, split with
a single chunk, and both legacy sys/rec layouts) and pins the ids, the header
width, that no stream escapes unlabeled via `--file`, and that the payload is
still `cat`'d in whole. Six mutations each fail it:

- the single-file path reverted to `--file`
- `_streamStem()` no longer stripping the chunk suffix
- the stem wrongly applied to `rec.img.NNN`
- the header width shrunk
- the `mcstreamid` token withdrawn
- the payload dropped, header only

The first draft of that test expected the legacy ids in the wrong order —
`natcasesort()` puts `rec` before `sys`, which is also the order FOS restores
them in. The code was right; the expectation was not, and it is pinned now.

**Against real udpcast**, feeding this command's own emitted output into FOS's
check over a loopback:

| Case | Result |
|---|---|
| flat partition asked for by name | accepted, payload sha256-identical after the header |
| split partition asked for by glob | accepted, payload sha256-identical (both chunks) |
| partition 3's stream offered to partition 2 | refused, names the desync |

Local: full suite 348 passed / 0 failed, both phpstan passes `[OK] No errors`,
`us-spelling` clean over 990 files.

## Ordering

The header is sent unconditionally, so FOGProject/fos#178 **ships with this,
not after it**. An old FOS against a new server feeds 128 bytes into the
decompressor and fails there — a clean failure rather than corruption, which
is the property that matters — and in practice FOS is served by the server it
is talking to.

## Known gap

This detects, it does not prevent: a desynced client still ends its deploy with
an error rather than a correct image. Refusing a client that tries to join a
session already past its first stream would remove the common trigger, and is
deliberately not in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A767exFmz6sQUcuZofqE1V