### PR TITLE
Derive the DHCP subnet from the FOG address, not the interface (GH-1747)

### DIFF
--- a/lib/common/functions.sh
+++ b/lib/common/functions.sh
@@ -2026,9 +2026,21 @@ validhostname() {
     echo $?
 }
 getCidr() {
-    local cidr
-    cidr=$(ip -f inet -o addr | grep $1 | awk -F'[ /]+' '/global/ {print $5}' | head -n2 | tail -n1)
-    echo $cidr
+    # Prefix length of address $2 on interface $1. When $2 is not given, or is
+    # not on that interface, the prefix of the interface's first global address.
+    #
+    # GH-1747: this grepped the whole address table for the interface name and
+    # printed the SECOND global match (head -n2 | tail -n1). On an interface
+    # with more than one address that is another address's prefix: a stray
+    # 169.254.x.x/16 turned a /24 into 255.255.0.0. The unanchored grep also
+    # let eth1 read eth10.
+    [[ -n $1 ]] || return 0
+    ip -4 -o addr show dev "$1" 2>/dev/null | awk -v want="$2" '
+        $3 != "inet" { next }
+        { split($4, addr, "/") }
+        want != "" && addr[1] == want { print addr[2]; found = 1; exit }
+        first == "" && / scope global / { first = addr[2] }
+        END { if (!found && first != "") print first }'
 }
 mask2cidr() {
     local NET_subnet_mask=$1
@@ -2071,7 +2083,8 @@ mask2cidr() {
             0)
                 ;;
             *)
-                echo "Error: $dec is not recognized"
+                # stderr: every caller takes stdout as the prefix length.
+                echo "Error: $dec is not recognized" >&2
                 exit 1
                 ;;
         esac
