### PR TITLE
Allow an email address as a username

### DIFF
--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -11792,7 +11792,7 @@ msgstr ""
 msgid "You may not save a filter for everyone"
 msgstr ""
 
-msgid "You may use _, ., -, or a space between."
+msgid "You may use _, ., -, @, or a space between."
 msgstr ""
 
 msgid "You must enable JavaScript to use FOG Management."

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -11800,7 +11800,7 @@ msgstr ""
 msgid "You may not save a filter for everyone"
 msgstr ""
 
-msgid "You may use _, ., -, or a space between."
+msgid "You may use _, ., -, @, or a space between."
 msgstr ""
 
 msgid "You must enable JavaScript to use FOG Management."

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -11959,7 +11959,7 @@ msgstr ""
 msgid "You may not save a filter for everyone"
 msgstr ""
 
-msgid "You may use _, ., -, or a space between."
+msgid "You may use _, ., -, @, or a space between."
 msgstr ""
 
 msgid "You must enable JavaScript to use FOG Management."

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -11793,7 +11793,7 @@ msgstr ""
 msgid "You may not save a filter for everyone"
 msgstr ""
 
-msgid "You may use _, ., -, or a space between."
+msgid "You may use _, ., -, @, or a space between."
 msgstr ""
 
 msgid "You must enable JavaScript to use FOG Management."

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -11785,7 +11785,7 @@ msgstr ""
 msgid "You may not save a filter for everyone"
 msgstr ""
 
-msgid "You may use _, ., -, or a space between."
+msgid "You may use _, ., -, @, or a space between."
 msgstr ""
 
 msgid "You must enable JavaScript to use FOG Management."

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -11471,7 +11471,7 @@ msgstr ""
 msgid "You may not save a filter for everyone"
 msgstr ""
 
-msgid "You may use _, ., -, or a space between."
+msgid "You may use _, ., -, @, or a space between."
 msgstr ""
 
 msgid "You must enable JavaScript to use FOG Management."

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -11428,7 +11428,7 @@ msgstr ""
 msgid "You may not save a filter for everyone"
 msgstr ""
 
-msgid "You may use _, ., -, or a space between."
+msgid "You may use _, ., -, @, or a space between."
 msgstr ""
 
 msgid "You must enable JavaScript to use FOG Management."

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -10148,7 +10148,7 @@ msgstr ""
 msgid "You may not save a filter for everyone"
 msgstr ""
 
-msgid "You may use _, ., -, or a space between."
+msgid "You may use _, ., -, @, or a space between."
 msgstr ""
 
 msgid "You must enable JavaScript to use FOG Management."

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -11788,7 +11788,7 @@ msgstr ""
 msgid "You may not save a filter for everyone"
 msgstr ""
 
-msgid "You may use _, ., -, or a space between."
+msgid "You may use _, ., -, @, or a space between."
 msgstr ""
 
 msgid "You must enable JavaScript to use FOG Management."

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -11788,7 +11788,7 @@ msgstr ""
 msgid "You may not save a filter for everyone"
 msgstr ""
 
-msgid "You may use _, ., -, or a space between."
+msgid "You may use _, ., -, @, or a space between."
 msgstr ""
 
 msgid "You must enable JavaScript to use FOG Management."

