### PR TITLE
Keep the agent routes out of the API switch (forum 18241)

### DIFF
--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -913,10 +913,24 @@ class Route extends FOGBase
         $webrootbase = '/' . ($webrootbase === '' ? '' : $webrootbase . '/');
         self::$_webrootbase = $webrootbase;
 
+        $requripath = strtok((string)self::$requesturi, '?');
         /**
          * If API is not enabled redirect to home page.
+         *
+         * Not the agent routes. FOG_API_ENABLED switches off the REST API
+         * that people and API tokens use; /agent/v1/ is FOG's client
+         * channel, which the setting never governed for the legacy client
+         * (service/*.php) either. Caught here, every fog-agent on a server
+         * with the API off was sent a 308 to the login page and could never
+         * enroll or poll (forum topic 18241). The agent routes keep their
+         * own gate below: enroll issues nothing without an approval, and
+         * everything else needs a certificate bound to a host.
          */
-        if (!self::$ajax && !self::$_enabled) {
+        $isAgentRoute = 0 === strpos(
+            $requripath,
+            $webrootbase . self::AGENT_ROUTE_SEGMENT
+        );
+        if (!self::$ajax && !self::$_enabled && !$isAgentRoute) {
             header(
                 sprintf(
                     'Location: %s://%s%smanagement/index.php',
@@ -975,7 +989,6 @@ class Route extends FOGBase
             }
             $unauthexact[] = $webrootbase . ltrim($pluginRoute['path'], '/');
         }
-        $requripath = strtok((string)self::$requesturi, '?');
         $requribase = dirname($requripath);
         $isunauth = in_array($requribase, $unauthprefixes)
             || in_array(rtrim($requripath, '/'), $unauthexact);
@@ -997,9 +1010,7 @@ class Route extends FOGBase
          * without a bound host whatever it forgets to check. Enroll is
          * the one exception and it is in $unauthexact above.
          */
-        if (!$isunauth
-            && 0 === strpos($requripath, $webrootbase . self::AGENT_ROUTE_SEGMENT)
-        ) {
+        if (!$isunauth && $isAgentRoute) {
             self::$agentHost = self::_agentPrincipal();
             if (!self::$agentHost) {
                 HTTPResponseCodes::breakHead(

--- a/packages/web/src/Router/Route.php
+++ b/packages/web/src/Router/Route.php
@@ -1010,7 +1010,9 @@ class Route extends FOGBase
          * without a bound host whatever it forgets to check. Enroll is
          * the one exception and it is in $unauthexact above.
          */
-        if (!$isunauth && $isAgentRoute) {
+        if (!$isunauth
+            && 0 === strpos($requripath, $webrootbase . self::AGENT_ROUTE_SEGMENT)
+        ) {
             self::$agentHost = self::_agentPrincipal();
             if (!self::$agentHost) {
                 HTTPResponseCodes::breakHead(

--- a/tests/agent-routes-ignore-api-switch.test.php
+++ b/tests/agent-routes-ignore-api-switch.test.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * The API switch must not switch off fog-agent.
+ *
+ * While FOG_API_ENABLED is off, Route answers with a 308 to the login page.
+ * That check ran before anything else looked at the path, so it took
+ * /agent/v1/ with it: on a server with the REST API off, every fog-agent was
+ * redirected on enroll and on every poll, and could never join. Reported on
+ * the forum as topic 18241:
+ *
+ *   POST https://192.168.1.100/fog/agent/v1/enroll
+ *   HTTP/1.1 308 Permanent Redirect
+ *   Location: https://192.168.1.100/fog/management/index.php
+ *
+ * The setting governs the REST API that people and API tokens use. The agent
+ * routes are FOG's client channel and have their own gate.
+ *
+ * What this pins, each case in its own process because the gate exits:
+ *
+ * - enroll with the API off is not redirected;
+ * - poll with the API off reaches the agent gate and gets its 401, which
+ *   proves the request got past the switch and still needs a certificate;
+ * - an ordinary API route with the API off is still redirected, so the
+ *   switch still does its job.
+ *
+ * The request statics are preset rather than fed through a CGI environment.
+ * Route's dispatcher reads REQUEST_METHOD through filter_input(), which the
+ * CLI SAPI leaves empty, so no route matches and enroll's handler is never
+ * reached. That is why the enroll case asserts only "not a redirect" and the
+ * poll case carries the proof.
+ *
+ * Usage: php tests/agent-routes-ignore-api-switch.test.php
+ * Exit status 0 = pass, 1 = fail.
+ */
+
+use FOG\Router\Route;
+
+require_once __DIR__ . '/lib/fog-test-harness.php';
+
+$childCase = null;
+foreach (array_slice(isset($argv) ? $argv : [], 1) as $arg) {
+    if (0 === strpos($arg, '--case=')) {
+        $childCase = substr($arg, 7);
+    }
+}
+if (null !== $childCase) {
+    runChild($childCase);
+    exit(0);
+}
+
+/**
+ * Construct Route for one request and print what it answered. Never
+ * asserts -- the parent owns the verdict.
+ *
+ * @param string $case "<FOG_API_ENABLED> <request uri>"
+ *
+ * @return void
+ */
+function runChild($case)
+{
+    list($flag, $uri) = explode(' ', $case, 2);
+    FogTestHarness::boot('agent-routes-ignore-api-switch');
+    $db = FogTestHarness::fakeDb();
+    $db->responder = function ($sql) use ($flag) {
+        if (false === strpos($sql, 'globalSettings')) {
+            return null;
+        }
+        return [
+            ['settingKey' => 'FOG_API_ENABLED', 'settingValue' => $flag],
+            ['settingKey' => 'FOG_API_TOKEN', 'settingValue' => 'test'],
+            ['settingKey' => 'FOG_WEB_ROOT', 'settingValue' => '/fog/'],
+        ];
+    };
+    foreach (
+        [
+            '_initialized' => true,
+            'requesturi' => $uri,
+            'reqmethod' => 'POST',
+            'post' => true,
+            'ajax' => false,
+            'httpproto' => 'https',
+            'httphost' => '192.168.1.100',
+            'remoteaddr' => '192.168.102.20',
+            'scriptname' => '/fog/api/index.php',
+            'querystring' => '',
+        ] as $property => $value
+    ) {
+        FogTestHarness::setStatic('FOGBase', $property, $value);
+    }
+    ob_start();
+    register_shutdown_function(
+        function () {
+            $body = trim((string)ob_get_clean());
+            echo 'RESULT ' . (int)http_response_code() . ' '
+                . str_replace("\n", ' ', $body) . "\n";
+        }
+    );
+    new Route();
+}
+
+/**
+ * Run one request in a child process.
+ *
+ * @param string $flag FOG_API_ENABLED
+ * @param string $uri  the request uri
+ *
+ * @return array [int status (0 when the child printed nothing), string body]
+ */
+function child($flag, $uri)
+{
+    $pipes = [];
+    $proc = proc_open(
+        [PHP_BINARY, __FILE__, '--case=' . $flag . ' ' . $uri],
+        [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+        $pipes
+    );
+    if (!is_resource($proc)) {
+        return [0, 'SPAWN FAILED'];
+    }
+    fclose($pipes[0]);
+    $out = stream_get_contents($pipes[1]);
+    $err = stream_get_contents($pipes[2]);
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    proc_close($proc);
+    if (preg_match('/^RESULT (\d+) ?(.*)$/m', (string)$out, $m)) {
+        return [(int)$m[1], $m[2]];
+    }
+    return [0, 'NO RESULT: ' . trim(str_replace("\n", ' | ', $out . ' ' . $err))];
+}
+
+$t = new FogChecks();
+
+list($code, $body) = child('0', '/fog/agent/v1/enroll');
+$t->check(
+    "enroll with the API off is not redirected (got $code $body)",
+    0 !== $code && ($code < 300 || $code >= 400)
+);
+
+list($code, $body) = child('0', '/fog/agent/v1/poll');
+$t->check(
+    "poll with the API off reaches the agent gate and gets 401 (got $code)",
+    401 === $code
+);
+$t->check(
+    'and the agent gate is what answered, not a token check',
+    false !== strpos($body, '"reason":"no_client_certificate"')
+);
+
+list($code, $body) = child('0', '/fog/host');
+$t->check(
+    "an API route with the API off is still redirected (got $code)",
+    308 === $code
+);
+
+$t->finish();

--- a/tests/agent-routes-ignore-api-switch.test.php
+++ b/tests/agent-routes-ignore-api-switch.test.php
@@ -44,7 +44,7 @@ foreach (array_slice(isset($argv) ? $argv : [], 1) as $arg) {
     }
 }
 if (null !== $childCase) {
-    runChild($childCase);
+    apiSwitchRunChild($childCase);
     exit(0);
 }
 
@@ -52,11 +52,16 @@ if (null !== $childCase) {
  * Construct Route for one request and print what it answered. Never
  * asserts -- the parent owns the verdict.
  *
+ * Both helpers carry a prefix because phpstan analyses tests/ as one
+ * program, and route-read-path-guards.test.php already declares runChild()
+ * and child(). Unprefixed, phpstan read this file's calls against those
+ * declarations and failed the CI job.
+ *
  * @param string $case "<FOG_API_ENABLED> <request uri>"
  *
  * @return void
  */
-function runChild($case)
+function apiSwitchRunChild($case)
 {
     list($flag, $uri) = explode(' ', $case, 2);
     FogTestHarness::boot('agent-routes-ignore-api-switch');
@@ -106,7 +111,7 @@ function runChild($case)
  *
  * @return array [int status (0 when the child printed nothing), string body]
  */
-function child($flag, $uri)
+function apiSwitchChild($flag, $uri)
 {
     $pipes = [];
     $proc = proc_open(
@@ -131,13 +136,13 @@ function child($flag, $uri)
 
 $t = new FogChecks();
 
-list($code, $body) = child('0', '/fog/agent/v1/enroll');
+list($code, $body) = apiSwitchChild('0', '/fog/agent/v1/enroll');
 $t->check(
     "enroll with the API off is not redirected (got $code $body)",
     0 !== $code && ($code < 300 || $code >= 400)
 );
 
-list($code, $body) = child('0', '/fog/agent/v1/poll');
+list($code, $body) = apiSwitchChild('0', '/fog/agent/v1/poll');
 $t->check(
     "poll with the API off reaches the agent gate and gets 401 (got $code)",
     401 === $code
@@ -147,7 +152,7 @@ $t->check(
     false !== strpos($body, '"reason":"no_client_certificate"')
 );
 
-list($code, $body) = child('0', '/fog/host');
+list($code, $body) = apiSwitchChild('0', '/fog/host');
 $t->check(
     "an API route with the API off is still redirected (got $code)",
     308 === $code


### PR DESCRIPTION
## Problem

With `FOG_API_ENABLED` off, `Route::__construct()` sends a 308 to `management/index.php` before it looks at the path. That includes `/agent/v1/`. No fog-agent can enroll or poll on a server with the REST API off.

Reported in [forum topic 18241](https://forums.fogproject.org/topic/18241):

```
POST https://192.168.1.100/fog/agent/v1/enroll
HTTP/1.1 308 Permanent Redirect
Location: https://192.168.1.100/fog/management/index.php
```

That `Location` shape (absolute, no query) comes only from this gate. The schema redirect carries `?node=schema`, and it already skips agent routes.

Workaround until this merges: turn `FOG_API_ENABLED` on.

## Change

The API switch now skips paths under `<webroot>/agent/v1/`. The agent routes keep their own gate: enroll issues nothing without an approval, and every other agent route needs a certificate bound to a host.

**Behavior change:** with the API off, `/agent/v1/` answers as it does with the API on. Every other API route still gets the 308.

## Access change

This widens what is reachable when an admin has turned the API off. Enroll becomes reachable anonymously again (it still needs an approval to issue anything). A maintainer approved this.

## Tests

`tests/agent-routes-ignore-api-switch.test.php` constructs `Route` in child processes with `FOG_API_ENABLED=0`:

| Case | Before | After |
|---|---|---|
| `POST /fog/agent/v1/enroll` | 308 | not a redirect |
| `POST /fog/agent/v1/poll` | 308 | 401 `no_client_certificate` |
| `POST /fog/host` | 308 | 308 |

- Against unfixed `working-1.6`: 3 of 4 checks fail, each with the reporter's 308. On this branch: 4 of 4 pass.
- The first commit broke `route-read-path-guards.test.php` (2 of 139 failed). It rewrote the agent block's condition, and that test finds the block by that text. The second commit restores the text. It now passes 139 of 139.
- The first two commits failed CI's phpstan tests pass (6 errors). The new test's helpers shared names with `route-read-path-guards.test.php`. The third commit prefixes them. Both phpstan passes are clean locally.
- `tests/run-all.sh`: 355 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBAeoaZ3a3chFAvQdfxrh7

