### PR TITLE
Take the version base from a release tag only

### DIFF
--- a/.githooks/lib/fog-version.sh
+++ b/.githooks/lib/fog-version.sh
@@ -31,7 +31,11 @@ system_file="$project_dir/packages/web/src/Base/System.php"
 gitbranch="${1:-$(git branch --show-current)}"
 mode="${2:-0}"
 
-gitcom=$(git rev-list --tags --no-walk --max-count=1)
+# Release tags only. A release tag is the version string itself (1.5.10.2253),
+# so it starts with a digit. Any other tag -- archive/feature-fog2-gui, pushed
+# on 2026-09-06 -- would otherwise become the base version whenever it is the
+# newest tag, and its slash then breaks the sed in apply-fog-version.sh.
+gitcom=$(git rev-list --tags='[0-9]*' --no-walk --max-count=1)
 
 git fetch origin master:master 2>/dev/null || true
 gitcount=$(git rev-list master..HEAD --count)
@@ -70,13 +74,13 @@ compute_version() {
     # is. tests/update-channel-vocabulary.test.sh fails if the halves drift.
     case "$branchon" in
         dev)
-            tagversion=$(git describe --tags "$gitcom")
+            tagversion=$(git describe --tags --match '[0-9]*' "$gitcom")
             baseversion=${tagversion%.*}
             trunkversion="${baseversion}.${count}"
             channel="Patches"
             ;;
         stable)
-            tagversion=$(git describe --tags "$gitcom")
+            tagversion=$(git describe --tags --match '[0-9]*' "$gitcom")
             baseversion=${tagversion%.*}
             count=$(git rev-list master..dev-branch --count) # Get the gitcount from dev-branch instead
             trunkversion="${baseversion}.${count}"

--- a/tests/fog-version-release-tag.test.sh
+++ b/tests/fog-version-release-tag.test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Pins that FOG_VERSION takes its base from a RELEASE tag, never from the
+# newest tag of any name.
+#
+#   tests/fog-version-release-tag.test.sh
+#
+# .githooks/lib/fog-version.sh finds the newest tagged commit and strips the
+# last dot-field from its tag to get the base (1.5.10.2253 -> 1.5.10). On
+# 2026-09-06 the tag archive/feature-fog2-gui was pushed and became the newest
+# tag. The dev arm then computed archive/feature-fog2-gui.2479, the slash broke
+# the sed in apply-fog-version.sh, and fog-workflows' daily sweep failed on
+# dev-branch every day after.
+#
+# Builds a throwaway repo with one release tag and a NEWER non-release tag, and
+# checks that the dev and stable arms still report the release base.
+#
+# Exit 0 = pass, 1 = fail.
+
+set -u
+
+repo=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+script="$repo/.githooks/lib/fog-version.sh"
+
+rc=0
+bad() {
+    printf 'FAIL: %s\n' "$1" >&2
+    rc=1
+}
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+fx="$tmp/fixture"
+
+# Commit dates are set explicitly: rev-list orders tags by commit date, and
+# commits made in the same second would leave "newest" undefined.
+commit() {
+    GIT_COMMITTER_DATE="$1" GIT_AUTHOR_DATE="$1" \
+        git -C "$fx" commit -q --allow-empty -m "$2"
+}
+
+git init -q -b master "$fx"
+git -C "$fx" config user.email t@example.invalid
+git -C "$fx" config user.name t
+git -C "$fx" config commit.gpgsign false
+git -C "$fx" config tag.gpgsign false
+
+# The script reads the committed version from whichever System file its branch
+# uses, so the fixture carries both.
+mkdir -p "$fx/.githooks/lib" "$fx/packages/web/src/Base" "$fx/packages/web/lib/fog"
+cp "$script" "$fx/.githooks/lib/fog-version.sh"
+for f in packages/web/src/Base/System.php packages/web/lib/fog/system.class.php; do
+    printf "<?php\ndefine('FOG_VERSION', '1.5.10.1');\n" > "$fx/$f"
+done
+git -C "$fx" add -A
+commit '2020-01-01T00:00:00Z' 'master'
+
+git -C "$fx" checkout -q -b dev-branch
+commit '2020-01-02T00:00:00Z' 'release'
+git -C "$fx" tag 1.5.10.1
+commit '2020-01-03T00:00:00Z' 'patch'
+
+# An archived feature branch, tagged the way archive/feature-fog2-gui is:
+# annotated, and on a commit newer than the release.
+git -C "$fx" checkout -q -b feature-x master
+commit '2020-02-01T00:00:00Z' 'feature work'
+git -C "$fx" tag -a archive/feature-x -m 'archive'
+git -C "$fx" checkout -q dev-branch
+
+count=$(git -C "$fx" rev-list master..dev-branch --count)
+want="1.5.10.$count"
+
+for arm in dev-branch stable; do
+    got=$(cd "$fx" && sh .githooks/lib/fog-version.sh "$arm" head 2>/dev/null | sed -n '1p')
+    [ "$got" = "$want" ] || bad "$arm computed '$got', expected '$want'. A non-release tag newer than the last release must not become the base version."
+done
+
+exit $rc


### PR DESCRIPTION
## Problem

fog-workflows' daily sweep has failed on dev-branch every day since 2026-09-06:

```
sed: -e expression #1, char 60: unknown option to `s'
```

## Cause

`fog-version.sh` takes the newest tag of any name as the base version. The tag `archive/feature-fog2-gui` was pushed on 2026-09-06 and is now the newest tag. The dev arm computes `archive/feature-fog2-gui.2479`, and the slash breaks the `sed` in `apply-fog-version.sh`. The stable arm uses the same lookup. The Beta arm does not use tags, so `version.php` on this branch is not affected.

## Fix

`git rev-list --tags` and `git describe --tags` now match `'[0-9]*'` only. A release tag is the version string itself, so it starts with a digit.

## Verification

- Against the real repo: `fog-version.sh dev-branch head` gives `archive/feature-fog2-gui.2479` before and `1.5.10.2479` after. `master..origin/dev-branch --count` is 2479.
- `tests/fog-version-release-tag.test.sh` builds a fixture repo with a release tag and a newer annotated archive tag. It passes with the fix. With the old script it fails with `dev-branch computed 'archive/feature-x.2', expected '1.5.10.2'`, and the same for stable.

The dev-branch port is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RANCjBL6XSavKYf58MZKZj