@@ -2080,6 +2093,10 @@ mask2cidr() {
     echo "$nbits"
 }
 cidr2mask() {
+    # No prefix means no mask. "$((/8))" put an arithmetic syntax error on the
+    # screen instead (GH-1747), and every caller already treats an empty mask
+    # as unknown.
+    [[ $1 =~ ^[0-9]+$ && $1 -le 32 ]] || return 1
     local i=""
     local mask=""
     local full_octets=$(($1/8))
@@ -2128,16 +2145,23 @@ interface2broadcast() {
         echo "No interface passed" >&2
         return 1
     fi
-    # One address per line means one brd per line, so an interface carrying a
-    # second address returned two. Take the first, matching the ${NET_fog_server_ip} /
-    # ${PKI_san_ip_addresses} contract from GH-954. Empty is a legitimate answer -- a /32
-    # or a point-to-point link has no broadcast -- and the caller falls back.
+    # The brd of address $2 on that interface. Without $2, or when $2 is not
+    # there, the first brd on the interface. Empty is a legitimate answer -- a
+    # /32 or a point-to-point link has no broadcast -- and the caller falls back.
     # awk rather than `grep -oP 'brd \K\S+'`: busybox grep has no -P at all,
     # so on Alpine that printed grep's whole usage screen into the middle of
     # the install and returned nothing -- the same trap as the -E/-P note in
     # installPackages. See #863.
-    ip -4 addr show ${NET_interface} \
-        | awk '{for (i = 1; i < NF; i++) if ($i == "brd") { print $(i + 1); exit }}'
+    #
+    # GH-1747: this always took the first brd, which belongs to whichever
+    # address is listed first. A link-local 169.254.x.x listed ahead of the
+    # real address ended the DHCP pool at 169.254.255.254.
+    ip -4 -o addr show dev "${NET_interface}" 2>/dev/null | awk -v want="$2" '
+        $3 != "inet" { next }
+        { split($4, addr, "/"); brd = ""; for (i = 5; i < NF; i++) if ($i == "brd") brd = $(i + 1) }
+        want != "" && addr[1] == want { print brd; found = 1; exit }
+        first == "" && brd != "" { first = brd }
+        END { if (!found) print first }'
 }
 subtract1fromAddress() {
     local ip=$1
@@ -12667,7 +12691,7 @@ configureHttpd() {
     # calls from the local subnet out of the box. Stays empty (no extra trust)
     # if it cannot be derived; the schema migration then leaves the group alone.
     storageDefaultCidr=""
-    storageTrustPrefix=$(getCidr "${NET_interface}")
+    storageTrustPrefix=$(getCidr "${NET_interface}" "${NET_fog_server_ip}")
     if [[ -n ${NET_fog_server_ip} && -n $storageTrustPrefix ]]; then
         storageTrustMask=$(cidr2mask "$storageTrustPrefix" 2>/dev/null)
         storageTrustNetwork=$(mask2network "${NET_fog_server_ip}" "$storageTrustMask" 2>/dev/null)
@@ -15892,18 +15916,19 @@ writeKeaSample() {
     local target="${webdirdest%/}/kea-dhcp4.conf.fog-sample"
     [[ -z $webdirdest ]] && target="/etc/kea/kea-dhcp4.conf.fog-sample"
     [[ -d $(dirname "$target") ]] || return 0
-    local sampleip
-    sampleip=$(ip -4 -o addr show ${NET_interface} | awk -F'([ /])+' '/global/ {print $4}')
-    [[ -z $sampleip ]] && sampleip="${NET_fog_server_ip}"
-    [[ -z ${NET_subnet_mask} ]] && NET_subnet_mask=$(cidr2mask $(getCidr ${NET_interface}))
-    local network=$(mask2network $sampleip ${NET_subnet_mask})
+    # GH-1747: the subnet comes from ${NET_fog_server_ip}, the address FOG
+    # advertises. This used to read every global address on the interface,
+    # unquoted, so a second address became mask2network's mask argument and
+    # the subnet came out as a host address ("10.0.45.2/24").
+    [[ -z ${NET_subnet_mask} ]] && NET_subnet_mask=$(cidr2mask $(getCidr ${NET_interface} ${NET_fog_server_ip}))
+    local network=$(mask2network ${NET_fog_server_ip} ${NET_subnet_mask})
     local cidr=$(mask2cidr ${NET_subnet_mask})
     local DHCP_range_start=$(addToAddress $network 10)
     # GH-667: an interface with no brd flag, or any failure inside these
     # helpers, used to leave endrange holding an error string that went
     # straight into the generated config. Fall back to the broadcast computed
     # from the network and mask we already have.
-    local broadcast=$(interface2broadcast ${NET_interface})
+    local broadcast=$(interface2broadcast ${NET_interface} ${NET_fog_server_ip})
     [[ $(validip $broadcast) -ne 0 ]] && broadcast=$(mask2broadcast $network ${NET_subnet_mask})
     local DHCP_range_end=$(subtract1fromAddress $broadcast)
     [[ $(validip ${DHCP_range_end}) -ne 0 ]] && DHCP_range_end=$(subtract1fromAddress $(mask2broadcast $network ${NET_subnet_mask}))
@@ -15946,17 +15971,17 @@ configureDHCP() {
     fi
     case ${DHCP_enabled} in
         yes)
-            # GH-954: one line per address, so a second address on the NIC
-            # made this multi-line and every consumer below it wrong.
-            serverip=$(ip -4 -o addr show ${NET_interface} | awk -F'([ /])+' '/global/ {print $4}' | head -1)
-            [[ -z $serverip ]] && serverip=$(/sbin/ifconfig ${NET_interface} | grep -oE 'inet[:]? addr[:]?([0-9]{1,3}\.){3}[0-9]{1,3}' | awk -F'(inet[:]? ?addr[:]?)' '{print $2}')
-            [[ -z ${NET_subnet_mask} ]] && NET_subnet_mask=$(cidr2mask $(getCidr ${NET_interface}))
-            network=$(mask2network $serverip ${NET_subnet_mask})
+            # GH-1747: the subnet comes from ${NET_fog_server_ip}, the address
+            # handed out as next-server. The first global address on the
+            # interface is not always that one: a global 169.254.x.x listed
+            # ahead of it put the pool in the link-local range.
+            [[ -z ${NET_subnet_mask} ]] && NET_subnet_mask=$(cidr2mask $(getCidr ${NET_interface} ${NET_fog_server_ip}))
+            network=$(mask2network ${NET_fog_server_ip} ${NET_subnet_mask})
             [[ -z ${DHCP_range_start} ]] && DHCP_range_start=$(addToAddress $network 10)
             # GH-667: same guard as writeKeaSample -- never let a helper's
             # failure become the value that lands in dhcpd.conf.
             if [[ -z ${DHCP_range_end} ]]; then
-                broadcast=$(interface2broadcast ${NET_interface})
+                broadcast=$(interface2broadcast ${NET_interface} ${NET_fog_server_ip})
                 [[ $(validip $broadcast) -ne 0 ]] && broadcast=$(mask2broadcast $network ${NET_subnet_mask})
                 DHCP_range_end=$(subtract1fromAddress $broadcast)
                 [[ $(validip ${DHCP_range_end}) -ne 0 ]] && DHCP_range_end=$(subtract1fromAddress $(mask2broadcast $network ${NET_subnet_mask}))

--- a/lib/common/input.sh
+++ b/lib/common/input.sh
@@ -134,21 +134,28 @@ testInterface
 # certificate SANs, nginx server_name, apache ServerAlias, the maintenance
 # allow list -- and normalizeIpAddress() then reduces ${NET_fog_server_ip} to the primary,
 # which is what every other consumer has always assumed it was.
+#
+# GH-1747: global addresses only, and never link-local 169.254.0.0/16. A
+# link-local address appears when DHCP gets no answer on the deployment NIC.
+# No client can reach FOG there, and listed first it became the primary.
 while [[ -z ${NET_fog_server_ip} ]]; do
-    NET_fog_server_ip=$(ip -4 addr show ${NET_interface} | awk '$1 == "inet" {gsub(/\/.*$/, "", $2); print $2}')
+    NET_fog_server_ip=$(ip -4 addr show ${NET_interface} | awk '$1 == "inet" && / scope global / && $2 !~ /^169\.254\./ {gsub(/\/.*$/, "", $2); print $2}')
     PKI_san_ip_addresses="${NET_fog_server_ip}"
     if [[ $(validip ${NET_fog_server_ip}) -ne 0 ]]; then
         echo
         echo "  * The interface ${NET_interface} does not seem to have a valid IP Configured to it."
+        # With -y nothing can pick another interface, so this loop would
+        # repeat the same answer forever.
+        [[ -n $autoaccept ]] && exit 1
         NET_interface=""
         testInterface
     fi
 done
-NET_subnet_mask=$(cidr2mask $(getCidr ${NET_interface}))
-if [[ -z ${NET_subnet_mask} ]]; then
-    NET_subnet_mask=$(/sbin/ifconfig -a | grep ${NET_fog_server_ip} -B1 | awk -F'[netmask ]+' '{print $4}' | head -n2)
-    NET_subnet_mask=$(mask2cidr ${NET_subnet_mask})
-fi
+# The mask of the primary address (the first one listed), not of whichever
+# address getCidr found. The ifconfig fallback that followed stored mask2cidr's
+# prefix length in the mask, and ifconfig is not installed before the package
+# step. An empty mask is derived again in configureDHCP.
+NET_subnet_mask=$(cidr2mask $(getCidr ${NET_interface} ${NET_fog_server_ip%%[[:space:]]*}))
 if [[ $strSuggestedHostname == ${NET_fog_server_ip} ]]; then
     strSuggestedHostname=$(hostnamectl --static)
 fi

--- a/tests/installer-subnet-detection.test.sh
+++ b/tests/installer-subnet-detection.test.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+#
+# Guards how the installer derives the DHCP subnet from the FOG interface (GH-1747).
+#
+#   tests/installer-subnet-detection.test.sh
+#
+# The report: on an interface with more than one IPv4 address, the saved mask
+# was 255.255.0.0 on a /24, the generated Kea subnet was "10.0.45.2/24" (a host
+# address, not a network), and the pool began at .12. Each helper looked at "the
+# interface" and took a different address from it:
+#
+#   input.sh             every inet address, link-local 169.254.x.x included,
+#                        so the primary could be one no client can reach.
+#   getCidr()            the SECOND global address's prefix (head -n2 | tail
+#                        -n1), through an unanchored grep, so eth1 matched eth10.
+#   configureDHCP        the first global address, which is not always
+#                        ${NET_fog_server_ip}; writeKeaSample took every one,
+#                        unquoted, so a second address became the MASK.
+#   interface2broadcast  the first brd on the interface, whichever address.
+#
+# Also: cidr2mask "" printed "arithmetic syntax error ... /8".
+#
+# Everything now derives from ONE address, ${NET_fog_server_ip}, the one FOG
+# advertises.
+#
+# A fake `ip` replays each address layout. Its rows are the one-line form
+# iproute2 prints for `ip -o`, copied from a real host. It builds the multi-line
+# form the way iproute2 does: -o only turns each newline into "\".
+#
+# No install, no network, no root.
+#
+# Exit status 0 = pass, 1 = fail.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+FUNCS="$REPO/lib/common/functions.sh"
+INPUT="$REPO/lib/common/input.sh"
+
+[[ -f $FUNCS && -f $INPUT ]] || { echo "ERROR: installer sources not found under $REPO/lib/common" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n' "$1"; }
+is()  { [[ "$1" == "$2" ]] && ok "$3" || bad "$3 (expected '$2', got '$1')"; }
+
+mkdir -p "$WORK/bin" "$WORK/web"
+cat > "$WORK/bin/ip" <<'EOF'
+#!/bin/bash
+# Replays $FAKE_IP_TABLE: one `ip -o -4 addr` row per address.
+oneline=0
+dev=""
+verb=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -o) oneline=1 ;;
+        -4|-f|inet|show) ;;
+        addr|address|link|route) verb=$1 ;;
+        dev) shift; dev=$1 ;;
+        *) dev=$1 ;;
+    esac
+    shift
+done
+[[ $verb == addr || $verb == address ]] || exit 0
+while IFS= read -r line; do
+    [[ -z $line ]] && continue
+    read -r _ name _ <<<"$line"
+    [[ -n $dev && $name != "$dev" ]] && continue
+    if [[ $oneline -eq 1 ]]; then
+        printf '%s\n' "$line"
+    else
+        body=${line#*"$name"}
+        body=${body#"${body%%[! ]*}"}
+        printf '    %s\n' "${body//\\/$'\n'}"
+    fi
+done < "$FAKE_IP_TABLE"
+EOF
+chmod +x "$WORK/bin/ip"
+
+# One `ip -o -4 addr` row: index, interface, address/prefix, broadcast, scope words.
+row() {
+    printf '%s: %s    inet %s %sscope %s %s\\       valid_lft forever preferred_lft forever\n' \
+        "$1" "$2" "$3" "${4:+brd $4 }" "$5" "$2"
+}
+table() { local name=$1; shift; printf '%s\n' "$@" > "$WORK/$name"; }
+
+lo=$(row 1 lo 127.0.0.1/8 "" host)
+nat=$(row 3 ens37 192.168.137.130/24 192.168.137.255 "global dynamic noprefixroute")
+primary=$(row 2 ens33 10.0.45.2/24 10.0.45.255 "global noprefixroute")
+# A second address in the same /24.
+table second "$lo" "$primary" "$(row 2 ens33 10.0.45.14/24 10.0.45.255 'global secondary dynamic noprefixroute')" "$nat"
+# The report's "stray 169.254.x.x/16 line", added as a global address.
+# With the old code this is the saved 255.255.0.0.
+table llglobal "$lo" "$primary" "$(row 2 ens33 169.254.33.7/16 169.254.255.255 'global noprefixroute')" "$nat"
+# Link-local listed first, as a link-scope address.
+table llfirst "$lo" "$(row 2 ens33 169.254.33.7/16 169.254.255.255 link)" "$primary" "$nat"
+# The same, as a global address: the old configureDHCP took it as the server.
+table llglobalfirst "$lo" "$(row 2 ens33 169.254.33.7/16 169.254.255.255 'global noprefixroute')" "$primary" "$nat"
+# DHCP never answered on the deployment NIC: link-local only. With the old
+# code this is the reported "arithmetic syntax error ... /8".
+table llonly "$lo" "$(row 2 ens33 169.254.33.7/16 169.254.255.255 link)" "$nat"
+# eth1 must not match eth10. eth1 is listed first, so the old "second match"
+# lands on eth10.
+table anchor "$lo" "$(row 2 eth1 10.1.0.5/24 10.1.0.255 global)" "$(row 3 eth10 172.16.0.5/16 172.16.255.255 global)"
+
+error_log="$WORK/error.log"
+: > "$error_log"
+timestamp=0
+# /usr/sbin is left out so no real kea-dhcp4 is found: the config is written
+# without validation, which is all this test reads.
+PATH="$WORK/bin:/usr/bin:/bin"
+FAKE_IP_TABLE="$WORK/second"
+export FAKE_IP_TABLE
+# shellcheck source=/dev/null
+. "$FUNCS" >/dev/null 2>&1
+
+dots() { :; }
+diffconfig() { :; }
+# Stop configureDHCP right after the Kea config is written, before it touches
+# any service: a failed configureKeaDHCP with exitFail set makes it return.
+eval "$(declare -f configureKeaDHCP | sed '1s/^configureKeaDHCP/_realConfigureKeaDHCP/')"
+configureKeaDHCP() { _realConfigureKeaDHCP >/dev/null 2>&1; return 1; }
+
+# The two input.sh lines under test, run as written rather than retyped here.
+ipline=$(grep -m1 -E '^[[:space:]]*NET_fog_server_ip=\$\(ip -4 addr show' "$INPUT")
+maskline=$(grep -m1 -E '^[[:space:]]*NET_subnet_mask=\$\(cidr2mask' "$INPUT")
+[[ -n $ipline ]] && ok "input.sh address assignment found" || bad "input.sh address assignment found"
+[[ -n $maskline ]] && ok "input.sh mask assignment found" || bad "input.sh mask assignment found"
+
+jsonval() { sed -n "s/.*\"$1\": \"\\([^\"]*\\)\".*/\\1/p" "$2" | head -n1; }
+
+# Replays input.sh's detection, then configureDHCP and writeKeaSample.
+detect() {
+    FAKE_IP_TABLE="$WORK/$1"
+    NET_interface=$2
+    unset NET_fog_server_ip PKI_san_ip_addresses NET_subnet_mask network DHCP_range_start DHCP_range_end
+    eval "$ipline"
+    PKI_san_ip_addresses="${NET_fog_server_ip}"
+    eval "$maskline" 2>"$WORK/mask.err"
+    [[ -n ${NET_fog_server_ip} ]] && normalizeIpAddress
+}
+build() {
+    rm -f "$WORK/kea.conf" "$WORK/web/kea-dhcp4.conf.fog-sample"
+    unset network DHCP_range_start DHCP_range_end
+    DHCP_enabled=yes DHCP_engine=kea dhcpconfig="$WORK/kea.conf" exitFail=1 webdirdest="$WORK/web"
+    configureDHCP >/dev/null 2>&1
+    writeKeaSample >/dev/null 2>&1
+}
+expect_config() {
+    is "$(jsonval subnet "$WORK/kea.conf")" 10.0.45.0/24 "$1: Kea subnet is the network"
+    is "$(jsonval pool "$WORK/kea.conf")" "10.0.45.10 - 10.0.45.254" "$1: Kea pool"
+    is "$(jsonval subnet "$WORK/web/kea-dhcp4.conf.fog-sample")" 10.0.45.0/24 "$1: sample subnet is the network"
+    is "$(jsonval pool "$WORK/web/kea-dhcp4.conf.fog-sample")" "10.0.45.10 - 10.0.45.254" "$1: sample pool"
+}
+
+for layout in second llglobal llfirst llglobalfirst; do
+    echo "$layout:"
+    detect "$layout" ens33
+    # A global link-local listed first is still skipped by input.sh.
+    is "${NET_fog_server_ip}" 10.0.45.2 "$layout: primary address"
+    is "${NET_subnet_mask}" 255.255.255.0 "$layout: saved mask"
+    build
+    expect_config "$layout"
+    # A re-run starts from the saved mask, and the sample writer derives its own.
+    saved=${NET_subnet_mask}
+    unset NET_subnet_mask
+    build
+    is "${NET_subnet_mask}" 255.255.255.0 "$layout: mask derived by configureDHCP"
+    NET_subnet_mask=$saved
+    expect_config "$layout (derived mask)"
+done
+
+echo "llonly:"
+detect llonly ens33
+is "${NET_fog_server_ip}" "" "llonly: a link-local address is not a server address"
+grep -q 'arithmetic' "$WORK/mask.err" && bad "llonly: no arithmetic error while reading the mask" || ok "llonly: no arithmetic error while reading the mask"
+
+echo "anchor:"
+FAKE_IP_TABLE="$WORK/anchor"
+is "$(getCidr eth1 10.1.0.5)" 24 "anchor: getCidr eth1 does not read eth10"
+is "$(getCidr eth1)" 24 "anchor: getCidr eth1 without an address"
+
+echo "helpers:"
+FAKE_IP_TABLE="$WORK/llglobal"
+is "$(getCidr ens33 10.0.45.2)" 24 "getCidr names the prefix of the address asked for"
+is "$(getCidr ens33 10.9.9.9)" 24 "getCidr falls back to the first global address"
+FAKE_IP_TABLE="$WORK/llfirst"
+is "$(interface2broadcast ens33 10.0.45.2)" 10.0.45.255 "interface2broadcast of the address asked for"
+is "$(cidr2mask 24)" 255.255.255.0 "cidr2mask 24"
+is "$(cidr2mask 27)" 255.255.255.224 "cidr2mask 27"
+is "$(cidr2mask '' 2>&1)" "" "cidr2mask with no prefix prints nothing"
+is "$(mask2cidr 255.255.255.224 2>/dev/null)" 27 "mask2cidr 255.255.255.224"
+is "$(mask2cidr 255.255.3.0 2>/dev/null)" "" "mask2cidr keeps its error off stdout"
+
+echo
+echo "installer-subnet-detection: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Problem

On an interface with more than one IPv4 address, the installer writes a DHCP subnet that is not a network. #1747 shows a saved mask of `255.255.0.0` on a /24, a Kea subnet of `"10.0.45.2/24"`, a pool starting at `.12`, and `arithmetic syntax error ... /8` during interface selection.

This is the `working-1.6` side of #1753, which fixed `dev-branch`.

## Cause

Each helper reads "the interface" and takes a different address from it:

| Where | What it took |
|---|---|
| `input.sh` | every inet address, link-local `169.254.x.x` included, so a link-local address listed first became the primary |
| `getCidr()` | the **second** global address's prefix (`head -n2 \| tail -n1`), through an unanchored grep, so `eth1` also read `eth10` |
| `writeKeaSample` | every global address, unquoted, into `mask2network`, so a second address became the mask |
| `configureDHCP` | the first global address, which is not always `${NET_fog_server_ip}` |
| `interface2broadcast()` | the first `brd`, whichever address it belonged to |

A second address in the same /24 gives exactly the reported config. A global `169.254.x.x/16` next to the /24 gives the saved `255.255.0.0`. A link-local-only NIC gives the `/8` error.

## Fix

Everything derives from `${NET_fog_server_ip}`, the address FOG advertises as next-server.

- `input.sh` takes global addresses only, and never `169.254.0.0/16`.
- `getCidr IFACE [ADDR]` and `interface2broadcast IFACE [ADDR]` read the named address on that interface only. Both stay awk, so they work with busybox (#863).
- `configureDHCP` and `writeKeaSample` compute the network from `${NET_fog_server_ip}`.
- `cidr2mask` with no prefix returns nothing, instead of printing the arithmetic error.
- `mask2cidr` sends its error message to stderr instead of into the caller's value.
- The `ifconfig` fallbacks in `input.sh` and `configureDHCP` are removed. `ifconfig` is not installed before the package step, and the `input.sh` one stored a prefix length as the mask.

## Behavior changes

- With `-y`, an interface with no usable address now exits. It used to repeat the same answer forever.
- **Default storage group trust.** `storageDefaultCidr` now takes the prefix of `${NET_fog_server_ip}`. On a multi-address interface it used to take the second address's prefix and apply it to the FOG address. On an interface with one address, nothing changes. This is the trusted CIDR for node-to-node status calls, so this PR is a draft until that change is approved.

## Test

`tests/installer-subnet-detection.test.sh` replays address layouts through the real functions and the real `input.sh` lines. The fake `ip` prints real `ip -o` output.

- On the old code: 21 passed, 37 failed. It reproduces the report exactly.
- After the fix: 58 passed, 0 failed.
- Alpine: the helpers ran against busybox `ip` and `awk` on a dummy interface with the same addresses, with the same results.

Refs #1747

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JsEqysRdWb914YC94Shvo
