### PR TITLE
The stream header width belongs to the record version

### DIFF
--- a/packages/web/src/Service/MulticastTask.php
+++ b/packages/web/src/Service/MulticastTask.php
@@ -243,6 +243,13 @@ class MulticastTask extends FOGService
      * Byte width of STREAM_HEADER_FORMAT once expanded. FOS reads exactly
      * this many bytes, so the two must move together.
      *
+     * The width belongs to the record VERSION, because nothing on the wire
+     * carries it: a FOGMC1 record is 128 bytes, on this side and on FOS's.
+     * So changing the width means changing the magic as well. A client that
+     * meets a version it does not read refuses and names it; one that meets
+     * an unannounced width reads the wrong number of bytes and fails
+     * somewhere inside the decompressor instead. fos issue #179.
+     *
      * @var int
      */
     const STREAM_HEADER_BYTES = 128;

--- a/tests/multicast-streams-are-self-identifying.test.php
+++ b/tests/multicast-streams-are-self-identifying.test.php
@@ -241,8 +241,21 @@ function idsFor($dir, $type, $format, $osid = 9)
 $headerBytes = constant('FOG\\Service\\MulticastTask::STREAM_HEADER_BYTES');
 /** @var string $headerFormat */
 $headerFormat = constant('FOG\\Service\\MulticastTask::STREAM_HEADER_FORMAT');
+/*
+ * THE CONTRACT WITH FOS. Nothing on the wire carries the width, so a
+ * FOGMC1 record is 128 bytes on both sides by agreement and by nothing
+ * else. Pinned as a PAIR, not as a number: if you are here because this
+ * failed, bump the magic too, in this constant and in FOS's
+ * checkStreamIdentity(). An old client then refuses FOGMC2 by name instead
+ * of reading the wrong number of bytes off a record it cannot frame.
+ * fos issue #179.
+ */
 check(
-    'STREAM_HEADER_BYTES is 128',
+    'the record magic is FOGMC1',
+    0 === strpos($headerFormat, 'FOGMC1 ')
+);
+check(
+    'a FOGMC1 record is 128 bytes -- change the width, change the magic',
     128 === $headerBytes
 );
 check(


### PR DESCRIPTION
Server half of FOGProject/fos#179. Client half is FOGProject/fos#180.

### The problem

The multicast identity header is 128 bytes. That number lived in `STREAM_HEADER_FORMAT` and `STREAM_HEADER_BYTES` here, and again as a `dd bs=1 count=128` in FOS. Nothing on the wire carries the width, so the two sides cannot negotiate it, and no check compared them. ADR-0018 recorded it as a known gap.

The failure mode was already safe — a mismatched width feeds the decompressor the wrong bytes and the deploy fails — but it fails a long way from its cause.

### The fix

Make the width a property of the record version. **A `FOGMC1` record is 128 bytes, and nothing else.**

`tests/multicast-streams-are-self-identifying.test.php` now pins the **pair** rather than the number: the format's magic and the byte width are asserted together, with a message that says what to do. FOS pins the same pair on its side. So a width change that keeps the magic fails a check on whichever side changed it.

Changing the width therefore means bumping the magic, and an old client then meets `FOGMC2`, fails its tag test, and names the version it cannot read.

This is deliberately per-repo enforcement. Neither repo has to check the other out and neither CI depends on the other. The FOS harness compares the two directly when both trees sit on one machine, and prints a line when it could not.

### Verification

Mutation-verified — each turns the test red on the named check:

- `STREAM_HEADER_FORMAT` widened to `%-152s` and `STREAM_HEADER_BYTES` to 160, magic unchanged → "a FOGMC1 record is 128 bytes"
- magic bumped to `FOGMC2`, width unchanged → "the record magic is FOGMC1"

Full suite 349 passed / 0 failed. Both phpstan passes clean. us-spelling clean.

### Downstream

None. No route, no schema, no class list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A767exFmz6sQUcuZofqE1V