--- a/packages/web/src/Items/User.php
+++ b/packages/web/src/Items/User.php
@@ -30,7 +30,10 @@ use FOG\Router\Route;
  */
 class User extends FOGController
 {
-    const PATTERN = '/(?=^.{3,50}$)^(?!.*[_\s\-\.]{2,})[\w0-9][\w0-9\s\-\.]*[\w0-9]$/i';
+    // "@" is allowed so an email address can sign in. The user form accepts
+    // one (UserManagement::USERNAME_REGEX), and an account the form can
+    // create must be one somebody can sign in as.
+    const PATTERN = '/(?=^.{3,50}$)^(?!.*[_\s\-\.]{2,})[\w0-9][\w0-9\s\-\.@]*[\w0-9]$/i';
     /**
      * A session established by presenting a local password.
      *

--- a/packages/web/src/Pages/UserManagement.php
+++ b/packages/web/src/Pages/UserManagement.php
@@ -39,6 +39,17 @@ class UserManagement extends FOGPage
      */
     public $node = 'user';
     /**
+     * What a username may look like on the add and edit forms.
+     *
+     * One copy, because the browser and the server both enforce it: the
+     * forms render it into beRegexTo and the POST handlers preg_match it.
+     * "@" is allowed so that an email address can be a username. Identity
+     * providers commonly send one as the username claim.
+     *
+     * @var string
+     */
+    const USERNAME_REGEX = '(?=^.{3,50}$)^(?!.*[_\s\-\.]{2,})[A-Za-z\d][\w\s\-\.@]*[A-Za-z\d]$';
+    /**
      * Initializes the user class.
      *
      * @param string $name The name to load this as.
@@ -112,13 +123,13 @@ class UserManagement extends FOGPage
                 3,
                 50,
                 'beRegexTo="'
-                . '(?=^.{3,50}$)^(?!.*[_\s\-\.]{2,})[A-Za-z\d][\w\s\-\.]*[A-Za-z\d]$"'
+                . self::USERNAME_REGEX . '"'
                 . ' requirements="'
                 . _('Username must begin with 2 numbers or letters.')
                 . ' '
                 . _('Username must end with a number or letter.')
                 . ' '
-                . _('You may use _, ., -, or a space between.')
+                . _('You may use _, ., -, @, or a space between.')
                 . ' '
                 . _('It must be between 3 and 50 characters.')
                 . '"'
@@ -294,12 +305,12 @@ class UserManagement extends FOGPage
         self::checkAuthAndCSRF();
         header('Content-type: application/json');
         self::$HookManager->processEvent('USER_ADD_POST');
-        $userPat = "/(?=^.{3,50}$)^(?!.*[_\s\-\.]{2,})[A-Za-z\d][\w\s\-\.]*[A-Za-z\d]$/";
+        $userPat = '/' . self::USERNAME_REGEX . '/';
         $userErr =  _('Username must begin with 2 numbers or letters.')
             . ' '
             . _('Username must end with a number or letter.')
             . ' '
-            . _('You may use _, ., -, or a space between.')
+            . _('You may use _, ., -, @, or a space between.')
             . ' '
             . _('It must be between 3 and 50 characters.');
         $user = strtolower(
@@ -433,13 +444,13 @@ class UserManagement extends FOGPage
                 3,
                 50,
                 'beRegexTo="'
-                . '(?=^.{3,50}$)^(?!.*[_\s\-\.]{2,})[A-Za-z\d][\w\s\-\.]*[A-Za-z\d]$"'
+                . self::USERNAME_REGEX . '"'
                 . ' requirements="'
                 . _('Username must begin with 2 numbers or letters.')
                 . ' '
                 . _('Username must end with a number or letter.')
                 . ' '
-                . _('You may use _, ., -, or a space between.')
+                . _('You may use _, ., -, @, or a space between.')
                 . ' '
                 . _('It must be between 3 and 50 characters.')
                 . '"'
@@ -610,12 +621,12 @@ class UserManagement extends FOGPage
     public function userGeneralPost()
     {
         self::checkAuthAndCSRF();
-        $userPat = "/(?=^.{3,50}$)^(?!.*[_\s\-\.]{2,})[A-Za-z\d][\w\s\-\.]*[A-Za-z\d]$/";
+        $userPat = '/' . self::USERNAME_REGEX . '/';
         $userErr =  _('Username must begin with 2 numbers or letters.')
             . ' '
             . _('Username must end with a number or letter.')
             . ' '
-            . _('You may use _, ., -, or a space between.')
+            . _('You may use _, ., -, @, or a space between.')
             . ' '
             . _('It must be between 3 and 50 characters.');
         $user = strtolower(
@@ -629,8 +640,12 @@ class UserManagement extends FOGPage
         if (!preg_match($userPat, $user)) {
             throw new \Exception($userErr);
         }
+        // Pass this account's own id, so the check cannot find this row.
+        // The name is lowercased above and uName compares case-insensitively,
+        // so a mixed-case name such as an IdP's "Rahman@Example.com" matched
+        // itself, and no save of that account could succeed.
         $exists = (new UserManager())
-            ->exists($user);
+            ->exists($user, $this->obj->get('id'));
         if ($user != $this->obj->get('name')
             && $exists
         ) {

--- a/tests/username-allows-email-address.test.php
+++ b/tests/username-allows-email-address.test.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * A username may be an email address, and an account can be saved under it.
+ *
+ * Reported on the forum (topic 18239): an OIDC provider sends the email
+ * address as the username claim. Just-in-time provisioning creates the
+ * account with that name, because it writes the row directly. Every later
+ * save of the account then failed, because the user form refused "@". An
+ * admin could not pre-create the account either, for the same reason.
+ *
+ * WHAT IS PINNED, and the failure each one catches:
+ *
+ *  1. The form rule accepts an email address, and still refuses what it
+ *     refused before: a leading or trailing separator, a doubled separator,
+ *     a name too short, a character outside the set.
+ *  2. The login rule (User::PATTERN) accepts the same names. Without it an
+ *     admin can create "bob@example.com" and nobody can sign in as it.
+ *  3. The form rule exists once. It was four literal copies -- two in the
+ *     rendered beRegexTo attributes, two in the POST handlers -- so a fix to
+ *     one copy left the browser and the server disagreeing.
+ *  4. userGeneralPost() excludes the account's own row from the duplicate
+ *     check. The form lowercases the name, and users.uName compares
+ *     case-insensitively, so an IdP name such as "Rahman@Example.com" found
+ *     ITSELF and every save answered "A user already exists with this name".
+ *     This one is a source check: the collation lives in MySQL, which no
+ *     test here has.
+ *
+ * Usage: php tests/username-allows-email-address.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('username-allows-email-address');
+
+$t = new FogChecks();
+
+$pageFile = dirname(__DIR__) . '/packages/web/src/Pages/UserManagement.php';
+$pageSrc = file_get_contents($pageFile);
+$strip = function ($src) {
+    $src = preg_replace('#/\*.*?\*/#s', '', $src);
+    return preg_replace('#(^|\s)//[^\n]*#', '$1', $src);
+};
+$code = $strip($pageSrc);
+
+$accept = [
+    'rahman@example.com',
+    'first.last@uni.edu.tr',
+    'fog',
+    'john doe',
+    'a_b-c',
+];
+$reject = [
+    '@example.com',
+    'rahman@',
+    'ab',
+    'a..b',
+    'bad!name',
+];
+
+// ---------------------------------------------------------------------------
+// 1. The form rule.
+// ---------------------------------------------------------------------------
+$formRule = defined('\FOG\Pages\UserManagement::USERNAME_REGEX')
+    ? '/' . \FOG\Pages\UserManagement::USERNAME_REGEX . '/'
+    : null;
+$t->check('UserManagement::USERNAME_REGEX is defined', null !== $formRule);
+foreach ($accept as $name) {
+    $t->check(
+        "the form rule accepts '$name'",
+        null !== $formRule && 1 === preg_match($formRule, $name)
+    );
+}
+foreach ($reject as $name) {
+    $t->check(
+        "the form rule still refuses '$name'",
+        null !== $formRule && 0 === preg_match($formRule, $name)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. The login rule.
+// ---------------------------------------------------------------------------
+foreach (['rahman@example.com', 'Rahman@Example.com'] as $name) {
+    $t->check(
+        "User::PATTERN accepts '$name'",
+        1 === preg_match(\FOG\Items\User::PATTERN, $name)
+    );
+}
+foreach (['@example.com', 'bad!name'] as $name) {
+    $t->check(
+        "User::PATTERN still refuses '$name'",
+        0 === preg_match(\FOG\Items\User::PATTERN, $name)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. One copy of the form rule.
+// ---------------------------------------------------------------------------
+$t->check(
+    'the username regex is written out once, in the constant',
+    1 === substr_count($code, '[A-Za-z\d][\w\s\-\.')
+);
+$t->check(
+    'both forms and both POST handlers read USERNAME_REGEX',
+    4 === substr_count($code, 'self::USERNAME_REGEX')
+);
+
+// ---------------------------------------------------------------------------
+// 4. The duplicate check on edit skips the account being edited.
+// ---------------------------------------------------------------------------
+$body = '';
+if (preg_match(
+    '/function userGeneralPost\(\).*?\n    }\n/s',
+    $code,
+    $m
+)) {
+    $body = $m[0];
+}
+$t->check('UserManagement::userGeneralPost() is found', '' !== $body);
+$t->check(
+    "userGeneralPost() passes the account's own id to exists()",
+    (bool)preg_match(
+        '/->exists\(\s*\$user\s*,\s*\$this->obj->get\(\'id\'\)\s*\)/',
+        $body
+    )
+);
+
+$t->finish();


### PR DESCRIPTION
## Problem
An OIDC provider often sends the email address as the username claim. Just-in-time provisioning creates the account with that name. The user form then refuses every save of that account, because the username rule does not allow `@`. An admin also cannot create the account by hand. Reported at https://forums.fogproject.org/topic/18239 (problem 1 of 2).

## Cause
- The form rule `[A-Za-z\d][\w\s\-\.]*[A-Za-z\d]` has no `@`. The rule had four literal copies: two `beRegexTo` attributes and two POST handlers.
- `User::PATTERN`, the login rule, also has no `@`.
- `userGeneralPost()` lowercases the name and calls `exists($user)` with no id. `uName` compares case-insensitively. So a mixed-case name such as `Rahman@Example.com` matches its own row, and the save fails with "A user already exists with this name".

## Change
- `UserManagement::USERNAME_REGEX` holds the form rule once, with `@` added. Both forms and both POST handlers read it.
- `User::PATTERN` allows `@`, so an account the form creates can sign in.
- `userGeneralPost()` passes the account id to `exists()`.

## Not in this PR
- Problem 2 of the forum post: delete re-authentication refuses an OIDC-provisioned account, because it has no local password. That is an auth design change, and it gets its own PR.
- `users.uName` is `VARCHAR(40)`, but the form rule allows 50 characters.

## Verification
- `tests/username-allows-email-address.test.php`: 16 of 19 checks fail on the base, and 19 of 19 pass with the change.
- `tests/apionly-password-and-validation.test.php` and `tests/user-password-tab-local-only.test.php` pass.
- Both phpstan passes report no errors.
- Live check on the 1.6 lab, before and after the change:

| Case | Base | This PR |
|---|---|---|
| Update `claude.oidc@example.com` (created through REST) | 400, username rule error | 202, "User updated!" |
| Update `Claude.Mixed@Example.com` | 400, username rule error | 202, saved as lowercase, no "already exists" |
| Create `claude.new@example.com` in the UI | 400, username rule error | 201, "User added!" |
| Create `@bad.example.com` | refused | still refused |
| Create `ab` | refused | still refused |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kd8mRPpMPXsCgXwhH4Xzu

