### PR TITLE
A task with no transfer data shows no progress text

### DIFF
--- a/packages/web/management/js/fog/task/fog.task.list.js
+++ b/packages/web/management/js/fog/task/fog.task.list.js
@@ -162,6 +162,12 @@
         },
         {
           render: function(data, type, row) {
+            // A task with no transfer data (queued, a snapin task, any
+            // non-imaging task) has nothing to show here -- rendering the
+            // fields anyway reads as "/ of (/min)" with an empty bar.
+            if (!row.dataTotal) {
+              return '';
+            }
             if (data) {
               data = parseInt(data);
             } else {

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -131,7 +131,7 @@ class System
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
         define('FOG_SCHEMA', 436);
-        define('FOG_BCACHE_VER', 365);
+        define('FOG_BCACHE_VER', 366);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/tests/task-progress-cell-empty-without-data.test.php
+++ b/tests/task-progress-cell-empty-without-data.test.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * The active-task progress cell must be blank when there is no transfer data.
+ *
+ * THE FAILURE. The Active Tasks grid's column 8 render (fog.task.list.js)
+ * always builds "timeElapsed / timeRemaining dataCopied of dataTotal
+ * (bpm/min)" plus a progress bar, whatever the task's state. A queued task,
+ * a snapin task, or any other non-imaging task never populates those
+ * transfer fields, so the cell renders literally "/ of (/min)" with an
+ * empty bar instead of nothing. Reported via the forum, screenshotted on
+ * two queued "All Snapins" tasks.
+ *
+ * THE FIX is a guard at the top of the render: when row.dataTotal is
+ * empty/falsy there is no transfer to describe, so the cell returns ''
+ * instead of building the string and the bar.
+ *
+ * WHAT THIS PINS is that the guard runs BEFORE the " of " string is ever
+ * assembled -- so the check has to come first in the render function, not
+ * be layered on after the fact.
+ *
+ * Usage: php tests/task-progress-cell-empty-without-data.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+$root = dirname(__DIR__);
+$failures = [];
+$checks = 0;
+
+function check($what, $ok, &$failures, &$checks)
+{
+    $checks++;
+    if (!$ok) {
+        $failures[] = $what;
+    }
+}
+
+$list = (string) file_get_contents(
+    $root . '/packages/web/management/js/fog/task/fog.task.list.js'
+);
+
+$render = '';
+if (preg_match(
+    '/render: function\(data, type, row\) \{\s*'
+    . '\/\/.*?\n\s*\/\/.*?\n\s*\/\/.*?\n'
+    . '.*?targets: 8/s',
+    $list,
+    $m
+)) {
+    $render = $m[0];
+}
+check(
+    'the column 8 progress-cell render was found',
+    '' !== $render,
+    $failures,
+    $checks
+);
+
+/*
+ * The guard must appear before the ' of ' string is ever built, otherwise
+ * it is dead code sitting after the cell has already been assembled.
+ */
+$guardPos = strpos($render, 'row.dataTotal');
+$ofPos = strpos($render, "' of '");
+check(
+    'row.dataTotal is checked',
+    false !== $guardPos,
+    $failures,
+    $checks
+);
+check(
+    "the ' of ' string is still built for the non-empty case",
+    false !== $ofPos,
+    $failures,
+    $checks
+);
+check(
+    'the dataTotal guard runs BEFORE the " of " string is assembled',
+    false !== $guardPos && false !== $ofPos && $guardPos < $ofPos,
+    $failures,
+    $checks
+);
+check(
+    'the guard returns an empty string, not partial markup',
+    (bool) preg_match(
+        "/if\s*\(\s*!row\.dataTotal\s*\)\s*\{\s*return\s*'';\s*\}/",
+        $render
+    ),
+    $failures,
+    $checks
+);
+
+if (count($failures)) {
+    fwrite(STDERR, 'FAIL (' . count($failures) . " of $checks):\n");
+    foreach ($failures as $f) {
+        fwrite(STDERR, "  - $f\n");
+    }
+    exit(1);
+}
+
+echo "ok  $checks checks passed\n";
+exit(0);


### PR DESCRIPTION
## What / why

The Active Tasks grid's column 8 render (`fog.task.list.js`) always built
`timeElapsed / timeRemaining dataCopied of dataTotal (bpm/min)` plus a
progress bar, whatever the task's state. A queued task, a snapin task, or
any other non-imaging task never populates the transfer fields, so the
cell rendered literally `/ of (/min)` with an empty bar instead of
nothing. A forum reporter's screenshot showed this on two queued "All
Snapins" tasks.

The render now guards on `row.dataTotal`: when it is empty/falsy there is
no transfer to describe, so the cell returns `''` instead of assembling
the string and the bar. Otherwise the output is unchanged.

## Census

Grepped `packages/web/management/js` for the same `' of '` + `'/min)'`
renderer shape and for the field names it depends on
(`dataCopied`/`dataTotal`/`timeElapsed`/`timeRemaining`). Only one copy
exists: `fog.task.list.js` column 8. No other file (host Tasks tab,
dashboard, etc.) needed the same guard.

## Gate test

Added `tests/task-progress-cell-empty-without-data.test.php`, modeled on
`tests/module-state-select-is-legible.test.php`. It pins that the
`row.dataTotal` guard runs before the `' of '` string is assembled.

Proved it's a gate by temporarily removing the guard and re-running:

```
FAIL (5 of 5):
  - the column 8 progress-cell render was found
  - row.dataTotal is checked
  - the ' of ' string is still built for the non-empty case
  - the dataTotal guard runs BEFORE the " of " string is assembled
  - the guard returns an empty string, not partial markup
```

Restored the guard and re-ran:

```
ok  5 checks passed
```

## Other

- `FOG_BCACHE_VER` bumped 365 -> 366 (JS changed).
- Both `phpstan` passes clean, unscoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8UmmbQHjihkSkd3r94Jgw