### PR TITLE
Keep the Kea config path on an installer re-run (GH-1747)

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -4000,14 +4000,18 @@ addOndrejRepo() {
 }
 resolveDHCPEngine() {
     # Decide between Kea and ISC-DHCP for the optional FOG-hosted DHCP service.
-    # Only relevant when FOG is actually building DHCP and the ISC package is
+    # Only relevant when FOG is actually building DHCP and a DHCP package is
     # still in the install set (the storage-node and DHCP_enabled=0 paths strip it in
     # doOSSpecificIncludes before we ever get here). Must run after repo setup
     # so the Kea availability probe sees enabled repos (e.g. EPEL on RHEL).
     [[ -z $keaconfig ]] && keaconfig="/etc/kea/kea-dhcp4.conf"
     [[ ${DHCP_enabled} == yes ]] || return 0
     local iscpkg="$dhcpname"
-    [[ -n $iscpkg && ${FOG_packages} == *"$iscpkg"* ]] || return 0
+    # Accept the Kea package as well. The swap below is saved with the package
+    # list, but $dhcpname and $dhcpconfig are re-seeded from the distro config
+    # on every run. Matching only the ISC name returned here on every re-run of
+    # a Kea install, which left the ISC config path for the Kea JSON (GH-1747).
+    [[ -n $iscpkg && ( ${FOG_packages} == *"$iscpkg"* || ( -n $keapackage && ${FOG_packages} == *"$keapackage"* ) ) ]] || return 0
     # Honor an explicit/persisted choice; an existing install is never switched.
     DHCP_engine="${DHCP_engine,,}"
     if [[ -z ${DHCP_engine} ]]; then
@@ -7435,8 +7439,10 @@ writeUpdateFile() {
         # FOG_installed stays unquoted+numeric in the emitted file to match the
         # historical format (see settingLine below).
         FOG_installed
-        # FOG_packages is a RECORD: re-derived every run from the distro package
-        # lists in lib/{redhat,ubuntu,alpine,arch}/config.sh.
+        # FOG_packages is NOT re-derived on an upgrade: this file is sourced
+        # before lib/{redhat,ubuntu,alpine,arch}/config.sh, and those only fill
+        # it when empty. So edits made to it during a run (the Kea swap in
+        # resolveDHCPEngine) come back on the next run (GH-1747).
         FOG_packages
         # FOG_git_path is a RECORD like FOG_program_dir (GH-850), not a control --
         # installfog.sh re-asserts the value it actually resolved after sourcing

--- a/tests/dhcp-engine-rerun.test.sh
+++ b/tests/dhcp-engine-rerun.test.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+#
+# Guards the Kea engine choice across installer re-runs (GH-1747).
+#
+#   tests/dhcp-engine-rerun.test.sh
+#
+# resolveDHCPEngine() swaps the ISC package for the Kea package in
+# ${FOG_packages}, and the installer saves that list. It does not save
+# $dhcpname or $dhcpconfig, so the next run re-seeds both from the distro
+# config: the ISC package name and the ISC config path. The guard looked only
+# for the ISC name in the saved list. Every re-run of a Kea install therefore
+# returned early and kept the ISC path. On Ubuntu that wrote the Kea JSON to
+# /etc/dhcp3/dhcpd.conf, AppArmor refused kea-dhcp4 the read, and the install
+# stopped before TFTP.
+#
+# The first run always worked, which is why nobody saw it. So this replays two
+# runs through the real function, per distro, with each distro's own defaults
+# read from lib/<distro>/config.sh.
+#
+# No install, no network, no root.
+#
+# Exit status 0 = pass, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+
+[[ -f $FUNCS ]] || { echo "ERROR: $FUNCS not found" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+# The re-run below rests on which keys the installer saves. Pin that here, so a
+# change to the saved list fails this test instead of leaving it replaying a
+# re-run the installer no longer does.
+saved=$(awk '/^writeUpdateFile\(\) *\{/,/^\}/' "$FUNCS" | sed 's/#.*//')
+[[ -n $saved ]] || bad "writeUpdateFile() found in functions.sh"
+for key in FOG_packages DHCP_engine; do
+    grep -qw -- "$key" <<<"$saved" && ok "$key is saved" || bad "$key is saved"
+done
+for key in dhcpconfig dhcpname; do
+    grep -qw -- "$key" <<<"$saved" && bad "$key is not saved" || ok "$key is not saved"
+done
+
+error_log="$WORK/error.log"
+: > "$error_log"
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+
+# Defined after sourcing on purpose: the real ones ask the package manager.
+INSTALLED=""
+pkgIsInstalled() { [[ " $INSTALLED " == *" $1 "* ]]; }
+pkgIsAvailable() { return 0; }
+
+# What doOSSpecificIncludes gives each run: the distro's own [[ -z ]] defaults.
+seed() {
+    local cfg="$REPO/lib/$1/config.sh" v line
+    for v in dhcpconfig dhcpname keapackage keaservice; do
+        line=$(grep -m1 -E "^[[:space:]]*\[\[ -z \\\$$v \]\] && $v=\"[^\"]*\"[[:space:]]*$" "$cfg")
+        [[ -n $line ]] || { bad "$1: default for $v in lib/$1/config.sh"; return 1; }
+        eval "$line"
+    done
+}
+reset() { unset dhcpconfig dhcpname keapackage keaservice keaconfig DHCP_service_name dhcpconfigother; }
+
+DHCP_enabled=yes
+for distro in ubuntu redhat arch alpine; do
+    [[ -f $REPO/lib/$distro/config.sh ]] || continue
+    echo "$distro:"
+
+    reset; unset DHCP_engine; INSTALLED=""
+    seed "$distro" || continue
+    iscconfig=$dhcpconfig
+    iscpkg=$dhcpname
+    keapkg=$keapackage
+    FOG_packages="bc $iscpkg lftp"
+    resolveDHCPEngine
+    is "$DHCP_engine" kea "first run picks Kea"
+    is "$dhcpconfig" /etc/kea/kea-dhcp4.conf "first run writes the Kea config path"
+
+    # Re-run: the saved keys come back, everything else is re-seeded.
+    savedpackages=$FOG_packages
+    savedengine=$DHCP_engine
+    reset; INSTALLED="$keapkg"
+    FOG_packages=$savedpackages
+    DHCP_engine=$savedengine
+    seed "$distro"
+    resolveDHCPEngine
+    is "$DHCP_engine" kea "re-run stays on Kea"
+    is "$dhcpconfig" /etc/kea/kea-dhcp4.conf "re-run writes the Kea config path"
+    is "$dhcpname" "$keapkg" "re-run names the Kea package"
+    is "$FOG_packages" "$savedpackages" "re-run leaves the package list alone"
+
+    # An existing ISC install must not move on a re-run. Alpine has no ISC
+    # package: its $dhcpname is already the Kea package.
+    [[ $iscpkg == "$keapkg" ]] && continue
+    reset; INSTALLED="$iscpkg"
+    FOG_packages="bc $iscpkg lftp"
+    DHCP_engine=isc
+    seed "$distro"
+    resolveDHCPEngine
+    is "$DHCP_engine" isc "ISC re-run stays on ISC"
+    is "$dhcpconfig" "$iscconfig" "ISC re-run keeps the ISC config path"
+    is "$FOG_packages" "bc $iscpkg lftp" "ISC re-run keeps the ISC package"
+done
+
+echo
+echo "dhcp-engine-rerun: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Problem

A re-run of `installfog.sh` on a Kea install writes the Kea JSON to the distro's ISC config path: `/etc/dhcp3/dhcpd.conf` on Ubuntu. AppArmor denies `kea-dhcp4` that path, so validation fails. The install then stops before TFTP, iPXE, FTP and NFS. The first install works. Reported against 1.5.10 in #1747. This branch has the same guard.

## Cause

`resolveDHCPEngine()` swaps the ISC package for the Kea package in `${FOG_packages}`, and the installer saves that list. It does not save `$dhcpname` or `$dhcpconfig`, so the next run re-seeds both to the ISC values. The guard looked only for the ISC package name in the saved list. It returned before it set `$dhcpconfig`.

## Fix

- The guard also accepts the Kea package. An ISC install is unchanged. Alpine was never affected, because its `$dhcpname` is already the Kea package.
- The comment on `FOG_packages` in `writeUpdateFile()` said the list is re-derived every run. It is not. `installfog.sh` sources the saved settings before `doOSSpecificIncludes`, and the distro configs only fill `FOG_packages` when it is empty. The comment now says so.

## Test

`tests/dhcp-engine-rerun.test.sh` replays two runs through the real function for ubuntu, redhat, arch and alpine. It uses each distro's own defaults from `lib/<distro>/config.sh`. It also pins which keys the installer saves, because the replayed re-run depends on that.

- Before the fix: 31 passed, 6 failed. The failures are the re-run config path and package name on ubuntu, redhat and arch.
- After the fix: 37 passed, 0 failed.

The same fix for `dev-branch` is in a separate PR.

Refs #1747

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JsEqysRdWb914YC94Shvo
