### PR TITLE
Delete asks for confirmation, not a password

### DIFF
--- a/packages/web/commons/schema.php
+++ b/packages/web/commons/schema.php
@@ -11750,3 +11750,14 @@ $this->schema[] = [
     . ")",
     "UPDATE `multicastSessions` SET `msState` = 5 WHERE `msState` IS NULL",
 ];
+
+// 437
+$this->schema[] = [
+    // Delete asks for confirmation, not a password (forum topic 18239).
+    // FOG_REAUTH_ON_DELETE made every bulk delete re-enter the account
+    // password, which an account created by an identity provider does not
+    // have. FOG_REAUTH_ON_EXPORT had no code reading it at all.
+    "DELETE FROM `globalSettings` WHERE `settingKey` IN ("
+    . "'FOG_REAUTH_ON_DELETE',"
+    . "'FOG_REAUTH_ON_EXPORT')",
+];

--- a/packages/web/management/js/fog/fog.common.js
+++ b/packages/web/management/js/fog/fog.common.js
@@ -668,8 +668,7 @@ if (document.readyState === 'loading') {
   fogBindTimezonePicker();
 }
 
-var shouldReAuth,
-  reAuthModal,
+var deleteConfirmModal,
   deleteConfirmButton,
   deleteLang,
   // Per-column filtering, on every table that carries a button toolbar.
@@ -1230,14 +1229,14 @@ $.deleteAssociated = function(table, url, cb, opts) {
 // opts.modal      - confirm modal, when the page's own #deleteModal is not it.
 // opts.confirmSel - that modal's confirm button.
 // opts.noun       - what the confirm button should say is being deleted.
-//                   The last three are passed straight through to $.reAuth;
+//                   The last three are passed straight through to $.confirmDelete;
 //                   see the note there for why a page can need them.
 $.deleteSelected = function(table, cb, opts) {
   opts = opts || {};
   opts = $.fogDefaults(opts, {
     node: Common.node,
     rows: table.rows({selected: true}),
-    password: undefined
+    confirmed: false
   });
   opts = $.fogDefaults(opts, {
     ids: opts.rows.ids().toArray(),
@@ -1263,7 +1262,6 @@ $.deleteSelected = function(table, cb, opts) {
   $('#andHosts').trigger('change');
 
   var ajaxOpts = {
-    fogguipass: opts.password,
     confirmdel: 1,
     remitems: opts.ids,
     andHosts: 'andHosts' in opts ? 1 : 0,
@@ -1272,18 +1270,19 @@ $.deleteSelected = function(table, cb, opts) {
 
   var numItems = ajaxOpts.remitems.length;
 
-  // If we know in advance that the user should reauth,
-  // prompt them with a modal to do so instead of wasting
-  // an API call
-  if (opts.password === undefined && shouldReAuth) {
-    $.reAuth(numItems, function(err, password) {
+  // Always confirm first, whatever the settings. The dialog names how many
+  // items go, and that is the check that somebody meant to delete them. It
+  // used to be a password prompt shown only when FOG_REAUTH_ON_DELETE was
+  // on, so with the setting off a bulk delete ran on the first click.
+  if (!opts.confirmed) {
+    $.confirmDelete(numItems, function(err) {
       if (err) {
         if (cb && typeof(cb) === 'function') {
           cb(err);
         }
         return;
       }
-      opts.password = password;
+      opts.confirmed = true;
       $.deleteSelected(table, cb, opts);
     }, {
       modal: opts.modal,
@@ -1303,32 +1302,17 @@ $.deleteSelected = function(table, cb, opts) {
         if (table !== undefined) {
           table.draw(false);
         }
-        $.finishReAuth(opts.modal || reAuthModal);
+        $.finishConfirmDelete(opts.modal || deleteConfirmModal);
         $.notifyFromAPI(res, false);
         if (cb && typeof(cb) === 'function') {
           cb(null,res);
         }
       },
       error: function(res) {
-        if (res.status == 401) {
-          $.notifyFromAPI(res.responseJSON, res);
-          $.reAuth(numItems, function(err, password) {
-            if (err) {
-              if (cb && typeof(cb) === 'function') {
-                cb(err,res.responseJSON);
-              }
-              return;
-            }
-            opts.password = password;
-            $.deleteSelected(table, cb, opts);
-          });
-          return;
-        } else {
-          $.finishReAuth(opts.modal || reAuthModal);
-          $.notifyFromAPI(res.responseJSON, res);
-          if (cb && typeof(cb) === 'function') {
-            cb(res,res.responseJSON);
-          }
+        $.finishConfirmDelete(opts.modal || deleteConfirmModal);
+        $.notifyFromAPI(res.responseJSON, res);
+        if (cb && typeof(cb) === 'function') {
+          cb(res,res.responseJSON);
         }
       }
     });
@@ -2855,7 +2839,7 @@ $.notifyFromAPI = function(res, isError) {
   $.debugLog(res);
 };
 // opts.modal      - the confirm modal (default '#deleteModal', resolved once
-//                   at page load into reAuthModal).
+//                   at page load into deleteConfirmModal).
 // opts.confirmSel - its confirm button (default '#confirmDeleteModal').
 // opts.noun       - what is being deleted, for the button text. Defaults to
 //                   Common.node, which is the page's entity -- wrong for any
@@ -2864,14 +2848,16 @@ $.notifyFromAPI = function(res, isError) {
 // Parameterized because a page can carry more than one deletable grid. The
 // Bearer API token card sits on the USER edit page, whose own #deleteModal
 // deletes the account: sharing it meant the confirm read "Delete 1 users",
-// the password field the token delete needs was not in that modal at all,
 // and -- worst -- deleteConfirmButton.off('click') below tore the General
 // tab's delete-user handler off, leaving that button dead until a reload.
 // $.registerGeneralTab already parameterizes exactly these two selectors;
 // this follows it.
-$.reAuth = function(count, cb, opts) {
+//
+// It asks for confirmation, not a password. It was $.reAuth, a password
+// prompt, and an account from an identity provider has no password to type.
+$.confirmDelete = function(count, cb, opts) {
   opts = opts || {};
-  var modal = opts.modal ? $(opts.modal) : reAuthModal,
+  var modal = opts.modal ? $(opts.modal) : deleteConfirmModal,
     confirmBtn = opts.confirmSel ? $(opts.confirmSel) : deleteConfirmButton,
     // deleteLang is captured once at load from the default button. A custom
     // one carries its own template, so read it the first time and stash it
@@ -2880,45 +2866,26 @@ $.reAuth = function(count, cb, opts) {
       ? (confirmBtn.data('reauthLang')
         || confirmBtn.data('reauthLang', confirmBtn.text()).data('reauthLang'))
       : deleteLang,
-    noun = opts.noun || Common.node,
-    // Scoped to the modal: two of these on one page means two #deletePassword
-    // inputs, and a document-wide lookup reads whichever came first.
-    pw = modal.find('input[type="password"]').first();
+    noun = opts.noun || Common.node;
 
   confirmBtn.text(lang.replace('{0}', count).replace('{node}', noun + (count != 1 ? 's' : '')));
-  // enable all buttons / focus on the input box incase
-  //   the modal is already being shown
+  // enable all buttons in case the modal is already being shown
   modal.setContainerDisable(false);
-  pw.trigger('focus');
   modal.registerModal(
     // On show
     function(e) {
-      pw.val('');
-      pw.trigger('focus');
       modal.setContainerDisable(false);
     },
     // On close
     function(e) {
-      pw.val('');
-      cb('authClose');
+      cb('closed');
     }
   );
-  // The auth modal is not a form, so
-  //   the enter key must be manually bound
-  //   to submit the password
-  pw.off('keypress');
-  pw.keypress(function (e) {
-    if (e.which == 13) {
-      modal.setContainerDisable(true);
-      cb(null, pw.val());
-      return false;
-    }
-  });
 
   confirmBtn.off('click');
   confirmBtn.on('click', function(e) {
     modal.setContainerDisable(true);
-    cb(null, pw.val());
+    cb(null);
   });
   modal.modal('show');
 };
@@ -2937,7 +2904,7 @@ $.cachedScript = function(url, options) {
   // Return the jqXHR object so we can chain callbacks
   return $.ajax(options);
 };
-$.finishReAuth = function(modal) {
+$.finishConfirmDelete = function(modal) {
   $(modal).modal('hide');
 };
 $.mirror = function(start, selector, regex, replace) {
@@ -5145,8 +5112,7 @@ function reinitialize() {
     NodeList.prototype.forEach = Array.prototype.forEach;
   }
   $_GET = getQueryParams();
-  shouldReAuth = ($('#reAuthDelete').val() == '1') ? true : false;
-  reAuthModal = $('#deleteModal');
+  deleteConfirmModal = $('#deleteModal');
   deleteConfirmButton = $('#confirmDeleteModal');
   deleteLang = deleteConfirmButton.text();
   Common = {

--- a/packages/web/management/js/fog/plugin/fog.plugin.list.js
+++ b/packages/web/management/js/fog/plugin/fog.plugin.list.js
@@ -1,7 +1,6 @@
 (function($) {
     var deleteSelected = $('#deleteSelected'),
         deleteModal = $('#deleteModal'),
-        passwordField = $('#deletePassword'),
         confirmDelete = $('#confirmDeleteModal'),
         cancelDelete = $('#closeDeleteModal'),
         numPluginString = confirmDelete.val(),

--- a/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -2091,8 +2091,8 @@ msgid "Confirm Download"
 msgstr "Passwort ändern"
 
 #, fuzzy
-msgid "Confirm password"
-msgstr "Passwort ändern"
+msgid "Confirm delete"
+msgstr "Bestätige Task"
 
 msgid "Confirm that you would like to delete the MAC vendor listing"
 msgstr ""
@@ -10531,6 +10531,10 @@ msgstr ""
 msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
 msgstr ""
 
+#, fuzzy
+msgid "This cannot be undone."
+msgstr "Temporäre Datei konnte nicht gelesen werden."
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -10898,10 +10902,6 @@ msgstr ""
 
 msgid "UEFI, state unreadable"
 msgstr ""
-
-#, fuzzy
-msgid "Unable to Authenticate"
-msgstr "Authentifizieren nicht möglich"
 
 #, fuzzy
 msgid "Unable to connect to SSH"
@@ -13072,6 +13072,10 @@ msgstr ""
 #~ msgstr "Client Einstellungen"
 
 #, fuzzy
+#~ msgid "Confirm password"
+#~ msgstr "Passwort ändern"
+
+#, fuzzy
 #~ msgid "Could not read snapin file"
 #~ msgstr "Snapin-Datei konnte nicht gelesen werden."
 
@@ -13752,6 +13756,10 @@ msgstr ""
 
 #~ msgid "Total Rows"
 #~ msgstr "Zeilen gesamt"
+
+#, fuzzy
+#~ msgid "Unable to Authenticate"
+#~ msgstr "Authentifizieren nicht möglich"
 
 #, fuzzy
 #~ msgid "Unable to find basic information!"

--- a/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -2093,8 +2093,8 @@ msgid "Confirm Download"
 msgstr "Management Password"
 
 #, fuzzy
-msgid "Confirm password"
-msgstr "Management Password"
+msgid "Confirm delete"
+msgstr "Invalid task"
 
 msgid "Confirm that you would like to delete the MAC vendor listing"
 msgstr ""
@@ -10539,6 +10539,10 @@ msgstr ""
 msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
 msgstr ""
 
+#, fuzzy
+msgid "This cannot be undone."
+msgstr "Could not read temp file"
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -10907,10 +10911,6 @@ msgstr ""
 
 msgid "UEFI, state unreadable"
 msgstr ""
-
-#, fuzzy
-msgid "Unable to Authenticate"
-msgstr "Error contacting server"
 
 #, fuzzy
 msgid "Unable to connect to SSH"
@@ -13069,6 +13069,10 @@ msgstr ""
 #~ msgstr "Settings"
 
 #, fuzzy
+#~ msgid "Confirm password"
+#~ msgstr "Management Password"
+
+#, fuzzy
 #~ msgid "Could not read snapin file"
 #~ msgstr "Could not read tmp file."
 
@@ -13719,6 +13723,10 @@ msgstr ""
 
 #~ msgid "Total Rows"
 #~ msgstr "Total Rows"
+
+#, fuzzy
+#~ msgid "Unable to Authenticate"
+#~ msgstr "Error contacting server"
 
 #, fuzzy
 #~ msgid "Unable to find basic information!"

--- a/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2114,8 +2114,8 @@ msgid "Confirm Download"
 msgstr "La gestión de contraseñas"
 
 #, fuzzy
-msgid "Confirm password"
-msgstr "La gestión de contraseñas"
+msgid "Confirm delete"
+msgstr "tarea no válido"
 
 msgid "Confirm that you would like to delete the MAC vendor listing"
 msgstr ""
@@ -10698,6 +10698,10 @@ msgstr ""
 msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
 msgstr ""
 
+#, fuzzy
+msgid "This cannot be undone."
+msgstr "No se pudo leer el archivo temporal"
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -11060,10 +11064,6 @@ msgstr ""
 
 msgid "UEFI, state unreadable"
 msgstr ""
-
-#, fuzzy
-msgid "Unable to Authenticate"
-msgstr "servidor de ponerse en contacto con el error"
 
 #, fuzzy
 msgid "Unable to connect to SSH"
@@ -13222,6 +13222,10 @@ msgstr ""
 #~ msgstr "Configuración Tecla"
 
 #, fuzzy
+#~ msgid "Confirm password"
+#~ msgstr "La gestión de contraseñas"
+
+#, fuzzy
 #~ msgid "Could not read snapin file"
 #~ msgstr "No se pudo leer el archivo tmp."
 
@@ -13863,6 +13867,10 @@ msgstr ""
 
 #~ msgid "Total Rows"
 #~ msgstr "Filas totales"
+
+#, fuzzy
+#~ msgid "Unable to Authenticate"
+#~ msgstr "servidor de ponerse en contacto con el error"
 
 #, fuzzy
 #~ msgid "Unable to find basic information!"

--- a/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/eu_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2091,8 +2091,8 @@ msgid "Confirm Download"
 msgstr "Passwort ändern"
 
 #, fuzzy
-msgid "Confirm password"
-msgstr "Passwort ändern"
+msgid "Confirm delete"
+msgstr "Bestätige Task"
 
 msgid "Confirm that you would like to delete the MAC vendor listing"
 msgstr ""
@@ -10532,6 +10532,10 @@ msgstr ""
 msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
 msgstr ""
 
+#, fuzzy
+msgid "This cannot be undone."
+msgstr "Temporäre Datei konnte nicht gelesen werden."
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -10899,10 +10903,6 @@ msgstr ""
 
 msgid "UEFI, state unreadable"
 msgstr ""
-
-#, fuzzy
-msgid "Unable to Authenticate"
-msgstr "Authentifizieren nicht möglich"
 
 #, fuzzy
 msgid "Unable to connect to SSH"
@@ -13073,6 +13073,10 @@ msgstr ""
 #~ msgstr "Client Einstellungen"
 
 #, fuzzy
+#~ msgid "Confirm password"
+#~ msgstr "Passwort ändern"
+
+#, fuzzy
 #~ msgid "Could not read snapin file"
 #~ msgstr "Snapin-Datei konnte nicht gelesen werden."
 
@@ -13753,6 +13757,10 @@ msgstr ""
 
 #~ msgid "Total Rows"
 #~ msgstr "Zeilen gesamt"
+
+#, fuzzy
+#~ msgid "Unable to Authenticate"
+#~ msgstr "Authentifizieren nicht möglich"
 
 #, fuzzy
 #~ msgid "Unable to find basic information!"

--- a/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2095,8 +2095,8 @@ msgid "Confirm Download"
 msgstr "gestion Mot de passe"
 
 #, fuzzy
-msgid "Confirm password"
-msgstr "gestion Mot de passe"
+msgid "Confirm delete"
+msgstr "tâche non valide"
 
 msgid "Confirm that you would like to delete the MAC vendor listing"
 msgstr ""
@@ -10523,6 +10523,10 @@ msgstr ""
 msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
 msgstr ""
 
+#, fuzzy
+msgid "This cannot be undone."
+msgstr "Impossible de lire le fichier temporaire"
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -10891,10 +10895,6 @@ msgstr ""
 
 msgid "UEFI, state unreadable"
 msgstr ""
-
-#, fuzzy
-msgid "Unable to Authenticate"
-msgstr "Erreur serveur contactant"
 
 #, fuzzy
 msgid "Unable to connect to SSH"
@@ -13054,6 +13054,10 @@ msgstr ""
 #~ msgstr "Paramètres"
 
 #, fuzzy
+#~ msgid "Confirm password"
+#~ msgstr "gestion Mot de passe"
+
+#, fuzzy
 #~ msgid "Could not read snapin file"
 #~ msgstr "Impossible de lire le fichier tmp."
 
@@ -13708,6 +13712,10 @@ msgstr ""
 
 #~ msgid "Total Rows"
 #~ msgstr "Nombre de lignes"
+
+#, fuzzy
+#~ msgid "Unable to Authenticate"
+#~ msgstr "Erreur serveur contactant"
 
 #, fuzzy
 #~ msgid "Unable to find basic information!"

--- a/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/it_IT.UTF-8/LC_MESSAGES/messages.po
@@ -2043,8 +2043,8 @@ msgid "Confirm Download"
 msgstr "Cambia password"
 
 #, fuzzy
-msgid "Confirm password"
-msgstr "Cambia password"
+msgid "Confirm delete"
+msgstr "Conferma il task"
 
 msgid "Confirm that you would like to delete the MAC vendor listing"
 msgstr ""
@@ -10243,6 +10243,10 @@ msgstr ""
 msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
 msgstr ""
 
+#, fuzzy
+msgid "This cannot be undone."
+msgstr "Impossibile leggere il file temporaneo"
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -10601,10 +10605,6 @@ msgstr ""
 
 msgid "UEFI, state unreadable"
 msgstr ""
-
-#, fuzzy
-msgid "Unable to Authenticate"
-msgstr "Impossibile contattare il server"
 
 #, fuzzy
 msgid "Unable to connect to SSH"
@@ -12696,6 +12696,10 @@ msgstr ""
 #~ msgid "Client Module Settings"
 #~ msgstr "Impostazioni Client"
 
+#, fuzzy
+#~ msgid "Confirm password"
+#~ msgstr "Cambia password"
+
 #~ msgid "Could not read snapin file"
 #~ msgstr "Impossibile leggere il file snapin"
 
@@ -13359,6 +13363,10 @@ msgstr ""
 
 #~ msgid "Total Rows"
 #~ msgstr "Righe totali"
+
+#, fuzzy
+#~ msgid "Unable to Authenticate"
+#~ msgstr "Impossibile contattare il server"
 
 #~ msgid "Unable to find basic information!"
 #~ msgstr "Impossibile trovare informazioni di base!"

--- a/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/ja_JP.UTF-8/LC_MESSAGES/messages.po
@@ -2028,8 +2028,8 @@ msgid "Confirm Download"
 msgstr "FOG クライアントのダウンロード"
 
 #, fuzzy
-msgid "Confirm password"
-msgstr "パスワードを変更"
+msgid "Confirm delete"
+msgstr "タスクを確認"
 
 msgid "Confirm that you would like to delete the MAC vendor listing"
 msgstr ""
@@ -10200,6 +10200,10 @@ msgstr ""
 msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
 msgstr ""
 
+#, fuzzy
+msgid "This cannot be undone."
+msgstr "Windows で使用できます"
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -10558,9 +10562,6 @@ msgstr ""
 
 msgid "UEFI, state unreadable"
 msgstr ""
-
-msgid "Unable to Authenticate"
-msgstr "認証できません"
 
 #, fuzzy
 msgid "Unable to connect to SSH"
@@ -12821,6 +12822,10 @@ msgstr ""
 #~ msgid "Computer Information"
 #~ msgstr "コンピューター情報"
 
+#, fuzzy
+#~ msgid "Confirm password"
+#~ msgstr "パスワードを変更"
+
 #~ msgid "Conflicting path/file"
 #~ msgstr "競合するパス/ファイル"
 
@@ -14639,6 +14644,9 @@ msgstr ""
 
 #~ msgid "UAC introduced in Vista and up"
 #~ msgstr "UAC は Windows Vista 以降で導入されました"
+
+#~ msgid "Unable to Authenticate"
+#~ msgstr "認証できません"
 
 #~ msgid "Unable to find basic information!"
 #~ msgstr "基本情報が見つかりません！"

--- a/packages/web/management/languages/messages.pot
+++ b/packages/web/management/languages/messages.pot
@@ -1816,7 +1816,7 @@ msgstr ""
 msgid "Confirm Download"
 msgstr ""
 
-msgid "Confirm password"
+msgid "Confirm delete"
 msgstr ""
 
 msgid "Confirm that you would like to delete the MAC vendor listing"
@@ -9033,6 +9033,9 @@ msgstr ""
 msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
 msgstr ""
 
+msgid "This cannot be undone."
+msgstr ""
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -9376,9 +9379,6 @@ msgid "U-Boot TFTP sync: %s is not in %s, so a board booting over TFTP cannot fe
 msgstr ""
 
 msgid "UEFI, state unreadable"
-msgstr ""
-
-msgid "Unable to Authenticate"
 msgstr ""
 
 msgid "Unable to connect to SSH"

--- a/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -2094,8 +2094,8 @@ msgid "Confirm Download"
 msgstr "Gerenciamento de senha"
 
 #, fuzzy
-msgid "Confirm password"
-msgstr "Gerenciamento de senha"
+msgid "Confirm delete"
+msgstr "tarefa inválido"
 
 msgid "Confirm that you would like to delete the MAC vendor listing"
 msgstr ""
@@ -10526,6 +10526,10 @@ msgstr ""
 msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
 msgstr ""
 
+#, fuzzy
+msgid "This cannot be undone."
+msgstr "Não foi possível ler arquivo temporário"
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -10894,10 +10898,6 @@ msgstr ""
 
 msgid "UEFI, state unreadable"
 msgstr ""
-
-#, fuzzy
-msgid "Unable to Authenticate"
-msgstr "servidor entrar em contato com erro"
 
 #, fuzzy
 msgid "Unable to connect to SSH"
@@ -13057,6 +13057,10 @@ msgstr ""
 #~ msgstr "Configurações"
 
 #, fuzzy
+#~ msgid "Confirm password"
+#~ msgstr "Gerenciamento de senha"
+
+#, fuzzy
 #~ msgid "Could not read snapin file"
 #~ msgstr "Não foi possível ler o arquivo tmp."
 
@@ -13711,6 +13715,10 @@ msgstr ""
 
 #~ msgid "Total Rows"
 #~ msgstr "total de linhas"
+
+#, fuzzy
+#~ msgid "Unable to Authenticate"
+#~ msgstr "servidor entrar em contato com erro"
 
 #, fuzzy
 #~ msgid "Unable to find basic information!"

--- a/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
+++ b/packages/web/management/languages/zh_CN.UTF-8/LC_MESSAGES/messages.po
@@ -2094,8 +2094,8 @@ msgid "Confirm Download"
 msgstr "管理密码"
 
 #, fuzzy
-msgid "Confirm password"
-msgstr "管理密码"
+msgid "Confirm delete"
+msgstr "任务无效"
 
 msgid "Confirm that you would like to delete the MAC vendor listing"
 msgstr ""
@@ -10526,6 +10526,10 @@ msgstr ""
 msgid "This acts on the hosts that are in the group right now. It is a task, not a grant: a host added afterward is not affected."
 msgstr ""
 
+#, fuzzy
+msgid "This cannot be undone."
+msgstr "无法读取临时文件"
+
 msgid "This change would leave no user with administrator access."
 msgstr ""
 
@@ -10894,10 +10898,6 @@ msgstr ""
 
 msgid "UEFI, state unreadable"
 msgstr ""
-
-#, fuzzy
-msgid "Unable to Authenticate"
-msgstr "服务器连接出错"
 
 #, fuzzy
 msgid "Unable to connect to SSH"
@@ -13057,6 +13057,10 @@ msgstr ""
 #~ msgstr "设置"
 
 #, fuzzy
+#~ msgid "Confirm password"
+#~ msgstr "管理密码"
+
+#, fuzzy
 #~ msgid "Could not read snapin file"
 #~ msgstr "无法读取tmp文件。"
 
@@ -13711,6 +13715,10 @@ msgstr ""
 
 #~ msgid "Total Rows"
 #~ msgstr "共行"
+
+#, fuzzy
+#~ msgid "Unable to Authenticate"
+#~ msgstr "服务器连接出错"
 
 #, fuzzy
 #~ msgid "Unable to find basic information!"

--- a/packages/web/management/other/index.php
+++ b/packages/web/management/other/index.php
@@ -454,7 +454,6 @@ if ($isLoggedIn && \FOG\Auth\Identity::canStart()) : ?>
             </aside>
             <!-- Main Content -->
             <main class="app-main">
-                <?= FOGPage::makeInput('reAuthDelete', 'reAuthDelete', '', 'hidden', 'reAuthDelete', self::getSetting('FOG_REAUTH_ON_DELETE')); ?>
                 <?php
             $pageLength = self::getSetting('FOG_VIEW_DEFAULT_SCREEN');
 if (in_array(strtolower($pageLength), ['search', 'list'])) {

--- a/packages/web/src/Base/FOGBase.php
+++ b/packages/web/src/Base/FOGBase.php
@@ -56,18 +56,6 @@ abstract class FOGBase
      */
     public static $fogpingactive = false;
     /**
-     * Delete auth is active?
-     *
-     * @var bool
-     */
-    public static $fogdeleteactive = false;
-    /**
-     * Export auth is active?
-     *
-     * @var bool
-     */
-    public static $fogexportactive = false;
-    /**
      * The pending macs count.
      *
      * @var int
@@ -4774,41 +4762,6 @@ abstract class FOGBase
                 );
             }
             unset($file);
-        }
-    }
-    /**
-     * Does the work for reauthentication during delete, if needed.
-     *
-     * @return void
-     */
-    public static function checkauth()
-    {
-        if (self::getSetting('FOG_REAUTH_ON_DELETE')) {
-            $user = filter_input(INPUT_POST, 'fogguiuser');
-            if (empty($user)) {
-                $user = self::$FOGUser->get('name');
-            }
-            $pass = filter_input(INPUT_POST, 'fogguipass');
-            // Re-authentication proves a human with valid credentials is
-            // present; it is not a second authorization step. Whether this
-            // deletion is allowed was already decided by the node's delete
-            // permission before we got here.
-            $validate = (new User())
-                ->passwordValidate(
-                    $user,
-                    $pass
-                );
-            if (!$validate) {
-                header('Content-type: application/json');
-                echo json_encode(
-                    [
-                        'error' => self::$foglang['InvalidLogin'],
-                        'title' => _('Unable to Authenticate')
-                    ]
-                );
-                http_response_code(HTTPResponseCodes::HTTP_UNAUTHORIZED);
-                exit;
-            }
         }
     }
     /**

--- a/packages/web/src/Base/FOGCore.php
+++ b/packages/web/src/Base/FOGCore.php
@@ -206,23 +206,17 @@ class FOGCore extends FOGBase
         $getSettings = [
             'FOG_HOST_LOOKUP',
             'FOG_MEMORY_LIMIT',
-            'FOG_REAUTH_ON_DELETE',
-            'FOG_REAUTH_ON_EXPORT',
             'FOG_TZ_INFO',
             'FOG_VIEW_DEFAULT_SCREEN',
         ];
         list(
             $hostLookup,
             $memoryLimit,
-            $authdelete,
-            $authexport,
             $tzInfo,
             $view
         ) = self::getSetting($getSettings);
         self::$defaultscreen = $view;
         self::$fogpingactive = $hostLookup;
-        self::$fogdeleteactive = $authdelete;
-        self::$fogexportactive = $authexport;
         $GLOBALS['TimeZone'] = $tzInfo ?? (ini_get('date.timezone') ?: 'UTC');
         ini_set('max_input_vars', 10000);
         $memorySet = preg_replace('#M#', '', ini_get('memory_limit'));

--- a/packages/web/src/Base/FOGPage.php
+++ b/packages/web/src/Base/FOGPage.php
@@ -2065,17 +2065,10 @@ abstract class FOGPage extends FOGBase
                     $actionbox .= '</div>';
                     $modals .= self::makeModal(
                         'deleteModal',
-                        _('Confirm password'),
-                        '<div class="input-group">'
-                        . self::makeInput(
-                            'form-control',
-                            'deletePW',
-                            _('Password'),
-                            'password',
-                            'deletePassword'
-                        )
-                        . '</div>'
-                        . '<br/>'
+                        _('Confirm delete'),
+                        // Confirmation, not a password: the confirm button
+                        // names how many items go, and that is the check.
+                        '<p>' . _('This cannot be undone.') . '</p>'
                         . (
                             in_array($node, ['snapin', 'image', 'group']) ?
                             self::makeLabel(
@@ -2337,7 +2330,6 @@ abstract class FOGPage extends FOGBase
     public function deletemulti()
     {
         header('Content-type: application/json');
-        self::checkauth();
         $remitems = filter_input_array(
             INPUT_POST,
             [
@@ -3907,10 +3899,7 @@ abstract class FOGPage extends FOGBase
         // CSRF::requireForStateChanging() returns early by design and would
         // never have fired. Every shipped caller already POSTs with a token
         // ($.registerGeneralTab in fog.common.js), so this is transparent to
-        // the UI. Deliberately NOT calling checkauth() here -- the edit-page
-        // delete modal carries no password field, so with the default
-        // FOG_REAUTH_ON_DELETE=1 that would 401 every legitimate delete.
-        // Reported by Aisle Research (064 / 3.25.1).
+        // the UI. Reported by Aisle Research (064 / 3.25.1).
         if ('POST' !== strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET')) {
             header('Content-type: application/json');
             http_response_code(HTTPResponseCodes::HTTP_METHOD_NOT_ALLOWED);

--- a/packages/web/src/Base/System.php
+++ b/packages/web/src/Base/System.php
@@ -130,8 +130,8 @@ class System
         // 1.5.x carried count does, see SchemaReconciler's docstring -- is
         // permanently "up to date" from the updater's point of view and will
         // never run another indexed step, whatever this constant says.
-        define('FOG_SCHEMA', 436);
-        define('FOG_BCACHE_VER', 366);
+        define('FOG_SCHEMA', 437);
+        define('FOG_BCACHE_VER', 367);
         define('FOG_CLIENT_VERSION', '0.13.0');
         // GH-959: iPXE lives in FOGProject/fog-ipxe and its binaries arrive as
         // a release asset. Pinned here rather than tracked as "latest" so a

--- a/packages/web/src/Items/User.php
+++ b/packages/web/src/Items/User.php
@@ -122,14 +122,10 @@ class User extends FOGController
      * Validates the users password and user
      *
      * The $adminTest parameter is gone. It made the credential typed into
-     * the re-authentication prompt (FOG_REAUTH_ON_DELETE) have to belong to
-     * a uType 0 account -- pre-RBAC shorthand for "not a mobile user", back
-     * when FOG had exactly two tiers and the mobile one could not perform a
-     * destructive action anyway. Under roles the tiering is the role's job:
-     * the acting user has already had to pass the node's delete permission
-     * before checkauth() is reached, so re-testing an account type here
-     * decided nothing and would, if translated literally to "must hold '*'",
-     * have newly blocked every scoped role from deleting anything.
+     * the old delete re-authentication prompt belong to a uType 0 account --
+     * pre-RBAC shorthand for "not a mobile user". Under roles the tiering is
+     * the role's job. That prompt is gone too: delete now asks for
+     * confirmation, not a password.
      *
      * @param string $username the username to test
      * @param string $password the password to test

--- a/packages/web/src/Pages/FOGConfigurationPage.php
+++ b/packages/web/src/Pages/FOGConfigurationPage.php
@@ -3792,12 +3792,11 @@ class FOGConfigurationPage extends FOGPage
 
         $modals = '';
         if ($mayDelete) {
-            // The re-auth prompt $.deleteSelected drives when
-            // FOG_DELETE_REAUTH is on. process() builds this for a page
-            // whose sub is 'list' and this pane's is not, so without it
-            // $.reAuth calls modal('show') on an empty jQuery set:
-            // nothing opens, nothing is deleted, nothing is logged, and
-            // the button looks broken rather than gated.
+            // The confirm dialog $.deleteSelected opens before every delete.
+            // process() builds this for a page whose sub is 'list' and this
+            // pane's is not, so without it $.confirmDelete calls
+            // modal('show') on an empty jQuery set: nothing opens, nothing
+            // is deleted, nothing is logged, and the button looks broken.
             // Named for this grid rather than reusing 'deleteModal', so the
             // pane never depends on being the only deletable thing on its
             // page -- the assumption that broke the same card on the user
@@ -3805,16 +3804,8 @@ class FOGConfigurationPage extends FOGPage
             // that id.
             $modals .= self::makeModal(
                 'apitokenDeleteModal',
-                _('Confirm password'),
-                '<div class="input-group">'
-                . self::makeInput(
-                    'form-control',
-                    'apitokenDeletePW',
-                    _('Password'),
-                    'password',
-                    'apitokenDeletePassword'
-                )
-                . '</div>',
+                _('Confirm delete'),
+                '<p>' . _('This cannot be undone.') . '</p>',
                 self::makeButton(
                     'closeAPITokenDeleteModal',
                     _('Cancel'),
@@ -4506,8 +4497,6 @@ class FOGConfigurationPage extends FOGPage
             'FOG_API_ENABLED' => true,
             'FOG_ENABLE_SHOW_PASSWORDS' => true,
             'FOG_IMAGE_LIST_MENU' => true,
-            'FOG_REAUTH_ON_DELETE' => true,
-            'FOG_REAUTH_ON_EXPORT' => true,
             'FOG_LOG_INFO' => true,
             'FOG_LOG_ERROR' => true,
             'FOG_LOG_DEBUG' => true,

--- a/packages/web/src/Pages/HostManagement.php
+++ b/packages/web/src/Pages/HostManagement.php
@@ -285,18 +285,8 @@ class HostManagement extends FOGPage
         );
         $deleteModal = self::makeModal(
             'deleteModal',
-            _('Confirm password'),
-            '<div class="input-group">'
-            . self::makeInput(
-                'form-control',
-                'deletePassword',
-                _('Password'),
-                'password',
-                'deletePassword',
-                '',
-                true
-            )
-            . '</div>',
+            _('Confirm delete'),
+            '<p>' . _('This cannot be undone.') . '</p>',
             $modalDeleteBtns,
             '',
             'danger'
@@ -346,7 +336,6 @@ class HostManagement extends FOGPage
         $remitems = $items['remitems'];
         $pending = $items['pending'];
         if (isset($_POST['confirmdel'])) {
-            self::checkauth();
             Route::deletemass(
                 'host',
                 [
@@ -449,18 +438,8 @@ class HostManagement extends FOGPage
         );
         $deleteModal = self::makeModal(
             'deleteModal',
-            _('Confirm password'),
-            '<div class="input-group">'
-            . self::makeInput(
-                'form-control',
-                'deletePassword',
-                _('Password'),
-                'password',
-                'deletePassword',
-                '',
-                true
-            )
-            . '</div>',
+            _('Confirm delete'),
+            '<p>' . _('This cannot be undone.') . '</p>',
             $modalDeleteBtns,
             '',
             'danger'
@@ -518,7 +497,6 @@ class HostManagement extends FOGPage
         try {
             if (isset($_POST['confirmdel'])) {
                 $errt = _('Delete MAC Fail');
-                self::checkauth();
                 self::$HookManager->processEvent(
                     'MULTI_REMOVE',
                     ['removing' => &$remitems]

--- a/packages/web/src/Pages/RoleManagement.php
+++ b/packages/web/src/Pages/RoleManagement.php
@@ -795,7 +795,6 @@ class RoleManagement extends FOGPage
      */
     public function delete()
     {
-        self::checkauth();
         $this->_guardRoleRemoval([(int)$this->obj->get('id')]);
         parent::delete();
     }
@@ -807,7 +806,6 @@ class RoleManagement extends FOGPage
      */
     public function deletemulti()
     {
-        self::checkauth();
         $remitems = filter_input_array(
             INPUT_POST,
             ['remitems' => ['flags' => FILTER_REQUIRE_ARRAY]]

--- a/packages/web/src/Pages/UserGroupManagement.php
+++ b/packages/web/src/Pages/UserGroupManagement.php
@@ -456,7 +456,6 @@ class UserGroupManagement extends FOGPage
      */
     public function delete()
     {
-        self::checkauth();
         $this->_guardGroupRemoval([(int)$this->obj->get('id')]);
         parent::delete();
     }
@@ -468,7 +467,6 @@ class UserGroupManagement extends FOGPage
      */
     public function deletemulti()
     {
-        self::checkauth();
         $remitems = filter_input_array(
             INPUT_POST,
             ['remitems' => ['flags' => FILTER_REQUIRE_ARRAY]]

--- a/packages/web/src/Pages/UserManagement.php
+++ b/packages/web/src/Pages/UserManagement.php
@@ -1101,31 +1101,22 @@ class UserManagement extends FOGPage
             );
         }
         if ($mayDelete) {
-            // The re-auth prompt $.deleteSelected drives when
-            // FOG_DELETE_REAUTH is on. Without it $.reAuth calls
-            // modal('show') on an empty jQuery set: nothing opens, nothing
-            // is deleted, nothing is logged.
+            // The confirm dialog $.deleteSelected opens before every delete.
+            // Without it $.confirmDelete calls modal('show') on an empty
+            // jQuery set: nothing opens, nothing is deleted, nothing is
+            // logged.
             //
             // Its OWN id, not the shared 'deleteModal'. This page already
             // renders one of those -- the one that deletes the account --
-            // and reusing the id put two of them in the DOM: $.reAuth
-            // resolved the account's, so the confirm read "delete this
-            // user", the password field it needs was not in that modal at
-            // all, and its deleteConfirmButton.off('click') tore the
+            // and reusing the id put two of them in the DOM: the confirm
+            // helper resolved the account's, so the confirm read "delete
+            // this user", and its deleteConfirmButton.off('click') tore the
             // General tab's delete-user handler off for the rest of the
             // page's life.
             $modals .= self::makeModal(
                 'apitokenDeleteModal',
-                _('Confirm password'),
-                '<div class="input-group">'
-                . self::makeInput(
-                    'form-control',
-                    'apitokenDeletePW',
-                    _('Password'),
-                    'password',
-                    'apitokenDeletePassword'
-                )
-                . '</div>',
+                _('Confirm delete'),
+                '<p>' . _('This cannot be undone.') . '</p>',
                 self::makeButton(
                     'closeAPITokenDeleteModal',
                     _('Cancel'),

--- a/tests/apitoken-grid-and-scope.test.php
+++ b/tests/apitoken-grid-and-scope.test.php
@@ -24,12 +24,11 @@
  *     reject a duplicate -- it would UPDATE the existing row and replace a
  *     live credential's hash, revoking a working token with no audit row
  *     saying so.
- *  3. THE DELETE MODAL. $.deleteSelected drives $.reAuth, which calls
+ *  3. THE DELETE MODAL. $.deleteSelected drives $.confirmDelete, which calls
  *     modal('show') on $('#deleteModal'). process() renders that modal only
- *     when the sub is 'list', and this pane's is not -- so with
- *     FOG_DELETE_REAUTH on, delete would open nothing, do nothing and log
- *     nothing. A silent no-op, which is the failure class this codebase
- *     keeps paying for.
+ *     when the sub is 'list', and this pane's is not -- so delete would open
+ *     nothing, do nothing and log nothing. A silent no-op, which is the
+ *     failure class this codebase keeps paying for.
  *
  * Usage: php tests/apitoken-grid-and-scope.test.php
  * Exit status 0 = pass, 1 = fail.
@@ -198,14 +197,13 @@ $t->check(
 );
 // Its OWN modal, and both surfaces point $.deleteSelected at it. Reusing
 // the shared 'deleteModal' id is what broke the per-user card: that page
-// already renders one -- the one that deletes the ACCOUNT -- so $.reAuth
-// resolved the wrong modal, found no password field, and unbound the
-// General tab's delete-user handler on its way past.
+// already renders one -- the one that deletes the ACCOUNT -- so the confirm
+// helper resolved the wrong modal and unbound the General tab's delete-user
+// handler on its way past.
 $t->check(
-    'the re-auth modal $.reAuth needs is rendered by the pane',
+    'the confirm modal $.confirmDelete needs is rendered by the pane',
     (bool)preg_match("/'apitokenDeleteModal',/", $cfg)
     && (bool)preg_match("/'confirmAPITokenDelete',/", $cfg)
-    && (bool)preg_match("/'apitokenDeletePassword'/", $cfg)
 );
 $t->check(
     'neither surface reuses the shared deleteModal id',
@@ -221,34 +219,24 @@ $t->check(
     )
     && 2 === substr_count($js . $usrJsStripped, "noun: 'API token'")
 );
-// $.reAuth defaults its noun to Common.node, which on these two pages is
-// 'about' and 'user' -- so without the override the confirm button offers to
-// delete "1 abouts" or "1 users".
+// $.confirmDelete defaults its noun to Common.node, which on these two pages
+// is 'about' and 'user' -- so without the override the confirm button offers
+// to delete "1 abouts" or "1 users".
 $t->check(
-    '$.reAuth honors an explicit modal, button and noun',
+    '$.confirmDelete honors an explicit modal, button and noun',
     (bool)preg_match(
-        '/\$\.reAuth = function\(count, cb, opts\)/',
+        '/\$\.confirmDelete = function\(count, cb, opts\)/',
         $common
     )
     && (bool)preg_match('/noun = opts\.noun \|\| Common\.node/', $common)
     && (bool)preg_match(
-        '/modal = opts\.modal \? \$\(opts\.modal\) : reAuthModal/',
+        '/modal = opts\.modal \? \$\(opts\.modal\) : deleteConfirmModal/',
         $common
     )
     && (bool)preg_match(
         '/confirmBtn = opts\.confirmSel \? \$\(opts\.confirmSel\)/',
         $common
     )
-);
-// The password input is read out of the modal that was opened. Document-wide
-// it picks whichever #deletePassword came first in the DOM.
-$t->check(
-    'the password field is scoped to that modal',
-    (bool)preg_match(
-        "/pw = modal\.find\('input\[type=\"password\"\]'\)\.first\(\)/",
-        $common
-    )
-    && false === strpos($common, '$("#deletePassword")')
 );
 $t->check(
     'enable and disable are one endpoint driven by a flag',

--- a/tests/delete-confirms-without-password.test.php
+++ b/tests/delete-confirms-without-password.test.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Delete asks for confirmation, never for a password.
+ *
+ * Reported on the forum (topic 18239): an account that an OIDC provider
+ * created has no local password, so the delete password prompt refused it
+ * on every bulk delete. The prompt existed to confirm that somebody meant to
+ * delete many items. A password proves who is at the keyboard, not what they
+ * meant. FOG also already skipped it on the edit-page delete of a host and
+ * on the REST API, so it was never a complete control.
+ *
+ * WHAT IS PINNED, and the failure each one catches:
+ *
+ *  1. No server path asks for a password. checkauth() and every call to it
+ *     are gone. One call left behind is a fatal on every delete that reaches
+ *     it. The role and user group edit-page deletes called it with no
+ *     password field, so they answered 401 whenever the setting was on.
+ *  2. No delete dialog renders a password field.
+ *  3. $.deleteSelected ALWAYS opens the count dialog before it posts. With
+ *     FOG_REAUTH_ON_DELETE off it used to delete on the first click, with no
+ *     dialog at all, because the password prompt WAS the dialog.
+ *  4. It posts no password, and has no 401 retry that prompts for one.
+ *  5. Both settings are retired: a schema step deletes the rows, nothing
+ *     loads them, the settings page does not list them, and the hidden input
+ *     that carried one to the browser is gone.
+ *  6. FOG_BCACHE_VER moved, or browsers keep the old fog.common.js.
+ *
+ * Usage: php tests/delete-confirms-without-password.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+FogTestHarness::boot('delete-confirms-without-password');
+
+$t = new FogChecks();
+
+$web = dirname(__DIR__) . '/packages/web';
+
+// Comments name every symbol searched for below, so each source check runs
+// against a comment-stripped copy. Otherwise the fix and a comment that
+// describes the fix are indistinguishable.
+$strip = function ($src) {
+    $src = preg_replace('#/\*.*?\*/#s', '', $src);
+    return preg_replace('#(^|\s)//[^\n]*#', '$1', $src);
+};
+$read = function ($rel) use ($web, $strip) {
+    return $strip((string)file_get_contents($web . '/' . $rel));
+};
+
+// ---------------------------------------------------------------------------
+// 1. No server path asks for a password.
+// ---------------------------------------------------------------------------
+$files = new \RecursiveIteratorIterator(
+    new \RecursiveDirectoryIterator($web . '/src', \FilesystemIterator::SKIP_DOTS)
+);
+$scanned = 0;
+$callers = [];
+foreach ($files as $file) {
+    if ('php' !== $file->getExtension()) {
+        continue;
+    }
+    $scanned++;
+    // Case-sensitive, whole word: checkAuthAndCSRF() is the CSRF gate and
+    // stays.
+    if (preg_match('/\bcheckauth\b/', $strip(file_get_contents($file)))) {
+        $callers[] = substr($file->getPathname(), strlen($web) + 1);
+    }
+}
+$t->check('the src/ sweep read real files', $scanned > 100);
+$t->check(
+    'nothing in src/ defines or calls checkauth(): '
+    . (count($callers) ? implode(', ', $callers) : 'none'),
+    count($callers) < 1
+);
+
+// ---------------------------------------------------------------------------
+// 2. No delete dialog renders a password field.
+// ---------------------------------------------------------------------------
+$pages = [
+    'src/Base/FOGPage.php',
+    'src/Pages/HostManagement.php',
+    'src/Pages/FOGConfigurationPage.php',
+    'src/Pages/UserManagement.php',
+];
+foreach ($pages as $rel) {
+    $src = $read($rel);
+    $t->check(
+        "$rel renders no delete password field",
+        !preg_match("/'(deletePassword|deletePW|apitokenDeletePassword|apitokenDeletePW)'/", $src)
+        && false === strpos($src, "_('Confirm password')")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3 and 4. The shared helper always confirms, and never posts a password.
+// ---------------------------------------------------------------------------
+$common = $read('management/js/fog/fog.common.js');
+$deleteSelected = '';
+if (preg_match('/\$\.deleteSelected = function\(.*?\n};\n/s', $common, $m)) {
+    $deleteSelected = $m[0];
+}
+$t->check('$.deleteSelected is found', '' !== $deleteSelected);
+$t->check(
+    '$.deleteSelected opens the confirm dialog unless already confirmed',
+    (bool)preg_match(
+        '/if \(!opts\.confirmed\) \{\s*\$\.confirmDelete\(/',
+        $deleteSelected
+    )
+);
+$t->check(
+    'the dialog is not conditional on a setting',
+    false === strpos($common, 'shouldReAuth')
+    && false === strpos($read('management/other/index.php'), 'reAuthDelete')
+);
+$t->check(
+    '$.deleteSelected posts no password and has no 401 re-prompt',
+    '' !== $deleteSelected
+    && false === strpos($deleteSelected, 'fogguipass')
+    && !preg_match('/status\s*==+\s*401/', $deleteSelected)
+);
+$confirm = '';
+if (preg_match('/\$\.confirmDelete = function\(count, cb, opts\) \{.*?\n};\n/s', $common, $m)) {
+    $confirm = $m[0];
+}
+$t->check('$.confirmDelete(count, cb, opts) is defined', '' !== $confirm);
+$t->check(
+    '$.confirmDelete reads no password',
+    '' !== $confirm && false === stripos($confirm, 'password')
+);
+$t->check('$.reAuth is gone', false === strpos($common, '$.reAuth'));
+
+// ---------------------------------------------------------------------------
+// 5. Both settings are retired.
+// ---------------------------------------------------------------------------
+$schema = (string)file_get_contents($web . '/commons/schema.php');
+$lastStep = (string)substr($schema, (int)strrpos($schema, '$this->schema[] = ['));
+$t->check(
+    'the newest schema step deletes both settings',
+    (bool)preg_match('/DELETE FROM `globalSettings`/', $lastStep)
+    && false !== strpos($lastStep, "'FOG_REAUTH_ON_DELETE'")
+    && false !== strpos($lastStep, "'FOG_REAUTH_ON_EXPORT'")
+);
+foreach ([
+    'src/Base/FOGCore.php',
+    'src/Base/FOGBase.php',
+    'src/Pages/FOGConfigurationPage.php',
+    'management/other/index.php',
+] as $rel) {
+    $src = $read($rel);
+    $t->check(
+        "$rel no longer reads the retired settings",
+        false === strpos($src, 'FOG_REAUTH_ON_')
+        && false === strpos($src, 'fogdeleteactive')
+        && false === strpos($src, 'fogexportactive')
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. The browser cache moved.
+// ---------------------------------------------------------------------------
+$t->check(
+    'FOG_BCACHE_VER is at least 367',
+    (bool)preg_match(
+        "/define\('FOG_BCACHE_VER', (\d+)\)/",
+        (string)file_get_contents($web . '/src/Base/System.php'),
+        $m
+    )
+    && (int)$m[1] >= 367
+);
+
+$t->finish();


### PR DESCRIPTION
## Problem
An account that an OIDC provider creates has no local password. With `FOG_REAUTH_ON_DELETE` on (the default), every bulk delete asks for the account password, so that account can never delete anything. Reported at https://forums.fogproject.org/topic/18239 (problem 2 of 2; problem 1 was #1749).

## Cause
The prompt was meant to confirm that somebody really wanted to delete many items. A password proves who is at the keyboard, not what they meant. The control was also partial: the host edit-page delete never asked (`FOGPage::delete()`), and no REST API route called `checkauth()`.

## Change
- Remove `FOGBase::checkauth()` and its six callers: `FOGPage::deletemulti`, the pending host and pending MAC deletes in `HostManagement`, and `delete`/`deletemulti` in `RoleManagement` and `UserGroupManagement`.
- Remove the password field from every delete dialog: the shared list dialog, the two pending-host dialogs, and both API token dialogs. The dialog title is "Confirm delete", the body says "This cannot be undone.", and the button still names the count.
- `$.deleteSelected` always opens the dialog before it posts, and posts no `fogguipass`. The 401 re-prompt is gone. `$.reAuth` is now `$.confirmDelete`, and `$.finishReAuth` is now `$.finishConfirmDelete`.
- Schema step 437 deletes `FOG_REAUTH_ON_DELETE` and `FOG_REAUTH_ON_EXPORT`. No code read the export setting. `FOG_SCHEMA` is 437 and `FOG_BCACHE_VER` is 367.

## Behavior changes
- An install with `FOG_REAUTH_ON_DELETE` off now gets a confirm dialog on bulk delete. Before, the delete ran on the first click.
- The role and user group edit-page delete works with the old default. It sent no password, so it answered 401 whenever the setting was on.
- The two settings disappear from FOG Configuration.

No fog-plugins change: no plugin uses the delete password path.

## Verification
- `tests/delete-confirms-without-password.test.php`: 17 of 19 checks fail on the base, and 19 of 19 pass with the change.
- `tests/apitoken-grid-and-scope.test.php` is updated for the rename and passes.
- All 284 PHP test files pass locally, and both phpstan passes report no errors.
- Live check against the lab database. The fix ran from a shadow tree with `FOG_SCHEMA` held at 436 in that copy, so nothing migrated. `FOG_REAUTH_ON_DELETE` is on in the lab.

| Case | Deployed base | This PR |
|---|---|---|
| Host `deletemulti`, no password posted | 401, `Invalid Login` | 200, `Delete Success` |
| Role edit-page `delete`, no password posted | 401, `Invalid Login` | 200, deleted |
| Delete dialogs (host list, pending hosts, API tokens, roles, user groups, user token card) | password field | "Confirm delete", no password field |

  The browser click-through was not run. The request checks above cover what it would show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kd8mRPpMPXsCgXwhH4Xzu

